### PR TITLE
Fix flaky rowsecurity test

### DIFF
--- a/test/expected/rowsecurity-14.out
+++ b/test/expected/rowsecurity-14.out
@@ -541,9 +541,10 @@ SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.
      |     |        |                 |                    |  33 | technology
 (6 rows)
 
+\set VERBOSITY sqlstate
 DELETE FROM category WHERE cid = 33;    -- fails with FK violation
-ERROR:  update or delete on table "category" violates foreign key constraint "document_cid_fkey" on table "document"
-DETAIL:  Key is still referenced from table "document".
+ERROR:  23503
+\set VERBOSITY default
 -- can insert FK referencing invisible PK
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;

--- a/test/expected/rowsecurity-15.out
+++ b/test/expected/rowsecurity-15.out
@@ -541,9 +541,10 @@ SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.
      |     |        |                 |                    |  33 | technology
 (6 rows)
 
+\set VERBOSITY sqlstate
 DELETE FROM category WHERE cid = 33;    -- fails with FK violation
-ERROR:  update or delete on table "category" violates foreign key constraint "document_cid_fkey" on table "document"
-DETAIL:  Key is still referenced from table "document".
+ERROR:  23503
+\set VERBOSITY default
 -- can insert FK referencing invisible PK
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -541,9 +541,10 @@ SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.
      |     |        |                 |                    |  33 | technology
 (6 rows)
 
+\set VERBOSITY sqlstate
 DELETE FROM category WHERE cid = 33;    -- fails with FK violation
-ERROR:  update or delete on table "category" violates foreign key constraint "document_cid_fkey" on table "document"
-DETAIL:  Key is still referenced from table "document".
+ERROR:  23503
+\set VERBOSITY default
 -- can insert FK referencing invisible PK
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;

--- a/test/expected/rowsecurity-17.out
+++ b/test/expected/rowsecurity-17.out
@@ -541,9 +541,10 @@ SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.
      |     |        |                 |                    |  33 | technology
 (6 rows)
 
+\set VERBOSITY sqlstate
 DELETE FROM category WHERE cid = 33;    -- fails with FK violation
-ERROR:  update or delete on table "category" violates foreign key constraint "document_cid_fkey" on table "document"
-DETAIL:  Key is still referenced from table "document".
+ERROR:  23503
+\set VERBOSITY default
 -- can insert FK referencing invisible PK
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;

--- a/test/sql/rowsecurity.sql.in
+++ b/test/sql/rowsecurity.sql.in
@@ -192,7 +192,9 @@ ALTER TABLE category ENABLE ROW LEVEL SECURITY;
 -- cannot delete PK referenced by invisible FK
 SET SESSION AUTHORIZATION regress_rls_bob;
 SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;
+\set VERBOSITY sqlstate
 DELETE FROM category WHERE cid = 33;    -- fails with FK violation
+\set VERBOSITY default
 
 -- can insert FK referencing invisible PK
 SET SESSION AUTHORIZATION regress_rls_carol;


### PR DESCRIPTION
Check sql state code instead of error message in row security foreign key check.

Disable-check: force-changelog-file
