### PR TITLE
Fix flaky transparent_decompress_chunk

### DIFF
--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -780,6 +780,9 @@ QUERY PLAN
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';
+-- Disable merge join to get stable tests. These queries uses hash
+-- joins.
+SET enable_mergejoin TO off;
 :PREFIX_NO_VERBOSE
 SELECT *
 FROM :TEST_TABLE m1
@@ -877,6 +880,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (10 rows)
 
+RESET enable_mergejoin;
 RESET parallel_leader_participation;
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -782,6 +782,9 @@ QUERY PLAN
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';
+-- Disable merge join to get stable tests. These queries uses hash
+-- joins.
+SET enable_mergejoin TO off;
 :PREFIX_NO_VERBOSE
 SELECT *
 FROM :TEST_TABLE m1
@@ -879,6 +882,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (10 rows)
 
+RESET enable_mergejoin;
 RESET parallel_leader_participation;
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -782,6 +782,9 @@ QUERY PLAN
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';
+-- Disable merge join to get stable tests. These queries uses hash
+-- joins.
+SET enable_mergejoin TO off;
 :PREFIX_NO_VERBOSE
 SELECT *
 FROM :TEST_TABLE m1
@@ -879,6 +882,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (10 rows)
 
+RESET enable_mergejoin;
 RESET parallel_leader_participation;
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-17.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-17.out
@@ -782,6 +782,9 @@ QUERY PLAN
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';
+-- Disable merge join to get stable tests. These queries uses hash
+-- joins.
+SET enable_mergejoin TO off;
 :PREFIX_NO_VERBOSE
 SELECT *
 FROM :TEST_TABLE m1
@@ -879,6 +882,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (10 rows)
 
+RESET enable_mergejoin;
 RESET parallel_leader_participation;
 :PREFIX
 SELECT *

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -241,6 +241,9 @@ FROM metrics m1
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';
+-- Disable merge join to get stable tests. These queries uses hash
+-- joins.
+SET enable_mergejoin TO off;
 :PREFIX_NO_VERBOSE
 SELECT *
 FROM :TEST_TABLE m1
@@ -288,6 +291,7 @@ ORDER BY m1.time,
     m1.device_id,
     m2.device_id
 LIMIT 10;
+RESET enable_mergejoin;
 RESET parallel_leader_participation;
 
 :PREFIX


### PR DESCRIPTION
It can pick merge joins in favor of hash joins when testing outer joins. Since these tests are only testing outer joins and currently uses hash joins, we ensure that it will consistently pick those by disabling merge joins for these queries only. Merge join is used for other queries, so we do not disable merge join for the entire test.

Disable-check: force-changelog-file