### PR TITLE
Fix flaky reorder regression test

### DIFF
--- a/tsl/test/expected/reorder.out
+++ b/tsl/test/expected/reorder.out
@@ -1273,9 +1273,10 @@ CREATE INDEX ct2_time_idx ON ct2(time DESC);
 CLUSTER ct2 USING ct2_time_idx;
 -- deleted chunks are removed correctly
 DELETE FROM ct2 where time < 2 OR val < 2;
+VACUUM ct2;
 SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', verbose => TRUE);
 INFO:  reordering "_timescaledb_internal._hyper_2_3_chunk" using sequential scan and sort
-INFO:  "_hyper_2_3_chunk": found 2 removable, 3 nonremovable row versions in 1 pages
+INFO:  "_hyper_2_3_chunk": found 0 removable, 3 nonremovable row versions in 1 pages
  reorder_chunk 
 ---------------
  

--- a/tsl/test/sql/reorder.sql
+++ b/tsl/test/sql/reorder.sql
@@ -200,6 +200,7 @@ CLUSTER ct2 USING ct2_time_idx;
 
 -- deleted chunks are removed correctly
 DELETE FROM ct2 where time < 2 OR val < 2;
+VACUUM ct2;
 
 SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', verbose => TRUE);
 SELECT ctid, time, val FROM _timescaledb_internal._hyper_2_3_chunk ORDER BY time;


### PR DESCRIPTION
Execute manual `VACUUM` on the hypertable before reordering a chunk to avoid flaky test output.

Disable-check: force-changelog-file
Disable-check: approval-count
