### PR TITLE
Remove custom hashagg code

### DIFF
--- a/.unreleased/pr_7390
+++ b/.unreleased/pr_7390
@@ -1,0 +1,1 @@
+Implements: #7390 Disable custom hashagg planner code

--- a/src/guc.c
+++ b/src/guc.c
@@ -135,6 +135,7 @@ TSDLLEXPORT bool ts_guc_enable_compression_wal_markers = false;
 TSDLLEXPORT bool ts_guc_enable_decompression_sorted_merge = true;
 bool ts_guc_enable_chunkwise_aggregation = true;
 bool ts_guc_enable_vectorized_aggregation = true;
+bool ts_guc_enable_custom_hashagg = false;
 TSDLLEXPORT bool ts_guc_enable_compression_indexscan = false;
 TSDLLEXPORT bool ts_guc_enable_bulk_decompression = true;
 TSDLLEXPORT bool ts_guc_auto_sparse_indexes = true;
@@ -753,6 +754,17 @@ _guc_init(void)
 							 " chunk level",
 							 &ts_guc_enable_chunkwise_aggregation,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_custom_hashagg"),
+							 "Enable custom hash aggregation",
+							 "Enable creating custom hash aggregation plans",
+							 &ts_guc_enable_custom_hashagg,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -44,6 +44,7 @@ extern TSDLLEXPORT bool ts_guc_enable_decompression_sorted_merge;
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan;
 extern TSDLLEXPORT bool ts_guc_enable_chunkwise_aggregation;
 extern TSDLLEXPORT bool ts_guc_enable_vectorized_aggregation;
+extern TSDLLEXPORT bool ts_guc_enable_custom_hashagg;
 extern bool ts_guc_restoring;
 extern int ts_guc_max_open_chunks_per_insert;
 extern int ts_guc_max_cached_chunks_per_hypertable;

