### PR TITLE
Set license specific extension comment in install script

### DIFF
--- a/.unreleased/pr_7320
+++ b/.unreleased/pr_7320
@@ -1,0 +1,1 @@
+Fixes: #7320 Set license specific extension comment in install script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,18 +397,6 @@ if(PG_SOURCE_DIR)
 endif(PG_SOURCE_DIR)
 
 set(EXT_CONTROL_FILE ${PROJECT_NAME}.control)
-
-# When building apt or rpm packages we build a separate loader package that will
-# be used by both the apache and community editions. Having the edition in the
-# description would be misleading so we remove it for these cases.
-set(GENERIC_LOADER_METHOD apt rpm)
-if(PROJECT_INSTALL_METHOD IN_LIST GENERIC_LOADER_METHOD)
-  set(COMMENT_SUFFIX "")
-elseif(APACHE_ONLY)
-  set(COMMENT_SUFFIX " (Apache 2 Edition)")
-else()
-  set(COMMENT_SUFFIX " (Community Edition)")
-endif()
 configure_file(${EXT_CONTROL_FILE}.in ${EXT_CONTROL_FILE})
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${EXT_CONTROL_FILE}

--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -79,6 +79,12 @@ list(APPEND SOURCE_FILES
 list(APPEND SOURCE_FILES
   bgw_startup.sql)
 
+if(APACHE_ONLY)
+  list(APPEND SOURCE_FILES comment_apache.sql)
+else()
+  list(APPEND SOURCE_FILES comment_tsl.sql)
+endif()
+
 # These files should be prepended to update scripts so that they are executed
 # before anything else during updates
 set(PRE_UPDATE_FILES updates/pre-version-change.sql updates/pre-update.sql)

--- a/sql/comment_apache.sql
+++ b/sql/comment_apache.sql
@@ -1,0 +1,5 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+COMMENT ON EXTENSION timescaledb IS 'Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)';

--- a/sql/comment_tsl.sql
+++ b/sql/comment_tsl.sql
@@ -1,0 +1,5 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+COMMENT ON EXTENSION timescaledb IS 'Enables scalable inserts and complex queries for time-series data (Community Edition)';

--- a/test/expected/loader-oss.out
+++ b/test/expected/loader-oss.out
@@ -31,11 +31,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-1';
@@ -78,11 +78,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --start new backend;
@@ -113,11 +113,11 @@ WARNING:  mock function call "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -219,11 +219,11 @@ CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --start a new backend to update
@@ -239,11 +239,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --drop extension
@@ -274,11 +274,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 -- test db 1 still has old version
@@ -293,11 +293,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --try a broken upgrade
@@ -305,11 +305,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 \dx
 WARNING:  mock init "mock-2"
 WARNING:  mock post_analyze_hook "mock-2"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 \set ON_ERROR_STOP 0
@@ -326,11 +326,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --drop extension
@@ -362,11 +362,11 @@ WARNING:  mock post_analyze_hook "mock-3"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-3"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-3  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-3  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 DROP EXTENSION timescaledb;
@@ -476,11 +476,11 @@ server closed the connection unexpectedly
 connection to server was lost
 \dx
 WARNING:  mock post_analyze_hook "mock-6"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-6  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-6  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --TEST: create extension when old .so already loaded
@@ -489,11 +489,11 @@ WARNING:  mock post_analyze_hook "mock-6"
 \dx
 WARNING:  mock init "mock-1"
 WARNING:  mock post_analyze_hook "mock-1"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 DROP EXTENSION timescaledb;
@@ -522,11 +522,11 @@ CREATE EXTENSION timescaledb VERSION 'mock-2';
 WARNING:  mock init "mock-2"
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                               List of installed extensions
-    Name     | Version |   Schema   |                                     Description                                      
--------------+---------+------------+--------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --make sure parallel workers started after a 'DISCARD ALL' work
@@ -536,8 +536,13 @@ INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
 WARNING:  mock post_analyze_hook "mock-2"
 DISCARD ALL;
 WARNING:  mock post_analyze_hook "mock-2"
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 WARNING:  mock post_analyze_hook "mock-2"
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 1;
 WARNING:  mock post_analyze_hook "mock-2"
 SELECT count(*) FROM test;

--- a/test/expected/loader-tsl.out
+++ b/test/expected/loader-tsl.out
@@ -31,11 +31,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-1';
@@ -78,11 +78,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --start new backend;
@@ -113,11 +113,11 @@ WARNING:  mock function call "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -219,11 +219,11 @@ CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --start a new backend to update
@@ -239,11 +239,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --drop extension
@@ -274,11 +274,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 -- test db 1 still has old version
@@ -293,11 +293,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-1"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --try a broken upgrade
@@ -305,11 +305,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 \dx
 WARNING:  mock init "mock-2"
 WARNING:  mock post_analyze_hook "mock-2"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 \set ON_ERROR_STOP 0
@@ -326,11 +326,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --drop extension
@@ -362,11 +362,11 @@ WARNING:  mock post_analyze_hook "mock-3"
 
 \dx
 WARNING:  mock post_analyze_hook "mock-3"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-3  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-3  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 DROP EXTENSION timescaledb;
@@ -476,11 +476,11 @@ server closed the connection unexpectedly
 connection to server was lost
 \dx
 WARNING:  mock post_analyze_hook "mock-6"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-6  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-6  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --TEST: create extension when old .so already loaded
@@ -489,11 +489,11 @@ WARNING:  mock post_analyze_hook "mock-6"
 \dx
 WARNING:  mock init "mock-1"
 WARNING:  mock post_analyze_hook "mock-1"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 DROP EXTENSION timescaledb;
@@ -522,11 +522,11 @@ CREATE EXTENSION timescaledb VERSION 'mock-2';
 WARNING:  mock init "mock-2"
 \dx
 WARNING:  mock post_analyze_hook "mock-2"
-                                                List of installed extensions
-    Name     | Version |   Schema   |                                      Description                                      
--------------+---------+------------+---------------------------------------------------------------------------------------
+                                      List of installed extensions
+    Name     | Version |   Schema   |                            Description                            
+-------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
- timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data (Community Edition)
+ timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
 --make sure parallel workers started after a 'DISCARD ALL' work

--- a/timescaledb.control.in
+++ b/timescaledb.control.in
@@ -1,5 +1,5 @@
 # timescaledb extension
-comment = 'Enables scalable inserts and complex queries for time-series data@COMMENT_SUFFIX@'
+comment = 'Enables scalable inserts and complex queries for time-series data'
 default_version = '@PROJECT_VERSION_MOD@'
 module_pathname = '$libdir/timescaledb-@PROJECT_VERSION_MOD@'
 #extension cannot be relocatable once installed because it uses multiple schemas and that is forbidden by PG.

--- a/tsl/test/shared/expected/build_info.out
+++ b/tsl/test/shared/expected/build_info.out
@@ -12,3 +12,9 @@ SELECT pg_typeof(commit_tag) AS commit_tag_type,
  text            | text             |                 40 | timestamp with time zone
 (1 row)
 
+SELECT extname, obj_description(oid, 'pg_extension') FROM pg_extension WHERE extname = 'timescaledb';
+   extname   |                                    obj_description                                    
+-------------+---------------------------------------------------------------------------------------
+ timescaledb | Enables scalable inserts and complex queries for time-series data (Community Edition)
+(1 row)
+

--- a/tsl/test/shared/sql/build_info.sql
+++ b/tsl/test/shared/sql/build_info.sql
@@ -8,3 +8,6 @@ SELECT pg_typeof(commit_tag) AS commit_tag_type,
        length(commit_hash) AS commit_hash_length,
        pg_typeof(commit_time) AS commit_time_type
   FROM _timescaledb_functions.get_git_commit();
+
+SELECT extname, obj_description(oid, 'pg_extension') FROM pg_extension WHERE extname = 'timescaledb';
+


### PR DESCRIPTION
Remove the license information from the control file as we package that with the generic loader and will be used for both Apache licensed and TSL licensed versions of the extension. This patch adjusts the extension comment in the install and update script and adds the appropriate license information.