### PR TITLE
Fix datetime parse error in chunk constraint creation

### DIFF
--- a/.unreleased/pr_7426
+++ b/.unreleased/pr_7426
@@ -1,0 +1,1 @@
+Fixes: #7426 Fix datetime parsing error in chunk constraint creation

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -330,9 +330,17 @@ create_dimension_check_constraint(const Dimension *dim, const DimensionSlice *sl
 		enddat = ts_internal_to_time_value(slice->fd.range_end, dim->fd.column_type);
 	}
 
-	/* Convert internal format datums to string (output) datums */
+	/*
+	 * Convert internal format datums to string (output) datums.
+	 *
+	 * We are forcing ISO datestyle here to prevent parsing errors with
+	 * certain timezone/datestyle combinations.
+	 */
+	int current_datestyle = DateStyle;
+	DateStyle = USE_ISO_DATES;
 	startdat = OidFunctionCall1(outfuncid, startdat);
 	enddat = OidFunctionCall1(outfuncid, enddat);
+	DateStyle = current_datestyle;
 
 	/* Elide range constraint for +INF or -INF */
 	if (slice->fd.range_start != PG_INT64_MIN)


### PR DESCRIPTION
With certain timezone settings chunk constraint creation could fail as we convert the internal time to string when creating the chunk constraint leading to parse errors when the produces string could not be parsed back.