### PR TITLE
Add GUC for segmentwise recompression

### DIFF
--- a/.unreleased/pr_7413
+++ b/.unreleased/pr_7413
@@ -1,0 +1,1 @@
+Implements: #7413: Add GUC for segmentwise recompression.

--- a/src/guc.c
+++ b/src/guc.c
@@ -139,6 +139,7 @@ TSDLLEXPORT bool ts_guc_enable_compression_indexscan = false;
 TSDLLEXPORT bool ts_guc_enable_bulk_decompression = true;
 TSDLLEXPORT bool ts_guc_auto_sparse_indexes = true;
 bool ts_guc_enable_chunk_skipping = false;
+TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
@@ -697,6 +698,17 @@ _guc_init(void)
 							 "filters",
 							 &ts_guc_enable_chunk_skipping,
 							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_segmentwise_recompression"),
+							 "Enable segmentwise recompression functionality",
+							 "Enable segmentwise recompression",
+							 &ts_guc_enable_segmentwise_recompression,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -52,6 +52,7 @@ extern bool ts_guc_enable_tss_callbacks;
 extern TSDLLEXPORT bool ts_guc_enable_delete_after_compression;
 extern TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh;
 extern bool ts_guc_enable_chunk_skipping;
+extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -593,3 +593,36 @@ select * from :compressed_chunk_name;
               2 | 1 |   | Sat Jan 01 01:00:00 2022 PST | Sat Jan 01 01:00:00 2022 PST | BAAAAneAR/JEAAAAAAAAAAAAAAAAAgAAAAIAAAAAAAAA7gAE7wCP5IgAAATvAI/kh/8= | BAEAAAAAAAAABAAAAAAAAAAEAAAAAQAAAAEAAAAAAAAABAAAAAAAAAAIAAAAAgAAAAEAAAAAAAAAAQAAAAAAAAAB
 (5 rows)
 
+--- Test behaviour when enable_segmentwise_recompression GUC if OFF
+CREATE TABLE guc_test(time timestamptz not null, a int, b int, c int);
+SELECT create_hypertable('guc_test', by_range('time', INTERVAL '1 day'));
+ create_hypertable 
+-------------------
+ (18,t)
+(1 row)
+
+ALTER TABLE guc_test set (timescaledb.compress, timescaledb.compress_segmentby = 'a, b');
+NOTICE:  default order by for hypertable "guc_test" is set to ""time" DESC"
+INSERT INTO guc_test VALUES ('2024-10-30 14:04:00.501519-06'::timestamptz, 1, 1, 1);
+SELECT show_chunks as chunk_to_compress FROM show_chunks('guc_test') LIMIT 1 \gset
+SELECT compress_chunk(:'chunk_to_compress');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_18_20_chunk
+(1 row)
+
+INSERT INTO guc_test VALUES ('2024-10-30 14:14:00.501519-06'::timestamptz, 1, 1, 2);
+-- When GUC is OFF, recompress function should throw an error
+SET timescaledb.enable_segmentwise_recompression TO OFF;
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+ERROR:  segmentwise recompression functionality disabled, enable it by first setting timescaledb.enable_segmentwise_recompression to on
+\set ON_ERROR_STOP 1
+-- When GUC is OFF, entire chunk should be fully uncompressed and compressed instead
+SELECT compress_chunk(:'chunk_to_compress');
+NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_18_20_chunk"
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_18_20_chunk
+(1 row)
+


### PR DESCRIPTION
Add GUC option to enable or disable segmentwise recompression. If disabled, then a full recompression is done instead when recompression is attempted through `compress_chunk`. If `recompress_chunk_segmentwise` is used when GUC is disabled, then an error is thrown.

Closes #7381.