### PR TITLE
Fix segfault when setting chunk replica identity

### DIFF
--- a/.unreleased/pr_7434
+++ b/.unreleased/pr_7434
@@ -1,0 +1,2 @@
+Fixes: #7434 Fixes segfault when internally set the replica identity for a given chunk
+Thanks: @bharrisau for reporting the segfault when creating chunks

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -221,3 +221,74 @@ ERROR:  invalid interval: an explicit interval must be specified
 SELECT set_chunk_time_interval('chunk_test2', NULL::INTERVAL);
 ERROR:  invalid interval: an explicit interval must be specified
 \set ON_ERROR_STOP 1
+-- Issue https://github.com/timescale/timescaledb/issues/7406
+CREATE TABLE test_ht (time TIMESTAMPTZ, v1 INTEGER);
+SELECT create_hypertable('test_ht', by_range('time', INTERVAL '1 hour'));
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ (4,t)
+(1 row)
+
+CREATE TABLE test_tb (time TIMESTAMPTZ, v1 INTEGER);
+CREATE OR REPLACE FUNCTION test_tb_trg_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO test_ht VALUES (NEW.time, NEW.v1);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER test_tb_trg_insert AFTER
+INSERT ON test_tb
+FOR EACH ROW EXECUTE FUNCTION test_tb_trg_insert();
+-- Creating new chunk inside a trigger called by
+-- a DDL statement should not fail.
+CREATE TABLE test_output AS
+WITH inserted AS (
+  INSERT INTO test_tb VALUES (NOW(), 1), (NOW(), 2) RETURNING *
+)
+SELECT * FROM inserted;
+-- Check the DEFAULT REPLICA IDENTITY of the chunks
+SELECT relname, relreplident FROM show_chunks('test_ht') ch JOIN pg_class c ON (ch = c.oid) ORDER BY relname;
+      relname      | relreplident 
+-------------------+--------------
+ _hyper_4_11_chunk | d
+(1 row)
+
+-- Clean up
+TRUNCATE test_ht, test_tb;
+DROP TABLE test_output;
+-- Change the DEFAULT REPLICA IDENTITY of the chunks
+ALTER TABLE test_ht REPLICA IDENTITY FULL;
+-- Internally we force new chunks have the same REPLICA IDENTITY
+-- as the parent table.
+CREATE TABLE test_output AS
+WITH inserted AS (
+  INSERT INTO test_tb VALUES (NOW(), 1), (NOW(), 2) RETURNING *
+)
+SELECT * FROM inserted;
+-- Check current new REPLICA IDENTITY FULL in the chunks
+SELECT relname, relreplident FROM show_chunks('test_ht') ch JOIN pg_class c ON (ch = c.oid) ORDER BY relname;
+      relname      | relreplident 
+-------------------+--------------
+ _hyper_4_12_chunk | f
+(1 row)
+
+-- All tables should have the same number of rows
+SELECT count(*) FROM test_tb;
+ count 
+-------
+     2
+(1 row)
+
+SELECT count(*) FROM test_ht;
+ count 
+-------
+     2
+(1 row)
+
+SELECT count(*) FROM test_output;
+ count 
+-------
+     2
+(1 row)
+


### PR DESCRIPTION
The segfault happened executing `AlterTableInternal` for setting the REPLICA IDENTITY during chunk creation (introduced by https://github.com/timescale/timescaledb/issues/5512) that is dispatched by a trigger invoked by a DDL statement.

Fixed it by using our internal `ts_alter_table_with_event_trigger` handler function to setup the event trigger context.

Fixes #7406