--- a/src/planner/add_hashagg.c
+++ b/src/planner/add_hashagg.c
@@ -142,6 +142,10 @@ ts_plan_add_hashagg(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output
 	PathTarget *target = root->upper_targets[UPPERREL_GROUP_AGG];
 	bool try_parallel_aggregation;
 
+	/* Custom HashAgg is disabled by default */
+	if (!ts_guc_enable_custom_hashagg)
+		return;
+
 	if (parse->groupingSets || !parse->hasAggs || parse->groupClause == NIL)
 		return;
 

--- a/test/expected/parallel-14.out
+++ b/test/expected/parallel-14.out
@@ -70,21 +70,22 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
-                     ->  Result
-                           ->  Append
-                                 ->  Seq Scan on _hyper_1_1_chunk
-                                 ->  Seq Scan on _hyper_1_2_chunk
-(12 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                           ->  Result
+                                 ->  Parallel Append
+                                       ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Parallel Seq Scan on _hyper_1_2_chunk
+(13 rows)
 
 -- test single copy parallel plan with parallel chunk append
 :PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -93,27 +94,28 @@ WHERE length(version()) > 0
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, test.ts)
-                     ->  Result
-                           One-Time Filter: (length(version()) > 0)
-                           ->  Custom Scan (ChunkAppend) on test
-                                 Chunks excluded during startup: 0
-                                 ->  Result
-                                       One-Time Filter: (length(version()) > 0)
-                                       ->  Seq Scan on _hyper_1_1_chunk
-                                 ->  Result
-                                       One-Time Filter: (length(version()) > 0)
-                                       ->  Seq Scan on _hyper_1_2_chunk
-(18 rows)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
+                           ->  Result
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Custom Scan (ChunkAppend) on test
+                                       Chunks excluded during startup: 0
+                                       ->  Result
+                                             One-Time Filter: (length(version()) > 0)
+                                             ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Result
+                                             One-Time Filter: (length(version()) > 0)
+                                             ->  Parallel Seq Scan on _hyper_1_2_chunk
+(19 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"

--- a/test/expected/parallel-15.out
+++ b/test/expected/parallel-15.out
@@ -70,21 +70,22 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
-                     ->  Result
-                           ->  Append
-                                 ->  Seq Scan on _hyper_1_1_chunk
-                                 ->  Seq Scan on _hyper_1_2_chunk
-(12 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                           ->  Result
+                                 ->  Parallel Append
+                                       ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Parallel Seq Scan on _hyper_1_2_chunk
+(13 rows)
 
 -- test single copy parallel plan with parallel chunk append
 :PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -93,28 +94,29 @@ WHERE length(version()) > 0
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, test.ts)
-                     ->  Result
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
                            ->  Result
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Custom Scan (ChunkAppend) on test
-                                       Chunks excluded during startup: 0
-                                       ->  Result
-                                             One-Time Filter: (length(version()) > 0)
-                                             ->  Seq Scan on _hyper_1_1_chunk
-                                       ->  Result
-                                             One-Time Filter: (length(version()) > 0)
-                                             ->  Seq Scan on _hyper_1_2_chunk
-(19 rows)
+                                 ->  Result
+                                       One-Time Filter: (length(version()) > 0)
+                                       ->  Parallel Custom Scan (ChunkAppend) on test
+                                             Chunks excluded during startup: 0
+                                             ->  Result
+                                                   One-Time Filter: (length(version()) > 0)
+                                                   ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                             ->  Result
+                                                   One-Time Filter: (length(version()) > 0)
+                                                   ->  Parallel Seq Scan on _hyper_1_2_chunk
+(20 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"

--- a/test/expected/parallel-16.out
+++ b/test/expected/parallel-16.out
@@ -70,21 +70,22 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
-                     ->  Result
-                           ->  Append
-                                 ->  Seq Scan on _hyper_1_1_chunk
-                                 ->  Seq Scan on _hyper_1_2_chunk
-(12 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                           ->  Result
+                                 ->  Parallel Append
+                                       ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Parallel Seq Scan on _hyper_1_2_chunk
+(13 rows)
 
 -- test single copy parallel plan with parallel chunk append
 :PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -93,28 +94,29 @@ WHERE length(version()) > 0
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, test.ts)
-                     ->  Result
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
                            ->  Result
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Custom Scan (ChunkAppend) on test
-                                       Chunks excluded during startup: 0
-                                       ->  Result
-                                             One-Time Filter: (length(version()) > 0)
-                                             ->  Seq Scan on _hyper_1_1_chunk
-                                       ->  Result
-                                             One-Time Filter: (length(version()) > 0)
-                                             ->  Seq Scan on _hyper_1_2_chunk
-(19 rows)
+                                 ->  Result
+                                       One-Time Filter: (length(version()) > 0)
+                                       ->  Parallel Custom Scan (ChunkAppend) on test
+                                             Chunks excluded during startup: 0
+                                             ->  Result
+                                                   One-Time Filter: (length(version()) > 0)
+                                                   ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                             ->  Result
+                                                   One-Time Filter: (length(version()) > 0)
+                                                   ->  Parallel Seq Scan on _hyper_1_2_chunk
+(20 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"

--- a/test/expected/parallel-17.out
+++ b/test/expected/parallel-17.out
@@ -70,21 +70,22 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
-                     ->  Result
-                           ->  Append
-                                 ->  Seq Scan on _hyper_1_1_chunk
-                                 ->  Seq Scan on _hyper_1_2_chunk
-(12 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+                           ->  Result
+                                 ->  Parallel Append
+                                       ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Parallel Seq Scan on _hyper_1_2_chunk
+(13 rows)
 
 -- test single copy parallel plan with parallel chunk append
 :PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -93,28 +94,29 @@ WHERE length(version()) > 0
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
-               ->  HashAggregate
-                     Group Key: time_bucket('@ 1 sec'::interval, test.ts)
-                     ->  Result
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit
+   ->  Finalize GroupAggregate
+         Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Partial GroupAggregate
+                     Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
                            ->  Result
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Custom Scan (ChunkAppend) on test
-                                       Chunks excluded during startup: 0
-                                       ->  Result
-                                             One-Time Filter: (length(version()) > 0)
-                                             ->  Seq Scan on _hyper_1_1_chunk
-                                       ->  Result
-                                             One-Time Filter: (length(version()) > 0)
-                                             ->  Seq Scan on _hyper_1_2_chunk
-(19 rows)
+                                 ->  Result
+                                       One-Time Filter: (length(version()) > 0)
+                                       ->  Parallel Custom Scan (ChunkAppend) on test
+                                             Chunks excluded during startup: 0
+                                             ->  Result
+                                                   One-Time Filter: (length(version()) > 0)
+                                                   ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                             ->  Result
+                                                   One-Time Filter: (length(version()) > 0)
+                                                   ->  Parallel Seq Scan on _hyper_1_2_chunk
+(20 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"

--- a/test/expected/plan_hashagg-14.out
+++ b/test/expected/plan_hashagg-14.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+SET max_parallel_workers_per_gather TO 0;
 \set PREFIX 'EXPLAIN (costs off) '
 \ir include/plan_hashagg_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
@@ -29,40 +30,32 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 EXPLAIN (costs off) SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 -- Test partitioning function on an open (time) dimension
 CREATE OR REPLACE FUNCTION unix_to_timestamp(unixtime float8)
@@ -93,10 +86,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -109,10 +102,10 @@ GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.metricid
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -124,20 +117,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -146,10 +135,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -162,10 +151,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -178,10 +167,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -192,20 +181,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
-               ->  Partial HashAggregate
-                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -214,10 +199,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -230,20 +215,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 \set ON_ERROR_STOP 1
 :PREFIX SELECT date_trunc('day', time_date) AS MetricMinuteTs, AVG(value) as avg
@@ -251,20 +232,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
-               ->  Partial HashAggregate
-                     Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 --joins
 --with hypertable, optimize
@@ -276,10 +253,10 @@ GROUP BY MetricMinuteTs, metric.id
 ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
-   ->  HashAggregate
-         Group Key: time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint), metric.id
+ GroupAggregate
+   Group Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)), metric.id
+   ->  Sort
+         Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
          ->  Hash Join
                Hash Cond: (_hyper_1_1_chunk.metricid = metric.id)
                ->  Seq Scan on _hyper_1_1_chunk

--- a/test/expected/plan_hashagg-15.out
+++ b/test/expected/plan_hashagg-15.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+SET max_parallel_workers_per_gather TO 0;
 \set PREFIX 'EXPLAIN (costs off) '
 \ir include/plan_hashagg_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
@@ -29,40 +30,32 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 EXPLAIN (costs off) SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 -- Test partitioning function on an open (time) dimension
 CREATE OR REPLACE FUNCTION unix_to_timestamp(unixtime float8)
@@ -93,10 +86,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -109,10 +102,10 @@ GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.metricid
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -124,20 +117,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -146,10 +135,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -162,10 +151,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -178,10 +167,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -192,20 +181,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
-               ->  Partial HashAggregate
-                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -214,10 +199,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -230,20 +215,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 \set ON_ERROR_STOP 1
 :PREFIX SELECT date_trunc('day', time_date) AS MetricMinuteTs, AVG(value) as avg
@@ -251,20 +232,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
-               ->  Partial HashAggregate
-                     Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 --joins
 --with hypertable, optimize
@@ -276,10 +253,10 @@ GROUP BY MetricMinuteTs, metric.id
 ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
-   ->  HashAggregate
-         Group Key: time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint), metric.id
+ GroupAggregate
+   Group Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)), metric.id
+   ->  Sort
+         Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
          ->  Hash Join
                Hash Cond: (_hyper_1_1_chunk.metricid = metric.id)
                ->  Seq Scan on _hyper_1_1_chunk

