### PR TITLE
Fix unrecognized value error in upgrade test

### DIFF
--- a/test/sql/updates/post.v7.sql
+++ b/test/sql/updates/post.v7.sql
@@ -2,7 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+\set PG_UPGRADE_TEST false
 \ir post.catalog.sql
+\unset PG_UPGRADE_TEST
 \ir post.insert.sql
 \ir post.integrity_test.sql
 \ir catalog_missing_columns.sql

--- a/test/sql/updates/post.v8.sql
+++ b/test/sql/updates/post.v8.sql
@@ -2,7 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+\set PG_UPGRADE_TEST false
 \ir post.catalog.sql
+\unset PG_UPGRADE_TEST
 \ir post.insert.sql
 \ir post.integrity_test.sql
 \ir catalog_missing_columns.sql


### PR DESCRIPTION
When post.catalog.sql is run outside of pgupgrade test it will raise the error `unrecognized value ":PG_UPGRADE_TEST" for "\if expression": Boolean expected` This patch defines the variable and sets it to false for non pgupgrade runs.