### PR TITLE
Add ability to plan based on chunk table AM

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1614,12 +1614,14 @@ chunk_tuple_found(TupleInfo *ti, void *arg)
 	 * ts_chunk_build_from_tuple_and_stub() since chunk_resurrect() also uses
 	 * that function and, in that case, the chunk object is needed to create
 	 * the data table and related objects. */
-	chunk->table_id =
-		ts_get_relation_relid(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), false);
-
 	chunk->hypertable_relid = ts_hypertable_id_to_relid(chunk->fd.hypertable_id, false);
+	ts_get_rel_info_by_name(NameStr(chunk->fd.schema_name),
+							NameStr(chunk->fd.table_name),
+							&chunk->table_id,
+							&chunk->amoid,
+							&chunk->relkind);
 
-	chunk->relkind = get_rel_relkind(chunk->table_id);
+	Assert(OidIsValid(chunk->amoid) || chunk->fd.osm_chunk);
 
 	Ensure(chunk->relkind > 0,
 		   "relkind for chunk \"%s\".\"%s\" is invalid",

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -66,6 +66,7 @@ typedef struct Chunk
 	char relkind;
 	Oid table_id;
 	Oid hypertable_relid;
+	Oid amoid; /* Table access method used by chunk */
 
 	/*
 	 * The hypercube defines the chunks position in the N-dimensional space.

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -130,7 +130,10 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 	for (int i = 0; i < locked_chunk_count; i++)
 	{
 		Chunk *chunk = locked_chunks[i];
-		chunk->relkind = get_rel_relkind(chunk->table_id);
+
+		ts_get_rel_info(chunk->table_id, &chunk->amoid, &chunk->relkind);
+
+		Assert(OidIsValid(chunk->amoid) || chunk->fd.osm_chunk);
 	}
 
 	/*

--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -187,16 +187,15 @@ ts_set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *parent_rel, Index pare
 		TsRelType reltype = ts_classify_relation(root, child_rel, &ht);
 		if (reltype == TS_REL_CHUNK_CHILD && !TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 		{
-			TimescaleDBPrivate *fdw_private = (TimescaleDBPrivate *) child_rel->fdw_private;
+			const Chunk *chunk = ts_planner_chunk_fetch(root, child_rel);
 
 			/*
 			 * This function is called only in tandem with our own hypertable
 			 * expansion, so the Chunk struct must be initialized already.
 			 */
-			Assert(fdw_private->cached_chunk_struct != NULL);
+			Assert(chunk != NULL);
 
-			if (!ts_chunk_is_partial(fdw_private->cached_chunk_struct) &&
-				ts_chunk_is_compressed(fdw_private->cached_chunk_struct))
+			if (!ts_chunk_is_partial(chunk) && ts_chunk_is_compressed(chunk))
 			{
 				child_rel->indexlist = NIL;
 			}

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1419,12 +1419,9 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 				(type == TS_REL_CHUNK_CHILD) && IS_UPDL_CMD(query);
 			if (use_transparent_decompression && (is_standalone_chunk || is_child_chunk_in_update))
 			{
-				TimescaleDBPrivate *fdw_private = (TimescaleDBPrivate *) rel->fdw_private;
-				Assert(fdw_private->cached_chunk_struct == NULL);
-				fdw_private->cached_chunk_struct =
-					ts_chunk_get_by_relid(rte->relid, /* fail_if_not_found = */ true);
-				if (!ts_chunk_is_partial(fdw_private->cached_chunk_struct) &&
-					ts_chunk_is_compressed(fdw_private->cached_chunk_struct))
+				const Chunk *chunk = ts_planner_chunk_fetch(root, rel);
+
+				if (!ts_chunk_is_partial(chunk) && ts_chunk_is_compressed(chunk))
 				{
 					rel->indexlist = NIL;
 				}

--- a/src/utils.h
+++ b/src/utils.h
@@ -371,3 +371,8 @@ ts_datum_set_objectid(const AttrNumber attno, NullableDatum *datums, const Oid v
 	else
 		datums[AttrNumberGetAttrOffset(attno)].isnull = true;
 }
+
+extern TSDLLEXPORT void ts_get_rel_info_by_name(const char *relnamespace, const char *relname,
+												Oid *relid, Oid *amoid, char *relkind);
+extern TSDLLEXPORT void ts_get_rel_info(Oid relid, Oid *amoid, char *relkind);
+extern TSDLLEXPORT bool ts_is_hypercore_am(Oid amoid);

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -67,10 +67,11 @@ static DecompressChunkPath *decompress_chunk_path_create(PlannerInfo *root, Comp
 														 int parallel_workers,
 														 Path *compressed_path);
 
-static void decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk *chunk,
-											 RelOptInfo *chunk_rel, bool needs_sequence_num);
+static void decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info,
+											 const Chunk *chunk, RelOptInfo *chunk_rel,
+											 bool needs_sequence_num);
 
