### PR TITLE
Avoid unnecessary DELETE on materialization

### DIFF
--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -61,6 +61,9 @@ static uint64 spi_insert_materializations(Hypertable *mat_ht, const ContinuousAg
 										  const NameData *time_column_name,
 										  TimeRange materialization_range,
 										  const char *const chunk_condition);
+static bool spi_exists_materializations(SchemaAndName materialization_table,
+										const NameData *time_column_name,
+										TimeRange materialization_range);
 static uint64 spi_merge_materializations(Hypertable *mat_ht, const ContinuousAgg *cagg,
 										 SchemaAndName partial_view,
 										 SchemaAndName materialization_table,
@@ -295,7 +298,7 @@ build_merge_join_clause(List *column_names)
 
 		appendStringInfoString(ret, "P.");
 		appendStringInfoString(ret, quote_identifier(column));
-		appendStringInfoString(ret, " IS NOT DISTINCT FROM M.");
+		appendStringInfoString(ret, " = M.");
 		appendStringInfoString(ret, quote_identifier(column));
 	}
 
@@ -434,6 +437,43 @@ spi_update_materializations(Hypertable *mat_ht, const ContinuousAgg *cagg,
 	}
 }
 
+static bool
+spi_exists_materializations(SchemaAndName materialization_table, const NameData *time_column_name,
+							TimeRange materialization_range)
+{
+	int res;
+	StringInfo command = makeStringInfo();
+	Oid types[] = { materialization_range.type, materialization_range.type };
+	Datum values[] = { materialization_range.start, materialization_range.end };
+	char nulls[] = { false, false };
+
+	appendStringInfo(command,
+					 "SELECT 1 FROM %s.%s AS M "
+					 "WHERE M.%s >= $1 AND M.%s < $2 "
+					 "LIMIT 1;",
+					 quote_identifier(NameStr(*materialization_table.schema)),
+					 quote_identifier(NameStr(*materialization_table.name)),
+					 quote_identifier(NameStr(*time_column_name)),
+					 quote_identifier(NameStr(*time_column_name)));
+
+	elog(DEBUG2, "%s", command->data);
+	res = SPI_execute_with_args(command->data,
+								2,
+								types,
+								values,
+								nulls,
+								true /* read_only */,
+								0 /* count */);
+
+	if (res < 0)
+		elog(ERROR,
+			 "could not check the materialization table \"%s.%s\"",
+			 NameStr(*materialization_table.schema),
+			 NameStr(*materialization_table.name));
+
+	return (SPI_processed > 0);
+}
+
 static uint64
 spi_merge_materializations(Hypertable *mat_ht, const ContinuousAgg *cagg,
 						   SchemaAndName partial_view, SchemaAndName materialization_table,
@@ -444,6 +484,24 @@ spi_merge_materializations(Hypertable *mat_ht, const ContinuousAgg *cagg,
 	Oid types[] = { materialization_range.type, materialization_range.type };
 	Datum values[] = { materialization_range.start, materialization_range.end };
 	char nulls[] = { false, false };
+
+	/* Fallback to INSERT materializations if there's no rows to change on it */
+	if (!spi_exists_materializations(materialization_table,
+									 time_column_name,
+									 materialization_range))
+	{
+		elog(DEBUG2,
+			 "no rows to update on materialization table \"%s.%s\", falling back to INSERT",
+			 NameStr(*materialization_table.schema),
+			 NameStr(*materialization_table.name));
+		return spi_insert_materializations(mat_ht,
+										   cagg,
+										   partial_view,
+										   materialization_table,
+										   time_column_name,
+										   materialization_range,
+										   "" /* empty chunk condition for Finalized CAggs */);
+	}
 
 	List *grp_colnames = cagg_find_groupingcols((ContinuousAgg *) cagg, mat_ht);
 	List *agg_colnames = cagg_find_aggref_and_var_cols((ContinuousAgg *) cagg, mat_ht);

--- a/tsl/test/expected/cagg_query_using_merge.out
+++ b/tsl/test/expected/cagg_query_using_merge.out
@@ -1547,8 +1547,7 @@ SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:683: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 00:00:00 2020 PST, Thu Jan 02 12:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:683: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:683: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
@@ -1768,34 +1767,28 @@ CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  merged 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  merged 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  merged 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  merged 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
 psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
-psql:include/cagg_query_common.sql:727: LOG:  merged 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
 psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:727: LOG:  merged 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:727: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 1577955600000000
 RESET client_min_messages;
 psql:include/cagg_query_common.sql:728: LOG:  statement: RESET client_min_messages;
@@ -2251,8 +2244,7 @@ psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous
 psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
-psql:include/cagg_query_common.sql:824: LOG:  merged 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
-psql:include/cagg_query_common.sql:824: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
+psql:include/cagg_query_common.sql:824: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
 RESET client_min_messages;
 psql:include/cagg_query_common.sql:825: LOG:  statement: RESET client_min_messages;
 SELECT * FROM cagg_int_offset;

--- a/tsl/test/expected/cagg_refresh_using_merge.out
+++ b/tsl/test/expected/cagg_refresh_using_merge.out
@@ -122,8 +122,7 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '2020-05-04');
 psql:include/cagg_refresh_common.sql:65: LOG:  statement: CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '2020-05-04');
 psql:include/cagg_refresh_common.sql:65: DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 1588723200000000 1588550400000000
 psql:include/cagg_refresh_common.sql:65: DEBUG:  continuous aggregate refresh (individual invalidation) on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
