### PR TITLE
Fix index column check while searching for index

### DIFF
--- a/.unreleased/pr_7286
+++ b/.unreleased/pr_7286
@@ -1,0 +1,1 @@
+Fixes: #7286: Fix index column check while searching for index

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -157,6 +157,16 @@ decompress_batches_for_insert(const ChunkInsertState *cis, TupleTableSlot *slot)
 	if (index_rel)
 		null_columns = NULL;
 
+	if (ts_guc_debug_compression_path_info)
+	{
+		elog(INFO,
+			 "Using %s scan with scan keys: index %d, heap %d, memory %d. ",
+			 index_rel ? "index" : "table",
+			 num_index_scankeys,
+			 num_heap_scankeys,
+			 num_mem_scankeys);
+	}
+
 	/*
 	 * Using latest snapshot to scan the heap since we are doing this to build
 	 * the index on the uncompressed chunks in order to do speculative insertion
@@ -332,20 +342,12 @@ decompress_batch_beginscan(Relation in_rel, Relation index_rel, Snapshot snapsho
 
 	if (index_rel)
 	{
-		if (ts_guc_debug_compression_path_info)
-		{
-			elog(INFO, "Using index scan for DML decompression");
-		}
 		scan->index_scan = index_beginscan(in_rel, index_rel, snapshot, num_scankeys, 0);
 		index_rescan(scan->index_scan, scankeys, num_scankeys, NULL, 0);
 		scan->scan = NULL;
 	}
 	else
 	{
-		if (ts_guc_debug_compression_path_info)
-		{
-			elog(INFO, "Using table scan for DML decompression");
-		}
 		scan->scan = table_beginscan(in_rel, snapshot, num_scankeys, scankeys);
 		scan->index_scan = NULL;
 	}

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -769,6 +769,7 @@ get_batch_keys_for_unique_constraints(const ChunkInsertState *cis, Relation rela
 {
 	tuple_filtering_constraints *constraints = palloc0(sizeof(tuple_filtering_constraints));
 	constraints->on_conflict = ONCONFLICT_UPDATE;
+	constraints->nullsnotdistinct = false;
 	ListCell *lc;
 
 	/* Fast path if definitely no indexes */
@@ -832,6 +833,12 @@ get_batch_keys_for_unique_constraints(const ChunkInsertState *cis, Relation rela
 			constraints->key_columns = bms_intersect(idx_attrs, constraints->key_columns);
 			constraints->covered = false;
 		}
+
+#if PG15_GE
+		/* If any of the unique indexes have NULLS NOT DISTINCT set, we proceed
+		 * with checking the constraints with decompression */
+		constraints->nullsnotdistinct |= indexDesc->rd_index->indnullsnotdistinct;
+#endif
 
 		/* When multiple unique indexes are present, in theory there could be no shared
 		 * columns even though that is very unlikely as they will probably at least share

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -332,12 +332,20 @@ decompress_batch_beginscan(Relation in_rel, Relation index_rel, Snapshot snapsho
 
 	if (index_rel)
 	{
+		if (ts_guc_debug_compression_path_info)
+		{
+			elog(INFO, "Using index scan for DML decompression");
+		}
 		scan->index_scan = index_beginscan(in_rel, index_rel, snapshot, num_scankeys, 0);
 		index_rescan(scan->index_scan, scankeys, num_scankeys, NULL, 0);
 		scan->scan = NULL;
 	}
 	else
 	{
+		if (ts_guc_debug_compression_path_info)
+		{
+			elog(INFO, "Using table scan for DML decompression");
+		}
 		scan->scan = table_beginscan(in_rel, snapshot, num_scankeys, scankeys);
 		scan->index_scan = NULL;
 	}

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -322,11 +322,11 @@ build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel, Relation 
 			AttrNumber idx_attnum = AttrOffsetGetAttrNumber(i);
 			AttrNumber in_attnum = index_rel->rd_index->indkey.values[i];
 			const NameData *attname = attnumAttName(in_rel, in_attnum);
+			AttrNumber column_attno =
+				get_attnum(out_rel->rd_id, NameStr(*attname)) - FirstLowInvalidHeapAttributeNumber;
 
 			/* Make sure we find columns in key columns in order to select the right index */
