### PR TITLE
Use more reasonable log level when logging compression progress

### DIFF
--- a/.unreleased/pr_7335
+++ b/.unreleased/pr_7335
@@ -1,0 +1,2 @@
+Fixes: #7335 Change log level used in compression
+Thanks: @gmilamjr for reporting an issue with the log level of compression messages

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -398,7 +398,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	compresschunkcxt_init(&cxt, hcache, hypertable_relid, chunk_relid);
 
 	/* acquire locks on src and compress hypertable and src chunk */
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("acquiring locks for compressing \"%s.%s\"",
 					get_namespace_name(get_rel_namespace(chunk_relid)),
 					get_rel_name(chunk_relid))));
@@ -408,7 +408,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 
 	/* acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("locks acquired for compressing \"%s.%s\"",
 					get_namespace_name(get_rel_namespace(chunk_relid)),
 					get_rel_name(chunk_relid))));
@@ -441,7 +441,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 		/* create compressed chunk and a new table */
 		compress_ht_chunk = create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, InvalidOid);
 		new_compressed_chunk = true;
-		ereport(LOG,
+		ereport(DEBUG1,
 				(errmsg("new compressed chunk \"%s.%s\" created",
 						NameStr(compress_ht_chunk->fd.schema_name),
 						NameStr(compress_ht_chunk->fd.table_name))));
@@ -452,7 +452,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 		/* use an existing compressed chunk to compress into */
 		compress_ht_chunk = ts_chunk_get_by_id(mergable_chunk->fd.compressed_chunk_id, true);
 		result_chunk_id = mergable_chunk->table_id;
-		ereport(LOG,
+		ereport(DEBUG1,
 				(errmsg("merge into existing compressed chunk \"%s.%s\"",
 						NameStr(compress_ht_chunk->fd.schema_name),
 						NameStr(compress_ht_chunk->fd.table_name))));
@@ -590,7 +590,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk, CHUNK_DECOMPRESS, true);
 	compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
 
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("acquiring locks for decompressing \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),
 					NameStr(uncompressed_chunk->fd.table_name))));
@@ -617,7 +617,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 
 	/* acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("locks acquired for decompressing \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),
 					NameStr(uncompressed_chunk->fd.table_name))));
@@ -1152,12 +1152,12 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 	 */
 	if (ts_chunk_clear_status(uncompressed_chunk,
 							  CHUNK_STATUS_COMPRESSED_UNORDERED | CHUNK_STATUS_COMPRESSED_PARTIAL))
-		ereport(LOG,
+		ereport(DEBUG1,
 				(errmsg("cleared chunk status for recompression: \"%s.%s\"",
 						NameStr(uncompressed_chunk->fd.schema_name),
 						NameStr(uncompressed_chunk->fd.table_name))));
 
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("acquiring locks for recompression: \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),
 					NameStr(uncompressed_chunk->fd.table_name))));
