### PR TITLE
Relax catalog access during restore

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -288,17 +288,6 @@ ts_extension_invalidate(void)
 bool
 ts_extension_is_loaded(void)
 {
-	/* When restoring deactivate extension.
-	 *
-	 * We are using IsBinaryUpgrade (and ts_guc_restoring).  If a user set
-	 * `ts_guc_restoring` for a database, it will be stored in
-	 * `pg_db_role_settings` and be included in a dump, which will cause
-	 * `pg_upgrade` to fail.
-	 *
-	 * See dumpDatabaseConfig in pg_dump.c. */
-	if (ts_guc_restoring || IsBinaryUpgrade)
-		return false;
-
 	if (EXTENSION_STATE_UNKNOWN == extstate || EXTENSION_STATE_TRANSITIONING == extstate)
 	{
 		/* status may have updated without a relcache invalidate event */
@@ -340,6 +329,23 @@ ts_extension_is_loaded(void)
 			elog(ERROR, "unknown state: %d", extstate);
 			return false;
 	}
+}
+
+bool
+ts_extension_is_loaded_and_not_upgrading(void)
+{
+	/* When restoring deactivate extension.
+	 *
+	 * We are using IsBinaryUpgrade (and ts_guc_restoring).  If a user set
+	 * `ts_guc_restoring` for a database, it will be stored in
+	 * `pg_db_role_settings` and be included in a dump, which will cause
+	 * `pg_upgrade` to fail.
+	 *
+	 * See dumpDatabaseConfig in pg_dump.c. */
+	if (ts_guc_restoring || IsBinaryUpgrade)
+		return false;
+
+	return ts_extension_is_loaded();
 }
 
 const char *

--- a/src/extension.h
+++ b/src/extension.h
@@ -13,6 +13,7 @@
 
 extern void ts_extension_invalidate(void);
 extern TSDLLEXPORT bool ts_extension_is_loaded(void);
+extern bool ts_extension_is_loaded_and_not_upgrading(void);
 extern void ts_extension_check_version(const char *so_version);
 extern void ts_extension_check_server_version(void);
 extern TSDLLEXPORT Oid ts_extension_schema_oid(void);

--- a/src/func_cache.c
+++ b/src/func_cache.c
@@ -575,7 +575,7 @@ initialize_func_info()
 		{
 			/* The function cache could be accessed during an extension upgrade. Not all expected
 			 * functions have to exist at this point. */
-			elog(ts_extension_is_loaded() ? ERROR : NOTICE,
+			elog(ts_extension_is_loaded_and_not_upgrading() ? ERROR : NOTICE,
 				 "cache lookup failed for function \"%s\" with %d args",
 				 finfo->funcname,
 				 finfo->nargs);

--- a/src/guc.c
+++ b/src/guc.c
@@ -258,7 +258,7 @@ static bool
 check_segmentby_func(char **newval, void **extra, GucSource source)
 {
 	/* if the extension doesn't exist you can't check for the function, have to take it on faith */
-	if (ts_extension_is_loaded())
+	if (ts_extension_is_loaded_and_not_upgrading())
 	{
 		Oid segment_func_oid = get_segmentby_func(*newval);
 
@@ -300,7 +300,7 @@ static bool
 check_orderby_func(char **newval, void **extra, GucSource source)
 {
 	/* if the extension doesn't exist you can't check for the function, have to take it on faith */
-	if (ts_extension_is_loaded())
+	if (ts_extension_is_loaded_and_not_upgrading())
 	{
 		Oid func_oid = get_orderby_func(*newval);
 

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -642,7 +642,7 @@ timescaledb_planner(Query *parse, const char *query_string, int cursor_opts,
 		context.rootquery = parse;
 		context.current_query = parse;
 
-		if (ts_extension_is_loaded())
+		if (ts_extension_is_loaded_and_not_upgrading())
 		{
 #ifdef USE_TELEMETRY
 			ts_telemetry_function_info_gather(parse);
@@ -663,7 +663,7 @@ timescaledb_planner(Query *parse, const char *query_string, int cursor_opts,
 			/* Call the standard planner */
 			stmt = standard_planner(parse, query_string, cursor_opts, bound_params);
 
-		if (ts_extension_is_loaded())
+		if (ts_extension_is_loaded_and_not_upgrading())
 		{
 			/*
 			 * Our top-level HypertableInsert plan node that wraps ModifyTable needs
@@ -1254,7 +1254,7 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 static bool
 valid_hook_call(void)
 {
-	return ts_extension_is_loaded() && planner_hcache_exists();
+	return ts_extension_is_loaded_and_not_upgrading() && planner_hcache_exists();
 }
 
 static bool
@@ -1595,7 +1595,7 @@ timescaledb_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage,
 	if (prev_create_upper_paths_hook != NULL)
 		prev_create_upper_paths_hook(root, stage, input_rel, output_rel, extra);
 
-	if (!ts_extension_is_loaded())
+	if (!ts_extension_is_loaded_and_not_upgrading())
 		return;
 
 	if (input_rel != NULL)

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4606,7 +4606,7 @@ timescaledb_ddl_command_start(PlannedStmt *pstmt, const char *query_string, bool
 	 * We don't want to load the extension if we just got the command to alter
 	 * it.
 	 */
-	if (altering_timescaledb || !ts_extension_is_loaded())
+	if (altering_timescaledb || !ts_extension_is_loaded_and_not_upgrading())
 	{
 		prev_ProcessUtility(&args);
 		return;
@@ -4675,7 +4675,7 @@ ts_timescaledb_process_ddl_event(PG_FUNCTION_ARGS)
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo))
 		elog(ERROR, "not fired by event trigger manager");
 
-	if (!ts_extension_is_loaded())
+	if (!ts_extension_is_loaded_and_not_upgrading())
 		PG_RETURN_NULL();
 
 	if (strcmp("ddl_command_end", trigdata->event) == 0)

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -47,7 +47,7 @@ cache_invalidate_callback(Datum arg, Oid relid)
 static void
 post_analyze_hook(ParseState *pstate, Query *query, JumbleState *jstate)
 {
-	if (ts_extension_is_loaded())
+	if (ts_extension_is_loaded_and_not_upgrading())
 		elog(WARNING, "mock post_analyze_hook " STR(TIMESCALEDB_VERSION_MOD));
 
 		/*


### PR DESCRIPTION
It should be possible to read the TimescaleDB catalog during restore and pg_upgrade. Currently, this is blocked in
`ts_extension_is_loaded()` by checking whether the GUC `timescaledb.restoring` is set or `IsBinaryUpgrade` is true, causing the "loaded" check to fail even though the extension is loaded and usable.

To allow catalog access while minimizing changes to existing code, the block is moved out of `ts_extension_is_loaded()` into a new function that has the old behavior.

Accessing the catalog during restores should be safe since the extension catalog tables are created and populated before regular data tables.

Note that the blocking was moved into `ts_extension_is_loaded()` in an earlier commit out of convenience, but it seems this also blocks legitimate access to the TimescaleDB catalog during restores and upgrades. Such access is necessary to implement a table access method (TAM) that might need catalog access during restores.

Currently, the blocking error is only hit in the background worker scheduler. However, this error isn't really noticed since it is swallowed by the worker, which then exits. This implicit behavior occurs when the scheduler tries to access the catalog during startup and `timescaledb.restoring` is true. Instead of throwing an error, this is now changed to an explicit check in the scheduler followed by clean exit.

Disable-check: force-changelog-file