### PR TITLE
Reenable autovacuum in CI

### DIFF
--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -1,7 +1,7 @@
 # NOTE: any changes here require changes to tsl/test/postgresql.conf. Its prefix
 # must be the same as this file.
 
-autovacuum=false
+autovacuum=true
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -1,6 +1,6 @@
 # This section has to be equivalent to test/postgresql.conf
 
-autovacuum=false
+autovacuum=true
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'


### PR DESCRIPTION
We want to run autovacuum in CI to find bugs with our own code when parallel vacuum is happening.

Disable-check: force-changelog-file
Disable-check: approval-count

