### PR TITLE
Remove debian 10 from package tests since its EOL

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "debian:10-slim", "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04" ]
+        image: [ "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04" ]
         pg: [ 14, 15, 16 ]
 
     steps:

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "debian:10-slim", "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04" ]
+        image: [ "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04" ]
         pg: [ 14, 15, 16 ]
         license: [ "TSL", "Apache"]
         include:


### PR DESCRIPTION
Debian 10 is EOL since June 30th 2024 and PGDG repo has been removed for it leading to failing tests.

Disable-check: force-changelog-file
