### PR TITLE
Fix CAgg permissions regression leftovers

### DIFF
--- a/tsl/test/expected/cagg_permissions-14.out
+++ b/tsl/test/expected/cagg_permissions-14.out
@@ -64,6 +64,7 @@ CREATE USER not_priv;
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
 ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -193,6 +194,7 @@ group by time_bucket(100, timec), location WITH NO DATA;
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for function get_constant
 DROP MATERIALIZED VIEW mat_perm_view_test;
+\set ON_ERROR_STOP 1
 --can create a mat view on something with select and trigger grants
 CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
@@ -213,9 +215,11 @@ REVOKE SELECT ON conditions_for_perm_check_w_grant FROM public;
 insert into conditions_for_perm_check_w_grant
 select generate_series(100, 130, 10), 'POR', 65, 85, 30, 90, NULL;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
 --refresh mat view should now fail due to lack of permissions
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for table conditions_for_perm_check_w_grant
+\set ON_ERROR_STOP 1
 --but the old data will still be there
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/expected/cagg_permissions-15.out
+++ b/tsl/test/expected/cagg_permissions-15.out
@@ -64,6 +64,7 @@ CREATE USER not_priv;
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
 ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -193,6 +194,7 @@ group by time_bucket(100, timec), location WITH NO DATA;
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for function get_constant
 DROP MATERIALIZED VIEW mat_perm_view_test;
+\set ON_ERROR_STOP 1
 --can create a mat view on something with select and trigger grants
 CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
@@ -213,9 +215,11 @@ REVOKE SELECT ON conditions_for_perm_check_w_grant FROM public;
 insert into conditions_for_perm_check_w_grant
 select generate_series(100, 130, 10), 'POR', 65, 85, 30, 90, NULL;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
 --refresh mat view should now fail due to lack of permissions
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for table conditions_for_perm_check_w_grant
+\set ON_ERROR_STOP 1
 --but the old data will still be there
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/expected/cagg_permissions-16.out
+++ b/tsl/test/expected/cagg_permissions-16.out
@@ -64,6 +64,7 @@ CREATE USER not_priv;
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
 ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -193,6 +194,7 @@ group by time_bucket(100, timec), location WITH NO DATA;
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for function get_constant
 DROP MATERIALIZED VIEW mat_perm_view_test;
+\set ON_ERROR_STOP 1
 --can create a mat view on something with select and trigger grants
 CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
@@ -213,9 +215,11 @@ REVOKE SELECT ON conditions_for_perm_check_w_grant FROM public;
 insert into conditions_for_perm_check_w_grant
 select generate_series(100, 130, 10), 'POR', 65, 85, 30, 90, NULL;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
 --refresh mat view should now fail due to lack of permissions
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for table conditions_for_perm_check_w_grant
+\set ON_ERROR_STOP 1
 --but the old data will still be there
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/expected/cagg_permissions-17.out
+++ b/tsl/test/expected/cagg_permissions-17.out
@@ -64,6 +64,7 @@ CREATE USER not_priv;
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
 ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -193,6 +194,7 @@ group by time_bucket(100, timec), location WITH NO DATA;
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for function get_constant
 DROP MATERIALIZED VIEW mat_perm_view_test;
+\set ON_ERROR_STOP 1
 --can create a mat view on something with select and trigger grants
 CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
@@ -213,9 +215,11 @@ REVOKE SELECT ON conditions_for_perm_check_w_grant FROM public;
 insert into conditions_for_perm_check_w_grant
 select generate_series(100, 130, 10), 'POR', 65, 85, 30, 90, NULL;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
 --refresh mat view should now fail due to lack of permissions
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for table conditions_for_perm_check_w_grant
+\set ON_ERROR_STOP 1
 --but the old data will still be there
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/sql/cagg_permissions.sql.in
+++ b/tsl/test/sql/cagg_permissions.sql.in
@@ -62,6 +62,7 @@ CREATE USER not_priv;
 -- A user with no ownership on the Cagg cannot create index on it. -- This should fail
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -182,6 +183,7 @@ group by time_bucket(100, timec), location WITH NO DATA;
 --this should fail
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 DROP MATERIALIZED VIEW mat_perm_view_test;
+\set ON_ERROR_STOP 1
 
 --can create a mat view on something with select and trigger grants
 CREATE MATERIALIZED VIEW mat_perm_view_test
@@ -202,8 +204,10 @@ insert into conditions_for_perm_check_w_grant
 select generate_series(100, 130, 10), 'POR', 65, 85, 30, 90, NULL;
 
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
 --refresh mat view should now fail due to lack of permissions
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
+\set ON_ERROR_STOP 1
 
 --but the old data will still be there
 SELECT * FROM mat_perm_view_test;


### PR DESCRIPTION
We missed to re-enable ON_ERROR_STOP after some failed tests.

Disable-check: force-changelog-file
Disable-check: approval-count
