### PR TITLE
Adapt test result parser for latest pg_regress output

### DIFF
--- a/scripts/upload_ci_stats.sh
+++ b/scripts/upload_ci_stats.sh
@@ -94,6 +94,9 @@ then
     match($0, /^(test|    ) ([^ ]+)[ ]+\.\.\.[ ]+([^ ]+) (|\(.*\))[ ]+([0-9]+) ms$/, a) {
         print ENVIRON["JOB_DATE"], a[2], tolower(a[3] (a[4] ? (" " a[4]) : "")), a[5];
     }
+    match($0, /^([^0-9]+) [0-9]+ +- ([^ ]+) +([0-9]+) ms/, a) {
+    	print ENVIRON["JOB_DATE"], a[2], a[1], a[3];
+    }
     ' installcheck.log > tests.tsv
 
     # Save the test results into the database.


### PR DESCRIPTION
We only parsed the old format that is used up to PG15.

Disable-check: approval-count
Disable-check: force-changelog-file
