### PR TITLE
Allow DROP NOT NULL on column of compressed table

### DIFF
--- a/.unreleased/pr_7455
+++ b/.unreleased/pr_7455
@@ -1,0 +1,1 @@
+Implements: #7455: Support DROP NOT NULL on compressed hypertables

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -280,6 +280,7 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 			case AT_ReplicaIdentity:
 			case AT_ReAddStatistics:
 			case AT_SetCompression:
+			case AT_DropNotNull:
 #if PG15_GE
 			case AT_SetAccessMethod:
 #endif

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -31,7 +31,7 @@ CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SET timezone TO 'America/Los_Angeles';
-CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
+CREATE TABLE test1 ("Time" timestamptz, i integer not null, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
 NOTICE:  adding not-null constraint to column "Time"
  table_name 
@@ -2536,3 +2536,59 @@ ALTER TABLE compression_drop DROP COLUMN v0;
 ERROR:  cannot drop orderby or segmentby column from a chunk with compression enabled
 \set ON_ERROR_STOP 1
 DROP TABLE compression_drop;
+SET client_min_messages = ERROR;
+CREATE TABLE test2 (ts timestamptz, i integer not null, b bigint, t text);
+SELECT table_name from create_hypertable('test2', 'ts', chunk_time_interval=> INTERVAL '1 day');
+ table_name 
+------------
+ test2
+(1 row)
+
+INSERT INTO test2
+SELECT t,
+       gen_rand_minstd(),
+       gen_rand_minstd(),
+       gen_rand_minstd()::text
+FROM   generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
+ALTER TABLE test2 SET (
+      timescaledb.compress,
+      timescaledb.compress_segmentby = 'b',
+      timescaledb.compress_orderby = 'ts DESC'
+);
+\set ON_ERROR_STOP 0
+INSERT INTO test2(ts,b,t) VALUES ('2024-11-18 18:04:51',99,'magic');
+ERROR:  null value in column "i" of relation "_hyper_44_180_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+ALTER TABLE test2 ALTER COLUMN i DROP NOT NULL;
+INSERT INTO test2(ts,b,t) VALUES ('2024-11-18 18:04:51',99,'magic');
+SELECT count(*) FROM test2 WHERE i IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('test2') ch;
+ count 
+-------
+    28
+(1 row)
+
+SELECT count(*) FROM test2 WHERE i IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(decompress_chunk(ch)) FROM show_chunks('test2') ch;
+ count 
+-------
+    28
+(1 row)
+
+SELECT count(*) FROM test2 WHERE i IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+SET client_min_messages = NOTICE;

--- a/tsl/test/expected/hypercore_ddl.out
+++ b/tsl/test/expected/hypercore_ddl.out
@@ -11,15 +11,14 @@ select setseed(1);
 (1 row)
 
 create table readings(
-       time timestamptz unique,
-       location int,
-       device int,
+       time timestamptz not null unique,
+       location int not null,
+       device int not null,
        temp numeric(4,1),
        humidity float,
        jdata jsonb
 );
 select create_hypertable('readings', by_range('time', '1d'::interval));
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (1,t)
@@ -98,5 +97,34 @@ select (select count(*) from readings) tuples,
  tuples | chunks 
 --------+--------
       0 |      0
+(1 row)
+
+\set ON_ERROR_STOP 0
+insert into readings(time,device,temp,humidity,jdata)
+values ('2024-01-01 00:00:00', 1, 99.0, 99.0, '{"magic": "yes"}'::jsonb);
+ERROR:  null value in column "location" of relation "_hyper_1_9_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+-- Test altering column definitions
+alter table readings
+      alter column location drop not null;
+-- This should now work.
+insert into readings(time,device,temp,humidity,jdata)
+values ('2024-01-01 00:00:00', 1, 99.0, 99.0, '{"magic": "yes"}'::jsonb);
+select count(*) from readings where location is null;
+ count 
+-------
+     1
+(1 row)
+
+select compress_chunk(show_chunks('readings'), hypercore_use_access_method => true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_10_chunk
+(1 row)
+
+select count(*) from readings where location is null;
+ count 
+-------
+     1
 (1 row)
 

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -17,7 +17,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 
 SET timezone TO 'America/Los_Angeles';
 
-CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
+CREATE TABLE test1 ("Time" timestamptz, i integer not null, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
 
 INSERT INTO test1 SELECT t,  gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd()::text FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
@@ -1041,3 +1041,32 @@ ALTER TABLE compression_drop DROP COLUMN v0;
 \set ON_ERROR_STOP 1
 
 DROP TABLE compression_drop;
+
+SET client_min_messages = ERROR;
+CREATE TABLE test2 (ts timestamptz, i integer not null, b bigint, t text);
+SELECT table_name from create_hypertable('test2', 'ts', chunk_time_interval=> INTERVAL '1 day');
+
+INSERT INTO test2
+SELECT t,
+       gen_rand_minstd(),
+       gen_rand_minstd(),
+       gen_rand_minstd()::text
+FROM   generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
+
+ALTER TABLE test2 SET (
+      timescaledb.compress,
+      timescaledb.compress_segmentby = 'b',
+      timescaledb.compress_orderby = 'ts DESC'
+);
+
+\set ON_ERROR_STOP 0
+INSERT INTO test2(ts,b,t) VALUES ('2024-11-18 18:04:51',99,'magic');
+\set ON_ERROR_STOP 1
+ALTER TABLE test2 ALTER COLUMN i DROP NOT NULL;
+INSERT INTO test2(ts,b,t) VALUES ('2024-11-18 18:04:51',99,'magic');
+SELECT count(*) FROM test2 WHERE i IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test2') ch;
+SELECT count(*) FROM test2 WHERE i IS NULL;
+SELECT count(decompress_chunk(ch)) FROM show_chunks('test2') ch;
+SELECT count(*) FROM test2 WHERE i IS NULL;
+SET client_min_messages = NOTICE;


### PR DESCRIPTION
Remove the restriction on `ALTER TABLE ... ALTER COLUMN SET/DROP NOT NULL` on compressed tables.

Dropping or setting the `NOT NULL` constraint on a column of a compressed table is safe since it does not require re-writing any data. Setting `NOT NULL` will require a full table scan to verify that there are no NULL in the table.

Fixes #5776 