### PR TITLE
Disable autovacuum on TSL regression tests

### DIFF
--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -1,6 +1,6 @@
 # This section has to be equivalent to test/postgresql.conf
 
-autovacuum=true
+autovacuum=false
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'


### PR DESCRIPTION
We disable autovacuum on Apache regression tests to avoid flaky results and time to time we face some issues on TSL regression tests as well.

https://github.com/timescale/timescaledb/actions/runs/11470614522/job/31920227424#step:12:43

Disable-check: force-changelog-file
Disable-check: approval-count
