### PR TITLE
Update bgw job table when altering procedure

### DIFF
--- a/.unreleased/pr_7409
+++ b/.unreleased/pr_7409
@@ -1,0 +1,1 @@
+Fixes: #7409 Update bgw job table when altering procedure

--- a/tsl/test/expected/bgw_job_ddl.out
+++ b/tsl/test/expected/bgw_job_ddl.out
@@ -2,6 +2,12 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Test for DDL-like functionality
+CREATE VIEW my_jobs AS
+SELECT proc_schema, proc_name, owner
+  FROM _timescaledb_config.bgw_job
+ WHERE id >= 1000
+ORDER BY proc_schema, proc_name, owner;
+GRANT SELECT ON my_jobs TO PUBLIC;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE OR REPLACE FUNCTION insert_job(
        application_name NAME,
@@ -18,14 +24,26 @@ $$
   retry_period,proc_name,proc_schema,owner,scheduled,fixed_schedule)
   VALUES($1,$3,$4,5,$5,$2,'public',$6,$7,$8) RETURNING id;
 $$;
+CREATE PROCEDURE more_magic(job_id INT, config jsonb) LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE NOTICE 'done';
+END;
+$$;
+CREATE PROCEDURE some_magic(job_id INT, config jsonb) LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE NOTICE 'done';
+END;
+$$;
 CREATE USER another_user;
 SET ROLE another_user;
