### PR TITLE
Remove obsolete job

### DIFF
--- a/.unreleased/pr_7378
+++ b/.unreleased/pr_7378
@@ -1,0 +1,2 @@
+Fixes: #7378 Remove obsolete job referencing policy_job_error_retention
+Thanks: @pgloader for reporting an issue an internal background job

--- a/sql/job_stat_history_log_retention.sql
+++ b/sql/job_stat_history_log_retention.sql
@@ -37,46 +37,6 @@ BEGIN
 END;
 $BODY$ SET search_path TO pg_catalog, pg_temp;
 
--- this is the previous job that was created for the same purpose
--- which has scheduled set to false. We need to keep it around to
--- not break loading dumps from older versions.
-INSERT INTO _timescaledb_config.bgw_job (
-    id,
-    application_name,
-    schedule_interval,
-    max_runtime,
-    max_retries,
-    retry_period,
-    proc_schema,
-    proc_name,
-    owner,
-    scheduled,
-    config,
-    check_schema,
-    check_name,
-    fixed_schedule,
-    initial_start
-)
-VALUES
-(
-    2,
-    'Error Log Retention Policy [2]',
-    INTERVAL '1 month',
-    INTERVAL '1 hour',
-    -1,
-    INTERVAL '1h',
-    '_timescaledb_functions',
-    'policy_job_error_retention',
-    pg_catalog.quote_ident(current_role)::regrole,
-    false,
-    '{"drop_after":"1 month"}',
-    '_timescaledb_functions',
-    'policy_job_error_retention_check',
-    false,
-    '2000-01-01 00:00:00+00'::timestamptz
-) ON CONFLICT (id) DO NOTHING;
-
-
 INSERT INTO _timescaledb_config.bgw_job (
     id,
     application_name,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,6 @@
+-- remove obsolete job
+DELETE FROM _timescaledb_config.bgw_job WHERE id = 2;
+
 -- Hypercore updates
 CREATE FUNCTION _timescaledb_debug.is_compressed_tid(tid) RETURNS BOOL
 AS '@MODULE_PATHNAME@', 'ts_update_placeholder' LANGUAGE C STRICT;


### PR DESCRIPTION
policy_job_error_retention was removed in 2.15.0 but we did not get rid of the job that called it back then. This patch removes the defunct job definition calling that function.

Fixes #7375 

Disable-check: approval-count
