### PR TITLE
Add syscache tuple lock for pg17.1 and backports

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1534,6 +1534,14 @@ ts_copy_relation_acl(const Oid source_relid, const Oid target_relid, const Oid o
 		new_repl[AttrNumberGetAttrOffset(Anum_pg_class_relacl)] = true;
 		new_val[AttrNumberGetAttrOffset(Anum_pg_class_relacl)] = PointerGetDatum(acl);
 
+		/*
+		 * ts_copy_relation_acl() is typically used to copy ACLs from the hypertable
+		 * to a newly created chunk. The creation is done via DefineRelation(),
+		 * which takes an AccessExclusiveLock and should be enough to handle any
+		 * inplace update issues.
+		 */
+		AssertSufficientPgClassUpdateLockHeld(target_relid);
+
 		/* Find the tuple for the target in `pg_class` */
 		target_tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(target_relid));
 		Assert(HeapTupleIsValid(target_tuple));

--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -1922,7 +1922,14 @@ compress_and_swap_heap(Relation rel, Tuplesortstate *tuplesort, TransactionId *x
 	table_close(new_compressed_rel, NoLock);
 	table_close(old_compressed_rel, NoLock);
 
-	/* Update stats for the compressed relation */
+	/*
+	 * Update stats for the compressed relation.
+	 *
+	 * We have an AccessExclusivelock from above so no tuple lock is needed
+	 * during update of the pg_class catalog table.
+	 */
+	AssertSufficientPgClassUpdateLockHeld(new_compressed_relid);
+
 	Relation relRelation = table_open(RelationRelationId, RowExclusiveLock);
 	HeapTuple reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(new_compressed_relid));
 	if (!HeapTupleIsValid(reltup))

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -926,6 +926,9 @@ swap_relation_files(Oid r1, Oid r2, bool swap_toast_by_content, bool is_internal
 	Oid swaptemp;
 	char swptmpchr;
 
+	AssertSufficientPgClassUpdateLockHeld(r1);
+	AssertSufficientPgClassUpdateLockHeld(r2);
+
 	/* We need writable copies of both pg_class tuples. */
 	relRelation = table_open(RelationRelationId, RowExclusiveLock);
 


### PR DESCRIPTION
PostgreSQL 17.1 introduced a fix for potential lost data when doing updates to pg_class and pg_database catalog tables. The reason the catalog update can be lost is because PG in some places performs non-MVCC compliant
inplace updates of tuples in those catalogs, which requires extra locking to prevent overwrites. See the following commit for more information:

https://github.com/postgres/postgres/commit/3b7a689e1a805c4dac2f35ff14fd5c9fdbddf150

This fix was also backported to older PG versions 14.14, 15.9, 16.5, which TimescaleDB supports.

To be safe against inplace updates, the relation that is updated in pg_class via heap_update() needs to be locked with ShareUpdateExclusiveLock on the relation, or a ShareRowExclusiveLock or stricter on the relation. Otherwise, the update code needs to take a tuple-level lock.

TimescaleDB is affected by this change in the function that performs "quick migration" from a compressed chunk to a Hypercore TAM chunk. In that case, the regular ALTER TABLE ... SET ACCESS METHOD handling is
bypassed and the pg_class catalog table is updated directly to avoid having to rewrite the compressed data. Since this migration doesn't take a heavy lock on the chunk, it needs the tuple-level lock in the update of pg_class.

Other places in our code that update pg_class tuples may be protected by locks on the relation and requires no extra tuple-level lock. A macro is added to check that appropriate level locks are held on the relation prior to the catalog changes.

Disable-check: force-changelog-file