### PR TITLE
Revert "Reenable autovacuum in CI" in 2.17.x

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -20,7 +20,8 @@ file(READ ${PG_REGRESS_DIR}/parallel_schedule PG_TEST_SCHEDULE)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testtablespace)
 
 # Tests to ignore
-set(PG_IGNORE_TESTS database event_trigger opr_sanity sanity_check type_sanity)
+set(PG_IGNORE_TESTS database event_trigger jsonb_jsonpath opr_sanity
+                    sanity_check type_sanity)
 
 # Modify the test schedule to ignore some tests
 foreach(IGNORE_TEST ${PG_IGNORE_TESTS})

--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -1,7 +1,7 @@
 # NOTE: any changes here require changes to tsl/test/postgresql.conf. Its prefix
 # must be the same as this file.
 
-autovacuum=true
+autovacuum=false
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -1,6 +1,6 @@
 # This section has to be equivalent to test/postgresql.conf
 
-autovacuum=true
+autovacuum=false
 datestyle='Postgres, MDY'
 hba_file='@TEST_PG_HBA_FILE@'
 log_destination='@TEST_PG_LOG_DESTINATION@'


### PR DESCRIPTION
This reverts commit 3130daa34f38e06b78b59ad3c092b87a64f592e4.

We will stabilize the CI after this commit in the main branch, for now it's preventing the release by making the tests too flaky.