### PR TITLE
Optimize array creation in vectorized aggregate functions

### DIFF
--- a/tsl/src/nodes/vector_agg/function/float48_accum_single.c
+++ b/tsl/src/nodes/vector_agg/function/float48_accum_single.c
@@ -69,9 +69,17 @@ FUNCTION_NAME(emit)(void *agg_state, Datum *out_result, bool *out_isnull)
 {
 	FUNCTION_NAME(state) *state = (FUNCTION_NAME(state) *) agg_state;
 
-	Datum transdatums[3] = {
-		Float8GetDatumFast(state->N),
-		Float8GetDatumFast(state->Sx),
+	const size_t nbytes = 3 * sizeof(float8) + ARR_OVERHEAD_NONULLS(/* ndims = */ 1);
+	ArrayType *result = palloc(nbytes);
+	SET_VARSIZE(result, nbytes);
+	result->ndim = 1;
+	result->dataoffset = 0;
+	result->elemtype = FLOAT8OID;
+	ARR_DIMS(result)[0] = 3;
+	ARR_LBOUND(result)[0] = 1;
+	((Datum *) ARR_DATA_PTR(result))[0] = Float8GetDatumFast(state->N);
+	((Datum *) ARR_DATA_PTR(result))[1] = Float8GetDatumFast(state->Sx);
+	((Datum *) ARR_DATA_PTR(result))[2] =
 		/*
 		 * Sxx should be NaN if any of the inputs are infinite or NaN. This is
 		 * checked by float8_combine even if it's not used for the actual
@@ -81,15 +89,7 @@ FUNCTION_NAME(emit)(void *agg_state, Datum *out_result, bool *out_isnull)
 #ifdef NEED_SXX
 					   + state->Sxx
 #endif
-					   ),
-	};
-
-	ArrayType *result = construct_array(transdatums,
-										3,
-										FLOAT8OID,
-										sizeof(float8),
-										FLOAT8PASSBYVAL,
-										TYPALIGN_DOUBLE);
+		);
 
 	*out_result = PointerGetDatum(result);
 	*out_isnull = false;

--- a/tsl/src/nodes/vector_agg/function/float48_accum_single.c
+++ b/tsl/src/nodes/vector_agg/function/float48_accum_single.c
@@ -77,19 +77,24 @@ FUNCTION_NAME(emit)(void *agg_state, Datum *out_result, bool *out_isnull)
 	result->elemtype = FLOAT8OID;
 	ARR_DIMS(result)[0] = 3;
 	ARR_LBOUND(result)[0] = 1;
-	((Datum *) ARR_DATA_PTR(result))[0] = Float8GetDatumFast(state->N);
-	((Datum *) ARR_DATA_PTR(result))[1] = Float8GetDatumFast(state->Sx);
-	((Datum *) ARR_DATA_PTR(result))[2] =
+
+	/*
+	 * The array elements are stored by value, regardless of if the float8
+	 * itself is by-value on this platform.
+	 */
+	((float8 *) ARR_DATA_PTR(result))[0] = state->N;
+	((float8 *) ARR_DATA_PTR(result))[1] = state->Sx;
+	((float8 *) ARR_DATA_PTR(result))[2] =
 		/*
 		 * Sxx should be NaN if any of the inputs are infinite or NaN. This is
 		 * checked by float8_combine even if it's not used for the actual
 		 * calculations.
 		 */
-		Float8GetDatum(0. * state->Sx
+		0. * state->Sx
 #ifdef NEED_SXX
-					   + state->Sxx
+		+ state->Sxx
 #endif
-		);
+		;
 
 	*out_result = PointerGetDatum(result);
 	*out_isnull = false;

--- a/tsl/src/nodes/vector_agg/function/int24_avg_accum_templates.c
+++ b/tsl/src/nodes/vector_agg/function/int24_avg_accum_templates.c
@@ -50,8 +50,13 @@ int24_avg_accum_emit(void *agg_state, Datum *out_result, bool *out_isnull)
 	result->elemtype = INT8OID;
 	ARR_DIMS(result)[0] = 2;
 	ARR_LBOUND(result)[0] = 1;
-	((Datum *) ARR_DATA_PTR(result))[0] = Int64GetDatumFast(state->count);
-	((Datum *) ARR_DATA_PTR(result))[1] = Int64GetDatumFast(state->sum);
+
+	/*
+	 * The array elements are stored by value, regardless of if the int8 itself
+	 * is by-value on this platform.
+	 */
+	((int64 *) ARR_DATA_PTR(result))[0] = state->count;
+	((int64 *) ARR_DATA_PTR(result))[1] = state->sum;
 
 	*out_result = PointerGetDatum(result);
 	*out_isnull = false;


### PR DESCRIPTION
We can inline the few lines of code required to create an array, instead of calling the very generic `construct_array` function which shows up in profiles.

Disable-check: force-changelog-file