-			if (!bms_is_member((get_attnum(out_rel->rd_id, NameStr(*attname)) -
-								FirstLowInvalidHeapAttributeNumber),
-							   key_columns))
+			if (!bms_is_member(column_attno, key_columns))
 			{
 				break;
 			}
@@ -337,6 +337,7 @@ build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel, Relation 
 
 			if (isnull)
 			{
+				*index_columns = bms_add_member(*index_columns, column_attno);
 				ScanKeyEntryInitialize(&scankeys[(*num_scan_keys)++],
 									   SK_ISNULL | SK_SEARCHNULL,
 									   idx_attnum,
@@ -377,6 +378,7 @@ build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel, Relation 
 			Ensure(OidIsValid(opcode),
 				   "no opcode found for column operator of a hypertable column");
 
+			*index_columns = bms_add_member(*index_columns, column_attno);
 			ScanKeyEntryInitialize(&scankeys[(*num_scan_keys)++],
 								   0, /* flags */
 								   idx_attnum,

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -324,7 +324,9 @@ build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel, Relation 
 			const NameData *attname = attnumAttName(in_rel, in_attnum);
 
 			/* Make sure we find columns in key columns in order to select the right index */
-			if (!bms_is_member(get_attnum(out_rel->rd_id, NameStr(*attname)), key_columns))
+			if (!bms_is_member((get_attnum(out_rel->rd_id, NameStr(*attname)) -
+								FirstLowInvalidHeapAttributeNumber),
+							   key_columns))
 			{
 				break;
 			}

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -49,13 +49,13 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail due to multiple entries with same time value
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "1_1_comp_conflicts_1_pkey"
 INSERT INTO comp_conflicts_1 VALUES
 ('2020-01-01','d1',0.1),
 ('2020-01-01','d2',0.2),
 ('2020-01-01','d3',0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "1_1_comp_conflicts_1_pkey"
 \set ON_ERROR_STOP 1
 -- no data should be in uncompressed chunk since the inserts failed and their transaction rolled back
@@ -71,11 +71,11 @@ BEGIN;
   ('2020-01-01 0:00:01','d1',0.1),
   ('2020-01-01 0:00:02','d2',0.2),
   ('2020-01-01 0:00:03','d3',0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have moved into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -96,11 +96,11 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "1_1_comp_conflicts_1_pkey"
 \set ON_ERROR_STOP 1
 INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1) ON CONFLICT DO NOTHING;
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 2, memory 1. 
 -- data should have move into uncompressed chunk for conflict check
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -134,16 +134,16 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail due to multiple entries with same time, device value
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d2',0.2);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 INSERT INTO comp_conflicts_2 VALUES
 ('2020-01-01','d1',0.1),
 ('2020-01-01','d2',0.2),
 ('2020-01-01','d3',0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 \set ON_ERROR_STOP 1
 -- no data should be in uncompressed chunk since the inserts failed and their transaction rolled back
@@ -159,11 +159,11 @@ BEGIN;
   ('2020-01-01 0:00:01','d1',0.1),
   ('2020-01-01 0:00:01','d2',0.2),
   ('2020-01-01 0:00:01','d3',0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -184,11 +184,11 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 \set ON_ERROR_STOP 1
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1) ON CONFLICT DO NOTHING;
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 -- data should have move into uncompressed chunk for conflict check
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -223,28 +223,28 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail due to multiple entries with same time, device value
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d2', 'label', 0.2);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 INSERT INTO comp_conflicts_3 VALUES
 ('2020-01-01','d1', 'label', 0.1),
 ('2020-01-01','d2', 'label', 0.2),
 ('2020-01-01','d3', 'label', 0.3);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 -- should work the same without the index present
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d2', 'label', 0.2);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 BEGIN;
@@ -253,7 +253,7 @@ BEGIN;
   ('2020-01-01','d1', 'label', 0.1),
   ('2020-01-01','d2', 'label', 0.2),
   ('2020-01-01','d3', 'label', 0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- using superuser to create indexes on compressed chunks
@@ -265,7 +265,7 @@ BEGIN;
   CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, label, _ts_meta_sequence_num)
 	WHERE label LIKE 'missing';
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore matching covering index
@@ -273,23 +273,23 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device) INCLUDE (label, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 1, heap 3, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
--- ignore matching but out of order segmentby index
+-- out of order segmentby index, index is still usable
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (label, device, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
--- ignore index with sequence number in the middle
+-- index with sequence number in the middle, index should be usable with single index scan key
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, _ts_meta_sequence_num, label);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 1, heap 3, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore expression index
@@ -297,7 +297,7 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, lower(label), _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore non-btree index
@@ -305,7 +305,7 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk USING brin (device, label, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 \set ON_ERROR_STOP 1
@@ -347,7 +347,7 @@ ROLLBACK;
 -- should succeed since there are no conflicts in the values
 BEGIN;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01 0:00:01','d1', 'label', 0.1);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 1.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -363,7 +363,7 @@ ROLLBACK;
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01 0:00:01','d1', 'label', 0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -379,11 +379,11 @@ BEGIN;
   ('2020-01-01 0:00:01','d1', 'label', 0.1),
   ('2020-01-01 0:00:01','d2', 'label', 0.2),
   ('2020-01-01 0:00:01','d3', 'label', 0.3);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 1.
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 1.
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 0. Number of compressed rows filtered by heap filters: 0.
   -- no data for should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -401,11 +401,11 @@ BEGIN;
   ('2020-01-01 0:00:01','d1', 'label', 0.1),
   ('2020-01-01 0:00:01','d2', 'label', 0.2),
   ('2020-01-01 0:00:01','d3', 'label', 0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data for should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -418,7 +418,7 @@ INFO:  Number of compressed rows fetched from table scan: 0. Number of compresse
 ROLLBACK;
 BEGIN;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01 0:00:01','d3', 'label', 0.2);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 0. Number of compressed rows filtered by heap filters: 0.
   -- count = 1 since no data should have move into uncompressed chunk for conflict check since d3 is new segment
   SELECT count(*) FROM ONLY :CHUNK;
@@ -438,11 +438,11 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 \set ON_ERROR_STOP 1
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1) ON CONFLICT DO NOTHING;
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 -- data should have move into uncompressed chunk for conflict check
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -489,7 +489,7 @@ ROLLBACK;
 -- should succeed since there are no conflicts in the values
 BEGIN;
   INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 2:00:01','d1',0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -505,11 +505,11 @@ BEGIN;
   ('2020-01-01 2:00:01','d1',0.1),
   ('2020-01-01 2:00:01','d2',0.2),
   ('2020-01-01 2:00:01','d3',0.3);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data for should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
@@ -522,7 +522,7 @@ INFO:  Number of compressed rows fetched from table scan: 0. Number of compresse
 ROLLBACK;
 BEGIN;
   INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:00:01','d3',0.2);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- count = 1 since no data should have move into uncompressed chunk for conflict check since d3 is new segment
   SELECT count(*) FROM ONLY :CHUNK;
@@ -542,7 +542,7 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01','d1',0.1);
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 ERROR:  duplicate key value violates unique constraint "7_4_comp_conflicts_4_time_device_key"
 \set ON_ERROR_STOP 1
 -- data not should have move into uncompressed chunk for conflict check
@@ -553,9 +553,9 @@ SELECT count(*) FROM ONLY :CHUNK;
 (1 row)
 
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:00:01','d1',0.1) ON CONFLICT DO NOTHING;
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:30:00','d1',0.1) ON CONFLICT DO NOTHING;
-INFO:  Using table scan for DML decompression
+INFO:  Using table scan with scan keys: index 0, heap 4, memory 2. 
 -- data should have move into uncompressed chunk for conflict check
 -- 2 segments (count = 2000)
 SELECT count(*) FROM ONLY :CHUNK;
@@ -643,7 +643,7 @@ SELECT COUNT(*) FROM compressed_ht WHERE name = 'ON CONFLICT DO UPDATE';
 INSERT INTO compressed_ht VALUES ('2017-12-28 01:10:28.192199+05:30', '1', 0.876, 4.123, 'new insert row')
   ON conflict(sensor_id, time)
 DO UPDATE SET sensor_id = excluded.sensor_id , name = 'ON CONFLICT DO UPDATE';
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 1, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 0.
 -- should report 1 row
 SELECT COUNT(*) FROM compressed_ht WHERE name = 'ON CONFLICT DO UPDATE';
@@ -667,7 +667,7 @@ WHERE hypertable_name = 'compressed_ht' ORDER BY chunk_name;
 INSERT INTO compressed_ht VALUES ('2022-01-24 01:10:28.192199+05:30', '6', 0.876, 4.123, 'new insert row')
   ON conflict(sensor_id, time)
 DO UPDATE SET sensor_id = excluded.sensor_id , name = 'ON CONFLICT DO UPDATE' RETURNING *;
-INFO:  Using index scan for DML decompression
+INFO:  Using index scan with scan keys: index 1, heap 2, memory 1. 
 INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 0.
                 time                 | sensor_id |  cpu  | temperature |         name          
 -------------------------------------+-----------+-------+-------------+-----------------------

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- test conflict handling on compressed hypertables with unique constraints
+set timescaledb.debug_compression_path_info to on;
 -- test 1: single column primary key
 CREATE TABLE comp_conflicts_1(time timestamptz, device text, value float, PRIMARY KEY(time));
 SELECT table_name FROM create_hypertable('comp_conflicts_1','time');
@@ -36,6 +37,7 @@ INSERT INTO comp_conflicts_1 VALUES
 ROLLBACK;
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_1') c
 \gset
+INFO:  compress_chunk_tuplesort_start
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -47,11 +49,13 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail due to multiple entries with same time value
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "1_1_comp_conflicts_1_pkey"
 INSERT INTO comp_conflicts_1 VALUES
 ('2020-01-01','d1',0.1),
 ('2020-01-01','d2',0.2),
 ('2020-01-01','d3',0.3);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "1_1_comp_conflicts_1_pkey"
 \set ON_ERROR_STOP 1
 -- no data should be in uncompressed chunk since the inserts failed and their transaction rolled back
@@ -67,6 +71,12 @@ BEGIN;
   ('2020-01-01 0:00:01','d1',0.1),
   ('2020-01-01 0:00:02','d2',0.2),
   ('2020-01-01 0:00:03','d3',0.3);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have moved into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -86,9 +96,11 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "1_1_comp_conflicts_1_pkey"
 \set ON_ERROR_STOP 1
 INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1) ON CONFLICT DO NOTHING;
+INFO:  Using table scan for DML decompression
 -- data should have move into uncompressed chunk for conflict check
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -111,6 +123,7 @@ INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1);
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d2',0.2);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_2') c
 \gset
+INFO:  compress_chunk_tuplesort_start
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -121,13 +134,16 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail due to multiple entries with same time, device value
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d2',0.2);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 INSERT INTO comp_conflicts_2 VALUES
 ('2020-01-01','d1',0.1),
 ('2020-01-01','d2',0.2),
 ('2020-01-01','d3',0.3);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 \set ON_ERROR_STOP 1
 -- no data should be in uncompressed chunk since the inserts failed and their transaction rolled back
@@ -143,6 +159,12 @@ BEGIN;
   ('2020-01-01 0:00:01','d1',0.1),
   ('2020-01-01 0:00:01','d2',0.2),
   ('2020-01-01 0:00:01','d3',0.3);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -162,9 +184,11 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "3_2_comp_conflicts_2_time_device_key"
 \set ON_ERROR_STOP 1
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1) ON CONFLICT DO NOTHING;
+INFO:  Using table scan for DML decompression
 -- data should have move into uncompressed chunk for conflict check
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -188,6 +212,7 @@ INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d2', 'label', 0.2);
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01',NULL, 'label', 0.3);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_3') c
 \gset
+INFO:  compress_chunk_tuplesort_start
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -198,23 +223,28 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail due to multiple entries with same time, device value
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d2', 'label', 0.2);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 INSERT INTO comp_conflicts_3 VALUES
 ('2020-01-01','d1', 'label', 0.1),
 ('2020-01-01','d2', 'label', 0.2),
 ('2020-01-01','d3', 'label', 0.3);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 -- should work the same without the index present
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d2', 'label', 0.2);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 BEGIN;
@@ -223,16 +253,19 @@ BEGIN;
   ('2020-01-01','d1', 'label', 0.1),
   ('2020-01-01','d2', 'label', 0.2),
   ('2020-01-01','d3', 'label', 0.3);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- using superuser to create indexes on compressed chunks
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+set timescaledb.debug_compression_path_info to on;
 -- ignore matching partial index
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, label, _ts_meta_sequence_num)
 	WHERE label LIKE 'missing';
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore matching covering index
@@ -240,6 +273,7 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device) INCLUDE (label, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore matching but out of order segmentby index
@@ -247,6 +281,7 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (label, device, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore index with sequence number in the middle
@@ -254,6 +289,7 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, _ts_meta_sequence_num, label);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore expression index
@@ -261,6 +297,7 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, lower(label), _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 -- ignore non-btree index
@@ -268,10 +305,12 @@ BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk USING brin (device, label, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 ROLLBACK;
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+set timescaledb.debug_compression_path_info to on;
 -- no data should be in uncompressed chunk since the inserts failed and their transaction rolled back
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -308,6 +347,8 @@ ROLLBACK;
 -- should succeed since there are no conflicts in the values
 BEGIN;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01 0:00:01','d1', 'label', 0.1);
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 1.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -322,6 +363,8 @@ ROLLBACK;
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01 0:00:01','d1', 'label', 0.1);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -336,6 +379,12 @@ BEGIN;
   ('2020-01-01 0:00:01','d1', 'label', 0.1),
   ('2020-01-01 0:00:01','d2', 'label', 0.2),
   ('2020-01-01 0:00:01','d3', 'label', 0.3);
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 1.
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 1.
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 0. Number of compressed rows filtered by heap filters: 0.
   -- no data for should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -352,6 +401,12 @@ BEGIN;
   ('2020-01-01 0:00:01','d1', 'label', 0.1),
   ('2020-01-01 0:00:01','d2', 'label', 0.2),
   ('2020-01-01 0:00:01','d3', 'label', 0.3);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data for should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -363,6 +418,8 @@ BEGIN;
 ROLLBACK;
 BEGIN;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01 0:00:01','d3', 'label', 0.2);
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 0. Number of compressed rows filtered by heap filters: 0.
   -- count = 1 since no data should have move into uncompressed chunk for conflict check since d3 is new segment
   SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -381,9 +438,11 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
+INFO:  Using index scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "5_3_comp_conflicts_3_time_device_label_key"
 \set ON_ERROR_STOP 1
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1) ON CONFLICT DO NOTHING;
+INFO:  Using index scan for DML decompression
 -- data should have move into uncompressed chunk for conflict check
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -406,6 +465,7 @@ INSERT INTO comp_conflicts_4 VALUES ('2020-01-01','d2',0.2);
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01',NULL,0.3);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_4') c
 \gset