@@ -1279,7 +1279,7 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 
 	/* Index scan */
 	Relation index_rel = index_open(row_compressor.index_oid, ExclusiveLock);
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("locks acquired for recompression: \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),
 					NameStr(uncompressed_chunk->fd.table_name))));

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -442,18 +442,7 @@ compress_chunk(Oid in_table, Oid out_table, int insert_options)
 	{
 		int64 nrows_processed = 0;
 
-		/*
-		 * even though we log the information below, this debug info
-		 * is still used for INFO messages to clients and our tests.
-		 */
-		if (ts_guc_debug_compression_path_info)
-		{
-			elog(INFO,
-				 "compress_chunk_indexscan_start matched index \"%s\"",
-				 get_rel_name(matched_index_rel->rd_id));
-		}
-
-		elog(LOG,
+		elog(ts_guc_debug_compression_path_info ? INFO : DEBUG1,
 			 "using index \"%s\" to scan rows for compression",
 			 get_rel_name(matched_index_rel->rd_id));
 
@@ -465,7 +454,7 @@ compress_chunk(Oid in_table, Oid out_table, int insert_options)
 		{
 			row_compressor_process_ordered_slot(&row_compressor, slot, mycid);
 			if ((++nrows_processed % report_reltuples) == 0)
-				elog(LOG,
+				elog(DEBUG2,
 					 "compressed " INT64_FORMAT " rows from \"%s\"",
 					 nrows_processed,
 					 RelationGetRelationName(in_rel));
@@ -474,7 +463,7 @@ compress_chunk(Oid in_table, Oid out_table, int insert_options)
 		if (row_compressor.rows_compressed_into_current_value > 0)
 			row_compressor_flush(&row_compressor, mycid, true);
 
-		elog(LOG,
+		elog(DEBUG1,
 			 "finished compressing " INT64_FORMAT " rows from \"%s\"",
 			 nrows_processed,
 			 RelationGetRelationName(in_rel));
@@ -485,16 +474,7 @@ compress_chunk(Oid in_table, Oid out_table, int insert_options)
 	}
 	else
 	{
-		/*
-		 * even though we log the information below, this debug info
-		 * is still used for INFO messages to clients and our tests.
-		 */
-		if (ts_guc_debug_compression_path_info)
-		{
-			elog(INFO, "compress_chunk_tuplesort_start");
-		}
-
-		elog(LOG,
+		elog(ts_guc_debug_compression_path_info ? INFO : DEBUG1,
 			 "using tuplesort to scan rows from \"%s\" for compression",
 			 RelationGetRelationName(in_rel));
 
@@ -862,7 +842,7 @@ row_compressor_append_sorted_rows(RowCompressor *row_compressor, Tuplesortstate 
 	{
 		row_compressor_process_ordered_slot(row_compressor, slot, mycid);
 		if ((++nrows_processed % report_reltuples) == 0)
-			elog(LOG,
+			elog(DEBUG2,
 				 "compressed " INT64_FORMAT " rows from \"%s\"",
 				 nrows_processed,
 				 RelationGetRelationName(in_rel));
@@ -870,7 +850,7 @@ row_compressor_append_sorted_rows(RowCompressor *row_compressor, Tuplesortstate 
 
 	if (row_compressor->rows_compressed_into_current_value > 0)
 		row_compressor_flush(row_compressor, mycid, true);
-	elog(LOG,
+	elog(DEBUG1,
 		 "finished compressing " INT64_FORMAT " rows from \"%s\"",
 		 nrows_processed,
 		 RelationGetRelationName(in_rel));
@@ -1330,13 +1310,13 @@ decompress_chunk(Oid in_table, Oid out_table)
 		row_decompressor_decompress_row_to_table(&decompressor);
 
 		if ((++nrows_processed % report_reltuples) == 0)
-			elog(LOG,
+			elog(DEBUG2,
 				 "decompressed " INT64_FORMAT " rows from \"%s\"",
 				 nrows_processed,
 				 RelationGetRelationName(in_rel));
 	}
 
-	elog(LOG,
+	elog(DEBUG1,
 		 "finished decompressing " INT64_FORMAT " rows from \"%s\"",
 		 nrows_processed,
 		 RelationGetRelationName(in_rel));

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -351,11 +351,6 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
 LOG:  statement: CALL run_job(1004);
-LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_11_40_chunk"
-LOG:  locks acquired for compressing "_timescaledb_internal._hyper_11_40_chunk"
-LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_13_61_chunk" created
-LOG:  using tuplesort to scan rows from "_hyper_11_40_chunk" for compression
-LOG:  finished compressing 144 rows from "_hyper_11_40_chunk"
 LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
 LOG:  statement: set client_min_messages TO NOTICE;

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -37,7 +37,7 @@ INSERT INTO comp_conflicts_1 VALUES
 ROLLBACK;
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_1') c
 \gset
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -123,7 +123,7 @@ INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1);
 INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d2',0.2);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_2') c
 \gset
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_3_3_chunk" for compression
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -212,7 +212,7 @@ INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d2', 'label', 0.2);
 INSERT INTO comp_conflicts_3 VALUES ('2020-01-01',NULL, 'label', 0.3);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_3') c
 \gset
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_5_5_chunk" for compression
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -465,7 +465,7 @@ INSERT INTO comp_conflicts_4 VALUES ('2020-01-01','d2',0.2);
 INSERT INTO comp_conflicts_4 VALUES ('2020-01-01',NULL,0.3);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_4') c
 \gset
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_7_7_chunk" for compression
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
  count 
@@ -611,9 +611,9 @@ ALTER TABLE compressed_ht SET (
 );
 NOTICE:  default order by for hypertable "compressed_ht" is set to ""time" DESC"
 SELECT COMPRESS_CHUNK(SHOW_CHUNKS('compressed_ht'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_9_9_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_9_10_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_9_11_chunk" for compression
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_9_9_chunk

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -50,10 +50,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_asc_null_first"
+INFO:  using index "_hyper_1_1_chunk_idx_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_idx_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_idx_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_idx_asc_null_first" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -82,10 +82,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -114,10 +114,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -147,10 +147,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -181,10 +181,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -213,10 +213,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_asc_null_last"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_asc_null_last"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_asc_null_last"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_asc_null_last"
+INFO:  using index "_hyper_1_1_chunk_idx_asc_null_last" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_idx_asc_null_last" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_idx_asc_null_last" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_idx_asc_null_last" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -245,10 +245,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -278,10 +278,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -312,10 +312,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -344,10 +344,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -376,10 +376,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_desc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_desc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_desc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_desc_null_first"
+INFO:  using index "_hyper_1_1_chunk_idx_desc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_idx_desc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_idx_desc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_idx_desc_null_first" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -409,10 +409,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -443,10 +443,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -475,10 +475,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -507,10 +507,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_desc_null_last"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_desc_null_last"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_desc_null_last"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_desc_null_last"
+INFO:  using index "_hyper_1_1_chunk_idx_desc_null_last" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_idx_desc_null_last" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_idx_desc_null_last" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_idx_desc_null_last" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -539,10 +539,10 @@ SELECT * FROM timescaledb_information.compression_settings;
 (2 rows)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -562,10 +562,10 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'time');
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_tab1_time_idx"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_tab1_time_idx"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_tab1_time_idx"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_tab1_time_idx"
+INFO:  using index "_hyper_1_1_chunk_tab1_time_idx" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_tab1_time_idx" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_tab1_time_idx" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_tab1_time_idx" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -595,10 +595,10 @@ SHOW timescaledb.enable_compression_indexscan;
 (1 row)
 
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -619,10 +619,10 @@ SELECT decompress_chunk(show_chunks('tab1'));
 --Test with this guc enabled
 SET timescaledb.enable_compression_indexscan = 'ON';
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_tab1_time_idx"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_tab1_time_idx"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_tab1_time_idx"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_tab1_time_idx"
+INFO:  using index "_hyper_1_1_chunk_tab1_time_idx" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_tab1_time_idx" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_tab1_time_idx" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_tab1_time_idx" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -648,10 +648,10 @@ ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id'
 ALTER TABLE tab2 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
 RESET timescaledb.enable_compression_indexscan;
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -662,10 +662,10 @@ INFO:  compress_chunk_tuplesort_start
 
 SET timescaledb.enable_compression_indexscan = 'ON';
 SELECT compress_chunk(show_chunks('tab2'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_81_chunk_idx2_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_82_chunk_idx2_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_83_chunk_idx2_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_84_chunk_idx2_asc_null_first"
+INFO:  using index "_hyper_2_81_chunk_idx2_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_2_82_chunk_idx2_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_2_83_chunk_idx2_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_2_84_chunk_idx2_asc_null_first" to scan rows for compression
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_2_81_chunk
@@ -722,10 +722,10 @@ time;
 CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "C", time ASC NULLS FIRST);
 ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'name, time NULLS FIRST');
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_5_93_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_5_94_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_5_95_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_5_96_chunk" for compression
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_93_chunk
@@ -745,10 +745,10 @@ SELECT decompress_chunk(show_chunks('tab3'));
 
 CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_93_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_94_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_95_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_96_chunk_idxcol_asc_null_first"
+INFO:  using index "_hyper_5_93_chunk_idxcol_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_5_94_chunk_idxcol_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_5_95_chunk_idxcol_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_5_96_chunk_idxcol_asc_null_first" to scan rows for compression
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_93_chunk
@@ -772,10 +772,10 @@ DROP INDEX idxcol_asc_null_first;
 CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "ucs_basic", time ASC NULLS FIRST);
 ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = 'name', timescaledb.compress_orderby = 'time NULLS FIRST');
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_5_93_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_5_94_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_5_95_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_5_96_chunk" for compression
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_93_chunk
@@ -795,10 +795,10 @@ SELECT decompress_chunk(show_chunks('tab3'));
 
 CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_93_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_94_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_95_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_5_96_chunk_idxcol_asc_null_first"
+INFO:  using index "_hyper_5_93_chunk_idxcol_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_5_94_chunk_idxcol_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_5_95_chunk_idxcol_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_5_96_chunk_idxcol_asc_null_first" to scan rows for compression
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_93_chunk
@@ -822,10 +822,10 @@ DROP INDEX idxcol_asc_null_first;
 CREATE INDEX idx_asc_null_first ON tab1(id, c1, time ASC NULLS FIRST);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_asc_null_first"
+INFO:  using index "_hyper_1_1_chunk_idx_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_2_chunk_idx_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_3_chunk_idx_asc_null_first" to scan rows for compression
+INFO:  using index "_hyper_1_4_chunk_idx_asc_null_first" to scan rows for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -847,10 +847,10 @@ DROP INDEX idx_asc_null_first;
 CREATE INDEX idx_asc_null_first ON tab1(id, c1 DESC, time ASC NULLS FIRST);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -874,10 +874,10 @@ DROP INDEX idx_asc_null_first;
 CREATE INDEX idx_asc_null_first ON tab1(id, c1, c2);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -899,10 +899,10 @@ DROP INDEX idx_asc_null_first;
 --Index Column out of order
 CREATE INDEX idx_asc_null_first ON tab1(c1, id, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -930,10 +930,10 @@ select count(*) from tab1;
 (1 row)
 
 select compress_chunk(show_chunks('tab1'));
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_3_chunk" for compression
+INFO:  using tuplesort to scan rows from "_hyper_1_4_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -961,12 +961,7 @@ select count(*) from tab1;
 SET client_min_messages TO LOG;
 select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 LOG:  statement: select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_1_1_chunk"
-LOG:  locks acquired for compressing "_timescaledb_internal._hyper_1_1_chunk"
-LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_3_133_chunk" created
-INFO:  compress_chunk_tuplesort_start
-LOG:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
-LOG:  finished compressing 13500 rows from "_hyper_1_1_chunk"
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -990,14 +985,7 @@ ANALYZE _timescaledb_internal._hyper_1_2_chunk;
 SET client_min_messages TO LOG;
 select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 LOG:  statement: select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
-LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_1_2_chunk"
-LOG:  locks acquired for compressing "_timescaledb_internal._hyper_1_2_chunk"
-LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_3_134_chunk" created
-INFO:  compress_chunk_tuplesort_start
-LOG:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
-LOG:  compressed 100000 rows from "_hyper_1_2_chunk"
-LOG:  compressed 200000 rows from "_hyper_1_2_chunk"
-LOG:  finished compressing 218400 rows from "_hyper_1_2_chunk"
+INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -43,7 +43,7 @@ SELECT * FROM settings;
 --Enable compression path info
 SET timescaledb.debug_compression_path_info= 'on';
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk

--- a/tsl/test/shared/expected/compression_nulls_not_distinct.out
+++ b/tsl/test/shared/expected/compression_nulls_not_distinct.out
@@ -18,7 +18,7 @@ NOTICE:  default order by for hypertable "nulls_not_distinct" is set to ""time" 
 INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
 INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
 SELECT count(compress_chunk(c)) FROM show_chunks('nulls_not_distinct') c;
-INFO:  compress_chunk_tuplesort_start
+INFO:  using tuplesort to scan rows from "_hyper_X_X_chunk" for compression
  count 
      1
 (1 row)


### PR DESCRIPTION
Don't use LOG log level when printing out non-actionable progress information regarding compression.

Fixes #7280