### PR TITLE
Fix handling of oldtuple to match PG17 upstream

### DIFF
--- a/src/import/ht_hypertable_modify.c
+++ b/src/import/ht_hypertable_modify.c
@@ -460,6 +460,12 @@ lmerge_matched:;
 	 * visible to our MVCC snapshot.
 	 */
 
+#if PG17_GE
+	if (oldtuple != NULL)
+		ExecForceStoreHeapTuple(oldtuple, resultRelInfo->ri_oldTupleSlot,
+								false);
+	else
+#endif
 	if (!table_tuple_fetch_row_version(resultRelInfo->ri_RelationDesc,
 					   tupleid,
 					   SnapshotAny,


### PR DESCRIPTION
A [previous commit](https://github.com/timescale/timescaledb/commit/d7513b26f667fcdb269abf1ba0453ab28e0e3801) I made added support for MERGE ... RETURNING ....
While working on the coverity fix, I realized that this code handling oldtuple was not added; that's what this fixes.

Disable-check: force-changelog-file