### PR TITLE
Encapsulate runner output cleanup into single script

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -148,14 +148,4 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
      -v TEST_SUPPORT_FILE=${TEST_SUPPORT_FILE} \
      -v TEST_SUPPORT_FILE_INIT=${TEST_SUPPORT_FILE_INIT} \
-     "$@" -d ${TEST_DBNAME} 2>&1 | \
-          sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
-               -e 's! Memory: [0-9]\{1,\}kB!!' \
-               -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
-               -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
-          grep -v 'DEBUG:  rehashing catalog cache id' | \
-          grep -v 'DEBUG:  compacted fsync request queue from' | \
-          grep -v 'DEBUG:  creating and filling new WAL file' | \
-          grep -v 'DEBUG:  done creating and filling new WAL file' | \
-          grep -v 'DEBUG:  flushed relation because a checkpoint occurred concurrently' | \
-          grep -v 'NOTICE:  cancelling the background worker for job'
+     "$@" -d ${TEST_DBNAME} 2>&1 | ${CURRENT_DIR}/runner_cleanup_output.sh

--- a/test/runner_cleanup_output.sh
+++ b/test/runner_cleanup_output.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -u
+set -e
+
+RUNNER=${1:-""}
+
+sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
+     -e 's! Memory: [0-9]\{1,\}kB!!' \
+     -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
+     -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
+grep -v 'DEBUG:  rehashing catalog cache id' | \
+grep -v 'DEBUG:  compacted fsync request queue from' | \
+grep -v 'DEBUG:  creating and filling new WAL file' | \
+grep -v 'DEBUG:  done creating and filling new WAL file' | \
+grep -v 'DEBUG:  flushed relation because a checkpoint occurred concurrently' | \
+grep -v 'NOTICE:  cancelling the background worker for job' | \
+if [ "${RUNNER}" = "shared" ]; then \
+    sed -e '/^-\{1,\}$/d' \
+        -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \
+        -e 's!^ \{1,\}QUERY PLAN \{1,\}$!QUERY PLAN!'; \
+else \
+    cat; \
+fi | \
+if [ "${RUNNER}" = "isolation" ]; then \
+    sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \
+        -e 's!hypertable_[0-9]\{1,\}!hypertable_X!g'; \
+else \
+    cat; \
+fi

--- a/test/runner_isolation.sh
+++ b/test/runner_isolation.sh
@@ -7,6 +7,7 @@
 
 set -e
 set -u
+CURRENT_DIR=$(dirname $0)
 
 ISOLATIONTEST=$1
 shift
@@ -18,7 +19,4 @@ shift
 # the chunk numbers influence the names of indexes if they are long enough to be
 # truncated, so the only way to get a stable explain output is to run such a test
 # in a separate database.
-$ISOLATIONTEST "$@" | \
-   sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \
-    -e 's!hypertable_[0-9]\{1,\}!hypertable_X!g'
- 
+$ISOLATIONTEST "$@" | ${CURRENT_DIR}/runner_cleanup_output.sh "isolation"

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -79,18 +79,4 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
-     "$@" -d ${TEST_DBNAME} 2>&1 | \
-          sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
-               -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \
-               -e 's!^ \{1,\}QUERY PLAN \{1,\}$!QUERY PLAN!' \
-               -e 's!:  actual rows!: actual rows!' \
-               -e '/^-\{1,\}$/d' \
-               -e 's! Memory: [0-9]\{1,\}kB!!' \
-               -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
-               -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
-          grep -v 'DEBUG:  rehashing catalog cache id' | \
-          grep -v 'DEBUG:  compacted fsync request queue from' | \
-          grep -v 'DEBUG:  creating and filling new WAL file' | \
-          grep -v 'DEBUG:  done creating and filling new WAL file' | \
-          grep -v 'DEBUG:  flushed relation because a checkpoint occurred concurrently' | \
-          grep -v 'NOTICE:  cancelling the background worker for job'
+     "$@" -d ${TEST_DBNAME} 2>&1 | ${CURRENT_DIR}/runner_cleanup_output.sh "shared"


### PR DESCRIPTION
Disable-check: force-changelog-file