### PR TITLE
 Fix issue resulting from PG 17.1 ResultRelInfo size change

### DIFF
--- a/.unreleased/pr_7447
+++ b/.unreleased/pr_7447
@@ -1,0 +1,1 @@
+Fixes: #7447 Call InitResultRelInfo in ts_catalog_open_indexes

--- a/.unreleased/pr_7447
+++ b/.unreleased/pr_7447
@@ -1,1 +1,1 @@
-Fixes: #7447 Call InitResultRelInfo in ts_catalog_open_indexes
+Fixes: #7447 Fix issue resulting from PG 17.1 ResultRelInfo size change

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -122,6 +122,9 @@ create_chunk_rri_constraint_expr(ResultRelInfo *rri, Relation rel)
 	}
 }
 
+#undef makeNode
+#define makeNode(_type_) ((_type_ *) newNode(2 * sizeof(_type_), T_##_type_))
+
 /*
  * Create a new ResultRelInfo for a chunk.
  *


### PR DESCRIPTION
Because a new member was added to `ResulRelInfo` in 17.1, our initialization of `resultRelInfo` in `ts_catalog_open_indexes` did not work correctly.

Switching to use the PostgreSQL functions `CatalogOpenIndexes` and `CatalogCloseIndexes`.

---

If calling `InitResultRelInfo()` from a 17.0 build of timescaledb on a 17.1 PostgreSQL server, it will attempt to zero out memory for the new member `ri_needLockTagTuple` and for that reason (potentially) result in writing to unallocated memory.

Since we are only calling `InitResultRelInfo()` from one location in the code---inside `create_chunk_result_relation_info`---we redefine `makeNode` for this file to allocate `2 * sizeof(ResultRelInfo)`. This will overallocate memory for the structure, hence allow `InitResultRelInfo()` to write the additional field.

---

Calling `InitResultRelInfo()` in a 17.1 PostgreSQL server from an extension built with a 17.0 server will try to initialize the new field `ri_needLockTagTuple`, which will attempt to write outsize the bounds of the structure.

To deal with this, we create a union of the `ResultRelInfo` structure and a buffer with `2 * sizeof(ResultRelInfo)`, thereby making sure that calls of `InitResultRelInfo()` will not write outside allocated memory.
