### PR TITLE
Verify that heap tuple is valid before using

### DIFF
--- a/.unreleased/pr_7432
+++ b/.unreleased/pr_7432
@@ -1,0 +1,1 @@
+Fixes: #7432 Verify that heap tuple is valid before using

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -961,6 +961,10 @@ void
 ts_bgw_job_validate_job_owner(Oid owner)
 {
 	HeapTuple role_tup = SearchSysCache1(AUTHOID, ObjectIdGetDatum(owner));
+
+	if (!HeapTupleIsValid(role_tup))
+		elog(ERROR, "cache lookup failed for role %u", owner);
+
 	Form_pg_authid rform = (Form_pg_authid) GETSTRUCT(role_tup);
 
 	if (!rform->rolcanlogin)


### PR DESCRIPTION
In `ts_bgw_job_validate_job_owner` a heap tuple is fetched but it is
not verified that it is valid. If the heap tuple is later used it can
cause a crash at best, or leak information from random memory at worst.

Fixed this by adding a check that the tuple is valid before trying to
use it.
