### PR TITLE
PG17: Enable Windows tests on CI

### DIFF
--- a/.github/workflows/windows-build-and-test-ignored.yaml
+++ b/.github/workflows/windows-build-and-test-ignored.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [ 14, 15, 16 ]
+        pg: [ 14, 15, 16, 17 ]
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
     steps:

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [ 14, 15, 16 ]
+        pg: [ 14, 15, 16, 17 ]
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         ignores: ["chunk_adaptive metadata telemetry"]
@@ -113,13 +113,20 @@ jobs:
         key: "${{ runner.os }}-build-pg${{ matrix.pkg_version }}\
           -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
 
+    # Force install PostgreSQL 17 since the package still on moderation
+    # https://community.chocolatey.org/packages/postgresql17
     - name: Install PostgreSQL ${{ matrix.pg }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
         choco feature disable --name=usePackageExitCodes
         choco feature disable --name=showDownloadProgress
-        choco install postgresql${{ matrix.pg }} `
-          --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+        if(${{ matrix.pg }} -eq 17) {
+          choco install postgresql${{ matrix.pg }} --version 17.0.0 `
+            --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+        } else {
+          choco install postgresql${{ matrix.pg }} `
+            --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+        }
 
     - name: Configure TimescaleDB
       run: cmake -B build_win -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `


### PR DESCRIPTION
We're forcing PG17 installation since the package still on moderation by the Chocolatey Community:

https://community.chocolatey.org/packages/postgresql17

Disable-check: force-changelog-file
