### PR TITLE
Ignore failure in upstream test jsonb_jsonpath

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -24,6 +24,7 @@ set(PG_IGNORE_TESTS
     amutils
     database
     event_trigger
+    jsonb_jsonpath
     opr_sanity
     sanity_check
     type_sanity


### PR DESCRIPTION
Until PG 17.1 is released.

Currently shows a diff in PG 17.0 regression run as:

```
select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');
  jsonb_path_query_tz
 ---------------------
- "12:34:56-07:00"
+ "12:34:56-08:00"
```

Disable-check: force-changelog-file