### PR TITLE
Add assert for fetch_att and store_att_byval

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -188,6 +188,16 @@ extern TSDLLEXPORT List *ts_get_reloptions(Oid relid);
 		.value = 0, .isnull = true                                                                 \
 	}
 
+static inline Datum
+ts_fetch_att(const void *T, bool attbyval, int attlen)
+{
+	/* Length should be set to something sensible, otherwise an error will be
+	 * raised by fetch_att, so we assert this here to get a stack for
+	 * violations. */
+	Assert(!attbyval || (attlen > 0 && attlen <= 8));
+	return fetch_att(T, attbyval, attlen);
+}
+
 static inline int64
 int64_min(int64 a, int64 b)
 {

--- a/tsl/src/hypercore/arrow_array.c
+++ b/tsl/src/hypercore/arrow_array.c
@@ -13,6 +13,7 @@
 #include "arrow_array.h"
 #include "compression/arrow_c_data_interface.h"
 #include "compression/compression.h"
+#include "src/utils.h"
 
 #define TYPLEN_VARLEN (-1)
 
@@ -470,7 +471,7 @@ arrow_get_datum_fixlen(const ArrowArray *array, Oid typid, int16 typlen, uint16 
 	/* In order to handle fixed-length values of arbitrary size that are byref
 	 * and byval, we use fetch_all() rather than rolling our own. This is
 	 * taken from utils/adt/rangetypes.c */
-	Datum datum = fetch_att(&values[index * typlen], apriv->typbyval, typlen);
+	Datum datum = ts_fetch_att(&values[index * typlen], apriv->typbyval, typlen);
 
 	TS_DEBUG_LOG("retrieved fixlen value %s row %u from offset %u"
 				 " in memory context %s",

--- a/tsl/src/nodes/decompress_chunk/pred_vector_array.c
+++ b/tsl/src/nodes/decompress_chunk/pred_vector_array.c
@@ -7,10 +7,9 @@
 #include <postgres.h>
 
 #include "compression/arrow_c_data_interface.h"
-
-#include "vector_predicates.h"
-
 #include "compression/compression.h"
+#include "src/utils.h"
+#include "vector_predicates.h"
 
 /*
  * Vectorized implementation of ScalarArrayOpExpr. Applies scalar_predicate for
@@ -77,7 +76,7 @@ vector_array_predicate(VectorPredicate *vector_const_predicate, bool is_or,
 			}
 			return;
 		}
-		Datum constvalue = fetch_att(array_data, typbyval, typlen);
+		Datum constvalue = ts_fetch_att(array_data, typbyval, typlen);
 		array_data = att_addlength_pointer(array_data, typlen, array_data);
 		array_data = (const char *) att_align_nominal(array_data, typalign);
 


### PR DESCRIPTION
These two functions throw an error if you pass in a strange combination of typbyval and typlen, so we assert on bad values to get a backtrace.

Disable-check: force-changelog-file