-psql:include/cagg_refresh_common.sql:65: LOG:  merged 8 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-psql:include/cagg_refresh_common.sql:65: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+psql:include/cagg_refresh_common.sql:65: LOG:  inserted 8 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 psql:include/cagg_refresh_common.sql:65: DEBUG:  hypertable 2 existing watermark >= new watermark 1588723200000000 1588723200000000
 RESET client_min_messages;
 psql:include/cagg_refresh_common.sql:66: LOG:  statement: RESET client_min_messages;
@@ -491,3 +490,193 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 COMMIT;
+-- Additional tests for MERGE refresh
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 10 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_24_chunk
+CREATE TABLE conditions (
+    time TIMESTAMPTZ NOT NULL,
+    location TEXT NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION
+);
+SELECT FROM create_hypertable( 'conditions', 'time');
+--
+(1 row)
+
+INSERT INTO conditions
+VALUES
+    ('2018-01-01 09:20:00-08', 'SFO', 55, 45),
+    ('2018-01-02 09:30:00-08', 'POR', 100, 100),
+    ('2018-01-02 09:20:00-08', 'SFO', 65, 45),
+    ('2018-01-02 09:10:00-08', 'NYC', 65, 45),
+    ('2018-11-01 09:20:00-08', 'NYC', 45, 30),
+    ('2018-11-01 10:40:00-08', 'NYC', 55, 35),
+    ('2018-11-01 11:50:00-08', 'NYC', 65, 40),
+    ('2018-11-01 12:10:00-08', 'NYC', 75, 45),
+    ('2018-11-01 13:10:00-08', 'NYC', 85, 50),
+    ('2018-11-02 09:20:00-08', 'NYC', 10, 10),
+    ('2018-11-02 10:30:00-08', 'NYC', 20, 15),
+    ('2018-11-02 11:40:00-08', 'NYC', null, null),
+    ('2018-11-03 09:50:00-08', 'NYC', null, null);
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous) AS
+SELECT
+   time_bucket(INTERVAL '1 day', time) AS bucket,
+   location,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature)
+FROM conditions
+GROUP BY bucket, location
+WITH NO DATA;
+-- First refresh using MERGE should fall back to INSERT
+SET client_min_messages TO LOG;
+CALL refresh_continuous_aggregate('conditions_daily', NULL, '2018-11-01 23:59:59-08');
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', NULL, '2018-11-01 23:59:59-08');
+LOG:  inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+(5 rows)
+
+-- Second refresh using MERGE should also fall back to INSERT since there's no data in the materialization hypertable
+CALL refresh_continuous_aggregate('conditions_daily', '2018-11-01', NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', '2018-11-01', NULL);
+LOG:  inserted 2 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+ Thu Nov 01 17:00:00 2018 PDT | NYC      |  15 |  20 |  10
+ Fri Nov 02 17:00:00 2018 PDT | NYC      |     |     |    
+(7 rows)
+
+-- All data should be in the materialization hypertable
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+NOTICE:  continuous aggregate "conditions_daily" is already up-to-date
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+ Thu Nov 01 17:00:00 2018 PDT | NYC      |  15 |  20 |  10
+ Fri Nov 02 17:00:00 2018 PDT | NYC      |     |     |    
+(7 rows)
+
+-- Changing past data that is not part of the cagg
+UPDATE conditions SET humidity = humidity + 100 WHERE time = '2018-01-02 09:20:00-08' AND location = 'SFO';
+LOG:  statement: UPDATE conditions SET humidity = humidity + 100 WHERE time = '2018-01-02 09:20:00-08' AND location = 'SFO';
+-- Shoudn't affect the materialization hypertable (merged=0 and deleted=0)
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  merged 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_16"
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+ Thu Nov 01 17:00:00 2018 PDT | NYC      |  15 |  20 |  10
+ Fri Nov 02 17:00:00 2018 PDT | NYC      |     |     |    
+(7 rows)
+
+-- Backfill some data in the past
+INSERT INTO conditions
+VALUES
+    ('2017-01-01 09:20:00-08', 'GRU', 55, 45),
+    ('2017-01-01 09:30:00-08', 'POA', 100, 100),
+    ('2017-01-02 09:20:00-08', 'CNF', 65, 45);
+LOG:  statement: INSERT INTO conditions
+VALUES
+    ('2017-01-01 09:20:00-08', 'GRU', 55, 45),
+    ('2017-01-01 09:30:00-08', 'POA', 100, 100),
+    ('2017-01-02 09:20:00-08', 'CNF', 65, 45);
+-- There's no data in the affected range so the refresh should fall back to INSERT
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sat Dec 31 16:00:00 2016 PST | GRU      |  55 |  55 |  55
+ Sat Dec 31 16:00:00 2016 PST | POA      | 100 | 100 | 100
+ Sun Jan 01 16:00:00 2017 PST | CNF      |  65 |  65 |  65
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+ Thu Nov 01 17:00:00 2018 PDT | NYC      |  15 |  20 |  10
+ Fri Nov 02 17:00:00 2018 PDT | NYC      |     |     |    
+(10 rows)
+
+-- Update already materilized data in the past
+UPDATE conditions SET temperature = temperature + 100 WHERE time = '2018-11-02 10:30:00-08' AND location = 'NYC';
+LOG:  statement: UPDATE conditions SET temperature = temperature + 100 WHERE time = '2018-11-02 10:30:00-08' AND location = 'NYC';
+-- Should merge 1 bucket (merged=1 and deleted=0)
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  merged 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_16"
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sat Dec 31 16:00:00 2016 PST | GRU      |  55 |  55 |  55
+ Sat Dec 31 16:00:00 2016 PST | POA      | 100 | 100 | 100
+ Sun Jan 01 16:00:00 2017 PST | CNF      |  65 |  65 |  65
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+ Thu Nov 01 17:00:00 2018 PDT | NYC      |  65 | 120 |  10
+ Fri Nov 02 17:00:00 2018 PDT | NYC      |     |     |    
+(10 rows)
+
+-- Delete one entire bucket
+DELETE FROM conditions WHERE time >= '2018-11-02' AND time < '2018-11-03' AND location = 'NYC';
+LOG:  statement: DELETE FROM conditions WHERE time >= '2018-11-02' AND time < '2018-11-03' AND location = 'NYC';
+-- Should not merge any bucket but delete one bucket (merged=0 and deleted=1)
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+LOG:  merged 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_16"
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+LOG:  statement: SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+            bucket            | location | avg | max | min 
+------------------------------+----------+-----+-----+-----
+ Sat Dec 31 16:00:00 2016 PST | GRU      |  55 |  55 |  55
+ Sat Dec 31 16:00:00 2016 PST | POA      | 100 | 100 | 100
+ Sun Jan 01 16:00:00 2017 PST | CNF      |  65 |  65 |  65
+ Sun Dec 31 16:00:00 2017 PST | SFO      |  55 |  55 |  55
+ Mon Jan 01 16:00:00 2018 PST | NYC      |  65 |  65 |  65
+ Mon Jan 01 16:00:00 2018 PST | POR      | 100 | 100 | 100
+ Mon Jan 01 16:00:00 2018 PST | SFO      |  65 |  65 |  65
+ Wed Oct 31 17:00:00 2018 PDT | NYC      |  65 |  85 |  45
+ Fri Nov 02 17:00:00 2018 PDT | NYC      |     |     |    
+(9 rows)
+

--- a/tsl/test/sql/cagg_refresh_using_merge.sql
+++ b/tsl/test/sql/cagg_refresh_using_merge.sql
@@ -7,3 +7,85 @@ SET timescaledb.enable_merge_on_cagg_refresh TO ON;
 SET timezone TO PST8PDT;
 
 \ir include/cagg_refresh_common.sql
+
+-- Additional tests for MERGE refresh
+DROP TABLE conditions CASCADE;
+
+CREATE TABLE conditions (
+    time TIMESTAMPTZ NOT NULL,
+    location TEXT NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION
+);
+
+SELECT FROM create_hypertable( 'conditions', 'time');
+
+INSERT INTO conditions
+VALUES
+    ('2018-01-01 09:20:00-08', 'SFO', 55, 45),
+    ('2018-01-02 09:30:00-08', 'POR', 100, 100),
+    ('2018-01-02 09:20:00-08', 'SFO', 65, 45),
+    ('2018-01-02 09:10:00-08', 'NYC', 65, 45),
+    ('2018-11-01 09:20:00-08', 'NYC', 45, 30),
+    ('2018-11-01 10:40:00-08', 'NYC', 55, 35),
+    ('2018-11-01 11:50:00-08', 'NYC', 65, 40),
+    ('2018-11-01 12:10:00-08', 'NYC', 75, 45),
+    ('2018-11-01 13:10:00-08', 'NYC', 85, 50),
+    ('2018-11-02 09:20:00-08', 'NYC', 10, 10),
+    ('2018-11-02 10:30:00-08', 'NYC', 20, 15),
+    ('2018-11-02 11:40:00-08', 'NYC', null, null),
+    ('2018-11-03 09:50:00-08', 'NYC', null, null);
+
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous) AS
+SELECT
+   time_bucket(INTERVAL '1 day', time) AS bucket,
+   location,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature)
+FROM conditions
+GROUP BY bucket, location
+WITH NO DATA;
+
+-- First refresh using MERGE should fall back to INSERT
+SET client_min_messages TO LOG;
+CALL refresh_continuous_aggregate('conditions_daily', NULL, '2018-11-01 23:59:59-08');
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+
+-- Second refresh using MERGE should also fall back to INSERT since there's no data in the materialization hypertable
+CALL refresh_continuous_aggregate('conditions_daily', '2018-11-01', NULL);
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+
+-- All data should be in the materialization hypertable
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+
+-- Changing past data that is not part of the cagg
+UPDATE conditions SET humidity = humidity + 100 WHERE time = '2018-01-02 09:20:00-08' AND location = 'SFO';
+-- Shoudn't affect the materialization hypertable (merged=0 and deleted=0)
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+
+-- Backfill some data in the past
+INSERT INTO conditions
+VALUES
+    ('2017-01-01 09:20:00-08', 'GRU', 55, 45),
+    ('2017-01-01 09:30:00-08', 'POA', 100, 100),
+    ('2017-01-02 09:20:00-08', 'CNF', 65, 45);
+
+-- There's no data in the affected range so the refresh should fall back to INSERT
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+
+-- Update already materilized data in the past
+UPDATE conditions SET temperature = temperature + 100 WHERE time = '2018-11-02 10:30:00-08' AND location = 'NYC';
+-- Should merge 1 bucket (merged=1 and deleted=0)
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;
+
+-- Delete one entire bucket
+DELETE FROM conditions WHERE time >= '2018-11-02' AND time < '2018-11-03' AND location = 'NYC';
+-- Should not merge any bucket but delete one bucket (merged=0 and deleted=1)
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY 1, 2, 3 NULLS LAST, 4 NULLS LAST, 5 NULLS LAST;


### PR DESCRIPTION
If there's no rows in the materialization hypertable to be updated in the specific window range then fallback to INSERT rows.

It improves performance of the materialization step in the CAggs refresh and also avoid necessary DELETE.

Disable-check: force-changelog-file
