### PR TITLE
Fix notice when recompressing hypercore TAM

### DIFF
--- a/tsl/test/expected/hypercore.out
+++ b/tsl/test/expected/hypercore.out
@@ -521,7 +521,6 @@ SELECT sum(_ts_meta_count) FROM :cchunk;
 
 CALL recompress_chunk(:'chunk');
 WARNING:  procedure public.recompress_chunk(regclass,boolean) is deprecated and the functionality is now included in public.compress_chunk. this compatibility function will be removed in a future version.
-NOTICE:  cannot compress hypercore "_hyper_1_1_chunk" using heap, recompressing instead
 -- Data should be returned even after recompress, but now from the
 -- compressed relation. Still using index scan.
 EXPLAIN (verbose, costs off)
@@ -576,7 +575,6 @@ SELECT * FROM :chunk WHERE time = '2022-06-01 00:06:15'::timestamptz;
 -- Can't recompress twice without new non-compressed rows
 CALL recompress_chunk(:'chunk');
 WARNING:  procedure public.recompress_chunk(regclass,boolean) is deprecated and the functionality is now included in public.compress_chunk. this compatibility function will be removed in a future version.
-NOTICE:  cannot compress hypercore "_hyper_1_1_chunk" using heap, recompressing instead
 NOTICE:  chunk "_hyper_1_1_chunk" is already compressed
 \set ON_ERROR_STOP 1
 -- Compressed count after recompression

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -646,33 +646,12 @@ commit;
 select compress_chunk(ch, hypercore_use_access_method => true, if_not_compressed => false)
 from show_chunks('test2') ch;
 ERROR:  chunk "_hyper_1_1_chunk" is already compressed
-\set ON_ERROR_STOP 1
--- Compressing from hypercore not using access method should lead to
--- recompression of hypercore with a notice.
+-- Compressing from hypercore and not using access method should lead
+-- to an error since it is not supported.
 select compress_chunk(ch, hypercore_use_access_method => false)
 from show_chunks('test2') ch;
-NOTICE:  cannot compress hypercore "_hyper_1_1_chunk" using heap, recompressing instead
-NOTICE:  chunk "_hyper_1_1_chunk" is already compressed
-NOTICE:  cannot compress hypercore "_hyper_1_3_chunk" using heap, recompressing instead
-NOTICE:  chunk "_hyper_1_3_chunk" is already compressed
-NOTICE:  cannot compress hypercore "_hyper_1_5_chunk" using heap, recompressing instead
-NOTICE:  chunk "_hyper_1_5_chunk" is already compressed
-NOTICE:  cannot compress hypercore "_hyper_1_7_chunk" using heap, recompressing instead
-NOTICE:  chunk "_hyper_1_7_chunk" is already compressed
-NOTICE:  cannot compress hypercore "_hyper_1_9_chunk" using heap, recompressing instead
-NOTICE:  chunk "_hyper_1_9_chunk" is already compressed
-NOTICE:  cannot compress hypercore "_hyper_1_11_chunk" using heap, recompressing instead
-NOTICE:  chunk "_hyper_1_11_chunk" is already compressed
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_5_chunk
- _timescaledb_internal._hyper_1_7_chunk
- _timescaledb_internal._hyper_1_9_chunk
- _timescaledb_internal._hyper_1_11_chunk
-(6 rows)
-
+ERROR:  cannot compress "_hyper_1_1_chunk" without using Hypercore access method
+\set ON_ERROR_STOP 1
 -- Compressing a hypercore should by default lead to
 -- recompression. First check that :chunk is a hypercore.
 select ch as chunk from show_chunks('test2') ch limit 1 \gset
@@ -691,7 +670,6 @@ select ctid from :chunk where created_at = '2022-06-01 10:01' and device_id = 6;
 (1 row)
 
 select compress_chunk(:'chunk');
-NOTICE:  cannot compress hypercore "_hyper_1_1_chunk" using heap, recompressing instead
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk

--- a/tsl/test/expected/hypercore_vacuum.out
+++ b/tsl/test/expected/hypercore_vacuum.out
@@ -227,7 +227,6 @@ insert into hystable (time, location, device, temp)
 values ('2022-06-01 00:01', 1, 1, 1.0);
 -- Recompress to get data back into compressed form
 select compress_chunk(:'hystable_chunk');
-NOTICE:  cannot compress hypercore "_hyper_1_2_chunk" using heap, recompressing instead
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_2_chunk
@@ -311,7 +310,6 @@ select tuple_count from pgstattuple(:'hystable_device_chunk_idx');
 -- rebuild indexes. It will optimize the structure of the index and
 -- thus reduce the number of index tuples
 select compress_chunk(:'hystable_chunk');
-NOTICE:  cannot compress hypercore "_hyper_1_2_chunk" using heap, recompressing instead
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/sql/hypercore_create.sql
+++ b/tsl/test/sql/hypercore_create.sql
@@ -319,12 +319,11 @@ commit;
 select compress_chunk(ch, hypercore_use_access_method => true, if_not_compressed => false)
 from show_chunks('test2') ch;
 
-\set ON_ERROR_STOP 1
-
--- Compressing from hypercore not using access method should lead to
--- recompression of hypercore with a notice.
+-- Compressing from hypercore and not using access method should lead
+-- to an error since it is not supported.
 select compress_chunk(ch, hypercore_use_access_method => false)
 from show_chunks('test2') ch;
+\set ON_ERROR_STOP 1
 
 -- Compressing a hypercore should by default lead to
 -- recompression. First check that :chunk is a hypercore.


### PR DESCRIPTION
In a previous change, the parameter for using hypercore TAM when compressing a chunk changed, which also caused the compress_chunk() function to start emitting a notice when recompressing a chunk using Hypercore TAM. This message was meant to be emitted when recompressing and specifying an incompatible parameter option, but now it is emitted even when not specifying an option.

This change ensures the message is no longer emitted when recompressing, unless an incompatible option is specified. Also update the message to match the new parameter name.

Disable-check: force-changelog-file