--- a/test/expected/plan_hashagg-16.out
+++ b/test/expected/plan_hashagg-16.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+SET max_parallel_workers_per_gather TO 0;
 \set PREFIX 'EXPLAIN (costs off) '
 \ir include/plan_hashagg_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
@@ -29,40 +30,32 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 EXPLAIN (costs off) SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 -- Test partitioning function on an open (time) dimension
 CREATE OR REPLACE FUNCTION unix_to_timestamp(unixtime float8)
@@ -93,10 +86,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -109,10 +102,10 @@ GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.metricid
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -124,20 +117,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -146,10 +135,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -162,10 +151,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -178,10 +167,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -192,20 +181,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
-               ->  Partial HashAggregate
-                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -214,10 +199,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -230,20 +215,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 \set ON_ERROR_STOP 1
 :PREFIX SELECT date_trunc('day', time_date) AS MetricMinuteTs, AVG(value) as avg
@@ -251,20 +232,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
-               ->  Partial HashAggregate
-                     Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 --joins
 --with hypertable, optimize
@@ -276,10 +253,10 @@ GROUP BY MetricMinuteTs, metric.id
 ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
-   ->  HashAggregate
-         Group Key: time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint), metric.id
+ GroupAggregate
+   Group Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)), metric.id
+   ->  Sort
+         Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
          ->  Hash Join
                Hash Cond: (_hyper_1_1_chunk.metricid = metric.id)
                ->  Seq Scan on _hyper_1_1_chunk

