### PR TITLE
Fix issues with Hypercore TAM recompression

### DIFF
--- a/tsl/src/hypercore/hypercore_handler.h
+++ b/tsl/src/hypercore/hypercore_handler.h
@@ -18,6 +18,13 @@
  * individual access methods, so use bit 16. */
 #define SK_NO_COMPRESSED 0x8000
 
+typedef enum HypercoreScanOptions
+{
+	/* Normal scan options stretch to 9th bit. Start at bit 15 out of 32 to be
+	 * safe. */
+	SO_HYPERCORE_SKIP_COMPRESSED = 1 << 15,
+} HypercoreScanOptions;
+
 extern void hypercore_set_analyze_relid(Oid relid);
 extern const TableAmRoutine *hypercore_routine(void);
 extern void hypercore_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht);
@@ -25,6 +32,7 @@ extern void hypercore_alter_access_method_begin(Oid relid, bool to_other_am);
 extern void hypercore_alter_access_method_finish(Oid relid, bool to_other_am);
 extern Datum hypercore_handler(PG_FUNCTION_ARGS);
 extern void hypercore_xact_event(XactEvent event, void *arg);
+extern bool hypercore_set_truncate_compressed(bool onoff);
 
 typedef struct ColumnCompressionSettings
 {
@@ -55,5 +63,7 @@ typedef struct HypercoreInfo
 	/* Per-column information follows. */
 	ColumnCompressionSettings columns[FLEXIBLE_ARRAY_MEMBER];
 } HypercoreInfo;
+
+#define REL_IS_HYPERCORE(rel) ((rel)->rd_tableam == hypercore_routine())
 
 extern HypercoreInfo *RelationGetHypercoreInfo(Relation rel);

--- a/tsl/test/expected/hypercore.out
+++ b/tsl/test/expected/hypercore.out
@@ -592,3 +592,167 @@ SELECT count(*) FROM :chunk;
 (1 row)
 
 drop table readings;
