### PR TITLE
Emit error on transition table trigger for chunks

### DIFF
--- a/.unreleased/pr_7488
+++ b/.unreleased/pr_7488
@@ -1,0 +1,1 @@
+Fixes: #7488 Emit error for transition table trigger on chunks

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4452,6 +4452,12 @@ process_create_trigger_start(ProcessUtilityArgs *args)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("triggers are not supported on continuous aggregate")));
 
+		if (stmt->transitionRels)
+			if (ts_chunk_get_by_relid(relid, false) != NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg(
+							 "trigger with transition tables not supported on hypertable chunks")));
 		return DDL_CONTINUE;
 	}
 

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -428,6 +428,9 @@ SELECT create_hypertable('transition_test','time');
  (4,public,transition_test,t)
 (1 row)
 
+-- Insert some rows to create a chunk
+INSERT INTO transition_test values ('2020-01-10');
+SELECT chunk FROM show_chunks('transition_test') tbl(chunk) limit 1 \gset
 -- test creating trigger with transition tables on existing hypertable
 \set ON_ERROR_STOP 0
 CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
@@ -436,6 +439,12 @@ CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_t
 ERROR:  trigger with transition tables not supported on hypertables
 CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 ERROR:  trigger with transition tables not supported on hypertables
+CREATE TRIGGER t2 AFTER INSERT ON :chunk REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+ERROR:  trigger with transition tables not supported on hypertable chunks
+CREATE TRIGGER t3 AFTER UPDATE ON :chunk REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+ERROR:  trigger with transition tables not supported on hypertable chunks
+CREATE TRIGGER t4 AFTER DELETE ON :chunk REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+ERROR:  trigger with transition tables not supported on hypertable chunks
 CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 ERROR:  trigger with transition tables not supported on hypertables
 CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -313,11 +313,18 @@ SELECT create_hypertable('transition_test','time');
 DROP TRIGGER t1 ON transition_test;
 SELECT create_hypertable('transition_test','time');
 
+-- Insert some rows to create a chunk
+INSERT INTO transition_test values ('2020-01-10');
+SELECT chunk FROM show_chunks('transition_test') tbl(chunk) limit 1 \gset
+
 -- test creating trigger with transition tables on existing hypertable
 \set ON_ERROR_STOP 0
 CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t2 AFTER INSERT ON :chunk REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t3 AFTER UPDATE ON :chunk REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t4 AFTER DELETE ON :chunk REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();


### PR DESCRIPTION
If a transition table trigger is added to a hypertable, an error is generated indicating that this is not supported. However, if it is added to a chunk, it is accepted but generates an assertion failure in debug builds.

Instead, we generate an error when an attempt is made to add a transition table trigger to a chunk of a hypertable, regardless of whether the compression flag is set or not.

Fixes #7487