### PR TITLE
Fix flaky append regression test

### DIFF
--- a/test/expected/append-14.out
+++ b/test/expected/append-14.out
@@ -57,10 +57,11 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2
                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_load.sql:47: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -69,11 +70,13 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+VACUUM (ANALYZE) join_test;
 -- Create another table to join with which is not a hypertable.
 CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
 INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
                              ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
                              ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
+VACUUM (ANALYZE) join_test_plain;
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -83,18 +86,18 @@ SELECT create_hypertable('metrics_date','time');
 (1 row)
 
 INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_date;
+VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:70: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
 (1 row)
 
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_timestamp;
+VACUUM (ANALYZE) metrics_timestamp;
 -- create hypertable with TIMESTAMPTZ time dimension
 CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL, device_id INT NOT NULL);
 CREATE INDEX ON metrics_timestamptz(device_id,time);
@@ -107,7 +110,7 @@ SELECT create_hypertable('metrics_timestamptz','time');
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 1;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 2;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 3;
-ANALYZE metrics_timestamptz;
+VACUUM (ANALYZE) metrics_timestamptz;
 -- create space partitioned hypertable
 CREATE TABLE metrics_space(time timestamptz NOT NULL, device_id int NOT NULL, v1 float, v2 float, v3 text);
 SELECT create_hypertable('metrics_space','time','device_id',3);
@@ -121,7 +124,7 @@ SELECT time, device_id, device_id + 0.25, device_id + 0.75, device_id
 FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m'::interval) g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
-ANALYZE metrics_space;
+VACUUM (ANALYZE) metrics_space;
 -- test ChunkAppend projection #2661
 CREATE TABLE i2661 (
   machine_id int4 NOT NULL,
@@ -130,14 +133,14 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:102: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)
 (1 row)
 
 INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
-ANALYZE i2661;
+VACUUM (ANALYZE) i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -162,12 +165,14 @@ psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
-   Order: append_test."time" DESC
-   Chunks excluded during startup: 3
-(3 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: append_test."time" DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
+         Chunks excluded during startup: 3
+(5 rows)
 
 --query should exclude all chunks and be a MergeAppend
 :PREFIX
@@ -202,12 +207,12 @@ psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
    Chunks excluded during startup: 2
-   ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > (now_s() - '@ 2 mons'::interval))
 (4 rows)
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
@@ -223,15 +228,17 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-         Order: append_test."time"
-         Chunks excluded during startup: 2
-         ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(6 rows)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: append_test."time"
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+               Chunks excluded during startup: 2
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(8 rows)
 
 -- no optimized plan for queries with restrictions that can be
 -- constified at planning time. Regular planning-time constraint
@@ -240,14 +247,16 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
 psql:include/append_query.sql:37: NOTICE:  Immutable function now_i() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
-(5 rows)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
+(7 rows)
 
 -- currently, we cannot distinguish between stable and volatile
 -- functions as far as applying our modified plan. However, volatile
