### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,8 @@ multiple workers.
 
 ### Releases & updates
 
- - [Timescale Release Notes & Future Plans](https://tsdb.co/GitHubTimescaleReleaseNotes): see planned and
-   in-progress updates and detailed information about current and past
-   releases. - [Subscribe to Timescale Release
-   Notes](https://tsdb.co/GitHubTimescaleGetReleaseNotes) to get
+ - [Timescale Release Notes](https://tsdb.co/GitHubTimescaleReleaseNotes): see detailed information about current and past
+   versions and subscribe to get
    notified about new releases, fixes, and early access/beta programs.
 
 ### Contributing


### PR DESCRIPTION
Updates per issue https://github.com/timescale/docs/issues/3469: 

- The release notes page at https://docs.timescale.com/ already provides steps to subscribe to updates, hence removing the no longer working subscribe bullet point from here. 
- The release notes page at https://docs.timescale.com/ no longer mentions future plans, hence removing its mention from the wording here.

Disable-check: force-changelog-file
