### PR TITLE
Fix locking issues with new PG minor releases

### DIFF
--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -926,9 +926,6 @@ swap_relation_files(Oid r1, Oid r2, bool swap_toast_by_content, bool is_internal
 	Oid swaptemp;
 	char swptmpchr;
 
-	AssertSufficientPgClassUpdateLockHeld(r1);
-	AssertSufficientPgClassUpdateLockHeld(r2);
-
 	/* We need writable copies of both pg_class tuples. */
 	relRelation = table_open(RelationRelationId, RowExclusiveLock);
 


### PR DESCRIPTION
This change fixes the following:

[Add tuple locks when disabling autovacuum](https://github.com/timescale/timescaledb/commit/da32b25412eefa5ed71b64c1f8ba0af6a28b7db8)

A previous commit (https://github.com/timescale/timescaledb/commit/cbfd386c63842cb2779a8b598048381eb75a7db2) disabled autovacuum for internal
compressed relations when using Hypercore TAM, but it lacked the tuple
locks when updated pg_class that are now required by recent PG
versions.

Add the missing tuple locks to fix the issue. See commit https://github.com/timescale/timescaledb/commit/7e30ed65651ab5b0adee835f17829fa69a52382e for
more information.

[Remove lock check assertion for reorder](https://github.com/timescale/timescaledb/commit/dff09e7d55ca39db9d47a3da97fd2c0844cb0459)

A previous commit (7e30ed6) added an assertion check to the reorder
code's `swap_relation_files` to ensure that proper locks are held on
the relations when updating their pg_class entries, per new
requirements in recent PostgreSQL releases. However, this check failed
because the function could be called on indexes as well as tables, and
indexes have different locking requirements.

The assertions aren't strictly needed because heap_update() has a
check of its own that will raise a warning if locking requirements are
not met (assuming the code is compiled with assertions enabled).

Disable-check: force-changelog-file
Disable-check: commit-count
