### PR TITLE
Add index creation on orderby columns

### DIFF
--- a/.unreleased/pr_7436
+++ b/.unreleased/pr_7436
@@ -1,0 +1,1 @@
+Implements: #7436 Add index creation on orderby columns

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1066,6 +1066,18 @@ get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 
 	CompressionSettings *settings = ts_compression_settings_get(compressed_chunk->table_id);
 
+	// For chunks with no segmentby, we don't want to do segmentwise recompression as it is less
+	// performant than a full recompression. This is temporary; once we optimize recompression
+	// code for chunks with no segments we should remove this check.
+	int num_segmentby = ts_array_length(settings->fd.segmentby);
+
+	if (num_segmentby == 0)
+	{
+		table_close(compressed_chunk_rel, NoLock);
+		table_close(uncompressed_chunk_rel, NoLock);
+		return InvalidOid;
+	}
+
 	CatalogIndexState indstate = CatalogOpenIndexes(compressed_chunk_rel);
 	Oid index_oid = get_compressed_chunk_index(indstate, settings);
 	CatalogCloseIndexes(indstate);

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -308,11 +308,6 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 		}
 	}
 
-	if (list_length(indexcols) == 0)
-	{
-		return;
-	}
-
 	SortByDir ordering;
 	SortByNulls nulls_ordering;
 

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -175,8 +175,8 @@ WHERE compression_status LIKE 'Compressed'
 ORDER BY chunk_name;
     chunk_name    | before_compression_total_bytes | after_compression_total_bytes 
 ------------------+--------------------------------+-------------------------------
- _hyper_3_5_chunk |                          24576 |                         24576
- _hyper_3_6_chunk |                          24576 |                         24576
+ _hyper_3_5_chunk |                          24576 |                         40960
+ _hyper_3_6_chunk |                          24576 |                         40960
 (2 rows)
 
 --integer tests
@@ -215,8 +215,8 @@ WHERE compression_status LIKE 'Compressed'
 ORDER BY chunk_name;
     chunk_name     | before_compression_total_bytes | after_compression_total_bytes 
 -------------------+--------------------------------+-------------------------------
- _hyper_5_12_chunk |                          24576 |                         24576
- _hyper_5_13_chunk |                          24576 |                         24576
+ _hyper_5_12_chunk |                          24576 |                         40960
+ _hyper_5_13_chunk |                          24576 |                         40960
 (2 rows)
 
 --bigint test
@@ -255,8 +255,8 @@ WHERE compression_status LIKE 'Compressed'
 ORDER BY chunk_name;
     chunk_name     | before_compression_total_bytes | after_compression_total_bytes 
 -------------------+--------------------------------+-------------------------------
- _hyper_7_19_chunk |                          24576 |                         24576
- _hyper_7_20_chunk |                          24576 |                         24576
+ _hyper_7_19_chunk |                          24576 |                         40960
+ _hyper_7_20_chunk |                          24576 |                         40960
 (2 rows)
 
 --TEST 8

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1899,49 +1899,37 @@ SELECT compress_chunk(show_chunks('test_partials'));
 VACUUM ANALYZE test_partials;
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_123_chunk._ts_meta_min_1, compress_hyper_34_123_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_123_chunk
+         ->  Index Scan Backward using compress_hyper_34_123_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_123_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_124_chunk._ts_meta_min_1, compress_hyper_34_124_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_124_chunk
+         ->  Index Scan Backward using compress_hyper_34_124_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_124_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_125_chunk._ts_meta_min_1, compress_hyper_34_125_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_125_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_34_125_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_125_chunk
+(8 rows)
 
 -- test P, F, F
 INSERT INTO test_partials VALUES ('2020-01-01 00:03', 1, 2);
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_33_120_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_123_chunk._ts_meta_min_1, compress_hyper_34_123_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_123_chunk
+               ->  Index Scan Backward using compress_hyper_34_123_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_123_chunk
          ->  Sort
                Sort Key: _hyper_33_120_chunk."time"
                ->  Seq Scan on _hyper_33_120_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_124_chunk._ts_meta_min_1, compress_hyper_34_124_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_124_chunk