+INFO:  compress_chunk_tuplesort_start
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -429,6 +489,8 @@ ROLLBACK;
 -- should succeed since there are no conflicts in the values
 BEGIN;
   INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 2:00:01','d1',0.1);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -443,6 +505,12 @@ BEGIN;
   ('2020-01-01 2:00:01','d1',0.1),
   ('2020-01-01 2:00:01','d2',0.2),
   ('2020-01-01 2:00:01','d3',0.3);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- no data for should have move into uncompressed chunk for conflict check
   -- since we used metadata optimization to guarantee uniqueness
   SELECT count(*) FROM ONLY :CHUNK;
@@ -454,6 +522,8 @@ BEGIN;
 ROLLBACK;
 BEGIN;
   INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:00:01','d3',0.2);
+INFO:  Using table scan for DML decompression
+INFO:  Number of compressed rows fetched from table scan: 0. Number of compressed rows filtered: 0.
   -- count = 1 since no data should have move into uncompressed chunk for conflict check since d3 is new segment
   SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -472,6 +542,7 @@ SELECT count(*) FROM ONLY :CHUNK;
 -- should fail since it conflicts with existing row
 \set ON_ERROR_STOP 0
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01','d1',0.1);
+INFO:  Using table scan for DML decompression
 ERROR:  duplicate key value violates unique constraint "7_4_comp_conflicts_4_time_device_key"
 \set ON_ERROR_STOP 1
 -- data not should have move into uncompressed chunk for conflict check
