### PR TITLE
Pin setup-wsl version to 3.1.1

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -64,7 +64,7 @@ jobs:
       TABLESPACE2: D:\tablespace2\
     steps:
     - name: Setup WSL
-      uses: Vampire/setup-wsl@v3
+      uses: Vampire/setup-wsl@v3.1.1
       with:
         additional-packages:
           cmake


### PR DESCRIPTION
Looks like version 3.1.2 does not work so pin to the previous version instead of generic v3.

Disable-check: force-changelog-file