+         ->  Index Scan Backward using compress_hyper_34_124_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_124_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_125_chunk._ts_meta_min_1, compress_hyper_34_125_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_125_chunk
-(19 rows)
+         ->  Index Scan Backward using compress_hyper_34_125_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_125_chunk
+(13 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -1961,33 +1949,27 @@ SELECT * FROM test_partials ORDER BY time;
 -- P, P, F
 INSERT INTO test_partials VALUES ('2021-01-01 00:03', 1, 2);
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_33_120_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_123_chunk._ts_meta_min_1, compress_hyper_34_123_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_123_chunk
+               ->  Index Scan Backward using compress_hyper_34_123_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_123_chunk
          ->  Sort
                Sort Key: _hyper_33_120_chunk."time"
                ->  Seq Scan on _hyper_33_120_chunk
    ->  Merge Append
          Sort Key: _hyper_33_121_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_124_chunk._ts_meta_min_1, compress_hyper_34_124_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_124_chunk
+               ->  Index Scan Backward using compress_hyper_34_124_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_124_chunk
          ->  Sort
                Sort Key: _hyper_33_121_chunk."time"
                ->  Seq Scan on _hyper_33_121_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_125_chunk._ts_meta_min_1, compress_hyper_34_125_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_125_chunk
-(24 rows)
+         ->  Index Scan Backward using compress_hyper_34_125_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_125_chunk
+(18 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2009,39 +1991,33 @@ SELECT * FROM test_partials ORDER BY time;
 INSERT INTO test_partials VALUES ('2022-01-01 00:03', 1, 2);
 INSERT INTO test_partials VALUES ('2023-01-01 00:03', 1, 2);
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_33_120_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_123_chunk._ts_meta_min_1, compress_hyper_34_123_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_123_chunk
+               ->  Index Scan Backward using compress_hyper_34_123_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_123_chunk
          ->  Sort
                Sort Key: _hyper_33_120_chunk."time"
                ->  Seq Scan on _hyper_33_120_chunk
    ->  Merge Append
          Sort Key: _hyper_33_121_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_124_chunk._ts_meta_min_1, compress_hyper_34_124_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_124_chunk
+               ->  Index Scan Backward using compress_hyper_34_124_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_124_chunk
          ->  Sort
                Sort Key: _hyper_33_121_chunk."time"
                ->  Seq Scan on _hyper_33_121_chunk
    ->  Merge Append
          Sort Key: _hyper_33_122_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_125_chunk._ts_meta_min_1, compress_hyper_34_125_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_125_chunk
+               ->  Index Scan Backward using compress_hyper_34_125_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_125_chunk
          ->  Sort
                Sort Key: _hyper_33_122_chunk."time"
                ->  Seq Scan on _hyper_33_122_chunk
    ->  Index Scan Backward using _hyper_33_126_chunk_test_partials_time_idx on _hyper_33_126_chunk
-(30 rows)
+(24 rows)
 
 -- F, F, P, U
 -- recompress all chunks
@@ -2060,29 +2036,23 @@ END
 $$;
 INSERT INTO test_partials VALUES ('2022-01-01 00:02', 1, 2);
 EXPLAIN (COSTS OFF) SELECT * FROM test_partials ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_127_chunk._ts_meta_min_1, compress_hyper_34_127_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_127_chunk
+         ->  Index Scan Backward using compress_hyper_34_127_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_127_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_128_chunk._ts_meta_min_1, compress_hyper_34_128_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_128_chunk
+         ->  Index Scan Backward using compress_hyper_34_128_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_128_chunk
    ->  Merge Append
          Sort Key: _hyper_33_122_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_129_chunk._ts_meta_min_1, compress_hyper_34_129_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_129_chunk
+               ->  Index Scan Backward using compress_hyper_34_129_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_129_chunk
          ->  Sort
                Sort Key: _hyper_33_122_chunk."time"
                ->  Seq Scan on _hyper_33_122_chunk
    ->  Index Scan Backward using _hyper_33_126_chunk_test_partials_time_idx on _hyper_33_126_chunk
-(20 rows)
+(14 rows)
 
 -- F, F, P, F, F
 INSERT INTO test_partials VALUES ('2024-01-01 00:02', 1, 2);
@@ -2094,36 +2064,26 @@ SELECT compress_chunk(c) FROM show_chunks('test_partials', newer_than => '2022-0
 (2 rows)
 
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_127_chunk._ts_meta_min_1, compress_hyper_34_127_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_127_chunk
+         ->  Index Scan Backward using compress_hyper_34_127_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_127_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_128_chunk._ts_meta_min_1, compress_hyper_34_128_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_128_chunk
+         ->  Index Scan Backward using compress_hyper_34_128_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_128_chunk
    ->  Merge Append
          Sort Key: _hyper_33_122_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_34_129_chunk._ts_meta_min_1, compress_hyper_34_129_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_34_129_chunk
+               ->  Index Scan Backward using compress_hyper_34_129_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_129_chunk
          ->  Sort
                Sort Key: _hyper_33_122_chunk."time"
                ->  Seq Scan on _hyper_33_122_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_126_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_131_chunk._ts_meta_min_1, compress_hyper_34_131_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_131_chunk
+         ->  Index Scan Backward using compress_hyper_34_131_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_131_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_33_130_chunk
-         ->  Sort
-               Sort Key: compress_hyper_34_132_chunk._ts_meta_min_1, compress_hyper_34_132_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_34_132_chunk
-(27 rows)
+         ->  Index Scan Backward using compress_hyper_34_132_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_34_132_chunk
+(17 rows)
 
 -- verify result correctness
 SELECT * FROM test_partials ORDER BY time;
@@ -2191,24 +2151,20 @@ SELECT add_dimension('space_part', 'a', number_partitions => 5);
 
 -- plan is still the same
 EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
          Sort Key: _hyper_35_133_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_135_chunk._ts_meta_min_1, compress_hyper_36_135_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_135_chunk
+               ->  Index Scan Backward using compress_hyper_36_135_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_135_chunk
          ->  Sort
                Sort Key: _hyper_35_133_chunk."time"
                ->  Seq Scan on _hyper_35_133_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_136_chunk._ts_meta_min_1, compress_hyper_36_136_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_136_chunk
-(15 rows)
+         ->  Index Scan Backward using compress_hyper_36_136_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_136_chunk
+(11 rows)
 
 -- now add more chunks that do adhere to the new space partitioning
 -- chunks 3,4
@@ -2219,28 +2175,24 @@ INSERT INTO space_part VALUES
 ('2022-01-01 00:03', 2, 1, 1);
 -- plan still ok
 EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
          Sort Key: _hyper_35_133_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_135_chunk._ts_meta_min_1, compress_hyper_36_135_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_135_chunk
+               ->  Index Scan Backward using compress_hyper_36_135_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_135_chunk
          ->  Sort
                Sort Key: _hyper_35_133_chunk."time"
                ->  Seq Scan on _hyper_35_133_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_136_chunk._ts_meta_min_1, compress_hyper_36_136_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_136_chunk
+         ->  Index Scan Backward using compress_hyper_36_136_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_136_chunk
    ->  Merge Append
          Sort Key: _hyper_35_137_chunk."time"
          ->  Index Scan Backward using _hyper_35_137_chunk_space_part_time_idx on _hyper_35_137_chunk
          ->  Index Scan Backward using _hyper_35_138_chunk_space_part_time_idx on _hyper_35_138_chunk
-(19 rows)
+(15 rows)
 
 -- compress them
 SELECT compress_chunk(c, if_not_compressed=>true) FROM show_chunks('space_part') c;
@@ -2255,95 +2207,71 @@ NOTICE:  chunk "_hyper_35_134_chunk" is already compressed
 
 -- plan still ok
 EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_139_chunk._ts_meta_min_1, compress_hyper_36_139_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_139_chunk
+         ->  Index Scan Backward using compress_hyper_36_139_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_139_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_136_chunk._ts_meta_min_1, compress_hyper_36_136_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_136_chunk
+         ->  Index Scan Backward using compress_hyper_36_136_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_136_chunk
    ->  Merge Append
          Sort Key: _hyper_35_137_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_137_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_140_chunk._ts_meta_min_1, compress_hyper_36_140_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_140_chunk
+               ->  Index Scan Backward using compress_hyper_36_140_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_140_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_35_138_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_141_chunk._ts_meta_min_1, compress_hyper_36_141_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_141_chunk
-(20 rows)
+               ->  Index Scan Backward using compress_hyper_36_141_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_141_chunk
+(12 rows)
 
 -- make second one of them partial
 insert into space_part values
 ('2022-01-01 00:02', 2, 1, 1),
 ('2022-01-01 00:02', 2, 1, 1);
 EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_139_chunk._ts_meta_min_1, compress_hyper_36_139_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_139_chunk
+         ->  Index Scan Backward using compress_hyper_36_139_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_139_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_136_chunk._ts_meta_min_1, compress_hyper_36_136_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_136_chunk
+         ->  Index Scan Backward using compress_hyper_36_136_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_136_chunk
    ->  Merge Append
          Sort Key: _hyper_35_137_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_137_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_140_chunk._ts_meta_min_1, compress_hyper_36_140_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_140_chunk
+               ->  Index Scan Backward using compress_hyper_36_140_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_140_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_35_138_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_141_chunk._ts_meta_min_1, compress_hyper_36_141_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_141_chunk
+               ->  Index Scan Backward using compress_hyper_36_141_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_141_chunk
          ->  Sort
                Sort Key: _hyper_35_138_chunk."time"
                ->  Seq Scan on _hyper_35_138_chunk
-(23 rows)
+(15 rows)
 
 -- make other one partial too
 INSERT INTO space_part VALUES
 ('2022-01-01 00:02', 1, 1, 1);
 EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_139_chunk._ts_meta_min_1, compress_hyper_36_139_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_139_chunk
+         ->  Index Scan Backward using compress_hyper_36_139_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_139_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_136_chunk._ts_meta_min_1, compress_hyper_36_136_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_136_chunk
+         ->  Index Scan Backward using compress_hyper_36_136_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_136_chunk
    ->  Merge Append
          Sort Key: _hyper_35_137_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_137_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_140_chunk._ts_meta_min_1, compress_hyper_36_140_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_140_chunk
+               ->  Index Scan Backward using compress_hyper_36_140_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_140_chunk
          ->  Sort
                Sort Key: _hyper_35_137_chunk."time"
                ->  Seq Scan on _hyper_35_137_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_35_138_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_141_chunk._ts_meta_min_1, compress_hyper_36_141_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_141_chunk
+               ->  Index Scan Backward using compress_hyper_36_141_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_141_chunk
          ->  Sort
                Sort Key: _hyper_35_138_chunk."time"
                ->  Seq Scan on _hyper_35_138_chunk
-(26 rows)
+(18 rows)
 
 -- test creation of unique expression index does not interfere with enabling compression
 -- github issue 6205

--- a/tsl/test/expected/compression_indexcreate.out
+++ b/tsl/test/expected/compression_indexcreate.out
@@ -1,0 +1,124 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- force index scan to be used when possible
+set enable_seqscan to false;
+\set PREFIX 'EXPLAIN (analyze, costs off, summary off, timing off) '
+create table segind(time timestamptz, a int, b int);
+select create_hypertable('segind', by_range('time'));
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ (1,t)
+(1 row)
+
+-- enable compression on hypertable with no segment by column
+alter table segind set (timescaledb.compress, timescaledb.compress_segmentby='', timescaledb.compress_orderby='time, b');
+insert into segind values('2024-11-08 10:31:28.436014-07', 1, 1), ('2024-11-08 10:32:28.436014-07', 2, 1), ('2024-11-08 10:33:28.436014-07', 3, 1), ('2024-11-08 10:34:28.436014-07', 2, 1), ('2024-11-08 10:35:28.436014-07', 1, 2), ('2024-11-08 10:36:28.436014-07', 4, 1);
+-- compress chunk
+-- this should create an index using orderby columns
+select compress_chunk(show_chunks('segind'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- query using orderby columns should use the index
+:PREFIX select * from segind where b = 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=5 loops=1)
+   Vectorized Filter: (b = 1)
+   Rows Removed by Filter: 1
+   ->  Index Scan using compress_hyper_2_2_chunk__ts_meta_min_1__ts_meta_max_1__ts__idx on compress_hyper_2_2_chunk (actual rows=1 loops=1)
+         Index Cond: ((_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1))
+(5 rows)
+
+:PREFIX select * from segind where time = '2024-11-08 10:32:28.436014-07';
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+   Vectorized Filter: ("time" = 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone)
+   Rows Removed by Filter: 5
+   ->  Index Scan using compress_hyper_2_2_chunk__ts_meta_min_1__ts_meta_max_1__ts__idx on compress_hyper_2_2_chunk (actual rows=1 loops=1)
+         Index Cond: ((_ts_meta_min_1 <= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone))
+(5 rows)
+
+:PREFIX select * from segind where b = 1 and time = '2024-11-08 10:32:28.436014-07';
+                                                                                                                      QUERY PLAN                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+   Vectorized Filter: ((b = 1) AND ("time" = 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone))
+   Rows Removed by Filter: 5
+   ->  Index Scan using compress_hyper_2_2_chunk__ts_meta_min_1__ts_meta_max_1__ts__idx on compress_hyper_2_2_chunk (actual rows=1 loops=1)
+         Index Cond: ((_ts_meta_min_1 <= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone) AND (_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1))
+(5 rows)
+
+-- a query on another column should perform a seq scan since there is no index on it
+:PREFIX select * from segind where a = 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2 loops=1)
+   Vectorized Filter: (a = 1)
+   Rows Removed by Filter: 4
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=1 loops=1)
+(4 rows)
+
+-- decompress the chunk to drop the index
+select decompress_chunk(show_chunks('segind'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- change compression settings to use segmentby column
+alter table segind set (timescaledb.compress, timescaledb.compress_segmentby='a', timescaledb.compress_orderby='time, b');
+-- compress chunk
+-- this should create an index using segmentby and orderby columns
+select compress_chunk(show_chunks('segind'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- queries using segmentby or orderby columns should use the index
+:PREFIX select * from segind where b = 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=5 loops=1)
+   Vectorized Filter: (b = 1)
+   Rows Removed by Filter: 1
+   ->  Index Scan using compress_hyper_2_3_chunk_a__ts_meta_min_1__ts_meta_max_1__t_idx on compress_hyper_2_3_chunk (actual rows=4 loops=1)
+         Index Cond: ((_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1))
+(5 rows)
+
+:PREFIX select * from segind where time = '2024-11-08 10:32:28.436014-07';
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+   Vectorized Filter: ("time" = 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone)
+   Rows Removed by Filter: 3
+   ->  Index Scan using compress_hyper_2_3_chunk_a__ts_meta_min_1__ts_meta_max_1__t_idx on compress_hyper_2_3_chunk (actual rows=2 loops=1)
+         Index Cond: ((_ts_meta_min_1 <= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone))
+(5 rows)
+
+:PREFIX select * from segind where b = 1 and time = '2024-11-08 10:32:28.436014-07';
+                                                                                                                      QUERY PLAN                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+   Vectorized Filter: ((b = 1) AND ("time" = 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone))
+   Rows Removed by Filter: 3
+   ->  Index Scan using compress_hyper_2_3_chunk_a__ts_meta_min_1__ts_meta_max_1__t_idx on compress_hyper_2_3_chunk (actual rows=2 loops=1)
+         Index Cond: ((_ts_meta_min_1 <= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Nov 08 09:32:28.436014 2024 PST'::timestamp with time zone) AND (_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1))
+(5 rows)
+
+:PREFIX select * from segind where a = 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2 loops=1)
+   ->  Index Scan using compress_hyper_2_3_chunk_a__ts_meta_min_1__ts_meta_max_1__t_idx on compress_hyper_2_3_chunk (actual rows=1 loops=1)
+         Index Cond: (a = 1)
+(3 rows)
+
+-- cleanup
+RESET enable_seqscan;

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -790,13 +790,11 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-   ->  Sort
-         Sort Key: compress_hyper_14_21_chunk._ts_meta_min_1, compress_hyper_14_21_chunk._ts_meta_max_1
-         ->  Seq Scan on compress_hyper_14_21_chunk
-(4 rows)
+   ->  Index Scan Backward using compress_hyper_14_21_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_14_21_chunk
+(2 rows)
 
 INSERT INTO test_ordering SELECT 1;
 -- should not be ordered append
@@ -807,39 +805,35 @@ INSERT INTO test_ordering SELECT 1;
 -- It was hard to include a path without pushed down sort for consideration, as `add_path` would reject
 -- the path with sort pushdown, which is desirable in most cases
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Merge Append
          Sort Key: _hyper_13_20_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_14_21_chunk._ts_meta_min_1, compress_hyper_14_21_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_14_21_chunk
+               ->  Index Scan Backward using compress_hyper_14_21_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_14_21_chunk
          ->  Sort
                Sort Key: _hyper_13_20_chunk."time"
                ->  Seq Scan on _hyper_13_20_chunk
-(11 rows)
+(9 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Merge Append
          Sort Key: _hyper_13_20_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_14_21_chunk._ts_meta_min_1, compress_hyper_14_21_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_14_21_chunk
+               ->  Index Scan Backward using compress_hyper_14_21_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_14_21_chunk
          ->  Sort
                Sort Key: _hyper_13_20_chunk."time"
                ->  Seq Scan on _hyper_13_20_chunk
    ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
-(12 rows)
+(10 rows)
 
 --insert into compressed + uncompressed chunk
 INSERT INTO test_ordering VALUES (21), (22),(113);
@@ -881,19 +875,15 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_23_chunk._ts_meta_min_1, compress_hyper_14_23_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_14_23_chunk
+         ->  Index Scan Backward using compress_hyper_14_23_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_14_23_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_24_chunk._ts_meta_min_1, compress_hyper_14_24_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_14_24_chunk
-(10 rows)
+         ->  Index Scan Backward using compress_hyper_14_24_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_14_24_chunk
+(6 rows)
 
 SET timescaledb.enable_decompression_sorted_merge = 1;
 -- TEST cagg triggers with insert into compressed chunk

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -135,9 +135,9 @@ order by factorid, end_dt;
          Output: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt, _hyper_3_4_chunk.logret
          Filter: ((_hyper_3_4_chunk.end_dt >= '12-10-2012'::date) AND (_hyper_3_4_chunk.end_dt <= '12-11-2012'::date))
          Vectorized Filter: (_hyper_3_4_chunk.fmid = 56)
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_5_chunk
+         ->  Index Scan using compress_hyper_4_5_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_4_5_chunk
                Output: compress_hyper_4_5_chunk._ts_meta_count, compress_hyper_4_5_chunk.fmid, compress_hyper_4_5_chunk.factorid, compress_hyper_4_5_chunk.start_dt, compress_hyper_4_5_chunk._ts_meta_min_1, compress_hyper_4_5_chunk._ts_meta_max_1, compress_hyper_4_5_chunk.end_dt, compress_hyper_4_5_chunk.interval_number, compress_hyper_4_5_chunk.logret, compress_hyper_4_5_chunk.knowledge_date
-               Filter: ((compress_hyper_4_5_chunk._ts_meta_max_1 >= '12-10-2012'::date) AND (compress_hyper_4_5_chunk._ts_meta_min_1 <= '12-11-2012'::date))
+               Index Cond: ((compress_hyper_4_5_chunk._ts_meta_min_1 <= '12-11-2012'::date) AND (compress_hyper_4_5_chunk._ts_meta_max_1 >= '12-10-2012'::date))
 (10 rows)
 
 --no pushdown here

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -310,8 +310,8 @@ SELECT compress_chunk(show_chunks('hyper'));
 
 :EXPLAIN SELECT * FROM hyper
 ORDER BY time;
-                                                                                                                           QUERY PLAN                                                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on public.hyper
    Output: hyper."time", hyper.device_id, hyper.val
    Order: hyper."time"
@@ -319,33 +319,21 @@ ORDER BY time;
    Runtime Exclusion: false
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
          Output: _hyper_1_10_chunk."time", _hyper_1_10_chunk.device_id, _hyper_1_10_chunk.val
-         ->  Sort
+         ->  Index Scan using compress_hyper_2_14_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_2_14_chunk
                Output: compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1, compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.device_id, compress_hyper_2_14_chunk.val
-               Sort Key: compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
-                     Output: compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1, compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.device_id, compress_hyper_2_14_chunk.val
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_11_chunk
          Output: _hyper_1_11_chunk."time", _hyper_1_11_chunk.device_id, _hyper_1_11_chunk.val
-         ->  Sort
+         ->  Index Scan using compress_hyper_2_15_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_2_15_chunk
                Output: compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1, compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.device_id, compress_hyper_2_15_chunk.val
-               Sort Key: compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
-                     Output: compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1, compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.device_id, compress_hyper_2_15_chunk.val
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_12_chunk
          Output: _hyper_1_12_chunk."time", _hyper_1_12_chunk.device_id, _hyper_1_12_chunk.val
-         ->  Sort
+         ->  Index Scan using compress_hyper_2_16_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_2_16_chunk
                Output: compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1, compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.device_id, compress_hyper_2_16_chunk.val
-               Sort Key: compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
-                     Output: compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1, compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.device_id, compress_hyper_2_16_chunk.val
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_13_chunk
          Output: _hyper_1_13_chunk."time", _hyper_1_13_chunk.device_id, _hyper_1_13_chunk.val
-         ->  Sort
+         ->  Index Scan using compress_hyper_2_17_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_2_17_chunk
                Output: compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1, compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.device_id, compress_hyper_2_17_chunk.val
-               Sort Key: compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
-                     Output: compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1, compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.device_id, compress_hyper_2_17_chunk.val
-(33 rows)
+(21 rows)
 
 -- modify two chunks by adding sequence number to the segments
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
@@ -399,18 +387,12 @@ ORDER BY time;
                      Output: compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1, compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.device_id, compress_hyper_2_14_chunk.val, compress_hyper_2_14_chunk._ts_meta_sequence_num
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_11_chunk
          Output: _hyper_1_11_chunk."time", _hyper_1_11_chunk.device_id, _hyper_1_11_chunk.val
-         ->  Sort
+         ->  Index Scan using compress_hyper_2_15_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_2_15_chunk
                Output: compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1, compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.device_id, compress_hyper_2_15_chunk.val
-               Sort Key: compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
-                     Output: compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1, compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.device_id, compress_hyper_2_15_chunk.val
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_12_chunk
          Output: _hyper_1_12_chunk."time", _hyper_1_12_chunk.device_id, _hyper_1_12_chunk.val
-         ->  Sort
+         ->  Index Scan using compress_hyper_2_16_chunk__ts_meta_min_1__ts_meta_max_1_idx on _timescaledb_internal.compress_hyper_2_16_chunk
                Output: compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1, compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.device_id, compress_hyper_2_16_chunk.val
-               Sort Key: compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
-                     Output: compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1, compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.device_id, compress_hyper_2_16_chunk.val
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_13_chunk
          Output: _hyper_1_13_chunk."time", _hyper_1_13_chunk.device_id, _hyper_1_13_chunk.val
          ->  Sort
@@ -418,7 +400,7 @@ ORDER BY time;
                Sort Key: compress_hyper_2_17_chunk._ts_meta_sequence_num
                ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
                      Output: compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1, compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.device_id, compress_hyper_2_17_chunk.val, compress_hyper_2_17_chunk._ts_meta_sequence_num
-(33 rows)
+(27 rows)
 
 -- test rolling up chunks during compression
 -- this will not work with chunks which have sequence numbers

--- a/tsl/test/expected/compression_update_delete-14.out
+++ b/tsl/test/expected/compression_update_delete-14.out
@@ -2779,23 +2779,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_71_chunk
+         ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_72_chunk
+         ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_73_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
+(8 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2844,38 +2838,32 @@ EXPLAIN (costs off) DELETE FROM test_partials WHERE time >= ALL(SELECT time from
 DELETE FROM test_partials WHERE time >= ALL(SELECT time from test_partials);
 -- All 3 chunks will now become partially compressed chunks
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_35_68_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_71_chunk
+               ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
          ->  Sort
                Sort Key: _hyper_35_68_chunk."time"
                ->  Seq Scan on _hyper_35_68_chunk
    ->  Merge Append
          Sort Key: _hyper_35_69_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_72_chunk
+               ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
          ->  Sort
                Sort Key: _hyper_35_69_chunk."time"
                ->  Seq Scan on _hyper_35_69_chunk
    ->  Merge Append
          Sort Key: _hyper_35_70_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_73_chunk
+               ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
          ->  Sort
                Sort Key: _hyper_35_70_chunk."time"
                ->  Seq Scan on _hyper_35_70_chunk
-(29 rows)
+(23 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2899,23 +2887,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_74_chunk._ts_meta_min_1, compress_hyper_36_74_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_74_chunk
+         ->  Index Scan Backward using compress_hyper_36_74_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_74_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_75_chunk._ts_meta_min_1, compress_hyper_36_75_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_75_chunk
+         ->  Index Scan Backward using compress_hyper_36_75_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_75_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_76_chunk._ts_meta_min_1, compress_hyper_36_76_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_76_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_76_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_76_chunk
+(8 rows)
 
 DROP TABLE test_partials;
 CREATE TABLE test_meta_filters(time timestamptz NOT NULL, device text, metric text, v1 float, v2 float);

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -2779,23 +2779,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_71_chunk
+         ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_72_chunk
+         ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_73_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
+(8 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2844,38 +2838,32 @@ EXPLAIN (costs off) DELETE FROM test_partials WHERE time >= ALL(SELECT time from
 DELETE FROM test_partials WHERE time >= ALL(SELECT time from test_partials);
 -- All 3 chunks will now become partially compressed chunks
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_35_68_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_71_chunk
+               ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
          ->  Sort
                Sort Key: _hyper_35_68_chunk."time"
                ->  Seq Scan on _hyper_35_68_chunk
    ->  Merge Append
          Sort Key: _hyper_35_69_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_72_chunk
+               ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
          ->  Sort
                Sort Key: _hyper_35_69_chunk."time"
                ->  Seq Scan on _hyper_35_69_chunk
    ->  Merge Append
          Sort Key: _hyper_35_70_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_73_chunk
+               ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
          ->  Sort
                Sort Key: _hyper_35_70_chunk."time"
                ->  Seq Scan on _hyper_35_70_chunk
-(29 rows)
+(23 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2899,23 +2887,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_74_chunk._ts_meta_min_1, compress_hyper_36_74_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_74_chunk
+         ->  Index Scan Backward using compress_hyper_36_74_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_74_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_75_chunk._ts_meta_min_1, compress_hyper_36_75_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_75_chunk
+         ->  Index Scan Backward using compress_hyper_36_75_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_75_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_76_chunk._ts_meta_min_1, compress_hyper_36_76_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_76_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_76_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_76_chunk
+(8 rows)
 
 DROP TABLE test_partials;
 CREATE TABLE test_meta_filters(time timestamptz NOT NULL, device text, metric text, v1 float, v2 float);

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -2779,23 +2779,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_71_chunk
+         ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_72_chunk
+         ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_73_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
+(8 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2844,38 +2838,32 @@ EXPLAIN (costs off) DELETE FROM test_partials WHERE time >= ALL(SELECT time from
 DELETE FROM test_partials WHERE time >= ALL(SELECT time from test_partials);
 -- All 3 chunks will now become partially compressed chunks
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_35_68_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_71_chunk
+               ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
          ->  Sort
                Sort Key: _hyper_35_68_chunk."time"
                ->  Seq Scan on _hyper_35_68_chunk
    ->  Merge Append
          Sort Key: _hyper_35_69_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_72_chunk
+               ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
          ->  Sort
                Sort Key: _hyper_35_69_chunk."time"
                ->  Seq Scan on _hyper_35_69_chunk
    ->  Merge Append
          Sort Key: _hyper_35_70_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_73_chunk
+               ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
          ->  Sort
                Sort Key: _hyper_35_70_chunk."time"
                ->  Seq Scan on _hyper_35_70_chunk
-(29 rows)
+(23 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2899,23 +2887,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_74_chunk._ts_meta_min_1, compress_hyper_36_74_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_74_chunk
+         ->  Index Scan Backward using compress_hyper_36_74_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_74_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_75_chunk._ts_meta_min_1, compress_hyper_36_75_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_75_chunk
+         ->  Index Scan Backward using compress_hyper_36_75_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_75_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_76_chunk._ts_meta_min_1, compress_hyper_36_76_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_76_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_76_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_76_chunk
+(8 rows)
 
 DROP TABLE test_partials;
 CREATE TABLE test_meta_filters(time timestamptz NOT NULL, device text, metric text, v1 float, v2 float);

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -2779,23 +2779,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_71_chunk
+         ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_72_chunk
+         ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_73_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
+(8 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2844,38 +2838,32 @@ EXPLAIN (costs off) DELETE FROM test_partials WHERE time >= ALL(SELECT time from
 DELETE FROM test_partials WHERE time >= ALL(SELECT time from test_partials);
 -- All 3 chunks will now become partially compressed chunks
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
          Sort Key: _hyper_35_68_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_71_chunk._ts_meta_min_1, compress_hyper_36_71_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_71_chunk
+               ->  Index Scan Backward using compress_hyper_36_71_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_71_chunk
          ->  Sort
                Sort Key: _hyper_35_68_chunk."time"
                ->  Seq Scan on _hyper_35_68_chunk
    ->  Merge Append
          Sort Key: _hyper_35_69_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_72_chunk._ts_meta_min_1, compress_hyper_36_72_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_72_chunk
+               ->  Index Scan Backward using compress_hyper_36_72_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_72_chunk
          ->  Sort
                Sort Key: _hyper_35_69_chunk."time"
                ->  Seq Scan on _hyper_35_69_chunk
    ->  Merge Append
          Sort Key: _hyper_35_70_chunk."time"
          ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_36_73_chunk._ts_meta_min_1, compress_hyper_36_73_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_36_73_chunk
+               ->  Index Scan Backward using compress_hyper_36_73_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_73_chunk
          ->  Sort
                Sort Key: _hyper_35_70_chunk."time"
                ->  Seq Scan on _hyper_35_70_chunk
-(29 rows)
+(23 rows)
 
 -- verify correct results
 SELECT * FROM test_partials ORDER BY time;
@@ -2899,23 +2887,17 @@ SELECT compress_chunk(show_chunks('test_partials'));
 
 -- fully compressed
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_74_chunk._ts_meta_min_1, compress_hyper_36_74_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_74_chunk
+         ->  Index Scan Backward using compress_hyper_36_74_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_74_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_75_chunk._ts_meta_min_1, compress_hyper_36_75_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_75_chunk
+         ->  Index Scan Backward using compress_hyper_36_75_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_75_chunk
    ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
-         ->  Sort
-               Sort Key: compress_hyper_36_76_chunk._ts_meta_min_1, compress_hyper_36_76_chunk._ts_meta_max_1
-               ->  Seq Scan on compress_hyper_36_76_chunk
-(14 rows)
+         ->  Index Scan Backward using compress_hyper_36_76_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_36_76_chunk
+(8 rows)
 
 DROP TABLE test_partials;
 CREATE TABLE test_meta_filters(time timestamptz NOT NULL, device text, metric text, v1 float, v2 float);

--- a/tsl/test/expected/hypercore_vacuum.out
+++ b/tsl/test/expected/hypercore_vacuum.out
@@ -414,12 +414,15 @@ inner join pg_am am on (cl.relam = am.oid);
 select indexrelid::regclass
 from pg_index i inner join
 compressed_rels crels on (i.indrelid = crels.compressed_relid);
-                               indexrelid                               
-------------------------------------------------------------------------
+                                    indexrelid                                     
+-----------------------------------------------------------------------------------
  _timescaledb_internal.compress_hyper_5_13_chunk_ts_hypercore_proxy_idx
+ _timescaledb_internal.compress_hyper_5_13_chunk__ts_meta_min_1__ts_meta_max_1_idx
  _timescaledb_internal.compress_hyper_5_14_chunk_ts_hypercore_proxy_idx
+ _timescaledb_internal.compress_hyper_5_14_chunk__ts_meta_min_1__ts_meta_max_1_idx
  _timescaledb_internal.compress_hyper_5_15_chunk_ts_hypercore_proxy_idx
-(3 rows)
+ _timescaledb_internal.compress_hyper_5_15_chunk__ts_meta_min_1__ts_meta_max_1_idx
+(6 rows)
 
 -- delete some data to generate garbage
 delete from hystable where temp > 20;

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -328,13 +328,13 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
              "num_compressed_chunks": 5,                  +
              "uncompressed_heap_size": 221184,            +
              "uncompressed_row_count": 736,               +
-             "compressed_indexes_size": 16384,            +
+             "compressed_indexes_size": 81920,            +
              "uncompressed_toast_size": 0,                +
              "uncompressed_indexes_size": 131072,         +
              "num_compressed_hypertables": 2,             +
              "compressed_row_count_frozen_immediately": 14+
          },                                               +
-         "indexes_size": 204800,                          +
+         "indexes_size": 270336,                          +
          "num_children": 11,                              +
          "num_relations": 2,                              +
          "num_reltuples": 658                             +

--- a/tsl/test/expected/vector_agg_default.out
+++ b/tsl/test/expected/vector_agg_default.out
@@ -185,21 +185,17 @@ select sum(c) from dvagg having sum(c) > 0;
 -- Some negative cases.
 set timescaledb.debug_require_vector_agg to 'forbid';
 explain (costs off) select sum(c) from dvagg group by grouping sets ((), (a));
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  MixedAggregate
    Hash Key: _hyper_1_1_chunk.a
    Group Key: ()
    ->  Append
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Index Scan Backward using compress_hyper_2_2_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_2_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
-                     ->  Seq Scan on compress_hyper_2_4_chunk
-(12 rows)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_4_chunk
+(8 rows)
 
 -- As a reference, the result on decompressed table.
 select decompress_chunk(show_chunks('dvagg'));

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_FILES
     compression_defaults.sql
     compression_fks.sql
     compression_insert.sql
+    compression_indexcreate.sql
     compression_policy.sql
     compression_qualpushdown.sql
     compression_sequence_num_removal.sql

--- a/tsl/test/sql/compression_indexcreate.sql
+++ b/tsl/test/sql/compression_indexcreate.sql
@@ -1,0 +1,44 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- force index scan to be used when possible
+set enable_seqscan to false;
+\set PREFIX 'EXPLAIN (analyze, costs off, summary off, timing off) '
+create table segind(time timestamptz, a int, b int);
+select create_hypertable('segind', by_range('time'));
+
+-- enable compression on hypertable with no segment by column
+alter table segind set (timescaledb.compress, timescaledb.compress_segmentby='', timescaledb.compress_orderby='time, b');
+insert into segind values('2024-11-08 10:31:28.436014-07', 1, 1), ('2024-11-08 10:32:28.436014-07', 2, 1), ('2024-11-08 10:33:28.436014-07', 3, 1), ('2024-11-08 10:34:28.436014-07', 2, 1), ('2024-11-08 10:35:28.436014-07', 1, 2), ('2024-11-08 10:36:28.436014-07', 4, 1);
+
+-- compress chunk
+-- this should create an index using orderby columns
+select compress_chunk(show_chunks('segind'));
+
+-- query using orderby columns should use the index
+:PREFIX select * from segind where b = 1;
+:PREFIX select * from segind where time = '2024-11-08 10:32:28.436014-07';
+:PREFIX select * from segind where b = 1 and time = '2024-11-08 10:32:28.436014-07';
+
+-- a query on another column should perform a seq scan since there is no index on it
+:PREFIX select * from segind where a = 1;
+
+-- decompress the chunk to drop the index
+select decompress_chunk(show_chunks('segind'));
+
+-- change compression settings to use segmentby column
+alter table segind set (timescaledb.compress, timescaledb.compress_segmentby='a', timescaledb.compress_orderby='time, b');
+
+-- compress chunk
+-- this should create an index using segmentby and orderby columns
+select compress_chunk(show_chunks('segind'));
+
+-- queries using segmentby or orderby columns should use the index
+:PREFIX select * from segind where b = 1;
+:PREFIX select * from segind where time = '2024-11-08 10:32:28.436014-07';
+:PREFIX select * from segind where b = 1 and time = '2024-11-08 10:32:28.436014-07';
+:PREFIX select * from segind where a = 1;
+
+-- cleanup
+RESET enable_seqscan;


### PR DESCRIPTION
Previously, for chunks without a segmentby column specified in the compression settings, no indexes were created. This change allows indexes to be created on orderby columns only in this scenario.