@@ -482,7 +553,9 @@ SELECT count(*) FROM ONLY :CHUNK;
 (1 row)
 
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:00:01','d1',0.1) ON CONFLICT DO NOTHING;
+INFO:  Using table scan for DML decompression
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:30:00','d1',0.1) ON CONFLICT DO NOTHING;
+INFO:  Using table scan for DML decompression
 -- data should have move into uncompressed chunk for conflict check
 -- 2 segments (count = 2000)
 SELECT count(*) FROM ONLY :CHUNK;
@@ -538,6 +611,9 @@ ALTER TABLE compressed_ht SET (
 );
 NOTICE:  default order by for hypertable "compressed_ht" is set to ""time" DESC"
 SELECT COMPRESS_CHUNK(SHOW_CHUNKS('compressed_ht'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_9_9_chunk
@@ -567,6 +643,8 @@ SELECT COUNT(*) FROM compressed_ht WHERE name = 'ON CONFLICT DO UPDATE';
 INSERT INTO compressed_ht VALUES ('2017-12-28 01:10:28.192199+05:30', '1', 0.876, 4.123, 'new insert row')
   ON conflict(sensor_id, time)
 DO UPDATE SET sensor_id = excluded.sensor_id , name = 'ON CONFLICT DO UPDATE';
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 0.
 -- should report 1 row
 SELECT COUNT(*) FROM compressed_ht WHERE name = 'ON CONFLICT DO UPDATE';
  count 
@@ -589,6 +667,8 @@ WHERE hypertable_name = 'compressed_ht' ORDER BY chunk_name;
 INSERT INTO compressed_ht VALUES ('2022-01-24 01:10:28.192199+05:30', '6', 0.876, 4.123, 'new insert row')
   ON conflict(sensor_id, time)
 DO UPDATE SET sensor_id = excluded.sensor_id , name = 'ON CONFLICT DO UPDATE' RETURNING *;
+INFO:  Using index scan for DML decompression
+INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 0.
                 time                 | sensor_id |  cpu  | temperature |         name          
 -------------------------------------+-----------+-------+-------------+-----------------------
  Sun Jan 23 11:40:28.192199 2022 PST |         6 | 0.876 |       4.123 | ON CONFLICT DO UPDATE

--- a/tsl/test/shared/expected/compression_nulls_not_distinct.out
+++ b/tsl/test/shared/expected/compression_nulls_not_distinct.out
@@ -1,0 +1,33 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- test NULL NOT DISTINCT unique constraint
+-- this test is run only on PG15 since support for NULL NOT DISTINCT
+-- only exists since then. once we drop support for PG14, this test
+-- can be moved to non-shared compression_conflicts test
+set timescaledb.debug_compression_path_info to on;
+CREATE TABLE nulls_not_distinct(time timestamptz not null, device text, value float);
+CREATE UNIQUE INDEX ON nulls_not_distinct (time, device) NULLS NOT DISTINCT;
+SELECT table_name FROM create_hypertable('nulls_not_distinct', 'time');
+     table_name     
+ nulls_not_distinct
+(1 row)
+
+ALTER TABLE nulls_not_distinct SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+NOTICE:  default order by for hypertable "nulls_not_distinct" is set to ""time" DESC"
+INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+SELECT count(compress_chunk(c)) FROM show_chunks('nulls_not_distinct') c;
+INFO:  compress_chunk_tuplesort_start
+ count 
+     1
+(1 row)
+
+-- shouldn't succeed because nulls are not distinct
+\set ON_ERROR_STOP 0
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+INFO:  Using index scan with scan keys: index 1, heap 2, memory 1. 
+ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_nulls_not_distinct_time_device_idx"
+\set ON_ERROR_STOP 1
+RESET timescaledb.debug_compression_path_info;
+DROP TABLE nulls_not_distinct;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 # other dependent tests to fail. Hence running this test in solo
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
   list(APPEND SOLO_TESTS merge_dml.sql)
+  list(APPEND TEST_FILES_SHARED compression_nulls_not_distinct.sql)
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/tsl/test/shared/sql/compression_nulls_not_distinct.sql
+++ b/tsl/test/shared/sql/compression_nulls_not_distinct.sql
@@ -1,0 +1,28 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- test NULL NOT DISTINCT unique constraint
+
+-- this test is run only on PG15 since support for NULL NOT DISTINCT
+-- only exists since then. once we drop support for PG14, this test
+-- can be moved to non-shared compression_conflicts test
+
+set timescaledb.debug_compression_path_info to on;
+CREATE TABLE nulls_not_distinct(time timestamptz not null, device text, value float);
+CREATE UNIQUE INDEX ON nulls_not_distinct (time, device) NULLS NOT DISTINCT;
+SELECT table_name FROM create_hypertable('nulls_not_distinct', 'time');
+ALTER TABLE nulls_not_distinct SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+
+INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('nulls_not_distinct') c;
+
+-- shouldn't succeed because nulls are not distinct
+\set ON_ERROR_STOP 0
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+\set ON_ERROR_STOP 1
+
+RESET timescaledb.debug_compression_path_info;
+DROP TABLE nulls_not_distinct;

--- a/tsl/test/sql/compression_conflicts.sql
+++ b/tsl/test/sql/compression_conflicts.sql
@@ -194,14 +194,14 @@ BEGIN;
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 
--- ignore matching but out of order segmentby index
+-- out of order segmentby index, index is still usable
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (label, device, _ts_meta_sequence_num);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 
--- ignore index with sequence number in the middle
+-- index with sequence number in the middle, index should be usable with single index scan key
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
   CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, _ts_meta_sequence_num, label);

--- a/tsl/test/sql/compression_conflicts.sql
+++ b/tsl/test/sql/compression_conflicts.sql
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 -- test conflict handling on compressed hypertables with unique constraints
+set timescaledb.debug_compression_path_info to on;
 
 -- test 1: single column primary key
 CREATE TABLE comp_conflicts_1(time timestamptz, device text, value float, PRIMARY KEY(time));
@@ -177,6 +178,7 @@ ROLLBACK;
 
 -- using superuser to create indexes on compressed chunks
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+set timescaledb.debug_compression_path_info to on;
 -- ignore matching partial index
 BEGIN;
   DROP INDEX _timescaledb_internal.compress_hyper_6_6_chunk_device_label__ts_meta_sequence_num_idx;
@@ -221,6 +223,7 @@ BEGIN;
 ROLLBACK;
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+set timescaledb.debug_compression_path_info to on;
 
 -- no data should be in uncompressed chunk since the inserts failed and their transaction rolled back
 SELECT count(*) FROM ONLY :CHUNK;


### PR DESCRIPTION
Attribute numbers for key columns are stored with system column
offsets which need to be added every time we calculate an attribute
number from an index. This was causing us not to find appropriate
indexes for scanning during DML compression.

Disable-check: commit-count