### PR TITLE
Fix flaky continuous_aggs test

### DIFF
--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -1758,7 +1758,7 @@ group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_default"
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
-where view_name like 'cagg_index_%';
+where view_name like 'cagg_index_%' ORDER BY view_name;
      view_name      | materialization_hypertable_name 
 --------------------+---------------------------------
  cagg_index_default | _materialized_hypertable_51

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1758,7 +1758,7 @@ group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_default"
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
-where view_name like 'cagg_index_%';
+where view_name like 'cagg_index_%' ORDER BY view_name;
      view_name      | materialization_hypertable_name 
 --------------------+---------------------------------
  cagg_index_default | _materialized_hypertable_51

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -1758,7 +1758,7 @@ group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_default"
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
-where view_name like 'cagg_index_%';
+where view_name like 'cagg_index_%' ORDER BY view_name;
      view_name      | materialization_hypertable_name 
 --------------------+---------------------------------
  cagg_index_default | _materialized_hypertable_51

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -1758,7 +1758,7 @@ group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_default"
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
-where view_name like 'cagg_index_%';
+where view_name like 'cagg_index_%' ORDER BY view_name;
      view_name      | materialization_hypertable_name 
 --------------------+---------------------------------
  cagg_index_default | _materialized_hypertable_51

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -1271,7 +1271,7 @@ group by bucket, symbol;
 
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
-where view_name like 'cagg_index_%';
+where view_name like 'cagg_index_%' ORDER BY view_name;
 
 -- now make sure a group index has been created when explicitly asked for
 \x on


### PR DESCRIPTION
Add missing ORDER BY clause to continuous_aggs test to make output deterministic.

Disable-check: force-changelog-file
Disable-check: approval-count

