### PR TITLE
Disable warnings for GRANT in move test

### DIFF
--- a/src/import/ht_hypertable_modify.c
+++ b/src/import/ht_hypertable_modify.c
@@ -413,7 +413,7 @@ ht_ExecMergeMatched(ModifyTableContext * context, ResultRelInfo * resultRelInfo,
 {
 
 	ModifyTableState *mtstate = context->mtstate;
-	TupleTableSlot *newslot;
+	TupleTableSlot *newslot = NULL;
 	EState	       *estate = context->estate;
 	ExprContext    *econtext = mtstate->ps.ps_ExprContext;
 	bool		isNull;
@@ -814,6 +814,8 @@ if (TransactionIdIsCurrentTransactionId(context->tmfd.xmax))
 		switch (commandType)
 		{
 			case CMD_UPDATE:
+				/* Variable newslot should be set for CMD_UPDATE above */
+				Assert(newslot != NULL);
 				rslot = ExecProcessReturning(resultRelInfo, newslot,
 											 context->planSlot);
 				break;

--- a/tsl/test/expected/move.out
+++ b/tsl/test/expected/move.out
@@ -247,8 +247,10 @@ END;
 SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace2', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
 ERROR:  must be owner of hypertable "cluster_test"
 \set ON_ERROR_STOP 1
--- grant create permissions on tablespace2 so we can use it later
+-- grant create permissions on tablespace2 so we can use it later.
+SET client_min_messages TO error;
 GRANT CREATE ON TABLESPACE tablespace2 TO :ROLE_DEFAULT_PERM_USER;
+RESET client_min_messages;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- move with chunk index for reorder
 SELECT true INTO move_chunk_result FROM move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);

--- a/tsl/test/sql/move.sql
+++ b/tsl/test/sql/move.sql
@@ -58,8 +58,10 @@ END;
 SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace2', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
 \set ON_ERROR_STOP 1
 
--- grant create permissions on tablespace2 so we can use it later
+-- grant create permissions on tablespace2 so we can use it later.
+SET client_min_messages TO error;
 GRANT CREATE ON TABLESPACE tablespace2 TO :ROLE_DEFAULT_PERM_USER;
+RESET client_min_messages;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 


### PR DESCRIPTION
Warnings are generated for one `GRANT` statement in the `move` test on PG17 but not other versions, so disabling warnings for that statement.

Also set default value for variable in `src/import/ht_hypertable_modify.c` to avoid warning of potentially unassigned variable when building on PG17.

Disable-check: force-changelog-file, commit-count