### PR TITLE
Fix hypercore stats flaky tests

### DIFF
--- a/tsl/test/expected/hypercore_stats.out
+++ b/tsl/test/expected/hypercore_stats.out
@@ -180,6 +180,8 @@ alter table :chunk1 set access method hypercore;
 create index normaltable_location_id_idx on normaltable (location_id);
 -- Relstats should be the same for both tables, except for pages since
 -- a hypercore is compressed. Column stats is not updated.
+analyze :chunk1;
+analyze normaltable;
 select * from relstats_compare;
                  relid                  | reltuples 
 ----------------------------------------+-----------
@@ -188,9 +190,23 @@ select * from relstats_compare;
 (2 rows)
 
 select * from attrstats_compare;
- relid | attname | n_distinct | most_common_vals 
--------+---------+------------+------------------
-(0 rows)
+                 relid                  |   attname   | n_distinct |                                most_common_vals                                
+----------------------------------------+-------------+------------+--------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk | created_at  |         -1 | 
+ _timescaledb_internal._hyper_1_1_chunk | device_id   |  -0.147059 | 7,12,16,23,8,13,30,24,28,3,5,21,22,2,26,29,11,17,19,9,20,10,15,1,18,25,6,14,27
+ _timescaledb_internal._hyper_1_1_chunk | humidity    |         -1 | 
+ _timescaledb_internal._hyper_1_1_chunk | location_id |         10 | 3,6,5,2,7,8,1,9,10,4
+ _timescaledb_internal._hyper_1_1_chunk | metric_id   |         -1 | 
+ _timescaledb_internal._hyper_1_1_chunk | owner_id    |          5 | 1,4,2,5,3
+ _timescaledb_internal._hyper_1_1_chunk | temp        |         -1 | 
+ normaltable                            | created_at  |         -1 | 
+ normaltable                            | device_id   |  -0.147059 | 7,12,16,23,8,13,30,24,28,3,5,21,22,2,26,29,11,17,19,9,20,10,15,1,18,25,6,14,27
+ normaltable                            | humidity    |         -1 | 
+ normaltable                            | location_id |         10 | 3,6,5,2,7,8,1,9,10,4
+ normaltable                            | metric_id   |         -1 | 
+ normaltable                            | owner_id    |          5 | 1,4,2,5,3
+ normaltable                            | temp        |         -1 | 
+(14 rows)
 
 -- Drop the index again, we'll need to recreate it again later
 drop index normaltable_location_id_idx;
@@ -256,11 +272,13 @@ select * from normaltable where location_id = 1;
 
 delete from :chunk1 where location_id=1;
 delete from normaltable where location_id=1;
+analyze :chunk1;
+analyze normaltable;
 select * from relstats_compare;
                  relid                  | reltuples 
 ----------------------------------------+-----------
- _timescaledb_internal._hyper_1_1_chunk |       204
- normaltable                            |       204
+ _timescaledb_internal._hyper_1_1_chunk |       185
+ normaltable                            |       185
 (2 rows)
 
 select * from attrstats_same;

--- a/tsl/test/sql/hypercore_stats.sql
+++ b/tsl/test/sql/hypercore_stats.sql
@@ -67,6 +67,8 @@ create index normaltable_location_id_idx on normaltable (location_id);
 
 -- Relstats should be the same for both tables, except for pages since
 -- a hypercore is compressed. Column stats is not updated.
+analyze :chunk1;
+analyze normaltable;
 select * from relstats_compare;
 select * from attrstats_compare;
 
@@ -98,6 +100,8 @@ select * from normaltable where location_id = 1;
 delete from :chunk1 where location_id=1;
 delete from normaltable where location_id=1;
 
+analyze :chunk1;
+analyze normaltable;
 select * from relstats_compare;
 select * from attrstats_same;
 


### PR DESCRIPTION
Execute an ANALYZE on relations to avoid flaky results in case of an autovacuum execution in background.

https://github.com/timescale/timescaledb/actions/runs/11769763355/job/32781276171#step:12:39

Disable-check: force-changelog-file
