### PR TITLE
Fix flaky Hypercore tests

### DIFF
--- a/tsl/test/expected/hypercore_index_btree.out
+++ b/tsl/test/expected/hypercore_index_btree.out
@@ -258,6 +258,10 @@ and (attname='location_id' or attname='device_id' or attname='owner_id');
 
 -- the query should not use index-only scan on the hypestore chunk
 -- (number 2) because it is not supported on segmentby indexes
+--
+-- first, drop one of the indexes on location_id to make the index to
+-- pick predictible
+drop index hypertable_location_id_include_humidity_idx;
 select explain_anonymize(format($$
        select location_id, count(*) into comp from %s
        where location_id in (3,4,5) group by location_id
@@ -646,6 +650,8 @@ $$, :'chunk1'));
 -- Analyze will run the queries so we are satisfied with this right
 -- now and do not run the queries separately since they can generate
 -- different results depending on table contents.
+-- Add back covering index on location_id
+create index hypertable_location_id_include_humidity_idx on :hypertable (location_id) include (humidity);
 select explain_analyze_anonymize(format($$
     select location_id, avg(humidity) from %s where location_id between 5 and 10
     group by location_id order by location_id

--- a/tsl/test/expected/hypercore_join.out
+++ b/tsl/test/expected/hypercore_join.out
@@ -108,6 +108,8 @@ select format('%I.%I', chunk_schema, chunk_name)::regclass as chunk2
 -- We disable columnar scan for these tests since we have a dedicated
 -- test for this.
 set timescaledb.enable_columnarscan to false;
+-- Discourage seqscan to make sure we predictibly use indexscan
+set enable_seqscan to false;
 set enable_memoize to false;
 -- Create a hypercore with a few rows and use the big table to join
 -- with it. This should put the hypercore as the inner relation and

--- a/tsl/test/sql/hypercore_index_btree.sql
+++ b/tsl/test/sql/hypercore_index_btree.sql
@@ -93,6 +93,10 @@ and (attname='location_id' or attname='device_id' or attname='owner_id');
 
 -- the query should not use index-only scan on the hypestore chunk
 -- (number 2) because it is not supported on segmentby indexes
+--
+-- first, drop one of the indexes on location_id to make the index to
+-- pick predictible
+drop index hypertable_location_id_include_humidity_idx;
 select explain_anonymize(format($$
        select location_id, count(*) into comp from %s
        where location_id in (3,4,5) group by location_id
@@ -213,6 +217,10 @@ $$, :'chunk1'));
 -- Analyze will run the queries so we are satisfied with this right
 -- now and do not run the queries separately since they can generate
 -- different results depending on table contents.
+
+-- Add back covering index on location_id
+create index hypertable_location_id_include_humidity_idx on :hypertable (location_id) include (humidity);
+
 select explain_analyze_anonymize(format($$
     select location_id, avg(humidity) from %s where location_id between 5 and 10
     group by location_id order by location_id

--- a/tsl/test/sql/hypercore_join.sql
+++ b/tsl/test/sql/hypercore_join.sql
@@ -7,6 +7,8 @@
 -- We disable columnar scan for these tests since we have a dedicated
 -- test for this.
 set timescaledb.enable_columnarscan to false;
+-- Discourage seqscan to make sure we predictibly use indexscan
+set enable_seqscan to false;
 
 set enable_memoize to false;
 

--- a/tsl/test/sql/include/hypercore_join_test.sql
+++ b/tsl/test/sql/include/hypercore_join_test.sql
@@ -37,4 +37,3 @@ where r.device_id is distinct from e.device_id;
 
 drop table :inner;
 drop table :outer;
-


### PR DESCRIPTION
This change should fix two Hypercore tests that could sometimes fail due to different query plans.

Disable-check: force-changelog-file
Disable-check: commit-count
Disable-check: approval-count