### PR TITLE
Modify flakes table for jobs

### DIFF
--- a/scripts/upload_ci_stats.sh
+++ b/scripts/upload_ci_stats.sh
@@ -29,7 +29,10 @@ create table job(
     url text,
     run_attempt int,
     run_id bigint,
-    run_number int
+    run_number int,
+    pg_version text generated always as (
+        substring(job_name from 'PG([0-9]+(\.[0-9]+)*)')
+    ) stored
 );
 
 create unique index on job(job_date);
@@ -75,7 +78,13 @@ JOB_NAME="${JOB_NAME:-test-job}"
 export JOB_NAME
 
 JOB_DATE=$("${PSQL[@]}" -c "
-insert into job values (
+insert into job(
+    job_date, commit_sha, job_name,
+    repository, ref_name, event_name,
+    pr_number, job_status,
+    url,
+    run_attempt, run_id, run_number
+) values (
     now(), '$COMMIT_SHA', '$JOB_NAME',
     '$GITHUB_REPOSITORY', '$GITHUB_REF_NAME', '$GITHUB_EVENT_NAME',
     '$GITHUB_PR_NUMBER', '$JOB_STATUS',


### PR DESCRIPTION
This adds a generated column for extracting the version from the job name. It will read anything that matches `PG<number><alphanumeric>` or `PG<number>.<number>` and generate a version string. If the first pattern matches, it will generate `<number>.x` as string, signifying that this is an unknown minor version.

Disable-check: force-changelog-file, approval-count