### PR TITLE
Fix count when deleting compression chunk size entry

### DIFF
--- a/src/ts_catalog/compression_chunk_size.c
+++ b/src/ts_catalog/compression_chunk_size.c
@@ -33,7 +33,13 @@ ts_compression_chunk_size_delete(int32 uncompressed_chunk_id)
 	ts_scanner_foreach(&iterator)
 	{
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+		ts_catalog_delete_tid_only(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+		count++;
 	}
+
+	/* Make catalog changes visible */
+	if (count > 0)
+		CommandCounterIncrement();
+
 	return count;
 }


### PR DESCRIPTION
In the function `ts_compression_chunk_size_delete()` a counter is used to indicate the number of catalog entries deleted. But this counter is never incremented so the returned count is not accurate.

Fix this issue by incrementing the counter when entries are deleted. Also, increment the command counter (to make changes visible) only at the end if the count is non-zero.

Disable-check: force-changelog-file