### PR TITLE
Simplify dealing with attnos during decompression

### DIFF
--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -13,6 +13,11 @@
 
 typedef struct tuple_filtering_constraints
 {
+	/*
+	 * All key column heap attribute numbers on uncompressed chunk.
+	 * We shouldn't be dealing with system columns so no need to
+	 * add/subtract FirstLowInvalidHeapAttributeNumber from these.
+	 */
 	Bitmapset *key_columns;
 	/*
 	 * The covered flag is set to true if we have a single constraint that is covered

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -45,10 +45,9 @@ build_mem_scankeys_from_slot(Oid ht_relid, CompressionSettings *settings, Relati
 
 	scankeys = palloc(sizeof(ScanKeyData) * bms_num_members(constraints->key_columns));
 
-	int i = -1;
-	while ((i = bms_next_member(constraints->key_columns, i)) > 0)
+	AttrNumber attno = -1;
+	while ((attno = bms_next_member(constraints->key_columns, attno)) > 0)
 	{
-		AttrNumber attno = i + FirstLowInvalidHeapAttributeNumber;
 		bool isnull;
 
 		/*
@@ -125,10 +124,9 @@ build_heap_scankeys(Oid hypertable_relid, Relation in_rel, Relation out_rel,
 	if (!bms_is_empty(key_columns))
 	{
 		scankeys = palloc0(bms_num_members(key_columns) * 2 * sizeof(ScanKeyData));
-		int i = -1;
-		while ((i = bms_next_member(key_columns, i)) > 0)
+		AttrNumber attno = -1;
+		while ((attno = bms_next_member(key_columns, attno)) > 0)
 		{
-			AttrNumber attno = i + FirstLowInvalidHeapAttributeNumber;
 			char *attname = get_attname(out_rel->rd_id, attno, false);
 			bool isnull;
 			AttrNumber ht_attno = get_attnum(hypertable_relid, attname);
@@ -322,8 +320,7 @@ build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel, Relation 
 			AttrNumber idx_attnum = AttrOffsetGetAttrNumber(i);
 			AttrNumber in_attnum = index_rel->rd_index->indkey.values[i];
 			const NameData *attname = attnumAttName(in_rel, in_attnum);
-			AttrNumber column_attno =
-				get_attnum(out_rel->rd_id, NameStr(*attname)) - FirstLowInvalidHeapAttributeNumber;
+			AttrNumber column_attno = get_attnum(out_rel->rd_id, NameStr(*attname));
 
 			/* Make sure we find columns in key columns in order to select the right index */
 			if (!bms_is_member(column_attno, key_columns))


### PR DESCRIPTION
We fetch key column attribute numbers from indexes on uncompressed chunks. These should not contain
system attribute numbers so there is no point in
adding/subtracting FirstLowInvalidHeapAttributeNumber.

Disable-check: force-changelog-file