### PR TITLE
Use America/Los_Angeles in tests instead of PST8PDT

### DIFF
--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timezone TO 'America/Los_Angeles';
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 CREATE TABLE continuous_agg_test(time int, data int);
 SELECT create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
@@ -75,7 +74,6 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO 'America/Los_Angeles';
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
@@ -349,7 +347,6 @@ UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
 SET watermark = 2
 WHERE hypertable_id = 5;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO 'America/Los_Angeles';
 INSERT INTO ts_continuous_test VALUES (1, 1);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 CREATE TABLE continuous_agg_test(time int, data int);
 SELECT create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
@@ -75,7 +75,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
@@ -349,7 +349,7 @@ UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
 SET watermark = 2
 WHERE hypertable_id = 5;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 INSERT INTO ts_continuous_test VALUES (1, 1);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(
  RETURNS VOID
     AS :TSL_MODULE_PATHNAME, 'ts_test_merge_chunks_on_dimension' LANGUAGE C VOLATILE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
 SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
 NOTICE:  adding not-null constraint to column "Time"

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 SET timescaledb.enable_transparent_decompression to OFF;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 \ir include/rand_generator.sql
 -- This file and its contents are licensed under the Timescale License.
@@ -1498,7 +1498,7 @@ SET reltuples = 0, relpages = 0
   WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id
         AND ch.compressed_chunk_id > 0 );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE has been run
 SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, relpages, relallvisible FROM pg_class
  WHERE relname in ( SELECT ch.table_name FROM

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -7,7 +7,7 @@ CREATE ROLE NOLOGIN_ROLE WITH nologin noinherit;
 GRANT CREATE ON SCHEMA public TO NOLOGIN_ROLE;
 GRANT NOLOGIN_ROLE TO :ROLE_DEFAULT_PERM_USER WITH ADMIN OPTION;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE TABLE conditions (
       time        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,
@@ -287,7 +287,7 @@ ERROR:  permission denied to start background process as role "nologin_role"
 DROP TABLE test_table_nologin;
 RESET ROLE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE TABLE conditions(
     time TIMESTAMPTZ NOT NULL,
     device INTEGER,

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -30,7 +30,7 @@ SET client_min_messages = NOTICE;
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
 CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
 NOTICE:  adding not-null constraint to column "Time"
@@ -563,7 +563,7 @@ SELECT count(*) FROM test1_cont_view;
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 \set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 \set ANALYZE  'EXPLAIN (analyze, costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -755,7 +755,6 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -755,7 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -755,7 +755,6 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -755,7 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -755,7 +755,6 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -755,7 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -755,7 +755,6 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -755,7 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/feature_flags.out
+++ b/tsl/test/expected/feature_flags.out
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- hypertable creation
 SHOW timescaledb.enable_hypertable_create;
  timescaledb.enable_hypertable_create 

--- a/tsl/test/expected/information_view_chunk_count.out
+++ b/tsl/test/expected/information_view_chunk_count.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE TABLE sensor_data(
 time timestamptz not null,
 sensor_id integer not null,

--- a/tsl/test/expected/jit.out
+++ b/tsl/test/expected/jit.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 \set TEST_BASE_NAME jit
 SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
        format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",

--- a/tsl/test/expected/size_utils_tsl.out
+++ b/tsl/test/expected/size_utils_tsl.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- Prepare test data for continuous aggregate size function tests
 CREATE TABLE hypersize(time timestamptz, device int);
 SELECT * FROM create_hypertable('hypersize', 'time');

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 --telemetry tests that require a community license
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- function call info size is too variable for this test, so disable it
 SET timescaledb.telemetry_level='no_functions';
 SELECT setseed(1);

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -9,7 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- disable memoize node to avoid flaky results
 SET enable_memoize TO 'off';
 CREATE TABLE metrics (
@@ -171,7 +171,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -9,7 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- disable memoize node to avoid flaky results
 SET enable_memoize TO 'off';
 CREATE TABLE metrics (
@@ -171,7 +171,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -9,7 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- disable memoize node to avoid flaky results
 SET enable_memoize TO 'off';
 CREATE TABLE metrics (
@@ -171,7 +171,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -9,7 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 -- disable memoize node to avoid flaky results
 SET enable_memoize TO 'off';
 CREATE TABLE metrics (
@@ -171,7 +171,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/sql/cagg_watermark.sql
+++ b/tsl/test/sql/cagg_watermark.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 
@@ -46,7 +46,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 
@@ -187,7 +187,7 @@ SET watermark = 2
 WHERE hypertable_id = 5;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 INSERT INTO ts_continuous_test VALUES (1, 1);
 

--- a/tsl/test/sql/cagg_watermark.sql
+++ b/tsl/test/sql/cagg_watermark.sql
@@ -2,8 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timezone TO 'America/Los_Angeles';
-
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 
 CREATE TABLE continuous_agg_test(time int, data int);
@@ -45,8 +43,6 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-
-SET timezone TO 'America/Los_Angeles';
 
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 
@@ -186,8 +182,6 @@ UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
 SET watermark = 2
 WHERE hypertable_id = 5;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-
-SET timezone TO 'America/Los_Angeles';
 
 INSERT INTO ts_continuous_test VALUES (1, 1);
 

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(
     AS :TSL_MODULE_PATHNAME, 'ts_test_merge_chunks_on_dimension' LANGUAGE C VOLATILE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
 SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 SET timescaledb.enable_transparent_decompression to OFF;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 
@@ -631,7 +631,7 @@ SET reltuples = 0, relpages = 0
         AND ch.compressed_chunk_id > 0 );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE has been run
 SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, relpages, relallvisible FROM pg_class

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -11,7 +11,7 @@ GRANT NOLOGIN_ROLE TO :ROLE_DEFAULT_PERM_USER WITH ADMIN OPTION;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CREATE TABLE conditions (
       time        TIMESTAMPTZ       NOT NULL,
@@ -166,7 +166,7 @@ RESET ROLE;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CREATE TABLE conditions(
     time TIMESTAMPTZ NOT NULL,

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -15,7 +15,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
@@ -358,7 +358,7 @@ SELECT count(*) FROM test1_cont_view;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 \set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 \set ANALYZE  'EXPLAIN (analyze, costs off, summary off, timing off) '

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -606,7 +606,6 @@ WHERE user_view_name = 'mat_drop_test'
 \gset
 
 SET client_min_messages TO NOTICE;
-SET timezone TO 'America/Los_Angeles';
 
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -606,7 +606,7 @@ WHERE user_view_name = 'mat_drop_test'
 \gset
 
 SET client_min_messages TO NOTICE;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 

--- a/tsl/test/sql/feature_flags.sql
+++ b/tsl/test/sql/feature_flags.sql
@@ -4,7 +4,7 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 -- hypertable creation
 SHOW timescaledb.enable_hypertable_create;

--- a/tsl/test/sql/information_view_chunk_count.sql
+++ b/tsl/test/sql/information_view_chunk_count.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CREATE TABLE sensor_data(
 time timestamptz not null,

--- a/tsl/test/sql/jit.sql
+++ b/tsl/test/sql/jit.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 \set TEST_BASE_NAME jit
 SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",

--- a/tsl/test/sql/size_utils_tsl.sql
+++ b/tsl/test/sql/size_utils_tsl.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 -- Prepare test data for continuous aggregate size function tests
 CREATE TABLE hypersize(time timestamptz, device int);

--- a/tsl/test/sql/telemetry_stats.sql
+++ b/tsl/test/sql/telemetry_stats.sql
@@ -5,7 +5,7 @@
 --telemetry tests that require a community license
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 -- function call info size is too variable for this test, so disable it
 SET timescaledb.telemetry_level='no_functions';

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -12,7 +12,7 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMP
 
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 -- disable memoize node to avoid flaky results
 SET enable_memoize TO 'off';
@@ -191,7 +191,7 @@ FROM _timescaledb_catalog.hypertable ht
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
-SET timezone TO PST8PDT;
+SET timezone TO 'America/Los_Angeles';
 
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 


### PR DESCRIPTION
Follow the PG upstream changes in light of the upcoming timezone updates. This should fix our regression tests on latest PG snapshots.

https://github.com/postgres/postgres/commit/2b94ee58bf256e1b4682f21f13d0f2c73e1b0cc2

Example of the failing test on main: https://github.com/timescale/timescaledb/actions/runs/11666186287/job/32480586544

Disable-check: force-changelog-file

test

