### PR TITLE
Prevent building against pg versions with broken ABI

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -58,13 +58,13 @@ jobs:
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         include:
           - pg: 14
-            pg_version: 14.13
+            pg_version: "14.15"
           - pg: 15
-            pg_version: 15.8
+            pg_version: "15.10"
           - pg: 16
-            pg_version: 16.4
+            pg_version: "16.6"
           - pg: 17
-            pg_version: 17.0
+            pg_version: "17.2"
     env:
       # PostgreSQL configuration
       PGPORT: 55432

--- a/.unreleased/pr_7486
+++ b/.unreleased/pr_7486
@@ -1,0 +1,1 @@
+Implements: #7486 Prevent building against postgres versions with broken ABI

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -26,10 +26,19 @@
 
 #define PG_MAJOR_MIN 14
 
-#define is_supported_pg_version_14(version) ((version >= 140000) && (version < 150000))
-#define is_supported_pg_version_15(version) ((version >= 150000) && (version < 160000))
-#define is_supported_pg_version_16(version) ((version >= 160000) && (version < 170000))
-#define is_supported_pg_version_17(version) ((version >= 170000) && (version < 180000))
+/*
+ * Prevent building against upstream versions that had ABI breaking change (14.14, 15.9, 16.5, 17.1)
+ * that was reverted in the following release.
+ */
+
+#define is_supported_pg_version_14(version)                                                        \
+	((version >= 140000) && (version < 150000) && (version != 140014))
+#define is_supported_pg_version_15(version)                                                        \
+	((version >= 150000) && (version < 160000) && (version != 150009))
+#define is_supported_pg_version_16(version)                                                        \
+	((version >= 160000) && (version < 170000) && (version != 160005))
+#define is_supported_pg_version_17(version)                                                        \
+	((version >= 170000) && (version < 180000) && (version != 170001))
 
 /*
  * PG16 support is a WIP and not complete yet.


### PR DESCRIPTION
Disable-check: commit-count