### PR TITLE
Fix error: invalid child of chunk append

### DIFF
--- a/.unreleased/pr_7514
+++ b/.unreleased/pr_7514
@@ -1,0 +1,1 @@
+Fixes: #7514 Fix error: invalid child of chunk append


### PR DESCRIPTION
When doing startup and runtime chunk exclusion, the chunk append node could sometimes throw an error: "invalid child of chunk append: Sort". Unfortunately, this error hasn't been successfully reproduced in a test but has been reported by users.

However, it seems clear that the error happens in
ts_chunk_append_get_scan_plan() when it can't find a "known" plan node to use for chunk exclusion. This function should ideally never throw and error and instead just return NULL, which means that chunk append falls back to not doing any exclusion instead of throwing an error.

It is also possible to improve the code and make it properly handle Sort and Result nodes by not special-casing them. By inspecting ts_chunk_append_get_scan_plan(), it is clear that it can only throw the error if it encounters a Result node with a Sort child, because in those two cases it didn't descend down the lefttree child node using a recursive call. Therefore, remove the special case and instead do a recursive call similar to how other nodes are handled. Also remove the special case for the vector agg node, since it should be OK to recursively process all CustomScan nodes.