-SELECT insert_job('another_one', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS job_id \gset
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-   proc_name    |    owner     
-----------------+--------------
- bgw_test_job_1 | another_user
-(1 row)
+SELECT insert_job('one_job', 'some_magic', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS job_id_2 \gset
+SELECT insert_job('another_one', 'more_magic', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS job_id \gset
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |    owner     
+-------------+------------+--------------
+ public      | more_magic | another_user
+ public      | some_magic | another_user
+(2 rows)
 
 -- Test that reassigning to another user privileges does not work for
 -- a normal user. We test both users with superuser privileges and
@@ -39,53 +57,134 @@ ERROR:  permission denied to reassign objects
 RESET ROLE;
 -- Test that renaming a user changes keeps the job assigned to that user.
 ALTER USER another_user RENAME TO renamed_user;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-   proc_name    |    owner     
-----------------+--------------
- bgw_test_job_1 | renamed_user
-(1 row)
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |    owner     
+-------------+------------+--------------
+ public      | more_magic | renamed_user
+ public      | some_magic | renamed_user
+(2 rows)
 
+-- Test that renaming the procedure also modifies the entry in the
+-- jobs table.
+ALTER PROCEDURE more_magic RENAME TO magic;
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |    owner     
+-------------+------------+--------------
+ public      | magic      | renamed_user
+ public      | some_magic | renamed_user
+(2 rows)
+
+-- Test that modifying the schema also modifies the entry in the jobs
+-- table.
+CREATE SCHEMA frugal;
+ALTER PROCEDURE magic SET SCHEMA frugal;
+ALTER PROCEDURE some_magic SET SCHEMA frugal;
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |    owner     
+-------------+------------+--------------
+ frugal      | magic      | renamed_user
+ frugal      | some_magic | renamed_user
+(2 rows)
+
+-- Test that renaming the schema will rename the procedure schema
+START TRANSACTION;
+ALTER SCHEMA frugal RENAME TO wicked;
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |    owner     
+-------------+------------+--------------
+ wicked      | magic      | renamed_user
+ wicked      | some_magic | renamed_user
+(2 rows)
+
+ROLLBACK;
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |    owner     
+-------------+------------+--------------
+ frugal      | magic      | renamed_user
+ frugal      | some_magic | renamed_user
+(2 rows)
+
 -- Test that dropping a user owning a job fails.
 DROP USER renamed_user;
 ERROR:  role "renamed_user" cannot be dropped because some objects depend on it
-DETAIL:  owner of job 1000
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-   proc_name    |    owner     
-----------------+--------------
- bgw_test_job_1 | renamed_user
-(1 row)
-
+DETAIL:  owner of job 1001
+-- Test that dropping the procedure fails since there is a background
+-- job using it.
+DROP PROCEDURE frugal.magic;
+ERROR:  cannot drop frugal.magic because background job 1001 depends on it
+HINT:  Use delete_job() to drop the job first.
 -- Test that re-assigning objects owned by an unknown user still fails
 REASSIGN OWNED BY renamed_user, unknown_user TO :ROLE_DEFAULT_PERM_USER;
 ERROR:  role "unknown_user" does not exist
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-   proc_name    |    owner     
-----------------+--------------
- bgw_test_job_1 | renamed_user
-(1 row)
-
+-- Test that dropping the schema without CASCADE will error out
+DROP SCHEMA frugal;
+ERROR:  cannot drop schema frugal because other objects depend on it
+DETAIL:  function frugal.magic(integer,jsonb) depends on schema frugal
+function frugal.some_magic(integer,jsonb) depends on schema frugal
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 \set ON_ERROR_STOP 1
 -- Test that reassigning the owned job actually changes the owner of
 -- the job.
 START TRANSACTION;
 REASSIGN OWNED BY renamed_user TO :ROLE_DEFAULT_PERM_USER;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-   proc_name    |       owner       
-----------------+-------------------
- bgw_test_job_1 | default_perm_user
-(1 row)
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |       owner       
+-------------+------------+-------------------
+ frugal      | magic      | default_perm_user
+ frugal      | some_magic | default_perm_user
+(2 rows)
 
 ROLLBACK;
 -- Test that reassigning to postgres works
 REASSIGN OWNED BY renamed_user TO :ROLE_CLUSTER_SUPERUSER;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-   proc_name    |       owner        
-----------------+--------------------
- bgw_test_job_1 | cluster_super_user
-(1 row)
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |       owner        
+-------------+------------+--------------------
+ frugal      | magic      | cluster_super_user
+ frugal      | some_magic | cluster_super_user
+(2 rows)
 
 -- Dropping the user now should work.
 DROP USER renamed_user;
+-- Dropping using Cascade should work and remove the background worker
+-- entry as well.
+START TRANSACTION;
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |       owner        
+-------------+------------+--------------------
+ frugal      | magic      | cluster_super_user
+ frugal      | some_magic | cluster_super_user
+(2 rows)
+
+DROP PROCEDURE frugal.magic CASCADE;
+NOTICE:  drop cascades to job 1001
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |       owner        
+-------------+------------+--------------------
+ frugal      | some_magic | cluster_super_user
+(1 row)
+
+ROLLBACK;
 DELETE FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+-- We should be able to drop the procedure without CASCADE now since
+-- it is not used by any job.
+DROP PROCEDURE frugal.magic;
+-- We should be able to drop the schema with CASCADE despite
+-- containing a procedure used by a background worker, but this should
+-- remove the job from the background worker table.
+SELECT * FROM my_jobs;
+ proc_schema | proc_name  |       owner        
+-------------+------------+--------------------
+ frugal      | some_magic | cluster_super_user
+(1 row)
+
+DROP SCHEMA frugal CASCADE;
+NOTICE:  drop cascades to job 1000
+NOTICE:  drop cascades to function frugal.some_magic(integer,jsonb)
+SELECT * FROM my_jobs;
+ proc_schema | proc_name | owner 
+-------------+-----------+-------
+(0 rows)
+

--- a/tsl/test/sql/bgw_job_ddl.sql
+++ b/tsl/test/sql/bgw_job_ddl.sql
@@ -4,6 +4,14 @@
 
 -- Test for DDL-like functionality
 
+CREATE VIEW my_jobs AS
+SELECT proc_schema, proc_name, owner
+  FROM _timescaledb_config.bgw_job
+ WHERE id >= 1000
+ORDER BY proc_schema, proc_name, owner;
+
+GRANT SELECT ON my_jobs TO PUBLIC;
+
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE OR REPLACE FUNCTION insert_job(
        application_name NAME,
@@ -21,12 +29,25 @@ $$
   VALUES($1,$3,$4,5,$5,$2,'public',$6,$7,$8) RETURNING id;
 $$;
 
+CREATE PROCEDURE more_magic(job_id INT, config jsonb) LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE NOTICE 'done';
+END;
+$$;
+
+CREATE PROCEDURE some_magic(job_id INT, config jsonb) LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE NOTICE 'done';
+END;
+$$;
+
 CREATE USER another_user;
 
 SET ROLE another_user;
-SELECT insert_job('another_one', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS job_id \gset
+SELECT insert_job('one_job', 'some_magic', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS job_id_2 \gset
+SELECT insert_job('another_one', 'more_magic', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS job_id \gset
 
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+SELECT * FROM my_jobs;
 
 -- Test that reassigning to another user privileges does not work for
 -- a normal user. We test both users with superuser privileges and
@@ -40,18 +61,43 @@ RESET ROLE;
 
 -- Test that renaming a user changes keeps the job assigned to that user.
 ALTER USER another_user RENAME TO renamed_user;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+SELECT * FROM my_jobs;
+
+-- Test that renaming the procedure also modifies the entry in the
+-- jobs table.
+ALTER PROCEDURE more_magic RENAME TO magic;
+SELECT * FROM my_jobs;
+
+-- Test that modifying the schema also modifies the entry in the jobs
+-- table.
+CREATE SCHEMA frugal;
+ALTER PROCEDURE magic SET SCHEMA frugal;
+ALTER PROCEDURE some_magic SET SCHEMA frugal;
+SELECT * FROM my_jobs;
+
+-- Test that renaming the schema will rename the procedure schema
+START TRANSACTION;
+ALTER SCHEMA frugal RENAME TO wicked;
+SELECT * FROM my_jobs;
+ROLLBACK;
 
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 
+SELECT * FROM my_jobs;
+
 -- Test that dropping a user owning a job fails.
 DROP USER renamed_user;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+
+-- Test that dropping the procedure fails since there is a background
+-- job using it.
+DROP PROCEDURE frugal.magic;
 
 -- Test that re-assigning objects owned by an unknown user still fails
 REASSIGN OWNED BY renamed_user, unknown_user TO :ROLE_DEFAULT_PERM_USER;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+
+-- Test that dropping the schema without CASCADE will error out
+DROP SCHEMA frugal;
 
 \set ON_ERROR_STOP 1
 
@@ -59,16 +105,33 @@ SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
 -- the job.
 START TRANSACTION;
 REASSIGN OWNED BY renamed_user TO :ROLE_DEFAULT_PERM_USER;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+SELECT * FROM my_jobs;
 ROLLBACK;
 
 -- Test that reassigning to postgres works
 REASSIGN OWNED BY renamed_user TO :ROLE_CLUSTER_SUPERUSER;
-SELECT proc_name, owner FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+SELECT * FROM my_jobs;
 
 -- Dropping the user now should work.
 DROP USER renamed_user;
 
+-- Dropping using Cascade should work and remove the background worker
+-- entry as well.
+START TRANSACTION;
+SELECT * FROM my_jobs;
+DROP PROCEDURE frugal.magic CASCADE;
+SELECT * FROM my_jobs;
+ROLLBACK;
+
 DELETE FROM _timescaledb_config.bgw_job WHERE id = :job_id;
 
+-- We should be able to drop the procedure without CASCADE now since
+-- it is not used by any job.
+DROP PROCEDURE frugal.magic;
 
+-- We should be able to drop the schema with CASCADE despite
+-- containing a procedure used by a background worker, but this should
+-- remove the job from the background worker table.
+SELECT * FROM my_jobs;
+DROP SCHEMA frugal CASCADE;
+SELECT * FROM my_jobs;


### PR DESCRIPTION
This deals with the following modifications to the name of a procedure 
used by a background job:

- If a procedure that exists in the jobs table is renamed, the corresponding names in the table will also be changed.
- When a procedure that is used for a background worker job is moved to a different schema, modify the job entry as well.
- When a schema is renamed, rename the schema name in the procedures as well.
- When a schema is dropped and there are procedures used by jobs, it will either remove the entry or throw an error, depending on whether `CASCADE` or `RESTRICT` is in effect.
- When a procedure or function used by a job is dropped, it will error out or delete the job depending on whether `CASCADE` or `RESTRICT` is in effect.