--- a/test/expected/plan_hashagg-17.out
+++ b/test/expected/plan_hashagg-17.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+SET max_parallel_workers_per_gather TO 0;
 \set PREFIX 'EXPLAIN (costs off) '
 \ir include/plan_hashagg_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
@@ -29,40 +30,32 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 EXPLAIN (costs off) SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 -- Test partitioning function on an open (time) dimension
 CREATE OR REPLACE FUNCTION unix_to_timestamp(unixtime float8)
@@ -93,10 +86,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -109,10 +102,10 @@ GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.metricid
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 hour'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -124,20 +117,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs, metricid
 ORDER BY MetricMinuteTs DESC, metricid;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.metricid
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.metricid
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -146,10 +135,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)
+ GroupAggregate
+   Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -162,10 +151,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -178,10 +167,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
-   ->  HashAggregate
-         Group Key: time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)
+ GroupAggregate
+   Group Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint))
+   ->  Sort
+         Sort Key: (time_bucket('60'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -192,20 +181,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
-               ->  Partial HashAggregate
-                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)) DESC
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.time_date)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 :PREFIX SELECT date_trunc('minute', time) AS MetricMinuteTs, AVG(value) as avg
 FROM hyper
@@ -214,10 +199,10 @@ GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-   ->  HashAggregate
-         Group Key: date_trunc('minute'::text, _hyper_1_1_chunk."time")
+ GroupAggregate
+   Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
          ->  Result
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
@@ -230,20 +215,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
    Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Partial GroupAggregate
-               Group Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time"))
-               ->  Sort
-                     Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+   ->  Sort
+         Sort Key: (date_trunc('invalid'::text, _hyper_1_1_chunk."time")) DESC
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 \set ON_ERROR_STOP 1
 :PREFIX SELECT date_trunc('day', time_date) AS MetricMinuteTs, AVG(value) as avg
@@ -251,20 +232,16 @@ FROM hyper
 WHERE time >= '2001-01-04T00:00:00' AND time <= '2001-01-05T01:00:00'
 GROUP BY MetricMinuteTs
 ORDER BY MetricMinuteTs DESC;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone))
-   ->  Gather Merge
-         Workers Planned: 2
-         ->  Sort
-               Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
-               ->  Partial HashAggregate
-                     Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
-                     ->  Result
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                 Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
-(11 rows)
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)) DESC
+   ->  HashAggregate
+         Group Key: date_trunc('day'::text, (_hyper_1_1_chunk.time_date)::timestamp with time zone)
+         ->  Result
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (("time" >= 'Thu Jan 04 00:00:00 2001'::timestamp without time zone) AND ("time" <= 'Fri Jan 05 01:00:00 2001'::timestamp without time zone))
+(7 rows)
 
 --joins
 --with hypertable, optimize
@@ -276,10 +253,10 @@ GROUP BY MetricMinuteTs, metric.id
 ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
-   ->  HashAggregate
-         Group Key: time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint), metric.id
+ GroupAggregate
+   Group Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)), metric.id
+   ->  Sort
+         Sort Key: (time_bucket('3600'::bigint, _hyper_1_1_chunk.time_int, '10'::bigint)) DESC, metric.id
          ->  Hash Join
                Hash Cond: (_hyper_1_1_chunk.metricid = metric.id)
                ->  Seq Scan on _hyper_1_1_chunk

--- a/test/sql/plan_hashagg.sql.in
+++ b/test/sql/plan_hashagg.sql.in
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+SET max_parallel_workers_per_gather TO 0;
+
 \set PREFIX 'EXPLAIN (costs off) '
 \ir include/plan_hashagg_load.sql
 \ir include/plan_hashagg_query.sql
@@ -15,6 +17,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
+
 
 SET client_min_messages TO error;
 --generate the results into two different files


### PR DESCRIPTION
In the past postgres would not create hashagg plans due to costing. This has been fixed upstream a couple major versions ago and this code is no longer required.

Disable-check: approval-count
