### PR TITLE
Fix changelog reference

### DIFF
--- a/.unreleased/pr_7104
+++ b/.unreleased/pr_7104
@@ -1,1 +1,1 @@
-Implements: #7271 Hypercore table access method
+Implements: #7104 Hypercore table access method


### PR DESCRIPTION
The changelog entry for the Hypercore TAM pointed to the wrong PR, so fixing.

Disable-check: force-changelog-file
Disable-check: approval-count