### PR TITLE
PG17: Remove duplicated generated matrix

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -205,8 +205,9 @@ if not pull_request:
     # add debug test for first supported PG16 version
     m["include"].append(build_debug_config({"pg": PG16_EARLIEST}))
 
-    # add debug test for first supported PG16 version
-    m["include"].append(build_debug_config({"pg": PG17_EARLIEST}))
+    # add debug test for first supported PG17 version
+    if PG17_EARLIEST != PG17_LATEST:
+        m["include"].append(build_debug_config({"pg": PG17_EARLIEST}))
 
     # add debug tests for timescaledb on latest postgres release in MacOS
     m["include"].append(build_debug_config(macos_config({"pg": PG15_LATEST})))


### PR DESCRIPTION
For non pull-request we run CI over the EARLIEST and LATEST version but PG17 was released last week then both versions are equal so no need to add an extra item in the matrix.

https://github.com/timescale/timescaledb/actions/runs/11109257307/job/30864183372

Disable-check: force-changelog-file
