### PR TITLE
Remove unnecessary TimescaleDB functions

### DIFF
--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -789,28 +789,6 @@ ts_catalog_scan_all(CatalogTable table, int indexid, ScanKeyData *scankey, int n
 	ts_scanner_scan(&scanctx);
 }
 
-extern TSDLLEXPORT ResultRelInfo *
-ts_catalog_open_indexes(Relation heapRel)
-{
-	ResultRelInfo *resultRelInfo;
-
-	resultRelInfo = makeNode(ResultRelInfo);
-	resultRelInfo->ri_RangeTableIndex = 0; /* dummy */
-	resultRelInfo->ri_RelationDesc = heapRel;
-	resultRelInfo->ri_TrigDesc = NULL; /* we don't fire triggers */
-
-	ExecOpenIndices(resultRelInfo, false);
-
-	return resultRelInfo;
-}
-
-extern TSDLLEXPORT void
-ts_catalog_close_indexes(ResultRelInfo *indstate)
-{
-	ExecCloseIndices(indstate);
-	pfree(indstate);
-}
-
 /*
  * Copied verbatim from postgres source CatalogIndexInsert which is static
  * in postgres source code.

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1356,8 +1356,6 @@ extern TSDLLEXPORT void ts_catalog_update(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_delete_tid_only(Relation rel, ItemPointer tid);
 extern TSDLLEXPORT void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
 extern TSDLLEXPORT void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
-extern TSDLLEXPORT ResultRelInfo *ts_catalog_open_indexes(Relation heapRel);
-extern TSDLLEXPORT void ts_catalog_close_indexes(ResultRelInfo *indstate);
 extern TSDLLEXPORT void ts_catalog_index_insert(ResultRelInfo *indstate, HeapTuple heapTuple);
 
 bool TSDLLEXPORT ts_catalog_scan_one(CatalogTable table, int indexid, ScanKeyData *scankey,

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -13,6 +13,7 @@
 #include <access/xact.h>
 #include <catalog/dependency.h>
 #include <catalog/index.h>
+#include <catalog/indexing.h>
 #include <commands/event_trigger.h>
 #include <commands/tablecmds.h>
 #include <commands/trigger.h>
@@ -1092,10 +1093,9 @@ get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 
 	CompressionSettings *settings = ts_compression_settings_get(compressed_chunk->table_id);
 
-	ResultRelInfo *indstate = ts_catalog_open_indexes(compressed_chunk_rel);
+	CatalogIndexState indstate = CatalogOpenIndexes(compressed_chunk_rel);
 	Oid index_oid = get_compressed_chunk_index(indstate, settings);
-
-	ts_catalog_close_indexes(indstate);
+	CatalogCloseIndexes(indstate);
 
 	table_close(compressed_chunk_rel, NoLock);
 	table_close(uncompressed_chunk_rel, NoLock);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <postgres.h>
+#include <catalog/indexing.h>
 #include <executor/tuptable.h>
 #include <fmgr.h>
 #include <lib/stringinfo.h>
@@ -130,7 +131,7 @@ typedef struct RowDecompressor
 
 	TupleDesc out_desc;
 	Relation out_rel;
-	ResultRelInfo *indexstate;
+	CatalogIndexState indexstate;
 	EState *estate;
 
 	CommandId mycid;


### PR DESCRIPTION
Functions `ts_catalog_open_indexes` and friends are just a copy of the corresponding PostgreSQL function `CatalogOpenIndexes`, so remove them and use these instead.

Disable-check: force-changelog-file