### PR TITLE
Fix building against PG14.0

### DIFF
--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -3491,7 +3491,11 @@ convert_to_hypercore_finish(Oid relid)
 	 * relcache invalidations. Previously there was sometimes a crash here
 	 * because the tuple sort state had a reference to a tuple descriptor in
 	 * the relcache. */
+#if (PG_VERSION_NUM >= 140001)
 	RelationCacheInvalidate(false);
+#else
+	RelationCacheInvalidate();
+#endif
 #endif
 
 	Chunk *chunk = ts_chunk_get_by_relid(conversionstate->relid, true);


### PR DESCRIPTION
In #7467 we added a `RelationCacheInvalidate(false)` but on upstream this API changed on PG14.1 by postgres/postgres@dde966e.

We build agains first minor release in our nightly CI and also on ABI tests so make sure we're using the right function call based on the Postgres version we're building against.

https://github.com/timescale/timescaledb/actions/runs/11943958854/job/33294019881#step:12:360

Disable-check: force-changelog-file
Disable-check: approval-count