-static SortInfo build_sortinfo(Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info,
+static SortInfo build_sortinfo(const Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info,
 							   List *pathkeys);
 
 static bool
@@ -254,7 +255,8 @@ copy_decompress_chunk_path(DecompressChunkPath *src)
 }
 
 static CompressionInfo *
-build_compressioninfo(PlannerInfo *root, Hypertable *ht, Chunk *chunk, RelOptInfo *chunk_rel)
+build_compressioninfo(PlannerInfo *root, const Hypertable *ht, const Chunk *chunk,
+					  RelOptInfo *chunk_rel)
 {
 	AppendRelInfo *appinfo;
 	CompressionInfo *info = palloc0(sizeof(CompressionInfo));
@@ -510,7 +512,7 @@ cost_batch_sorted_merge(PlannerInfo *root, CompressionInfo *compression_info,
  * compatible and the optimization can be used.
  */
 static MergeBatchResult
-can_batch_sorted_merge(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
+can_batch_sorted_merge(PlannerInfo *root, CompressionInfo *info, const Chunk *chunk)
 {
 	PathKey *pk;
 	Var *var;
@@ -620,8 +622,8 @@ can_batch_sorted_merge(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
  * To save planning time, we therefore refrain from adding them.
  */
 static void
-add_chunk_sorted_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht, Index ht_relid,
-					   Path *path, Path *compressed_path)
+add_chunk_sorted_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const Hypertable *ht,
+					   Index ht_relid, Path *path, Path *compressed_path)
 {
 	if (root->query_pathkeys == NIL)
 		return;
@@ -681,8 +683,8 @@ add_chunk_sorted_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht,
 #define IS_UPDL_CMD(parse)                                                                         \
 	((parse)->commandType == CMD_UPDATE || (parse)->commandType == CMD_DELETE)
 void
-ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht,
-								   Chunk *chunk)
+ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const Hypertable *ht,
+								   const Chunk *chunk)
 {
 	RelOptInfo *compressed_rel;
 	ListCell *lc;
@@ -1650,7 +1652,7 @@ compressed_rel_setup_equivalence_classes(PlannerInfo *root, CompressionInfo *inf
  * and add it to PlannerInfo
  */
 static void
-decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk *chunk,
+decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Chunk *chunk,
 								 RelOptInfo *chunk_rel, bool needs_sequence_num)
 {
 	Index compressed_index = root->simple_rel_array_size;
@@ -2012,7 +2014,7 @@ find_const_segmentby(RelOptInfo *chunk_rel, CompressionInfo *info)
  * If query pathkeys is shorter than segmentby + compress_orderby pushdown can still be done
  */
 static SortInfo
-build_sortinfo(Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info, List *pathkeys)
+build_sortinfo(const Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info, List *pathkeys)
 {
 	int pk_index;
 	PathKey *pk;

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -57,8 +57,8 @@ typedef struct DecompressChunkPath
 	bool batch_sorted_merge;
 } DecompressChunkPath;
 
-void ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht,
-										Chunk *chunk);
+void ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *rel, const Hypertable *ht,
+										const Chunk *chunk);
 
 extern bool ts_is_decompress_chunk_path(Path *path);
 


### PR DESCRIPTION
A chunk can use different table access methods so to support this more easily, cache the AM oid in the chunk struct. This allows identifying the access method quickly at, e.g., planning time.

Disable-check: force-changelog-file