### PR TITLE
Ignore failure in upstream test jsonb_jsonpath

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -20,7 +20,8 @@ file(READ ${PG_REGRESS_DIR}/parallel_schedule PG_TEST_SCHEDULE)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testtablespace)
 
 # Tests to ignore
-set(PG_IGNORE_TESTS database event_trigger opr_sanity sanity_check type_sanity)
+set(PG_IGNORE_TESTS database event_trigger jsonb_jsonpath opr_sanity
+                    sanity_check type_sanity)
 
 # Modify the test schedule to ignore some tests
 foreach(IGNORE_TEST ${PG_IGNORE_TESTS})

--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -1,7 +1,7 @@
 # NOTE: any changes here require changes to tsl/test/postgresql.conf. Its prefix
 # must be the same as this file.
 
-autovacuum=true
+autovacuum=false
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -1,6 +1,6 @@
 # This section has to be equivalent to test/postgresql.conf
 
-autovacuum=true
+autovacuum=false
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'


### PR DESCRIPTION
Until PG 17.1 is released.

Currently shows a diff in PG 17.0 regression run as:

```
select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');
  jsonb_path_query_tz
 ---------------------
- "12:34:56-07:00"
+ "12:34:56-08:00"
```


Backport of https://github.com/timescale/timescaledb/pull/7419