@@ -261,20 +270,22 @@ psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 0
-   ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-(11 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+(13 rows)
 
 -- prepared statement output should be the same regardless of
 -- optimizations
@@ -290,14 +301,16 @@ psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(5 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(7 rows)
 
 DEALLOCATE query_opt;
 -- aggregates should produce same output
@@ -315,18 +328,21 @@ psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: (date_trunc('year'::text, append_test."time"))
-   ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
-         Order: date_trunc('year'::text, append_test."time") DESC
-         Chunks excluded during startup: 1
-         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-         ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(9 rows)
+   ->  Sort (actual rows=3 loops=1)
+         Sort Key: (date_trunc('year'::text, append_test."time")) DESC
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
+               Chunks excluded during startup: 1
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                     Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+(11 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node
@@ -357,11 +373,14 @@ SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 :PREFIX
 EXECUTE query_param(now_s() - interval '2 months');
 psql:include/append_query.sql:82: NOTICE:  Stable function now_s() called!
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-   Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
-(2 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: _hyper_1_3_chunk."time"
+   Sort Method: quicksort 
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
+(5 rows)
 
 DEALLOCATE query_param;
 --test with cte
@@ -392,8 +411,10 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Sort (actual rows=6 loops=1)
    Sort Key: (time_bucket('@ 30 days'::interval, "time"."time"))
    Sort Method: quicksort 
@@ -408,16 +429,13 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
                            Batches: 1 
                            ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                  Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
-                                       Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                       Filter: (colorid > 0)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                                       Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                       Filter: (colorid > 0)
-                                 ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                                       Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                       Filter: (colorid > 0)
-(23 rows)
+                                 ->  Seq Scan on _hyper_1_1_chunk (actual rows=2 loops=1)
+                                       Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                 ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                                       Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                 ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                                       Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+(20 rows)
 
 WITH data AS (
     SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
@@ -435,6 +453,8 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
@@ -480,18 +500,18 @@ psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
    Join Filter: (a.colorid = j.colorid)
    ->  Custom Scan (ChunkAppend) on append_test a (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
 (10 rows)
 
 reset enable_hashjoin;
@@ -506,13 +526,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -522,13 +542,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -539,13 +559,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -557,13 +577,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -573,13 +593,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -590,13 +610,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -608,10 +628,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -621,10 +641,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -635,10 +655,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -650,13 +670,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -666,13 +686,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -683,13 +703,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -701,13 +721,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -717,13 +737,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -734,13 +754,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -752,10 +772,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -765,10 +785,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -779,10 +799,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -795,13 +815,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -812,13 +832,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -828,13 +848,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -847,13 +867,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -864,13 +884,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -880,13 +900,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -899,10 +919,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -913,10 +933,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -926,10 +946,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -954,24 +974,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -994,24 +1014,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1023,24 +1043,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1065,24 +1085,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1105,24 +1125,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1134,24 +1154,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1176,24 +1196,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1216,24 +1236,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1245,24 +1265,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1273,38 +1293,32 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics_space (actual rows=2304 loops=1)
-   Order: metrics_space."time"
-   ->  Merge Append (actual rows=1534 loops=1)
-         Sort Key: _hyper_6_25_chunk."time"
-         ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-         ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-   ->  Merge Append (actual rows=770 loops=1)
-         Sort Key: _hyper_6_28_chunk."time"
-         ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-         ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-(22 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2304 loops=1)
+   Sort Key: _hyper_6_25_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=2304 loops=1)
+         ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+(16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
                                                                QUERY PLAN                                                               
@@ -1313,10 +1327,10 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1683,33 +1697,33 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4611
+                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1720,25 +1734,25 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 3744
+                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1778,19 +1792,19 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 5
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 6
+                     Heap Fetches: 0
 (20 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1818,19 +1832,19 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 15
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 18
+               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1845,19 +1859,19 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 4
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 5
+                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1874,7 +1888,7 @@ ORDER BY time DESC, device_id;
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 1
+                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
                                Heap Fetches: 0
@@ -1901,7 +1915,7 @@ ORDER BY time DESC, device_id;
          Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 3
+         Heap Fetches: 0
 (38 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1912,10 +1926,10 @@ ORDER BY time DESC, device_id;
    Order: m1."time"
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
          Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4032
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
          Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 3744
+         Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1932,10 +1946,10 @@ ORDER BY time DESC, device_id;
                        Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 3741
+                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 4032
+                       Heap Fetches: 0
 (28 rows)
 
 -- test EXISTS
@@ -1947,7 +1961,7 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 1003
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
@@ -1971,7 +1985,7 @@ ORDER BY time DESC, device_id;
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 1000
+                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -1984,10 +1998,10 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 4032
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 3744
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2002,10 +2016,10 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2017,7 +2031,7 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
@@ -2043,21 +2057,23 @@ ORDER BY time DESC, device_id;
 (8 rows)
 
 :PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          ->  Append (actual rows=37450 loops=1)
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(12 rows)
+(14 rows)
 
 -- HAVING should prevent pushdown
 :PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
@@ -2075,8 +2091,8 @@ ORDER BY time DESC, device_id;
 (9 rows)
 
 :PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          Filter: (count(*) > 1)
@@ -2084,13 +2100,15 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(13 rows)
+(15 rows)
 
 -- DISTINCT should prevent pushdown
 SET enable_hashagg TO false;
@@ -2102,15 +2120,15 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 2689
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 3075
+                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2121,23 +2139,23 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2159,6 +2177,7 @@ SELECT time, device_id
 FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
+VACUUM (ANALYZE) join_limit;
 -- get 2nd chunk oid
 SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
 \gset
@@ -2249,7 +2268,7 @@ SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes
 
 CREATE INDEX ON i3030(a,time);
 INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
-ANALYZE i3030;
+VACUUM (ANALYZE) i3030;
 :PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/append-15.out
+++ b/test/expected/append-15.out
@@ -57,10 +57,11 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2
                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_load.sql:47: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -69,11 +70,13 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+VACUUM (ANALYZE) join_test;
 -- Create another table to join with which is not a hypertable.
 CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
 INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
                              ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
                              ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
+VACUUM (ANALYZE) join_test_plain;
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -83,18 +86,18 @@ SELECT create_hypertable('metrics_date','time');
 (1 row)
 
 INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_date;
+VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:70: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
 (1 row)
 
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_timestamp;
+VACUUM (ANALYZE) metrics_timestamp;
 -- create hypertable with TIMESTAMPTZ time dimension
 CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL, device_id INT NOT NULL);
 CREATE INDEX ON metrics_timestamptz(device_id,time);
@@ -107,7 +110,7 @@ SELECT create_hypertable('metrics_timestamptz','time');
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 1;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 2;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 3;
-ANALYZE metrics_timestamptz;
+VACUUM (ANALYZE) metrics_timestamptz;
 -- create space partitioned hypertable
 CREATE TABLE metrics_space(time timestamptz NOT NULL, device_id int NOT NULL, v1 float, v2 float, v3 text);
 SELECT create_hypertable('metrics_space','time','device_id',3);
@@ -121,7 +124,7 @@ SELECT time, device_id, device_id + 0.25, device_id + 0.75, device_id
 FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m'::interval) g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
-ANALYZE metrics_space;
+VACUUM (ANALYZE) metrics_space;
 -- test ChunkAppend projection #2661
 CREATE TABLE i2661 (
   machine_id int4 NOT NULL,
@@ -130,14 +133,14 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:102: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)
 (1 row)
 
 INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
-ANALYZE i2661;
+VACUUM (ANALYZE) i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -162,12 +165,14 @@ psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
-   Order: append_test."time" DESC
-   Chunks excluded during startup: 3
-(3 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: append_test."time" DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
+         Chunks excluded during startup: 3
+(5 rows)
 
 --query should exclude all chunks and be a MergeAppend
 :PREFIX
@@ -202,12 +207,12 @@ psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
    Chunks excluded during startup: 2
-   ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > (now_s() - '@ 2 mons'::interval))
 (4 rows)
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
@@ -223,15 +228,17 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-         Order: append_test."time"
-         Chunks excluded during startup: 2
-         ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(6 rows)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: append_test."time"
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+               Chunks excluded during startup: 2
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(8 rows)
 
 -- no optimized plan for queries with restrictions that can be
 -- constified at planning time. Regular planning-time constraint
@@ -240,14 +247,16 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
 psql:include/append_query.sql:37: NOTICE:  Immutable function now_i() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
-(5 rows)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
+(7 rows)
 
 -- currently, we cannot distinguish between stable and volatile
 -- functions as far as applying our modified plan. However, volatile
@@ -261,20 +270,22 @@ psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 0
-   ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-(11 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+(13 rows)
 
 -- prepared statement output should be the same regardless of
 -- optimizations
@@ -290,14 +301,16 @@ psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(5 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(7 rows)
 
 DEALLOCATE query_opt;
 -- aggregates should produce same output
@@ -315,19 +328,22 @@ psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: (date_trunc('year'::text, append_test."time"))
-   ->  Result (actual rows=3 loops=1)
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
-               Order: date_trunc('year'::text, append_test."time") DESC
-               Chunks excluded during startup: 1
-               ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-               ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(10 rows)
+   ->  Sort (actual rows=3 loops=1)
+         Sort Key: (date_trunc('year'::text, append_test."time")) DESC
+         Sort Method: quicksort 
+         ->  Result (actual rows=3 loops=1)
+               ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
+                     Chunks excluded during startup: 1
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                           Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                           Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+(12 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node
@@ -358,11 +374,14 @@ SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 :PREFIX
 EXECUTE query_param(now_s() - interval '2 months');
 psql:include/append_query.sql:82: NOTICE:  Stable function now_s() called!
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-   Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
-(2 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: _hyper_1_3_chunk."time"
+   Sort Method: quicksort 
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
+(5 rows)
 
 DEALLOCATE query_param;
 --test with cte
@@ -393,8 +412,10 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=6 loops=1)
    Sort Key: (time_bucket('@ 30 days'::interval, "time"."time"))
    Sort Method: quicksort 
@@ -410,16 +431,13 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-                                       ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-(24 rows)
+                                       ->  Seq Scan on _hyper_1_1_chunk (actual rows=2 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                       ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                       ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+(21 rows)
 
 WITH data AS (
     SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
@@ -437,6 +455,8 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
@@ -482,18 +502,18 @@ psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
    Join Filter: (a.colorid = j.colorid)
    ->  Custom Scan (ChunkAppend) on append_test a (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
 (10 rows)
 
 reset enable_hashjoin;
@@ -508,13 +528,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -524,13 +544,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -541,13 +561,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -559,13 +579,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -575,13 +595,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -592,13 +612,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -610,10 +630,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -623,10 +643,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -637,10 +657,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -652,13 +672,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -668,13 +688,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -685,13 +705,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -703,13 +723,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -719,13 +739,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -736,13 +756,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -754,10 +774,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -767,10 +787,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -781,10 +801,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -797,13 +817,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -814,13 +834,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -830,13 +850,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -849,13 +869,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -866,13 +886,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -882,13 +902,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -901,10 +921,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -915,10 +935,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -928,10 +948,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -956,24 +976,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -996,24 +1016,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1025,24 +1045,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1067,24 +1087,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1107,24 +1127,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1136,24 +1156,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1178,24 +1198,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1218,24 +1238,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1247,24 +1267,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1275,38 +1295,32 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics_space (actual rows=2304 loops=1)
-   Order: metrics_space."time"
-   ->  Merge Append (actual rows=1534 loops=1)
-         Sort Key: _hyper_6_25_chunk."time"
-         ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-         ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-   ->  Merge Append (actual rows=770 loops=1)
-         Sort Key: _hyper_6_28_chunk."time"
-         ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-         ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-(22 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2304 loops=1)
+   Sort Key: _hyper_6_25_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=2304 loops=1)
+         ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+(16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
                                                                QUERY PLAN                                                               
@@ -1315,10 +1329,10 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1685,33 +1699,33 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4611
+                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1722,25 +1736,25 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 3744
+                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1781,19 +1795,19 @@ ORDER BY time DESC, device_id;
                      Chunks excluded during runtime: 4
                      ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 5
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 6
+                           Heap Fetches: 0
 (21 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1821,19 +1835,19 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 15
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 18
+               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1848,19 +1862,19 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 4
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 5
+                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1877,7 +1891,7 @@ ORDER BY time DESC, device_id;
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 1
+                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
                                Heap Fetches: 0
@@ -1904,7 +1918,7 @@ ORDER BY time DESC, device_id;
          Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 3
+         Heap Fetches: 0
 (38 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1916,10 +1930,10 @@ ORDER BY time DESC, device_id;
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1936,10 +1950,10 @@ ORDER BY time DESC, device_id;
                        Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 3741
+                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 4032
+                       Heap Fetches: 0
 (29 rows)
 
 -- test EXISTS
@@ -1951,7 +1965,7 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 1003
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
@@ -1975,7 +1989,7 @@ ORDER BY time DESC, device_id;
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 1000
+                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -1988,10 +2002,10 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 4032
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 3744
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2006,10 +2020,10 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2021,7 +2035,7 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
@@ -2047,21 +2061,23 @@ ORDER BY time DESC, device_id;
 (8 rows)
 
 :PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          ->  Append (actual rows=37450 loops=1)
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(12 rows)
+(14 rows)
 
 -- HAVING should prevent pushdown
 :PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
@@ -2079,8 +2095,8 @@ ORDER BY time DESC, device_id;
 (9 rows)
 
 :PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          Filter: (count(*) > 1)
@@ -2088,13 +2104,15 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(13 rows)
+(15 rows)
 
 -- DISTINCT should prevent pushdown
 SET enable_hashagg TO false;
@@ -2106,15 +2124,15 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 2689
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 3075
+                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2125,23 +2143,23 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2163,6 +2181,7 @@ SELECT time, device_id
 FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
+VACUUM (ANALYZE) join_limit;
 -- get 2nd chunk oid
 SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
 \gset
@@ -2254,7 +2273,7 @@ SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes
 
 CREATE INDEX ON i3030(a,time);
 INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
-ANALYZE i3030;
+VACUUM (ANALYZE) i3030;
 :PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -57,10 +57,11 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2
                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_load.sql:47: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -69,11 +70,13 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+VACUUM (ANALYZE) join_test;
 -- Create another table to join with which is not a hypertable.
 CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
 INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
                              ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
                              ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
+VACUUM (ANALYZE) join_test_plain;
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -83,18 +86,18 @@ SELECT create_hypertable('metrics_date','time');
 (1 row)
 
 INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_date;
+VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:70: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
 (1 row)
 
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_timestamp;
+VACUUM (ANALYZE) metrics_timestamp;
 -- create hypertable with TIMESTAMPTZ time dimension
 CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL, device_id INT NOT NULL);
 CREATE INDEX ON metrics_timestamptz(device_id,time);
@@ -107,7 +110,7 @@ SELECT create_hypertable('metrics_timestamptz','time');
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 1;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 2;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 3;
-ANALYZE metrics_timestamptz;
+VACUUM (ANALYZE) metrics_timestamptz;
 -- create space partitioned hypertable
 CREATE TABLE metrics_space(time timestamptz NOT NULL, device_id int NOT NULL, v1 float, v2 float, v3 text);
 SELECT create_hypertable('metrics_space','time','device_id',3);
@@ -121,7 +124,7 @@ SELECT time, device_id, device_id + 0.25, device_id + 0.75, device_id
 FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m'::interval) g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
-ANALYZE metrics_space;
+VACUUM (ANALYZE) metrics_space;
 -- test ChunkAppend projection #2661
 CREATE TABLE i2661 (
   machine_id int4 NOT NULL,
@@ -130,14 +133,14 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:102: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)
 (1 row)
 
 INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
-ANALYZE i2661;
+VACUUM (ANALYZE) i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -162,12 +165,14 @@ psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
-   Order: append_test."time" DESC
-   Chunks excluded during startup: 3
-(3 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: append_test."time" DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
+         Chunks excluded during startup: 3
+(5 rows)
 
 --query should exclude all chunks and be a MergeAppend
 :PREFIX
@@ -202,12 +207,12 @@ psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
    Chunks excluded during startup: 2
-   ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > (now_s() - '@ 2 mons'::interval))
 (4 rows)
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
@@ -223,15 +228,17 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-         Order: append_test."time"
-         Chunks excluded during startup: 2
-         ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(6 rows)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: append_test."time"
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+               Chunks excluded during startup: 2
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(8 rows)
 
 -- no optimized plan for queries with restrictions that can be
 -- constified at planning time. Regular planning-time constraint
@@ -240,14 +247,16 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
 psql:include/append_query.sql:37: NOTICE:  Immutable function now_i() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
-(5 rows)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
+(7 rows)
 
 -- currently, we cannot distinguish between stable and volatile
 -- functions as far as applying our modified plan. However, volatile
@@ -261,20 +270,22 @@ psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 0
-   ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-(11 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+(13 rows)
 
 -- prepared statement output should be the same regardless of
 -- optimizations
@@ -290,14 +301,16 @@ psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(5 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(7 rows)
 
 DEALLOCATE query_opt;
 -- aggregates should produce same output
@@ -315,19 +328,22 @@ psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: (date_trunc('year'::text, append_test."time"))
-   ->  Result (actual rows=3 loops=1)
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
-               Order: date_trunc('year'::text, append_test."time") DESC
-               Chunks excluded during startup: 1
-               ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-               ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(10 rows)
+   ->  Sort (actual rows=3 loops=1)
+         Sort Key: (date_trunc('year'::text, append_test."time")) DESC
+         Sort Method: quicksort 
+         ->  Result (actual rows=3 loops=1)
+               ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
+                     Chunks excluded during startup: 1
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                           Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                           Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+(12 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node
@@ -358,11 +374,14 @@ SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 :PREFIX
 EXECUTE query_param(now_s() - interval '2 months');
 psql:include/append_query.sql:82: NOTICE:  Stable function now_s() called!
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-   Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
-(2 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: _hyper_1_3_chunk."time"
+   Sort Method: quicksort 
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
+(5 rows)
 
 DEALLOCATE query_param;
 --test with cte
@@ -393,8 +412,10 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=6 loops=1)
    Sort Key: (time_bucket('@ 30 days'::interval, "time"."time"))
    Sort Method: quicksort 
@@ -410,16 +431,13 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-                                       ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-(24 rows)
+                                       ->  Seq Scan on _hyper_1_1_chunk (actual rows=2 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                       ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                       ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+(21 rows)
 
 WITH data AS (
     SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
@@ -437,6 +455,8 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
@@ -482,18 +502,18 @@ psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
    Join Filter: (a.colorid = j.colorid)
    ->  Custom Scan (ChunkAppend) on append_test a (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
 (10 rows)
 
 reset enable_hashjoin;
@@ -508,13 +528,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -524,13 +544,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -541,13 +561,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -559,13 +579,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -575,13 +595,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -592,13 +612,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -610,10 +630,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -623,10 +643,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -637,10 +657,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -652,13 +672,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -668,13 +688,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -685,13 +705,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -703,13 +723,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -719,13 +739,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -736,13 +756,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -754,10 +774,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -767,10 +787,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -781,10 +801,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -797,13 +817,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -814,13 +834,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -830,13 +850,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -849,13 +869,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -866,13 +886,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -882,13 +902,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -901,10 +921,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -915,10 +935,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -928,10 +948,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -956,24 +976,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -996,24 +1016,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1025,24 +1045,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1067,24 +1087,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1107,24 +1127,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1136,24 +1156,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1178,24 +1198,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1218,24 +1238,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1247,24 +1267,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1275,38 +1295,32 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics_space (actual rows=2304 loops=1)
-   Order: metrics_space."time"
-   ->  Merge Append (actual rows=1534 loops=1)
-         Sort Key: _hyper_6_25_chunk."time"
-         ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-         ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-   ->  Merge Append (actual rows=770 loops=1)
-         Sort Key: _hyper_6_28_chunk."time"
-         ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-         ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-(22 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2304 loops=1)
+   Sort Key: _hyper_6_25_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=2304 loops=1)
+         ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+(16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
                                                                QUERY PLAN                                                               
@@ -1315,10 +1329,10 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1685,33 +1699,33 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4611
+                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1722,25 +1736,25 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 3744
+                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1781,19 +1795,19 @@ ORDER BY time DESC, device_id;
                      Chunks excluded during runtime: 4
                      ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 5
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 6
+                           Heap Fetches: 0
 (21 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1821,19 +1835,19 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 15
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 18
+               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1848,19 +1862,19 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 4
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 5
+                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1877,7 +1891,7 @@ ORDER BY time DESC, device_id;
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 1
+                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
                                Heap Fetches: 0
@@ -1904,7 +1918,7 @@ ORDER BY time DESC, device_id;
          Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 3
+         Heap Fetches: 0
 (38 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1916,10 +1930,10 @@ ORDER BY time DESC, device_id;
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1936,10 +1950,10 @@ ORDER BY time DESC, device_id;
                        Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 3741
+                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 4032
+                       Heap Fetches: 0
 (29 rows)
 
 -- test EXISTS
@@ -1951,7 +1965,7 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 1003
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
@@ -1975,7 +1989,7 @@ ORDER BY time DESC, device_id;
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 1000
+                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -1988,10 +2002,10 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 4032
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 3744
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2006,10 +2020,10 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2021,7 +2035,7 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
@@ -2047,21 +2061,23 @@ ORDER BY time DESC, device_id;
 (8 rows)
 
 :PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          ->  Append (actual rows=37450 loops=1)
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(12 rows)
+(14 rows)
 
 -- HAVING should prevent pushdown
 :PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
@@ -2079,8 +2095,8 @@ ORDER BY time DESC, device_id;
 (9 rows)
 
 :PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          Filter: (count(*) > 1)
@@ -2088,13 +2104,15 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(13 rows)
+(15 rows)
 
 -- DISTINCT should prevent pushdown
 SET enable_hashagg TO false;
@@ -2106,15 +2124,15 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 2689
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 3075
+                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2125,23 +2143,23 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2163,6 +2181,7 @@ SELECT time, device_id
 FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
+VACUUM (ANALYZE) join_limit;
 -- get 2nd chunk oid
 SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
 \gset
@@ -2254,7 +2273,7 @@ SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes
 
 CREATE INDEX ON i3030(a,time);
 INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
-ANALYZE i3030;
+VACUUM (ANALYZE) i3030;
 :PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -57,10 +57,11 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2
                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_load.sql:47: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -69,11 +70,13 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+VACUUM (ANALYZE) join_test;
 -- Create another table to join with which is not a hypertable.
 CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
 INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
                              ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
                              ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
+VACUUM (ANALYZE) join_test_plain;
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -83,18 +86,18 @@ SELECT create_hypertable('metrics_date','time');
 (1 row)
 
 INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_date;
+VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:70: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
 (1 row)
 
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_timestamp;
+VACUUM (ANALYZE) metrics_timestamp;
 -- create hypertable with TIMESTAMPTZ time dimension
 CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL, device_id INT NOT NULL);
 CREATE INDEX ON metrics_timestamptz(device_id,time);
@@ -107,7 +110,7 @@ SELECT create_hypertable('metrics_timestamptz','time');
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 1;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 2;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 3;
-ANALYZE metrics_timestamptz;
+VACUUM (ANALYZE) metrics_timestamptz;
 -- create space partitioned hypertable
 CREATE TABLE metrics_space(time timestamptz NOT NULL, device_id int NOT NULL, v1 float, v2 float, v3 text);
 SELECT create_hypertable('metrics_space','time','device_id',3);
@@ -121,7 +124,7 @@ SELECT time, device_id, device_id + 0.25, device_id + 0.75, device_id
 FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m'::interval) g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
-ANALYZE metrics_space;
+VACUUM (ANALYZE) metrics_space;
 -- test ChunkAppend projection #2661
 CREATE TABLE i2661 (
   machine_id int4 NOT NULL,
@@ -130,14 +133,14 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:102: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)
 (1 row)
 
 INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
-ANALYZE i2661;
+VACUUM (ANALYZE) i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -162,12 +165,14 @@ psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:12: NOTICE:  Stable function now_s() called!
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
-   Order: append_test."time" DESC
-   Chunks excluded during startup: 3
-(3 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: append_test."time" DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
+         Chunks excluded during startup: 3
+(5 rows)
 
 --query should exclude all chunks and be a MergeAppend
 :PREFIX
@@ -202,12 +207,12 @@ psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:24: NOTICE:  Stable function now_s() called!
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
    Chunks excluded during startup: 2
-   ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > (now_s() - '@ 2 mons'::interval))
 (4 rows)
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
@@ -223,15 +228,17 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-         Order: append_test."time"
-         Chunks excluded during startup: 2
-         ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(6 rows)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: append_test."time"
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+               Chunks excluded during startup: 2
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(8 rows)
 
 -- no optimized plan for queries with restrictions that can be
 -- constified at planning time. Regular planning-time constraint
@@ -240,14 +247,16 @@ psql:include/append_query.sql:30: NOTICE:  Stable function now_s() called!
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
 psql:include/append_query.sql:37: NOTICE:  Immutable function now_i() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
-(5 rows)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
+(7 rows)
 
 -- currently, we cannot distinguish between stable and volatile
 -- functions as far as applying our modified plan. However, volatile
@@ -261,20 +270,22 @@ psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
 psql:include/append_query.sql:45: NOTICE:  Volatile function now_v() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 0
-   ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-         Rows Removed by Filter: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-(11 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+               Rows Removed by Filter: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+(13 rows)
 
 -- prepared statement output should be the same regardless of
 -- optimizations
@@ -290,14 +301,16 @@ psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:53: NOTICE:  Stable function now_s() called!
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
-   Order: append_test."time"
-   Chunks excluded during startup: 2
-   ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(5 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: append_test."time"
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=1 loops=1)
+         Chunks excluded during startup: 2
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 2 mons'::interval))
+(7 rows)
 
 DEALLOCATE query_opt;
 -- aggregates should produce same output
@@ -315,19 +328,22 @@ psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:62: NOTICE:  Stable function now_s() called!
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: (date_trunc('year'::text, append_test."time"))
-   ->  Result (actual rows=3 loops=1)
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
-               Order: date_trunc('year'::text, append_test."time") DESC
-               Chunks excluded during startup: 1
-               ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-               ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(10 rows)
+   ->  Sort (actual rows=3 loops=1)
+         Sort Key: (date_trunc('year'::text, append_test."time")) DESC
+         Sort Method: quicksort 
+         ->  Result (actual rows=3 loops=1)
+               ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
+                     Chunks excluded during startup: 1
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                           Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                           Filter: ("time" > (now_s() - '@ 4 mons'::interval))
+(12 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node
@@ -358,11 +374,14 @@ SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 :PREFIX
 EXECUTE query_param(now_s() - interval '2 months');
 psql:include/append_query.sql:82: NOTICE:  Stable function now_s() called!
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-   Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
-(2 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: _hyper_1_3_chunk."time"
+   Sort Method: quicksort 
+   ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+         Filter: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
+(5 rows)
 
 DEALLOCATE query_param;
 --test with cte
@@ -393,8 +412,10 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=6 loops=1)
    Sort Key: (time_bucket('@ 30 days'::interval, "time"."time"))
    Sort Method: quicksort 
@@ -410,16 +431,13 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-                                       ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
-                                             Filter: (colorid > 0)
-(24 rows)
+                                       ->  Seq Scan on _hyper_1_1_chunk (actual rows=2 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                       ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                                       ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+                                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+(21 rows)
 
 WITH data AS (
     SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
@@ -437,6 +455,8 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
+psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:119: NOTICE:  Stable function now_s() called!
@@ -482,18 +502,18 @@ psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:130: NOTICE:  Stable function now_s() called!
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
    Join Filter: (a.colorid = j.colorid)
    ->  Custom Scan (ChunkAppend) on append_test a (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_1_3_chunk a_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
          Chunks excluded during startup: 2
-         ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
-               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Seq Scan on _hyper_2_6_chunk j_1 (actual rows=1 loops=1)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
 (10 rows)
 
 reset enable_hashjoin;
@@ -508,13 +528,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -524,13 +544,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -541,13 +561,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -559,13 +579,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -575,13 +595,13 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -592,13 +612,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -610,10 +630,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -623,10 +643,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -637,10 +657,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -652,13 +672,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -668,13 +688,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -685,13 +705,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -703,13 +723,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -719,13 +739,13 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -736,13 +756,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1441
+         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -754,10 +774,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -767,10 +787,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -781,10 +801,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1439
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 288
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -797,13 +817,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -814,13 +834,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -830,13 +850,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -849,13 +869,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -866,13 +886,13 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -882,13 +902,13 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 6048
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4611
+         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -901,10 +921,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -915,10 +935,10 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -928,10 +948,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 4029
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 1152
+         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -956,24 +976,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -996,24 +1016,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1025,24 +1045,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1067,24 +1087,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1107,24 +1127,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1136,24 +1156,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1178,24 +1198,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1218,24 +1238,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1247,24 +1267,24 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3068
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1534
+               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1540
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 770
+               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1275,38 +1295,32 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics_space (actual rows=2304 loops=1)
-   Order: metrics_space."time"
-   ->  Merge Append (actual rows=1534 loops=1)
-         Sort Key: _hyper_6_25_chunk."time"
-         ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-         ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 2301
-   ->  Merge Append (actual rows=770 loops=1)
-         Sort Key: _hyper_6_28_chunk."time"
-         ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-         ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
-               Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 1155
-(22 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2304 loops=1)
+   Sort Key: _hyper_6_25_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=2304 loops=1)
+         ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
+               Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               Heap Fetches: 0
+(16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
                                                                QUERY PLAN                                                               
@@ -1315,10 +1329,10 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 767
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 385
+         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1685,33 +1699,33 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 6048
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 4611
+                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1722,25 +1736,25 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 6048
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 4611
+               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 4032
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 3744
+                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1781,19 +1795,19 @@ ORDER BY time DESC, device_id;
                      Chunks excluded during runtime: 4
                      ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 5
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 7
+                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 6
+                           Heap Fetches: 0
 (21 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1821,19 +1835,19 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 15
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 21
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 18
+               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1848,19 +1862,19 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 4
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 7
+                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 5
+                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1876,7 +1890,7 @@ ORDER BY time DESC, device_id;
                    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
-                               Heap Fetches: 1
+                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
@@ -1899,7 +1913,7 @@ ORDER BY time DESC, device_id;
          Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 3
+         Heap Fetches: 0
 (33 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1911,10 +1925,10 @@ ORDER BY time DESC, device_id;
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1931,10 +1945,10 @@ ORDER BY time DESC, device_id;
                        Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 3741
+                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 4032
+                       Heap Fetches: 0
 (29 rows)
 
 -- test EXISTS
@@ -1946,7 +1960,7 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 1003
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
@@ -1970,7 +1984,7 @@ ORDER BY time DESC, device_id;
                      Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 1000
+                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -1983,10 +1997,10 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 4032
+         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 3744
+         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2001,10 +2015,10 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 4032
+               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 3744
+               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2016,7 +2030,7 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
+               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
@@ -2042,21 +2056,23 @@ ORDER BY time DESC, device_id;
 (8 rows)
 
 :PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          ->  Append (actual rows=37450 loops=1)
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(12 rows)
+(14 rows)
 
 -- HAVING should prevent pushdown
 :PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
@@ -2074,8 +2090,8 @@ ORDER BY time DESC, device_id;
 (9 rows)
 
 :PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Aggregate (actual rows=1 loops=1)
          Filter: (count(*) > 1)
@@ -2083,13 +2099,15 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_22_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
-               ->  Seq Scan on _hyper_6_25_chunk (actual rows=8064 loops=1)
-               ->  Seq Scan on _hyper_6_26_chunk (actual rows=8064 loops=1)
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
+                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_30_chunk (actual rows=770 loops=1)
-(13 rows)
+(15 rows)
 
 -- DISTINCT should prevent pushdown
 SET enable_hashagg TO false;
@@ -2101,15 +2119,15 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 2689
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 4033
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 3075
+                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2120,23 +2138,23 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 1345
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 2017
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 386
+                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
+                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2158,6 +2176,7 @@ SELECT time, device_id
 FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
+VACUUM (ANALYZE) join_limit;
 -- get 2nd chunk oid
 SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
 \gset
@@ -2249,7 +2268,7 @@ SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes
 
 CREATE INDEX ON i3030(a,time);
 INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
-ANALYZE i3030;
+VACUUM (ANALYZE) i3030;
 :PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/sql/include/append_load.sql
+++ b/test/sql/include/append_load.sql
@@ -40,6 +40,7 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2
                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+VACUUM (ANALYZE) append_test;
 
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
@@ -48,6 +49,7 @@ SELECT create_hypertable('join_test', 'time', chunk_time_interval => 26280000000
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+VACUUM (ANALYZE) join_test;
 
 -- Create another table to join with which is not a hypertable.
 CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
@@ -55,18 +57,19 @@ CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr
 INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
                              ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
                              ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
+VACUUM (ANALYZE) join_test_plain;
 
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
 INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_date;
+VACUUM (ANALYZE) metrics_date;
 
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval);
-ANALYZE metrics_timestamp;
+VACUUM (ANALYZE) metrics_timestamp;
 
 -- create hypertable with TIMESTAMPTZ time dimension
 CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL, device_id INT NOT NULL);
@@ -75,7 +78,7 @@ SELECT create_hypertable('metrics_timestamptz','time');
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 1;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 2;
 INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '5m'::interval), 3;
-ANALYZE metrics_timestamptz;
+VACUUM (ANALYZE) metrics_timestamptz;
 
 -- create space partitioned hypertable
 CREATE TABLE metrics_space(time timestamptz NOT NULL, device_id int NOT NULL, v1 float, v2 float, v3 text);
@@ -87,7 +90,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m':
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
 
-ANALYZE metrics_space;
+VACUUM (ANALYZE) metrics_space;
 
 -- test ChunkAppend projection #2661
 CREATE TABLE i2661 (
@@ -99,5 +102,4 @@ CREATE TABLE i2661 (
 SELECT create_hypertable('i2661', 'timestamp');
 
 INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
-ANALYZE i2661;
-
+VACUUM (ANALYZE) i2661;

--- a/test/sql/include/append_query.sql
+++ b/test/sql/include/append_query.sql
@@ -320,6 +320,7 @@ SELECT time, device_id
 FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time),
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
+VACUUM (ANALYZE) join_limit;
 
 -- get 2nd chunk oid
 SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
@@ -353,7 +354,7 @@ CREATE TABLE i3030(time timestamptz NOT NULL, a int, b int);
 SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes=>false);
 CREATE INDEX ON i3030(a,time);
 INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
-ANALYZE i3030;
+VACUUM (ANALYZE) i3030;
 
 :PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
 DROP TABLE i3030;


### PR DESCRIPTION
Fixed it by manually running `VACUUM ANALYZE` in all involved hypertables to avoid flaky output tests.

https://github.com/timescale/timescaledb/actions/runs/12128976291/job/33819502944?pr=7505#step:17:23

Disable-check: force-changelog-file