+---------------------------------------------
+-- Test recompression via compress_chunk() --
+---------------------------------------------
+show timescaledb.enable_transparent_decompression;
+ timescaledb.enable_transparent_decompression 
+----------------------------------------------
+ off
+(1 row)
+
+create table recompress (time timestamptz, value int);
+select create_hypertable('recompress', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
+    create_hypertable    
+-------------------------
+ (3,public,recompress,t)
+(1 row)
+
+insert into recompress values ('2024-01-01 01:00', 1), ('2024-01-01 02:00', 2);
+select format('%I.%I', chunk_schema, chunk_name)::regclass as unique_chunk
+  from timescaledb_information.chunks
+ where format('%I.%I', hypertable_schema, hypertable_name)::regclass = 'recompress'::regclass
+ order by unique_chunk asc
+ limit 1 \gset
+alter table recompress set (timescaledb.compress_orderby='time');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "recompress" is set to ""
+alter table :unique_chunk set access method hypercore;
+-- Should already be compressed
+select compress_chunk(:'unique_chunk');
+NOTICE:  chunk "_hyper_3_34_chunk" is already compressed
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_34_chunk
+(1 row)
+
+-- Insert something to compress
+insert into recompress values ('2024-01-01 03:00', 3);
+select compress_chunk(:'unique_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_34_chunk
+(1 row)
+
+-- Make sure we see the data after recompression and everything is
+-- compressed
+select _timescaledb_debug.is_compressed_tid(ctid), * from recompress order by time;
+ is_compressed_tid |             time             | value 
+-------------------+------------------------------+-------
+ t                 | Mon Jan 01 01:00:00 2024 PST |     1
+ t                 | Mon Jan 01 02:00:00 2024 PST |     2
+ t                 | Mon Jan 01 03:00:00 2024 PST |     3
+(3 rows)
+
+-- Add a time index to test recompression with index scan. Index scans
+-- during compression is actually disabled for Hypercore TAM since the
+-- index covers also compressed data, so this is only a check that the
+-- GUC can be set without negative consequences.
+create index on recompress (time);
+set timescaledb.enable_compression_indexscan=true;
+-- Insert another value to compress
+insert into recompress values ('2024-01-02 04:00', 4);
+select compress_chunk(:'unique_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_34_chunk
+(1 row)
+
+select _timescaledb_debug.is_compressed_tid(ctid), * from recompress order by time;
+ is_compressed_tid |             time             | value 
+-------------------+------------------------------+-------
+ t                 | Mon Jan 01 01:00:00 2024 PST |     1
+ t                 | Mon Jan 01 02:00:00 2024 PST |     2
+ t                 | Mon Jan 01 03:00:00 2024 PST |     3
+ t                 | Tue Jan 02 04:00:00 2024 PST |     4
+(4 rows)
+
+-- Test using delete instead of truncate when compressing
+set timescaledb.enable_delete_after_compression=true;
+-- Insert another value to compress
+insert into recompress values ('2024-01-02 05:00', 5);
+select compress_chunk(:'unique_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_34_chunk
+(1 row)
+
+select _timescaledb_debug.is_compressed_tid(ctid), * from recompress order by time;
+ is_compressed_tid |             time             | value 
+-------------------+------------------------------+-------
+ t                 | Mon Jan 01 01:00:00 2024 PST |     1
+ t                 | Mon Jan 01 02:00:00 2024 PST |     2
+ t                 | Mon Jan 01 03:00:00 2024 PST |     3
+ t                 | Tue Jan 02 04:00:00 2024 PST |     4
+ t                 | Tue Jan 02 05:00:00 2024 PST |     5
+(5 rows)
+
+-- Add a segmentby key to test segmentwise recompression
+-- Insert another value to compress that goes into same segment
+alter table :unique_chunk set access method heap;
+alter table recompress set (timescaledb.compress_orderby='time', timescaledb.compress_segmentby='value');
+alter table :unique_chunk set access method hypercore;
+insert into recompress values ('2024-01-02 06:00', 5);
+select compress_chunk(:'unique_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_34_chunk
+(1 row)
+
+select _timescaledb_debug.is_compressed_tid(ctid), * from recompress order by time;
+ is_compressed_tid |             time             | value 
+-------------------+------------------------------+-------
+ t                 | Mon Jan 01 01:00:00 2024 PST |     1
+ t                 | Mon Jan 01 02:00:00 2024 PST |     2
+ t                 | Mon Jan 01 03:00:00 2024 PST |     3
+ t                 | Tue Jan 02 04:00:00 2024 PST |     4
+ t                 | Tue Jan 02 05:00:00 2024 PST |     5
+ t                 | Tue Jan 02 06:00:00 2024 PST |     5
+(6 rows)
+
+--------------------------------------
+-- C-native tests for hypercore TAM --
+--------------------------------------
+-- Test rescan functionality and ability to return only non-compressed data
+create table rescan (time timestamptz, device int, temp float);
+select create_hypertable('rescan', 'time');
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable  
+---------------------
+ (5,public,rescan,t)
+(1 row)
+
+alter table rescan set (timescaledb.compress_orderby='time', timescaledb.compress_segmentby='device');
+insert into rescan values ('2024-11-01 01:00', 1, 1.0), ('2024-11-01 02:00', 1, 2.0), ('2024-11-01 03:00', 1, 3.0), ('2024-11-01 06:00', 1, 4.0), ('2024-11-01 05:00', 1, 5.0);
+select format('%I.%I', chunk_schema, chunk_name)::regclass as rescan_chunk
+  from timescaledb_information.chunks
+ where format('%I.%I', hypertable_schema, hypertable_name)::regclass = 'rescan'::regclass
+ order by rescan_chunk asc
+ limit 1 \gset
+select compress_chunk(:'rescan_chunk', hypercore_use_access_method => true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_40_chunk
+(1 row)
+
+select relname, amname
+  from show_chunks('rescan') as chunk
+  join pg_class on (pg_class.oid = chunk)
+  join pg_am on (relam = pg_am.oid);
+      relname      |  amname   
+-------------------+-----------
+ _hyper_5_40_chunk | hypercore
+(1 row)
+
+insert into rescan values ('2024-11-02 01:00', 2, 1.0), ('2024-11-02 02:00', 2, 2.0), ('2024-11-02 03:00', 1, 3.0), ('2024-11-02 05:00', 2, 4.0);
+reset role;
+create function test_hypercore(relid regclass)
+returns void as :TSL_MODULE_PATHNAME, 'ts_test_hypercore' language c;
+set role :ROLE_DEFAULT_PERM_USER;
+select test_hypercore(:'rescan_chunk');
+ test_hypercore 
+----------------
+ 
+(1 row)
+

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -438,7 +438,7 @@ select * from compressed_rel_size_stats order by rel;
  _timescaledb_internal._hyper_1_7_chunk  | hypercore | test2     |                    2016 |                       10 |                         10
  _timescaledb_internal._hyper_1_9_chunk  | hypercore | test2     |                    2016 |                       10 |                         10
  _timescaledb_internal._hyper_1_11_chunk | hypercore | test2     |                     373 |                       10 |                         10
- _timescaledb_internal._hyper_4_13_chunk | hypercore | test3     |                       0 |                        0 |                          0
+ _timescaledb_internal._hyper_4_13_chunk | hypercore | test3     |                       1 |                        1 |                          1
  _timescaledb_internal._hyper_4_17_chunk | hypercore | test3     |                       1 |                        1 |                          1
  _timescaledb_internal._hyper_4_18_chunk | hypercore | test3     |                       1 |                        1 |                          1
 (9 rows)
@@ -476,7 +476,7 @@ select * from compressed_rel_size_stats order by rel;
  _timescaledb_internal._hyper_1_7_chunk  | heap   | test2     |                    2016 |                       10 |                         10
  _timescaledb_internal._hyper_1_9_chunk  | heap   | test2     |                    2016 |                       10 |                         10
  _timescaledb_internal._hyper_1_11_chunk | heap   | test2     |                     373 |                       10 |                         10
- _timescaledb_internal._hyper_4_13_chunk | heap   | test3     |                       0 |                        0 |                          0
+ _timescaledb_internal._hyper_4_13_chunk | heap   | test3     |                       1 |                        1 |                          1
  _timescaledb_internal._hyper_4_17_chunk | heap   | test3     |                       1 |                        1 |                          1
  _timescaledb_internal._hyper_4_18_chunk | heap   | test3     |                       1 |                        1 |                          1
 (9 rows)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -135,14 +135,13 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND TEST_FILES bgw_scheduler_control.sql)
+    list(APPEND TEST_FILES bgw_scheduler_control.sql hypercore.sql)
   endif()
   list(
     APPEND
     TEST_FILES
     merge_compress.sql
     cagg_refresh_using_merge.sql
-    hypercore.sql
     hypercore_columnar.sql
     hypercore_copy.sql
     hypercore_create.sql

--- a/tsl/test/src/CMakeLists.txt
+++ b/tsl/test/src/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(SOURCES
-    test_chunk_stats.c test_merge_chunk.c compression_unit_test.c
-    compression_sql_test.c decompress_text_test_impl.c test_continuous_agg.c)
+    test_chunk_stats.c
+    test_merge_chunk.c
+    compression_unit_test.c
+    compression_sql_test.c
+    decompress_text_test_impl.c
+    test_continuous_agg.c
+    test_hypercore.c)
 
 include(${PROJECT_SOURCE_DIR}/tsl/src/build-defs.cmake)
 

--- a/tsl/test/src/test_hypercore.c
+++ b/tsl/test/src/test_hypercore.c
@@ -1,0 +1,125 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <access/heapam.h>
+#include <access/htup_details.h>
+#include <utils/snapmgr.h>
+
+#include "export.h"
+#include "hypercore/arrow_tts.h"
+#include "hypercore/hypercore_handler.h"
+#include "test_utils.h"
+
+/*
+ * Test that Hypercore rescan API works correctly.
+ *
+ * In particular, test that scanning only non-compressed data across rescans
+ * work.
+ */
+static void
+test_rescan_hypercore(Oid relid)
+{
+	Relation rel = table_open(relid, AccessShareLock);
+	TupleTableSlot *slot = table_slot_create(rel, NULL);
+	TableScanDesc scan;
+	Snapshot snapshot = GetTransactionSnapshot();
+	ScanKeyData scankey = {
+		/* Let compression TAM know it should only return tuples from the
+		 * non-compressed relation. No actual scankey necessary */
+		.sk_flags = SK_NO_COMPRESSED,
+	};
+	unsigned int compressed_tuple_count = 0;
+	unsigned int noncompressed_tuple_count = 0;
+	unsigned int prev_noncompressed_tuple_count = 0;
+	unsigned int prev_compressed_tuple_count = 0;
+
+	TestAssertTrue(TTS_IS_ARROWTUPLE(slot));
+
+	/* Scan only non-compressed data */
+	scan = table_beginscan(rel, snapshot, 0, &scankey);
+
+	while (table_scan_getnextslot(scan, ForwardScanDirection, slot))
+	{
+		if (is_compressed_tid(&slot->tts_tid))
+			compressed_tuple_count++;
+		else
+			noncompressed_tuple_count++;
+	}
+
+	TestAssertTrue(compressed_tuple_count == 0);
+	TestAssertTrue(noncompressed_tuple_count > 0);
+	prev_noncompressed_tuple_count = noncompressed_tuple_count;
+	prev_compressed_tuple_count = compressed_tuple_count;
+	compressed_tuple_count = 0;
+	noncompressed_tuple_count = 0;
+
+	/* Rescan only non-compressed data */
+	table_rescan(scan, &scankey);
+
+	while (table_scan_getnextslot(scan, ForwardScanDirection, slot))
+	{
+		if (is_compressed_tid(&slot->tts_tid))
+			compressed_tuple_count++;
+		else
+			noncompressed_tuple_count++;
+	}
+
+	TestAssertTrue(compressed_tuple_count == 0);
+	TestAssertTrue(noncompressed_tuple_count == prev_noncompressed_tuple_count);
+	TestAssertTrue(compressed_tuple_count == prev_compressed_tuple_count);
+	prev_noncompressed_tuple_count = noncompressed_tuple_count;
+	prev_compressed_tuple_count = compressed_tuple_count;
+	compressed_tuple_count = 0;
+	noncompressed_tuple_count = 0;
+
+	/* Rescan only non-compressed data even though giving no new scan key */
+	table_rescan(scan, NULL);
+
+	while (table_scan_getnextslot(scan, ForwardScanDirection, slot))
+	{
+		if (is_compressed_tid(&slot->tts_tid))
+			compressed_tuple_count++;
+		else
+			noncompressed_tuple_count++;
+	}
+
+	TestAssertTrue(compressed_tuple_count == 0);
+	TestAssertTrue(noncompressed_tuple_count == prev_noncompressed_tuple_count);
+	TestAssertTrue(compressed_tuple_count == prev_compressed_tuple_count);
+	prev_noncompressed_tuple_count = noncompressed_tuple_count;
+	prev_compressed_tuple_count = compressed_tuple_count;
+	compressed_tuple_count = 0;
+	noncompressed_tuple_count = 0;
+
+	/* Rescan both compressed and non-compressed data by specifying new flag */
+	scankey.sk_flags = 0;
+	table_rescan(scan, &scankey);
+
+	while (table_scan_getnextslot(scan, ForwardScanDirection, slot))
+	{
+		if (is_compressed_tid(&slot->tts_tid))
+			compressed_tuple_count++;
+		else
+			noncompressed_tuple_count++;
+	}
+
+	TestAssertTrue(noncompressed_tuple_count == prev_noncompressed_tuple_count);
+	TestAssertTrue(compressed_tuple_count > 0);
+
+	table_endscan(scan);
+	table_close(rel, NoLock);
+	ExecDropSingleTupleTableSlot(slot);
+}
+
+TS_FUNCTION_INFO_V1(ts_test_hypercore);
+
+Datum
+ts_test_hypercore(PG_FUNCTION_ARGS)
+{
+	Oid relid = PG_GETARG_OID(0);
+	test_rescan_hypercore(relid);
+	PG_RETURN_VOID();
+}


### PR DESCRIPTION
A truncate on a hypercore TAM table is executed across both compressed and non-compressed data. This caused an issue when recompressing because it tries to truncate also the compressed data. Fix this issue by introducing a flag that allows truncating only the non-compressed data.

Another issue releated to cache invalidation is also fixed. Since a recompression sometimes creates a new compressed relation, and the compressed relid is cached in the Hypercore TAM's relcache entry, the cache needs to be invalidated during recompression. However, this wasn't done previously leading to an error. This is fixed by adding a relcache invalidation during recompression.

Finally, compression using an index scan is disabled for Hypercore TAM since the index covers also compressed data (in the recompression case). While the index could be used when compressing the first time (when only non-compressed data is indexed), it is still disabled completely for Hypercore TAM given that index scans are not used by default anyway.

Tests are added to cover all of the issues described above.

Disable-check: force-changelog-file