### PR TITLE
Fix flaky append regression test take 2

### DIFF
--- a/test/expected/append-14.out
+++ b/test/expected/append-14.out
@@ -526,13 +526,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -542,13 +539,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -559,13 +553,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -577,13 +568,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -593,13 +581,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -610,13 +595,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -628,10 +610,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -641,10 +621,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -655,10 +633,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -670,13 +646,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -686,13 +659,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -703,13 +673,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -721,13 +688,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -737,13 +701,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -754,13 +715,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -772,10 +730,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -785,10 +741,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -799,10 +753,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -815,13 +767,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -832,13 +781,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -848,13 +794,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -867,13 +810,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -884,13 +824,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -900,13 +837,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -919,10 +853,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -933,10 +865,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -946,10 +876,8 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -963,35 +891,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -1003,35 +922,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1043,24 +953,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1074,35 +978,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1114,35 +1009,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1154,24 +1040,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1185,35 +1065,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1225,35 +1096,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1265,24 +1127,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1293,10 +1149,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
@@ -1308,16 +1162,12 @@ reset enable_material;
    ->  Append (actual rows=2304 loops=1)
          ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
@@ -1327,10 +1177,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1444,35 +1292,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
 (35 rows)
 
 -- test CURRENT_TIMESTAMP
@@ -1510,35 +1349,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
 (35 rows)
 
 -- test now()
@@ -1576,35 +1406,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
 (35 rows)
 
 -- query with tablesample and planner exclusion
@@ -1697,33 +1518,23 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1734,25 +1545,18 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1792,19 +1596,14 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
 (20 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1832,19 +1631,14 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1859,19 +1653,14 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1888,34 +1677,24 @@ ORDER BY time DESC, device_id;
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
 (38 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1926,10 +1705,8 @@ ORDER BY time DESC, device_id;
    Order: m1."time"
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
          Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
          Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1937,19 +1714,14 @@ ORDER BY time DESC, device_id;
                  Chunks excluded during runtime: 3
                  ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_1 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_2 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
 (28 rows)
 
 -- test EXISTS
@@ -1961,31 +1733,21 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_4 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_5 (never executed)
-                     Heap Fetches: 0
          ->  Append (actual rows=1 loops=1003)
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -1998,10 +1760,8 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2016,10 +1776,8 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2031,15 +1789,10 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (never executed)
-               Heap Fetches: 0
 (13 rows)
 
 -- aggregates should prevent pushdown
@@ -2066,9 +1819,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2101,9 +1852,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2120,15 +1869,10 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2139,23 +1883,14 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2203,10 +1938,8 @@ DROP INDEX :INDEX_NAME;
                            Rows Removed by Filter: 650
                ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=22 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=19 loops=1)
                      Order: m1."time"

--- a/test/expected/append-15.out
+++ b/test/expected/append-15.out
@@ -528,13 +528,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -544,13 +541,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -561,13 +555,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -579,13 +570,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -595,13 +583,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -612,13 +597,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -630,10 +612,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -643,10 +623,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -657,10 +635,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -672,13 +648,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -688,13 +661,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -705,13 +675,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -723,13 +690,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -739,13 +703,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -756,13 +717,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -774,10 +732,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -787,10 +743,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -801,10 +755,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -817,13 +769,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -834,13 +783,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -850,13 +796,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -869,13 +812,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -886,13 +826,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -902,13 +839,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -921,10 +855,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -935,10 +867,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -948,10 +878,8 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -965,35 +893,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -1005,35 +924,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1045,24 +955,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1076,35 +980,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1116,35 +1011,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1156,24 +1042,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1187,35 +1067,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1227,35 +1098,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1267,24 +1129,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1295,10 +1151,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
@@ -1310,16 +1164,12 @@ reset enable_material;
    ->  Append (actual rows=2304 loops=1)
          ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
@@ -1329,10 +1179,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1446,35 +1294,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
 (35 rows)
 
 -- test CURRENT_TIMESTAMP
@@ -1512,35 +1351,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
 (35 rows)
 
 -- test now()
@@ -1578,35 +1408,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
 (35 rows)
 
 -- query with tablesample and planner exclusion
@@ -1699,33 +1520,23 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1736,25 +1547,18 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1795,19 +1599,14 @@ ORDER BY time DESC, device_id;
                      Chunks excluded during runtime: 4
                      ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
 (21 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1835,19 +1634,14 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1862,19 +1656,14 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1891,34 +1680,24 @@ ORDER BY time DESC, device_id;
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
 (38 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1930,10 +1709,8 @@ ORDER BY time DESC, device_id;
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1941,19 +1718,14 @@ ORDER BY time DESC, device_id;
                  Chunks excluded during runtime: 3
                  ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_1 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_2 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
 (29 rows)
 
 -- test EXISTS
@@ -1965,31 +1737,21 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_4 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_5 (never executed)
-                     Heap Fetches: 0
          ->  Append (actual rows=1 loops=1003)
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -2002,10 +1764,8 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2020,10 +1780,8 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2035,15 +1793,10 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (never executed)
-               Heap Fetches: 0
 (13 rows)
 
 -- aggregates should prevent pushdown
@@ -2070,9 +1823,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2105,9 +1856,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2124,15 +1873,10 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2143,23 +1887,14 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2207,10 +1942,8 @@ DROP INDEX :INDEX_NAME;
                            Rows Removed by Filter: 650
                ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=22 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=19 loops=1)
                      Order: m1."time"

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -528,13 +528,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -544,13 +541,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -561,13 +555,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -579,13 +570,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -595,13 +583,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -612,13 +597,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -630,10 +612,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -643,10 +623,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -657,10 +635,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -672,13 +648,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -688,13 +661,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -705,13 +675,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -723,13 +690,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -739,13 +703,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -756,13 +717,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -774,10 +732,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -787,10 +743,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -801,10 +755,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -817,13 +769,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -834,13 +783,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -850,13 +796,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -869,13 +812,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -886,13 +826,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -902,13 +839,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -921,10 +855,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -935,10 +867,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -948,10 +878,8 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -965,35 +893,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -1005,35 +924,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1045,24 +955,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1076,35 +980,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1116,35 +1011,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1156,24 +1042,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1187,35 +1067,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1227,35 +1098,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1267,24 +1129,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1295,10 +1151,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
@@ -1310,16 +1164,12 @@ reset enable_material;
    ->  Append (actual rows=2304 loops=1)
          ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
@@ -1329,10 +1179,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1446,35 +1294,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
 (35 rows)
 
 -- test CURRENT_TIMESTAMP
@@ -1512,35 +1351,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
 (35 rows)
 
 -- test now()
@@ -1578,35 +1408,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
 (35 rows)
 
 -- query with tablesample and planner exclusion
@@ -1699,33 +1520,23 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1736,25 +1547,18 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1795,19 +1599,14 @@ ORDER BY time DESC, device_id;
                      Chunks excluded during runtime: 4
                      ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
 (21 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1835,19 +1634,14 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1862,19 +1656,14 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1891,34 +1680,24 @@ ORDER BY time DESC, device_id;
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
 (38 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1930,10 +1709,8 @@ ORDER BY time DESC, device_id;
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1941,19 +1718,14 @@ ORDER BY time DESC, device_id;
                  Chunks excluded during runtime: 3
                  ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_1 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_2 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
 (29 rows)
 
 -- test EXISTS
@@ -1965,31 +1737,21 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_4 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_5 (never executed)
-                     Heap Fetches: 0
          ->  Append (actual rows=1 loops=1003)
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -2002,10 +1764,8 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2020,10 +1780,8 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2035,15 +1793,10 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (never executed)
-               Heap Fetches: 0
 (13 rows)
 
 -- aggregates should prevent pushdown
@@ -2070,9 +1823,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2105,9 +1856,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2124,15 +1873,10 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2143,23 +1887,14 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2207,10 +1942,8 @@ DROP INDEX :INDEX_NAME;
                            Rows Removed by Filter: 650
                ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=22 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=19 loops=1)
                      Order: m1."time"

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -528,13 +528,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -544,13 +541,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -561,13 +555,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -579,13 +570,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -595,13 +583,10 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -612,13 +597,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -630,10 +612,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -643,10 +623,8 @@ reset enable_material;
    Order: metrics_date."time"
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -657,10 +635,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -672,13 +648,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -688,13 +661,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -705,13 +675,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test Const OP Var
@@ -723,13 +690,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -739,13 +703,10 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (11 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -756,13 +717,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=2016 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk (actual rows=1441 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (12 rows)
 
 -- test 2 constraints
@@ -774,10 +732,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -787,10 +743,8 @@ reset enable_material;
    Order: metrics_timestamp."time"
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -801,10 +755,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk (actual rows=1439 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk (actual rows=288 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -817,13 +769,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
@@ -834,13 +783,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
@@ -850,13 +796,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test Const OP Var
@@ -869,13 +812,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > '01-15-2000'::date)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
@@ -886,13 +826,10 @@ reset enable_material;
    Chunks excluded during startup: 2
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-         Heap Fetches: 0
 (12 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
@@ -902,13 +839,10 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=6048 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=4611 loops=1)
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (11 rows)
 
 -- test 2 constraints
@@ -921,10 +855,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
@@ -935,10 +867,8 @@ reset enable_material;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-         Heap Fetches: 0
 (9 rows)
 
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
@@ -948,10 +878,8 @@ reset enable_material;
    Order: metrics_timestamptz."time"
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (actual rows=4029 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (actual rows=1152 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 -- test constraint_exclusion with space partitioning and DATE/TIMESTAMP/TIMESTAMPTZ constraints
@@ -965,35 +893,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp ORDER BY time;
@@ -1005,35 +924,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz ORDER BY time;
@@ -1045,24 +955,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test Const OP Var
@@ -1076,35 +980,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamp < time ORDER BY time;
@@ -1116,35 +1011,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE '2000-01-10'::timestamptz < time ORDER BY time;
@@ -1156,24 +1042,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (24 rows)
 
 -- test 2 constraints
@@ -1187,35 +1067,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamp AND time < '2000-01-15'::timestamp ORDER BY time;
@@ -1227,35 +1098,26 @@ reset enable_material;
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=7670 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
-               Heap Fetches: 0
 (35 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND time < '2000-01-15'::timestamptz ORDER BY time;
@@ -1267,24 +1129,18 @@ reset enable_material;
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
    ->  Merge Append (actual rows=3850 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=770 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (24 rows)
 
 -- test filtering on space partition
@@ -1295,10 +1151,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (1,2) ORDER BY time;
@@ -1310,16 +1164,12 @@ reset enable_material;
    ->  Append (actual rows=2304 loops=1)
          ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=767 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=385 loops=1)
                Index Cond: ((device_id = ANY ('{1,2}'::integer[])) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 0
 (16 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND device_id IN (VALUES(1)) ORDER BY time;
@@ -1329,10 +1179,8 @@ reset enable_material;
    Order: metrics_space."time"
    ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
          Index Cond: ((device_id = 1) AND ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 0
 (8 rows)
 
 :PREFIX SELECT time FROM metrics_space WHERE time > '2000-01-10'::timestamptz AND v3 IN (VALUES('1')) ORDER BY time;
@@ -1446,35 +1294,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
-               Heap Fetches: 0
 (35 rows)
 
 -- test CURRENT_TIMESTAMP
@@ -1512,35 +1351,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
-               Heap Fetches: 0
 (35 rows)
 
 -- test now()
@@ -1578,35 +1408,26 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          Sort Key: _hyper_6_22_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_25_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_6_28_chunk."time"
          ->  Index Only Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_6_30_chunk_metrics_space_time_idx on _hyper_6_30_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
-               Heap Fetches: 0
 (35 rows)
 
 -- query with tablesample and planner exclusion
@@ -1699,33 +1520,23 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=1 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=26787)
                Chunks excluded during runtime: 4
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=6048)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=4611)
                      Index Cond: ("time" = m1."time")
-                     Heap Fetches: 0
 (31 rows)
 
 -- test runtime exclusion and startup exclusions
@@ -1736,25 +1547,18 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
-               Heap Fetches: 0
    ->  Limit (actual rows=0 loops=26787)
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
                Chunks excluded during startup: 3
                Chunks excluded during runtime: 1
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
                      Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
-                     Heap Fetches: 0
 (23 rows)
 
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
@@ -1795,19 +1599,14 @@ ORDER BY time DESC, device_id;
                      Chunks excluded during runtime: 4
                      ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=5)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=6)
                            Index Cond: ("time" = g."time")
-                           Heap Fetches: 0
 (21 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time=g.time) m ON true;
@@ -1835,19 +1634,14 @@ ORDER BY time DESC, device_id;
          Chunks excluded during runtime: 4
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=3 loops=5)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=3 loops=7)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=3 loops=6)
                Index Cond: ("time" = g."time")
-               Heap Fetches: 0
 (19 rows)
 
 :PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) AS g(time) INNER JOIN LATERAL (SELECT time FROM metrics_timestamptz m WHERE time>g.time + '1 day' ORDER BY time LIMIT 1) m ON true;
@@ -1862,19 +1656,14 @@ ORDER BY time DESC, device_id;
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m_1 (actual rows=1 loops=4)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m_2 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m_3 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m_4 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m_5 (actual rows=1 loops=7)
                      Index Cond: ("time" > (g."time" + '@ 1 day'::interval))
-                     Heap Fetches: 0
 (22 rows)
 
 -- test runtime exclusion with subquery
@@ -1890,30 +1679,20 @@ ORDER BY time DESC, device_id;
                    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
                          Order: metrics_timestamptz."time" DESC
                          ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (actual rows=1 loops=1)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (never executed)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (never executed)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (never executed)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (never executed)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=3 loops=1)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
 (33 rows)
 
 -- test runtime exclusion with correlated subquery
@@ -1925,10 +1704,8 @@ ORDER BY time DESC, device_id;
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=3744 loops=1)
                Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
    SubPlan 1
      ->  Limit (actual rows=1 loops=7776)
            ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=7776)
@@ -1936,19 +1713,14 @@ ORDER BY time DESC, device_id;
                  Chunks excluded during runtime: 3
                  ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_1 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_2 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (never executed)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_4 (actual rows=1 loops=3741)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_5 (actual rows=1 loops=4035)
                        Index Cond: ("time" < m1."time")
-                       Heap Fetches: 0
 (29 rows)
 
 -- test EXISTS
@@ -1960,31 +1732,21 @@ ORDER BY time DESC, device_id;
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=1003 loops=1)
                Order: m1."time" DESC
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_1 (actual rows=1003 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_2 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_4 (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_5 (never executed)
-                     Heap Fetches: 0
          ->  Append (actual rows=1 loops=1003)
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=0 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=1003)
                      Index Cond: ("time" > m1."time")
-                     Heap Fetches: 0
 (30 rows)
 
 -- test constraint exclusion for subqueries with append
@@ -1997,10 +1759,8 @@ ORDER BY time DESC, device_id;
    Chunks excluded during startup: 3
    ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
          Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-         Heap Fetches: 0
 (9 rows)
 
 -- test constraint exclusion for subqueries with mergeappend
@@ -2015,10 +1775,8 @@ ORDER BY time DESC, device_id;
          Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LIMIT pushdown
@@ -2030,15 +1788,10 @@ ORDER BY time DESC, device_id;
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
          Order: metrics_timestamptz."time"
          ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (never executed)
-               Heap Fetches: 0
 (13 rows)
 
 -- aggregates should prevent pushdown
@@ -2065,9 +1818,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2100,9 +1851,7 @@ ORDER BY time DESC, device_id;
                ->  Seq Scan on _hyper_6_23_chunk (actual rows=5376 loops=1)
                ->  Seq Scan on _hyper_6_24_chunk (actual rows=2688 loops=1)
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=8064 loops=1)
-                     Heap Fetches: 0
                ->  Seq Scan on _hyper_6_27_chunk (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_6_28_chunk (actual rows=1540 loops=1)
                ->  Seq Scan on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -2119,15 +1868,10 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=17859 loops=1)
                Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=4033 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=3075 loops=1)
-                     Heap Fetches: 0
 (14 rows)
 
 :PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
@@ -2138,23 +1882,14 @@ SET enable_hashagg TO false;
          ->  Merge Append (actual rows=7491 loops=1)
                Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=2017 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=386 loops=1)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 0
 (22 rows)
 
 RESET enable_hashagg;
@@ -2202,10 +1937,8 @@ DROP INDEX :INDEX_NAME;
                            Rows Removed by Filter: 650
                ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=22 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=19 loops=1)
                      Order: m1."time"

--- a/test/expected/null_exclusion-14.out
+++ b/test/expected/null_exclusion-14.out
@@ -29,10 +29,8 @@ where ts >= (select max(ts) from metrics);
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: (ts >= $1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
@@ -56,10 +54,8 @@ where ts >= (select max(ts) from metrics)
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: ((ts >= $1) AND (id = 1))
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)

--- a/test/expected/null_exclusion-15.out
+++ b/test/expected/null_exclusion-15.out
@@ -29,10 +29,8 @@ where ts >= (select max(ts) from metrics);
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: (ts >= $1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
@@ -56,10 +54,8 @@ where ts >= (select max(ts) from metrics)
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: ((ts >= $1) AND (id = 1))
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)

--- a/test/expected/null_exclusion-16.out
+++ b/test/expected/null_exclusion-16.out
@@ -29,10 +29,8 @@ where ts >= (select max(ts) from metrics);
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: (ts >= $1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
@@ -56,10 +54,8 @@ where ts >= (select max(ts) from metrics)
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
                                Index Cond: (ts IS NOT NULL)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: ((ts >= $1) AND (id = 1))
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)

--- a/test/expected/null_exclusion-17.out
+++ b/test/expected/null_exclusion-17.out
@@ -28,9 +28,7 @@ where ts >= (select max(ts) from metrics);
                    ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=1 loops=1)
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: (ts >= (InitPlan 2).col1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
@@ -53,9 +51,7 @@ where ts >= (select max(ts) from metrics)
                    ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=1 loops=1)
                          Order: metrics_1.ts DESC
                          ->  Index Only Scan using _hyper_1_2_chunk_metrics_ts_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=1 loops=1)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_1_1_chunk_metrics_ts_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
-                               Heap Fetches: 0
    ->  Seq Scan on _hyper_1_1_chunk (never executed)
          Filter: ((ts >= (InitPlan 2).col1) AND (id = 1))
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)

--- a/test/expected/plan_ordered_append-14.out
+++ b/test/expected/plan_ordered_append-14.out
@@ -335,13 +335,9 @@ ORDER BY 1,2 LIMIT 1;
    ->  Custom Scan (ChunkAppend) on dimension_only (actual rows=1 loops=1)
          Order: dimension_only."time" DESC
          ->  Index Only Scan using _hyper_3_11_chunk_dimension_only_time_idx on _hyper_3_11_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_3_10_chunk_dimension_only_time_idx on _hyper_3_10_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_9_chunk_dimension_only_time_idx on _hyper_3_9_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_8_chunk_dimension_only_time_idx on _hyper_3_8_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LEFT JOIN against hypertable
@@ -563,39 +559,23 @@ ORDER BY time DESC;
    ->  Merge Append (actual rows=49928 loops=1)
          Sort Key: _hyper_7_52_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_52_chunk_space3_time_idx on _hyper_7_52_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_50_chunk_space3_time_idx on _hyper_7_50_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_48_chunk_space3_time_idx on _hyper_7_48_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_46_chunk_space3_time_idx on _hyper_7_46_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_44_chunk_space3_time_idx on _hyper_7_44_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_42_chunk_space3_time_idx on _hyper_7_42_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_40_chunk_space3_time_idx on _hyper_7_40_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_38_chunk_space3_time_idx on _hyper_7_38_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
    ->  Merge Append (actual rows=53760 loops=1)
          Sort Key: _hyper_7_53_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_53_chunk_space3_time_idx on _hyper_7_53_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_51_chunk_space3_time_idx on _hyper_7_51_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_49_chunk_space3_time_idx on _hyper_7_49_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_47_chunk_space3_time_idx on _hyper_7_47_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_45_chunk_space3_time_idx on _hyper_7_45_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_43_chunk_space3_time_idx on _hyper_7_43_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_41_chunk_space3_time_idx on _hyper_7_41_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_39_chunk_space3_time_idx on _hyper_7_39_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
 (38 rows)
 
 -- test COLLATION
@@ -608,9 +588,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device NULLS FIRST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullsfirst on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullsfirst on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 -- test NULLS LAST
@@ -620,9 +598,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device DESC NULLS LAST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullslast on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullslast on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 --generate the results into two different files

--- a/test/expected/plan_ordered_append-15.out
+++ b/test/expected/plan_ordered_append-15.out
@@ -335,13 +335,9 @@ ORDER BY 1,2 LIMIT 1;
    ->  Custom Scan (ChunkAppend) on dimension_only (actual rows=1 loops=1)
          Order: dimension_only."time" DESC
          ->  Index Only Scan using _hyper_3_11_chunk_dimension_only_time_idx on _hyper_3_11_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_3_10_chunk_dimension_only_time_idx on _hyper_3_10_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_9_chunk_dimension_only_time_idx on _hyper_3_9_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_8_chunk_dimension_only_time_idx on _hyper_3_8_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LEFT JOIN against hypertable
@@ -563,39 +559,23 @@ ORDER BY time DESC;
    ->  Merge Append (actual rows=49928 loops=1)
          Sort Key: _hyper_7_52_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_52_chunk_space3_time_idx on _hyper_7_52_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_50_chunk_space3_time_idx on _hyper_7_50_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_48_chunk_space3_time_idx on _hyper_7_48_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_46_chunk_space3_time_idx on _hyper_7_46_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_44_chunk_space3_time_idx on _hyper_7_44_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_42_chunk_space3_time_idx on _hyper_7_42_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_40_chunk_space3_time_idx on _hyper_7_40_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_38_chunk_space3_time_idx on _hyper_7_38_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
    ->  Merge Append (actual rows=53760 loops=1)
          Sort Key: _hyper_7_53_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_53_chunk_space3_time_idx on _hyper_7_53_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_51_chunk_space3_time_idx on _hyper_7_51_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_49_chunk_space3_time_idx on _hyper_7_49_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_47_chunk_space3_time_idx on _hyper_7_47_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_45_chunk_space3_time_idx on _hyper_7_45_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_43_chunk_space3_time_idx on _hyper_7_43_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_41_chunk_space3_time_idx on _hyper_7_41_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_39_chunk_space3_time_idx on _hyper_7_39_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
 (38 rows)
 
 -- test COLLATION
@@ -608,9 +588,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device NULLS FIRST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullsfirst on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullsfirst on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 -- test NULLS LAST
@@ -620,9 +598,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device DESC NULLS LAST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullslast on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullslast on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 --generate the results into two different files

--- a/test/expected/plan_ordered_append-16.out
+++ b/test/expected/plan_ordered_append-16.out
@@ -335,13 +335,9 @@ ORDER BY 1,2 LIMIT 1;
    ->  Custom Scan (ChunkAppend) on dimension_only (actual rows=1 loops=1)
          Order: dimension_only."time" DESC
          ->  Index Only Scan using _hyper_3_11_chunk_dimension_only_time_idx on _hyper_3_11_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_3_10_chunk_dimension_only_time_idx on _hyper_3_10_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_9_chunk_dimension_only_time_idx on _hyper_3_9_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_8_chunk_dimension_only_time_idx on _hyper_3_8_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LEFT JOIN against hypertable
@@ -563,39 +559,23 @@ ORDER BY time DESC;
    ->  Merge Append (actual rows=49928 loops=1)
          Sort Key: _hyper_7_52_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_52_chunk_space3_time_idx on _hyper_7_52_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_50_chunk_space3_time_idx on _hyper_7_50_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_48_chunk_space3_time_idx on _hyper_7_48_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_46_chunk_space3_time_idx on _hyper_7_46_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_44_chunk_space3_time_idx on _hyper_7_44_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_42_chunk_space3_time_idx on _hyper_7_42_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_40_chunk_space3_time_idx on _hyper_7_40_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_38_chunk_space3_time_idx on _hyper_7_38_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
    ->  Merge Append (actual rows=53760 loops=1)
          Sort Key: _hyper_7_53_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_53_chunk_space3_time_idx on _hyper_7_53_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_51_chunk_space3_time_idx on _hyper_7_51_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_49_chunk_space3_time_idx on _hyper_7_49_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_47_chunk_space3_time_idx on _hyper_7_47_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_45_chunk_space3_time_idx on _hyper_7_45_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_43_chunk_space3_time_idx on _hyper_7_43_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_41_chunk_space3_time_idx on _hyper_7_41_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_39_chunk_space3_time_idx on _hyper_7_39_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
 (38 rows)
 
 -- test COLLATION
@@ -608,9 +588,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device NULLS FIRST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullsfirst on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullsfirst on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 -- test NULLS LAST
@@ -620,9 +598,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device DESC NULLS LAST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullslast on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullslast on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 --generate the results into two different files

--- a/test/expected/plan_ordered_append-17.out
+++ b/test/expected/plan_ordered_append-17.out
@@ -335,13 +335,9 @@ ORDER BY 1,2 LIMIT 1;
    ->  Custom Scan (ChunkAppend) on dimension_only (actual rows=1 loops=1)
          Order: dimension_only."time" DESC
          ->  Index Only Scan using _hyper_3_11_chunk_dimension_only_time_idx on _hyper_3_11_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_3_10_chunk_dimension_only_time_idx on _hyper_3_10_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_9_chunk_dimension_only_time_idx on _hyper_3_9_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_3_8_chunk_dimension_only_time_idx on _hyper_3_8_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test LEFT JOIN against hypertable
@@ -563,39 +559,23 @@ ORDER BY time DESC;
    ->  Merge Append (actual rows=49928 loops=1)
          Sort Key: _hyper_7_52_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_52_chunk_space3_time_idx on _hyper_7_52_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_50_chunk_space3_time_idx on _hyper_7_50_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_48_chunk_space3_time_idx on _hyper_7_48_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_46_chunk_space3_time_idx on _hyper_7_46_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_44_chunk_space3_time_idx on _hyper_7_44_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_42_chunk_space3_time_idx on _hyper_7_42_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_40_chunk_space3_time_idx on _hyper_7_40_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
          ->  Index Only Scan using _hyper_7_38_chunk_space3_time_idx on _hyper_7_38_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
    ->  Merge Append (actual rows=53760 loops=1)
          Sort Key: _hyper_7_53_chunk."time" DESC
          ->  Index Only Scan using _hyper_7_53_chunk_space3_time_idx on _hyper_7_53_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_51_chunk_space3_time_idx on _hyper_7_51_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_49_chunk_space3_time_idx on _hyper_7_49_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_47_chunk_space3_time_idx on _hyper_7_47_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_45_chunk_space3_time_idx on _hyper_7_45_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_43_chunk_space3_time_idx on _hyper_7_43_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_41_chunk_space3_time_idx on _hyper_7_41_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
          ->  Index Only Scan using _hyper_7_39_chunk_space3_time_idx on _hyper_7_39_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
 (38 rows)
 
 -- test COLLATION
@@ -608,9 +588,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device NULLS FIRST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullsfirst on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullsfirst on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 -- test NULLS LAST
@@ -620,9 +598,7 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on sortopt_test (actual rows=12961 loops=1)
    Order: sortopt_test."time", sortopt_test.device DESC NULLS LAST
    ->  Index Only Scan using _hyper_8_55_chunk_time_device_nullslast on _hyper_8_55_chunk (actual rows=6720 loops=1)
-         Heap Fetches: 6720
    ->  Index Only Scan using _hyper_8_54_chunk_time_device_nullslast on _hyper_8_54_chunk (actual rows=6241 loops=1)
-         Heap Fetches: 6241
 (6 rows)
 
 --generate the results into two different files

--- a/test/runner_cleanup_output.sh
+++ b/test/runner_cleanup_output.sh
@@ -8,7 +8,8 @@ RUNNER=${1:-""}
 sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
      -e 's! Memory: [0-9]\{1,\}kB!!' \
      -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
-     -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
+     -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' \
+     -e '/Heap Fetches: [0-9]\{1,\}/d' | \
 grep -v 'DEBUG:  rehashing catalog cache id' | \
 grep -v 'DEBUG:  compacted fsync request queue from' | \
 grep -v 'DEBUG:  creating and filling new WAL file' | \

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -1629,17 +1629,14 @@ UNION ALL
                            Group Key: time_bucket('5'::bigint, _hyper_14_61_chunk."time")
                            ->  Index Only Scan Backward using _hyper_14_61_chunk_small_integer_ht_time_idx on _hyper_14_61_chunk (actual rows=10 loops=1)
                                  Index Cond: ("time" < COALESCE((_timescaledb_functions.cagg_watermark(15))::integer, (_timescaledb_functions.cagg_watermark(15))::integer))
-                                 Heap Fetches: 10
                      ->  Partial GroupAggregate (actual rows=2 loops=1)
                            Group Key: time_bucket('5'::bigint, _hyper_14_62_chunk."time")
                            ->  Index Only Scan Backward using _hyper_14_62_chunk_small_integer_ht_time_idx on _hyper_14_62_chunk (actual rows=10 loops=1)
                                  Index Cond: ("time" < COALESCE((_timescaledb_functions.cagg_watermark(15))::integer, (_timescaledb_functions.cagg_watermark(15))::integer))
-                                 Heap Fetches: 10
                      ->  Partial GroupAggregate (actual rows=2 loops=1)
                            Group Key: time_bucket('5'::bigint, _hyper_14_63_chunk."time")
                            ->  Index Only Scan Backward using _hyper_14_63_chunk_small_integer_ht_time_idx on _hyper_14_63_chunk (actual rows=6 loops=1)
                                  Index Cond: ("time" < COALESCE((_timescaledb_functions.cagg_watermark(15))::integer, (_timescaledb_functions.cagg_watermark(15))::integer))
-                                 Heap Fetches: 6
 (30 rows)
 
 -- test with non constant value of the watermark function (should not be constified)

--- a/tsl/test/expected/plan_skip_scan-14.out
+++ b/tsl/test/expected/plan_skip_scan-14.out
@@ -88,7 +88,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -98,7 +97,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -108,7 +106,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -121,7 +118,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -131,7 +127,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -144,7 +139,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -154,7 +148,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -164,7 +157,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -177,7 +169,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -187,7 +178,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -248,7 +238,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -259,7 +248,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -270,7 +258,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -283,7 +270,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -294,7 +280,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 -- volatile expression in targetlist
@@ -363,7 +348,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- distinct on expressions not supported
@@ -411,7 +395,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -422,7 +405,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -433,7 +415,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -444,7 +425,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -455,7 +435,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -492,7 +471,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -503,7 +481,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -523,7 +500,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -534,7 +510,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -545,7 +520,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -556,7 +530,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -567,7 +540,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -578,7 +550,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -589,7 +560,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -600,7 +570,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -637,7 +606,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -667,7 +635,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -727,7 +694,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -738,7 +704,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -749,7 +714,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 \qecho range queries on :TABLE
@@ -761,7 +725,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -771,7 +734,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -781,7 +743,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -799,7 +760,6 @@ ordered append on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-               Heap Fetches: 1001
 (5 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -822,7 +782,6 @@ SUBSELECTS on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -1004,7 +963,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
-               Heap Fetches: 5
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -1044,7 +1002,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -1054,7 +1011,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 -- test constants in ORDER BY
@@ -1078,7 +1034,6 @@ SELECT * FROM devices;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX WITH devices AS (
@@ -1091,7 +1046,6 @@ SELECT * FROM devices ORDER BY dev;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 -- prepared statements
@@ -1103,7 +1057,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1113,7 +1066,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1123,7 +1075,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 DEALLOCATE prep;
@@ -1184,7 +1135,6 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Result (actual rows=833 loops=12)
          ->  Unique (actual rows=833 loops=12)
                ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
@@ -1202,12 +1152,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -1221,12 +1169,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -1235,7 +1181,6 @@ DEALLOCATE prep;
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
          Index Cond: (dev IS NOT NULL)
-         Heap Fetches: 10001
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -1252,18 +1197,15 @@ UNION SELECT b.* FROM
                ->  Unique (actual rows=10001 loops=1)
                      ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 10001
                ->  Nested Loop (actual rows=10001 loops=1)
                      ->  Unique (actual rows=12 loops=1)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                  ->  Index Only Scan using skip_scan_dev_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                        Index Cond: (dev > NULL::integer)
-                                       Heap Fetches: 12
                      ->  Unique (actual rows=833 loops=12)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-                                       Heap Fetches: 10001
 (20 rows)
 
 -- SkipScan into INSERT
@@ -1292,7 +1234,6 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -1310,7 +1251,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -1321,7 +1261,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \set TABLE skip_scan_ht
@@ -1365,19 +1304,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -1389,19 +1324,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1413,19 +1344,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -1440,19 +1367,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -1464,19 +1387,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1491,19 +1410,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1515,19 +1430,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -1539,19 +1450,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -1563,7 +1470,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -1572,7 +1478,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -1661,19 +1566,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -1686,19 +1587,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -1711,19 +1608,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -1738,19 +1631,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -1763,19 +1652,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 -- volatile expression in targetlist
@@ -1870,19 +1755,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- distinct on expressions not supported
@@ -1952,19 +1833,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -1977,19 +1854,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -2002,19 +1875,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -2027,19 +1896,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -2052,19 +1917,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -2127,19 +1988,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -2152,19 +2009,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -2194,19 +2047,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -2219,19 +2068,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -2244,19 +2089,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -2269,19 +2110,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -2294,19 +2131,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -2319,19 +2152,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -2344,19 +2173,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -2369,19 +2194,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -2444,19 +2265,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -2501,19 +2318,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -2611,19 +2424,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -2636,19 +2445,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -2661,19 +2466,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 \qecho range queries on :TABLE
@@ -2687,11 +2488,9 @@ range queries on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -2701,7 +2500,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -2711,7 +2509,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -2736,19 +2533,15 @@ ordered append on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
 (19 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -2781,19 +2574,15 @@ SUBSELECTS on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -3145,7 +2934,6 @@ WHERE CLAUSES
  Unique (actual rows=5 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
          Index Cond: (("time" = 100) AND (dev > 5))
-         Heap Fetches: 5
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -3157,7 +2945,6 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
-                     Heap Fetches: 5
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
                      Index Cond: (dev > 5)
@@ -3212,19 +2999,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -3236,19 +3019,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 -- test constants in ORDER BY
@@ -3285,19 +3064,15 @@ SELECT * FROM devices;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX WITH devices AS (
@@ -3312,19 +3087,15 @@ SELECT * FROM devices ORDER BY dev;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 -- prepared statements
@@ -3338,19 +3109,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3362,19 +3129,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3386,19 +3149,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 DEALLOCATE prep;
@@ -3491,19 +3250,15 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Result (actual rows=909 loops=11)
          ->  Unique (actual rows=909 loops=11)
                ->  Merge Append (actual rows=909 loops=11)
@@ -3534,38 +3289,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -3581,38 +3328,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -3623,16 +3362,12 @@ DEALLOCATE prep;
          Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
 (15 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -3651,16 +3386,12 @@ UNION SELECT b.* FROM
                            Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
                            ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                ->  Nested Loop (actual rows=10000 loops=1)
                      ->  Unique (actual rows=11 loops=1)
                            ->  Merge Append (actual rows=44 loops=1)
@@ -3668,38 +3399,30 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                      ->  Unique (actual rows=909 loops=11)
                            ->  Merge Append (actual rows=909 loops=11)
                                  Sort Key: _hyper_1_1_chunk_2."time"
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
 (59 rows)
 
 -- SkipScan into INSERT
@@ -3738,19 +3461,15 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -3768,7 +3487,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -3779,7 +3497,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \ir include/skip_scan_query_ht.sql
@@ -3798,19 +3515,15 @@ CREATE INDEX ON :TABLE(time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
 (19 rows)
 
 --baseline query with skipscan
@@ -3985,6 +3698,5 @@ ANALYZE i3720;
    ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
-               Heap Fetches: 3
 (5 rows)
 

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -88,7 +88,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -98,7 +97,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -108,7 +106,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -121,7 +118,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -131,7 +127,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -144,7 +139,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -154,7 +148,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -164,7 +157,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -177,7 +169,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -187,7 +178,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -248,7 +238,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -259,7 +248,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -270,7 +258,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -283,7 +270,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -294,7 +280,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 -- volatile expression in targetlist
@@ -363,7 +348,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- distinct on expressions not supported
@@ -411,7 +395,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -422,7 +405,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -433,7 +415,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -444,7 +425,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -455,7 +435,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -492,7 +471,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -503,7 +481,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -523,7 +500,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -534,7 +510,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -545,7 +520,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -556,7 +530,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -567,7 +540,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -578,7 +550,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -589,7 +560,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -600,7 +570,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -637,7 +606,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -667,7 +635,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -727,7 +694,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -738,7 +704,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -749,7 +714,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 \qecho range queries on :TABLE
@@ -761,7 +725,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -771,7 +734,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -781,7 +743,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -799,7 +760,6 @@ ordered append on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-               Heap Fetches: 1001
 (5 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -822,7 +782,6 @@ SUBSELECTS on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -1004,7 +963,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
-               Heap Fetches: 5
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -1044,7 +1002,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -1054,7 +1011,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 -- test constants in ORDER BY
@@ -1078,7 +1034,6 @@ SELECT * FROM devices;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX WITH devices AS (
@@ -1091,7 +1046,6 @@ SELECT * FROM devices ORDER BY dev;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 -- prepared statements
@@ -1103,7 +1057,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1113,7 +1066,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1123,7 +1075,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 DEALLOCATE prep;
@@ -1184,7 +1135,6 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Result (actual rows=833 loops=12)
          ->  Unique (actual rows=833 loops=12)
                ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
@@ -1202,12 +1152,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -1221,12 +1169,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -1235,7 +1181,6 @@ DEALLOCATE prep;
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
          Index Cond: (dev IS NOT NULL)
-         Heap Fetches: 10001
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -1252,18 +1197,15 @@ UNION SELECT b.* FROM
                ->  Unique (actual rows=10001 loops=1)
                      ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 10001
                ->  Nested Loop (actual rows=10001 loops=1)
                      ->  Unique (actual rows=12 loops=1)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                  ->  Index Only Scan using skip_scan_dev_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                        Index Cond: (dev > NULL::integer)
-                                       Heap Fetches: 12
                      ->  Unique (actual rows=833 loops=12)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-                                       Heap Fetches: 10001
 (20 rows)
 
 -- SkipScan into INSERT
@@ -1292,7 +1234,6 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -1310,7 +1251,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -1321,7 +1261,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \set TABLE skip_scan_ht
@@ -1365,19 +1304,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -1389,19 +1324,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1413,19 +1344,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -1440,19 +1367,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -1464,19 +1387,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1491,19 +1410,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1515,19 +1430,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -1539,19 +1450,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -1563,7 +1470,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -1572,7 +1478,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -1661,19 +1566,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -1686,19 +1587,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -1711,19 +1608,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -1738,19 +1631,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -1763,19 +1652,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 -- volatile expression in targetlist
@@ -1870,19 +1755,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- distinct on expressions not supported
@@ -1952,19 +1833,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -1977,19 +1854,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -2002,19 +1875,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -2027,19 +1896,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -2052,19 +1917,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -2127,19 +1988,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -2152,19 +2009,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -2194,19 +2047,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -2219,19 +2068,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -2244,19 +2089,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -2269,19 +2110,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -2294,19 +2131,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -2319,19 +2152,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -2344,19 +2173,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -2369,19 +2194,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -2444,19 +2265,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -2501,19 +2318,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -2611,19 +2424,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -2636,19 +2445,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -2661,19 +2466,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 \qecho range queries on :TABLE
@@ -2687,11 +2488,9 @@ range queries on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -2701,7 +2500,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -2711,7 +2509,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -2736,19 +2533,15 @@ ordered append on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
 (19 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -2781,19 +2574,15 @@ SUBSELECTS on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -3145,7 +2934,6 @@ WHERE CLAUSES
  Unique (actual rows=5 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
          Index Cond: (("time" = 100) AND (dev > 5))
-         Heap Fetches: 5
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -3157,7 +2945,6 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
-                     Heap Fetches: 5
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
                      Index Cond: (dev > 5)
@@ -3212,19 +2999,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -3236,19 +3019,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 -- test constants in ORDER BY
@@ -3285,19 +3064,15 @@ SELECT * FROM devices;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX WITH devices AS (
@@ -3312,19 +3087,15 @@ SELECT * FROM devices ORDER BY dev;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 -- prepared statements
@@ -3338,19 +3109,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3362,19 +3129,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3386,19 +3149,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 DEALLOCATE prep;
@@ -3491,19 +3250,15 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Result (actual rows=909 loops=11)
          ->  Unique (actual rows=909 loops=11)
                ->  Merge Append (actual rows=909 loops=11)
@@ -3534,38 +3289,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -3581,38 +3328,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -3623,16 +3362,12 @@ DEALLOCATE prep;
          Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
 (15 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -3651,16 +3386,12 @@ UNION SELECT b.* FROM
                            Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
                            ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                ->  Nested Loop (actual rows=10000 loops=1)
                      ->  Unique (actual rows=11 loops=1)
                            ->  Merge Append (actual rows=44 loops=1)
@@ -3668,38 +3399,30 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                      ->  Unique (actual rows=909 loops=11)
                            ->  Merge Append (actual rows=909 loops=11)
                                  Sort Key: _hyper_1_1_chunk_2."time"
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
 (59 rows)
 
 -- SkipScan into INSERT
@@ -3738,19 +3461,15 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -3768,7 +3487,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -3779,7 +3497,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \ir include/skip_scan_query_ht.sql
@@ -3798,19 +3515,15 @@ CREATE INDEX ON :TABLE(time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
 (19 rows)
 
 --baseline query with skipscan
@@ -3985,6 +3698,5 @@ ANALYZE i3720;
    ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
-               Heap Fetches: 3
 (5 rows)
 

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -88,7 +88,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -98,7 +97,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -108,7 +106,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -121,7 +118,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -131,7 +127,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -144,7 +139,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -154,7 +148,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -164,7 +157,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -177,7 +169,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -187,7 +178,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -248,7 +238,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -259,7 +248,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -270,7 +258,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -283,7 +270,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -294,7 +280,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 -- volatile expression in targetlist
@@ -363,7 +348,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- distinct on expressions not supported
@@ -411,7 +395,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -422,7 +405,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -433,7 +415,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -444,7 +425,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -455,7 +435,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -492,7 +471,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -503,7 +481,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -523,7 +500,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -534,7 +510,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -545,7 +520,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -556,7 +530,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -567,7 +540,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -578,7 +550,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -589,7 +560,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -600,7 +570,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -637,7 +606,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -667,7 +635,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -727,7 +694,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -738,7 +704,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -749,7 +714,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 \qecho range queries on :TABLE
@@ -761,7 +725,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -771,7 +734,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -781,7 +743,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -799,7 +760,6 @@ ordered append on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-               Heap Fetches: 1001
 (5 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -822,7 +782,6 @@ SUBSELECTS on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -1004,7 +963,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
-               Heap Fetches: 5
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -1044,7 +1002,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -1054,7 +1011,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 -- test constants in ORDER BY
@@ -1077,7 +1033,6 @@ SELECT * FROM devices;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX WITH devices AS (
@@ -1090,7 +1045,6 @@ SELECT * FROM devices ORDER BY dev;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 -- prepared statements
@@ -1102,7 +1056,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1112,7 +1065,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1122,7 +1074,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 DEALLOCATE prep;
@@ -1183,7 +1134,6 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Result (actual rows=833 loops=12)
          ->  Unique (actual rows=833 loops=12)
                ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
@@ -1201,12 +1151,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -1220,12 +1168,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -1234,7 +1180,6 @@ DEALLOCATE prep;
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
          Index Cond: (dev IS NOT NULL)
-         Heap Fetches: 10001
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -1251,18 +1196,15 @@ UNION SELECT b.* FROM
                ->  Unique (actual rows=10001 loops=1)
                      ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 10001
                ->  Nested Loop (actual rows=10001 loops=1)
                      ->  Unique (actual rows=12 loops=1)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                  ->  Index Only Scan using skip_scan_dev_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                        Index Cond: (dev > NULL::integer)
-                                       Heap Fetches: 12
                      ->  Unique (actual rows=833 loops=12)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-                                       Heap Fetches: 10001
 (20 rows)
 
 -- SkipScan into INSERT
@@ -1291,7 +1233,6 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -1309,7 +1250,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -1320,7 +1260,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \set TABLE skip_scan_ht
@@ -1364,19 +1303,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -1388,19 +1323,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1412,19 +1343,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -1439,19 +1366,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -1463,19 +1386,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1490,19 +1409,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1514,19 +1429,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -1538,19 +1449,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -1562,7 +1469,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -1571,7 +1477,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -1660,19 +1565,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -1685,19 +1586,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -1710,19 +1607,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -1737,19 +1630,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -1762,19 +1651,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 -- volatile expression in targetlist
@@ -1869,19 +1754,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- distinct on expressions not supported
@@ -1951,19 +1832,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -1976,19 +1853,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -2001,19 +1874,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -2026,19 +1895,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -2051,19 +1916,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -2126,19 +1987,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -2151,19 +2008,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -2193,19 +2046,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -2218,19 +2067,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -2243,19 +2088,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -2268,19 +2109,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -2293,19 +2130,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -2318,19 +2151,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -2343,19 +2172,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -2368,19 +2193,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -2443,19 +2264,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -2500,19 +2317,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -2610,19 +2423,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -2635,19 +2444,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -2660,19 +2465,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 \qecho range queries on :TABLE
@@ -2686,11 +2487,9 @@ range queries on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -2700,7 +2499,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -2710,7 +2508,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -2735,19 +2532,15 @@ ordered append on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
 (19 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -2780,19 +2573,15 @@ SUBSELECTS on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -3144,7 +2933,6 @@ WHERE CLAUSES
  Unique (actual rows=5 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
          Index Cond: (("time" = 100) AND (dev > 5))
-         Heap Fetches: 5
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -3156,7 +2944,6 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
-                     Heap Fetches: 5
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
                      Index Cond: (dev > 5)
@@ -3211,19 +2998,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -3235,19 +3018,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 -- test constants in ORDER BY
@@ -3280,19 +3059,15 @@ SELECT * FROM devices;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX WITH devices AS (
@@ -3307,19 +3082,15 @@ SELECT * FROM devices ORDER BY dev;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 -- prepared statements
@@ -3333,19 +3104,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3357,19 +3124,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3381,19 +3144,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 DEALLOCATE prep;
@@ -3486,19 +3245,15 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Result (actual rows=909 loops=11)
          ->  Unique (actual rows=909 loops=11)
                ->  Merge Append (actual rows=909 loops=11)
@@ -3529,38 +3284,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -3576,38 +3323,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -3618,16 +3357,12 @@ DEALLOCATE prep;
          Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
 (15 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -3646,16 +3381,12 @@ UNION SELECT b.* FROM
                            Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
                            ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                            ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                                  Index Cond: (dev IS NOT NULL)
-                                 Heap Fetches: 2500
                ->  Nested Loop (actual rows=10000 loops=1)
                      ->  Unique (actual rows=11 loops=1)
                            ->  Merge Append (actual rows=44 loops=1)
@@ -3663,38 +3394,30 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                      ->  Unique (actual rows=909 loops=11)
                            ->  Merge Append (actual rows=909 loops=11)
                                  Sort Key: _hyper_1_1_chunk_2."time"
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
 (59 rows)
 
 -- SkipScan into INSERT
@@ -3733,19 +3456,15 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -3763,7 +3482,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -3774,7 +3492,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \ir include/skip_scan_query_ht.sql
@@ -3793,19 +3510,15 @@ CREATE INDEX ON :TABLE(time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
 (19 rows)
 
 --baseline query with skipscan
@@ -3979,6 +3692,5 @@ ANALYZE i3720;
    ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
-               Heap Fetches: 3
 (5 rows)
 

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -88,7 +88,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -98,7 +97,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -108,7 +106,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -121,7 +118,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -131,7 +127,6 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -144,7 +139,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -154,7 +148,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -164,7 +157,6 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev < NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -177,7 +169,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -187,7 +178,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
-               Heap Fetches: 11
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -248,7 +238,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -259,7 +248,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -270,7 +258,6 @@ basic DISTINCT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -283,7 +270,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -294,7 +280,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 -- volatile expression in targetlist
@@ -363,7 +348,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- distinct on expressions not supported
@@ -411,7 +395,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -422,7 +405,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -433,7 +415,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -444,7 +425,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -455,7 +435,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -492,7 +471,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -503,7 +481,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -523,7 +500,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -534,7 +510,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -545,7 +520,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -556,7 +530,6 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -567,7 +540,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -578,7 +550,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -589,7 +560,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -600,7 +570,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -637,7 +606,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -667,7 +635,6 @@ stable expression in targetlist on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -727,7 +694,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -738,7 +704,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -749,7 +714,6 @@ LIMIT queries on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 3
 (6 rows)
 
 \qecho range queries on :TABLE
@@ -761,7 +725,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -771,7 +734,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -781,7 +743,6 @@ range queries on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -799,7 +760,6 @@ ordered append on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-               Heap Fetches: 1001
 (5 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -822,7 +782,6 @@ SUBSELECTS on skip_scan
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
 (6 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -1004,7 +963,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
          ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
-               Heap Fetches: 5
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -1044,7 +1002,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -1054,7 +1011,6 @@ WHERE CLAUSES
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
                Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-               Heap Fetches: 1
 (5 rows)
 
 -- test constants in ORDER BY
@@ -1077,7 +1033,6 @@ SELECT * FROM devices;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX WITH devices AS (
@@ -1090,7 +1045,6 @@ SELECT * FROM devices ORDER BY dev;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 -- prepared statements
@@ -1102,7 +1056,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1112,7 +1065,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 :PREFIX EXECUTE prep;
@@ -1122,7 +1074,6 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
-               Heap Fetches: 12
 (5 rows)
 
 DEALLOCATE prep;
@@ -1183,7 +1134,6 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Result (actual rows=833 loops=12)
          ->  Unique (actual rows=833 loops=12)
                ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
@@ -1201,12 +1151,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -1220,12 +1168,10 @@ DEALLOCATE prep;
          ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 12
    ->  Unique (actual rows=833 loops=12)
          ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
-                     Heap Fetches: 10001
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -1234,7 +1180,6 @@ DEALLOCATE prep;
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
          Index Cond: (dev IS NOT NULL)
-         Heap Fetches: 10001
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -1249,7 +1194,6 @@ UNION SELECT b.* FROM
          ->  Unique (actual rows=10001 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
                      Index Cond: (dev IS NOT NULL)
-                     Heap Fetches: 10001
          ->  Sort (actual rows=10001 loops=1)
                Sort Key: skip_scan_2.dev, skip_scan_2."time"
                Sort Method: quicksort 
@@ -1258,12 +1202,10 @@ UNION SELECT b.* FROM
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                  ->  Index Only Scan using skip_scan_dev_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
                                        Index Cond: (dev > NULL::integer)
-                                       Heap Fetches: 12
                      ->  Unique (actual rows=833 loops=12)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-                                       Heap Fetches: 10001
 (21 rows)
 
 -- SkipScan into INSERT
@@ -1292,7 +1234,6 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
-               Heap Fetches: 12
 (5 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -1310,7 +1251,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -1321,7 +1261,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \set TABLE skip_scan_ht
@@ -1365,19 +1304,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
@@ -1389,19 +1324,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1413,19 +1344,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_last;
@@ -1440,19 +1367,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
@@ -1464,19 +1387,15 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1491,19 +1410,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -1515,19 +1430,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -1539,19 +1450,15 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev < NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_time_idx;
@@ -1563,7 +1470,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
@@ -1572,7 +1478,6 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
  Unique (actual rows=11 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
          Index Cond: ("time" = 100)
-         Heap Fetches: 11
 (4 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -1661,19 +1566,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
@@ -1686,19 +1587,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
@@ -1711,19 +1608,15 @@ basic DISTINCT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 \qecho stable expression in targetlist on :TABLE
@@ -1738,19 +1631,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
@@ -1763,19 +1652,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 -- volatile expression in targetlist
@@ -1870,19 +1755,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- distinct on expressions not supported
@@ -1952,19 +1833,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
@@ -1977,19 +1854,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
@@ -2002,19 +1875,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -2027,19 +1896,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
@@ -2052,19 +1917,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
@@ -2127,19 +1988,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
@@ -2152,19 +2009,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
@@ -2194,19 +2047,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
@@ -2219,19 +2068,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
@@ -2244,19 +2089,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 -- DISTINCT ON queries on TEXT column
@@ -2269,19 +2110,15 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -2294,19 +2131,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
@@ -2319,19 +2152,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -2344,19 +2173,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
@@ -2369,19 +2194,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
@@ -2444,19 +2265,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
@@ -2501,19 +2318,15 @@ stable expression in targetlist on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev_name > NULL::text)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
@@ -2611,19 +2424,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -2636,19 +2445,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev < NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
@@ -2661,19 +2466,15 @@ LIMIT queries on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 3
 (20 rows)
 
 \qecho range queries on :TABLE
@@ -2687,11 +2488,9 @@ range queries on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
-                     Heap Fetches: 11
 (11 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
@@ -2701,7 +2500,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" < 200))
-               Heap Fetches: 11
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
@@ -2711,7 +2509,6 @@ range queries on skip_scan_ht
    ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                Index Cond: ((dev > NULL::integer) AND ("time" > 800))
-               Heap Fetches: 11
 (5 rows)
 
 \qecho ordered append on :TABLE
@@ -2736,19 +2533,15 @@ ordered append on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
-                     Heap Fetches: 250
 (19 rows)
 
 \qecho SUBSELECTS on :TABLE
@@ -2781,19 +2574,15 @@ SUBSELECTS on skip_scan_ht
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
 (20 rows)
 
 :PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
@@ -3145,7 +2934,6 @@ WHERE CLAUSES
  Unique (actual rows=5 loops=1)
    ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
          Index Cond: (("time" = 100) AND (dev > 5))
-         Heap Fetches: 5
 (4 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
@@ -3157,7 +2945,6 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
-                     Heap Fetches: 5
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
                      Index Cond: (dev > 5)
@@ -3212,19 +2999,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
@@ -3236,19 +3019,15 @@ WHERE CLAUSES
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
-                     Heap Fetches: 1
 (19 rows)
 
 -- test constants in ORDER BY
@@ -3281,19 +3060,15 @@ SELECT * FROM devices;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX WITH devices AS (
@@ -3308,19 +3083,15 @@ SELECT * FROM devices ORDER BY dev;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 -- prepared statements
@@ -3334,19 +3105,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3358,19 +3125,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 :PREFIX EXECUTE prep;
@@ -3382,19 +3145,15 @@ PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
-                     Heap Fetches: 11
 (19 rows)
 
 DEALLOCATE prep;
@@ -3487,19 +3246,15 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Result (actual rows=909 loops=11)
          ->  Unique (actual rows=909 loops=11)
                ->  Merge Append (actual rows=909 loops=11)
@@ -3530,38 +3285,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
@@ -3577,38 +3324,30 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                            Index Cond: (dev > NULL::integer)
-                           Heap Fetches: 11
    ->  Unique (actual rows=909 loops=11)
          ->  Merge Append (actual rows=909 loops=11)
                Sort Key: _hyper_1_1_chunk_1."time"
                ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
                            Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
-                           Heap Fetches: 2500
 (39 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
@@ -3619,16 +3358,12 @@ DEALLOCATE prep;
          Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                Index Cond: (dev IS NOT NULL)
-               Heap Fetches: 2500
 (15 rows)
 
 :PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
@@ -3645,16 +3380,12 @@ UNION SELECT b.* FROM
                      Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 2500
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 2500
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 2500
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
                            Index Cond: (dev IS NOT NULL)
-                           Heap Fetches: 2500
          ->  Sort (actual rows=10000 loops=1)
                Sort Key: _hyper_1_1_chunk_2.dev, _hyper_1_1_chunk_2."time"
                Sort Method: quicksort 
@@ -3665,38 +3396,30 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
                                              Index Cond: (dev > NULL::integer)
-                                             Heap Fetches: 11
                      ->  Unique (actual rows=909 loops=11)
                            ->  Merge Append (actual rows=909 loops=11)
                                  Sort Key: _hyper_1_1_chunk_2."time"
                                  ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
-                                             Heap Fetches: 2500
 (60 rows)
 
 -- SkipScan into INSERT
@@ -3735,19 +3458,15 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
-                     Heap Fetches: 11
 (19 rows)
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -3765,7 +3484,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
                Index Cond: ("time" > NULL::integer)
-               Heap Fetches: 1
 (5 rows)
 
 -- no tuples in resultset
@@ -3776,7 +3494,6 @@ TRUNCATE skip_scan_insert;
    ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
          ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
                Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
-               Heap Fetches: 0
 (5 rows)
 
 \ir include/skip_scan_query_ht.sql
@@ -3795,19 +3512,15 @@ CREATE INDEX ON :TABLE(time);
          ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
                      Index Cond: ("time" > NULL::integer)
-                     Heap Fetches: 250
 (19 rows)
 
 --baseline query with skipscan
@@ -3981,6 +3694,5 @@ ANALYZE i3720;
    ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
-               Heap Fetches: 3
 (5 rows)
 

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -1196,7 +1196,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1680 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-               Heap Fetches: 0
          ->  Sort (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
@@ -2105,7 +2104,6 @@ ORDER BY device_id;
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
    ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=3360 loops=1)
          Output: _hyper_1_2_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1680 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
@@ -2887,7 +2885,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -4893,7 +4890,6 @@ LIMIT 10;
          ->  Merge Append (actual rows=10 loops=1)
                Sort Key: _hyper_2_12_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 0
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -4907,11 +4903,8 @@ LIMIT 10;
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_6_chunk."time" DESC
                ->  Sort (never executed)
@@ -5011,11 +5004,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=720 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -5027,7 +5017,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1008 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
 (36 rows)
 
 --
@@ -5144,15 +5133,12 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk."time"
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5178,7 +5164,6 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- test ordering only by segmentby columns
@@ -5200,15 +5185,12 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5234,7 +5216,6 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- should produce ordered path
@@ -5255,15 +5236,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5281,7 +5259,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- should produce ordered path
@@ -5304,15 +5281,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5330,7 +5304,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- These plans are flaky between MergeAppend and Sort over Append.
@@ -6007,7 +5980,6 @@ ORDER BY device_id,
    ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Sort (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
          Sort Key: _hyper_2_10_chunk."time"
@@ -6110,7 +6082,6 @@ ORDER BY device_id;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6140,7 +6111,6 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-                     Heap Fetches: 0
          ->  Custom Scan (VectorAgg) (actual rows=1 loops=1)
                Output: (PARTIAL count(*))
                Grouping Policy: all compressed batches
@@ -6178,13 +6148,10 @@ ORDER BY device_id;
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_8_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=672 loops=1)
          Output: _hyper_2_9_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6197,7 +6164,6 @@ ORDER BY device_id;
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id
-         Heap Fetches: 0
 (39 rows)
 
 DROP INDEX tmp_idx CASCADE;
@@ -6291,15 +6257,12 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -6315,7 +6278,6 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
-         Heap Fetches: 0
 (47 rows)
 
 --ensure that we can get a nested loop
@@ -6353,15 +6315,12 @@ WHERE device_id_peer IN (
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -7340,13 +7299,10 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7358,7 +7314,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
 (39 rows)
 
 -- test prepared statement with params pushdown
@@ -7386,7 +7341,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7409,7 +7363,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1196,7 +1196,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1680 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-               Heap Fetches: 0
          ->  Sort (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
@@ -2105,7 +2104,6 @@ ORDER BY device_id;
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
    ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=3360 loops=1)
          Output: _hyper_1_2_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1680 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
@@ -2887,7 +2885,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -4893,7 +4890,6 @@ LIMIT 10;
          ->  Merge Append (actual rows=10 loops=1)
                Sort Key: _hyper_2_12_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 0
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -4907,11 +4903,8 @@ LIMIT 10;
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_6_chunk."time" DESC
                ->  Sort (never executed)
@@ -5011,11 +5004,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=720 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -5027,7 +5017,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1008 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
 (36 rows)
 
 --
@@ -5144,15 +5133,12 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk."time"
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5178,7 +5164,6 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- test ordering only by segmentby columns
@@ -5200,15 +5185,12 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5234,7 +5216,6 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- should produce ordered path
@@ -5255,15 +5236,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5281,7 +5259,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- should produce ordered path
@@ -5304,15 +5281,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5330,7 +5304,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- These plans are flaky between MergeAppend and Sort over Append.
@@ -6007,7 +5980,6 @@ ORDER BY device_id,
    ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Sort (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
          Sort Key: _hyper_2_10_chunk."time"
@@ -6110,7 +6082,6 @@ ORDER BY device_id;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6140,7 +6111,6 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-                     Heap Fetches: 0
          ->  Custom Scan (VectorAgg) (actual rows=1 loops=1)
                Output: (PARTIAL count(*))
                Grouping Policy: all compressed batches
@@ -6178,13 +6148,10 @@ ORDER BY device_id;
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_8_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=672 loops=1)
          Output: _hyper_2_9_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6197,7 +6164,6 @@ ORDER BY device_id;
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id
-         Heap Fetches: 0
 (39 rows)
 
 DROP INDEX tmp_idx CASCADE;
@@ -6291,15 +6257,12 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -6315,7 +6278,6 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
-         Heap Fetches: 0
 (47 rows)
 
 --ensure that we can get a nested loop
@@ -6353,15 +6315,12 @@ WHERE device_id_peer IN (
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -7340,13 +7299,10 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7358,7 +7314,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
 (39 rows)
 
 -- test prepared statement with params pushdown
@@ -7386,7 +7341,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7409,7 +7363,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -1196,7 +1196,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1680 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-               Heap Fetches: 0
          ->  Sort (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
@@ -2105,7 +2104,6 @@ ORDER BY device_id;
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
    ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=3360 loops=1)
          Output: _hyper_1_2_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1680 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
@@ -2887,7 +2885,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -4893,7 +4890,6 @@ LIMIT 10;
          ->  Merge Append (actual rows=10 loops=1)
                Sort Key: _hyper_2_12_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 0
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -4907,11 +4903,8 @@ LIMIT 10;
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_6_chunk."time" DESC
                ->  Sort (never executed)
@@ -5011,11 +5004,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=720 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -5027,7 +5017,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1008 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
 (36 rows)
 
 --
@@ -5144,15 +5133,12 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk."time"
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5178,7 +5164,6 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- test ordering only by segmentby columns
@@ -5200,15 +5185,12 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5234,7 +5216,6 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- should produce ordered path
@@ -5255,15 +5236,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5281,7 +5259,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- should produce ordered path
@@ -5304,15 +5281,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5330,7 +5304,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- These plans are flaky between MergeAppend and Sort over Append.
@@ -6007,7 +5980,6 @@ ORDER BY device_id,
    ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Sort (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
          Sort Key: _hyper_2_10_chunk."time"
@@ -6110,7 +6082,6 @@ ORDER BY device_id;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6140,7 +6111,6 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-                     Heap Fetches: 0
          ->  Custom Scan (VectorAgg) (actual rows=1 loops=1)
                Output: (PARTIAL count(*))
                Grouping Policy: all compressed batches
@@ -6178,13 +6148,10 @@ ORDER BY device_id;
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_8_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=672 loops=1)
          Output: _hyper_2_9_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6197,7 +6164,6 @@ ORDER BY device_id;
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id
-         Heap Fetches: 0
 (39 rows)
 
 DROP INDEX tmp_idx CASCADE;
@@ -6291,15 +6257,12 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -6315,7 +6278,6 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
-         Heap Fetches: 0
 (47 rows)
 
 --ensure that we can get a nested loop
@@ -6353,15 +6315,12 @@ WHERE device_id_peer IN (
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -7340,13 +7299,10 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7358,7 +7314,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
 (39 rows)
 
 -- test prepared statement with params pushdown
@@ -7386,7 +7341,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7409,7 +7363,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -1196,7 +1196,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1680 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-               Heap Fetches: 0
          ->  Sort (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
@@ -2105,7 +2104,6 @@ ORDER BY device_id;
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
    ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=3360 loops=1)
          Output: _hyper_1_2_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1680 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
@@ -2887,7 +2885,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -4893,7 +4890,6 @@ LIMIT 10;
          ->  Merge Append (actual rows=10 loops=1)
                Sort Key: _hyper_2_12_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 0
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -4907,11 +4903,8 @@ LIMIT 10;
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_6_chunk."time" DESC
                ->  Sort (never executed)
@@ -5011,11 +5004,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=720 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -5027,7 +5017,6 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1008 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
-               Heap Fetches: 0
 (36 rows)
 
 --
@@ -5144,15 +5133,12 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk."time"
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5178,7 +5164,6 @@ LIMIT 100;
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- test ordering only by segmentby columns
@@ -5200,15 +5185,12 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1 loops=1)
                Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer
                Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5234,7 +5216,6 @@ LIMIT 100;
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (42 rows)
 
 -- should produce ordered path
@@ -5255,15 +5236,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5281,7 +5259,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- should produce ordered path
@@ -5304,15 +5281,12 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=447 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=447 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5330,7 +5304,6 @@ ORDER BY device_id,
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 0
 (32 rows)
 
 -- These plans are flaky between MergeAppend and Sort over Append.
@@ -6007,7 +5980,6 @@ ORDER BY device_id,
    ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Sort (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
          Sort Key: _hyper_2_10_chunk."time"
@@ -6110,7 +6082,6 @@ ORDER BY device_id;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6140,7 +6111,6 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-                     Heap Fetches: 0
          ->  Custom Scan (VectorAgg) (actual rows=1 loops=1)
                Output: (PARTIAL count(*))
                Grouping Policy: all compressed batches
@@ -6178,13 +6148,10 @@ ORDER BY device_id;
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=672 loops=1)
          Output: _hyper_2_7_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_8_chunk.device_id
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=672 loops=1)
          Output: _hyper_2_9_chunk.device_id
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
@@ -6197,7 +6164,6 @@ ORDER BY device_id;
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=336 loops=1)
          Output: _hyper_2_12_chunk.device_id
-         Heap Fetches: 0
 (39 rows)
 
 DROP INDEX tmp_idx CASCADE;
@@ -6291,15 +6257,12 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -6315,7 +6278,6 @@ ORDER BY device_id_peer;
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
-         Heap Fetches: 0
 (47 rows)
 
 --ensure that we can get a nested loop
@@ -6353,15 +6315,12 @@ WHERE device_id_peer IN (
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
-         Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
@@ -7340,13 +7299,10 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7358,7 +7314,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
-                     Heap Fetches: 0
 (39 rows)
 
 -- test prepared statement with params pushdown
@@ -7386,7 +7341,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160
@@ -7409,7 +7363,6 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
-                     Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 160

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -47,13 +47,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
 (13 rows)
 
 :PREFIX EXECUTE prep;
@@ -64,13 +61,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
 (13 rows)
 
 :PREFIX EXECUTE prep;
@@ -81,13 +75,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
 (13 rows)
 
 :PREFIX EXECUTE prep;
@@ -98,13 +89,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
 (13 rows)
 
 :PREFIX EXECUTE prep;
@@ -115,13 +103,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < now()))
-               Heap Fetches: 0
 (13 rows)
 
 DEALLOCATE prep;
@@ -141,10 +126,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -155,10 +138,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -169,10 +150,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -183,10 +162,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -197,10 +174,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
-               Heap Fetches: 0
 (10 rows)
 
 DEALLOCATE prep;
@@ -226,25 +201,19 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (25 rows)
 
 :PREFIX EXECUTE prep;
@@ -255,25 +224,19 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (25 rows)
 
 :PREFIX EXECUTE prep;
@@ -284,25 +247,19 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (25 rows)
 
 :PREFIX EXECUTE prep;
@@ -313,25 +270,19 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (25 rows)
 
 :PREFIX EXECUTE prep;
@@ -342,25 +293,19 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (25 rows)
 
 DEALLOCATE prep;
@@ -382,10 +327,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -396,10 +339,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -410,10 +351,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -424,10 +363,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX EXECUTE prep;
@@ -438,10 +375,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 100
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 DEALLOCATE prep;
@@ -768,43 +703,31 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 6
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_4 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_5 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_6 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_7 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_8 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_9 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (43 rows)
 
 :PREFIX EXECUTE prep;
@@ -815,43 +738,31 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 6
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_4 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_5 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_6 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_7 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_8 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_9 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (43 rows)
 
 :PREFIX EXECUTE prep;
@@ -862,43 +773,31 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 6
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_4 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_5 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_6 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_7 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_8 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_9 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (43 rows)
 
 :PREFIX EXECUTE prep;
@@ -909,43 +808,31 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 6
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_4 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_5 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_6 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_7 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_8 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_9 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (43 rows)
 
 :PREFIX EXECUTE prep;
@@ -956,43 +843,31 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
                      Index Cond: (device_id = 2)
-                     Heap Fetches: 0
          ->  Limit (actual rows=1 loops=100)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=1 loops=100)
                      Chunks excluded during runtime: 6
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=100)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_4 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_5 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_6 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_7 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_8 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_9 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (43 rows)
 
 DEALLOCATE prep;
@@ -1015,35 +890,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 60
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX EXECUTE prep;
@@ -1055,35 +921,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 60
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX EXECUTE prep;
@@ -1095,35 +952,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 60
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX EXECUTE prep;
@@ -1135,35 +983,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 60
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX EXECUTE prep;
@@ -1175,35 +1014,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 60
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 DEALLOCATE prep;
@@ -1230,22 +1060,16 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
 (24 rows)
 
 :PREFIX EXECUTE prep;
@@ -1258,22 +1082,16 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
 (24 rows)
 
 :PREFIX EXECUTE prep;
@@ -1286,22 +1104,16 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
 (24 rows)
 
 :PREFIX EXECUTE prep;
@@ -1314,22 +1126,16 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
 (24 rows)
 
 :PREFIX EXECUTE prep;
@@ -1342,22 +1148,16 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 100
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
 (24 rows)
 
 DEALLOCATE prep;

--- a/tsl/test/shared/expected/memoize.out
+++ b/tsl/test/shared/expected/memoize.out
@@ -32,11 +32,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=68370 loops=1)
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1 (actual rows=17990 loops=1)
-               Heap Fetches: 17990
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2 (actual rows=25190 loops=1)
-               Heap Fetches: 25190
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3 (actual rows=25190 loops=1)
-               Heap Fetches: 25190
    ->  Memoize (actual rows=1 loops=68370)
          Cache Key: m1."time"
          Cache Mode: binary
@@ -46,13 +43,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=3598)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 3598
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2 (actual rows=1 loops=5038)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 5038
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3 (actual rows=1 loops=5038)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 5038
 (25 rows)
 
 \set TEST_TABLE 'metrics_space'
@@ -77,27 +71,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=17990 loops=1)
                Sort Key: m1_1."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_1 (actual rows=3598 loops=1)
-                     Heap Fetches: 3598
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_2 (actual rows=10794 loops=1)
-                     Heap Fetches: 10794
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_3 (actual rows=3598 loops=1)
-                     Heap Fetches: 3598
          ->  Merge Append (actual rows=25190 loops=1)
                Sort Key: m1_4."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_4 (actual rows=5038 loops=1)
-                     Heap Fetches: 5038
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_5 (actual rows=15114 loops=1)
-                     Heap Fetches: 15114
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_6 (actual rows=5038 loops=1)
-                     Heap Fetches: 5038
          ->  Merge Append (actual rows=25190 loops=1)
                Sort Key: m1_7."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_7 (actual rows=5038 loops=1)
-                     Heap Fetches: 5038
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_8 (actual rows=15114 loops=1)
-                     Heap Fetches: 15114
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m1_9 (actual rows=5038 loops=1)
-                     Heap Fetches: 5038
    ->  Memoize (actual rows=1 loops=68370)
          Cache Key: m1."time"
          Cache Mode: binary
@@ -107,31 +92,22 @@ QUERY PLAN
                      Chunks excluded during runtime: 6
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_1 (actual rows=1 loops=3598)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 3598
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_2 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_3 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_4 (actual rows=1 loops=5038)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 5038
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_5 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_6 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_7 (actual rows=1 loops=5038)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 5038
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_8 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk m2_9 (never executed)
                            Index Cond: ("time" = m1."time")
-                           Heap Fetches: 0
 (61 rows)
 
 \set TEST_TABLE 'metrics_compressed'

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -36,11 +36,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test DESC for ordered chunks
@@ -54,11 +51,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -132,11 +126,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -150,11 +141,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 -- time column must be primary sort order
@@ -177,13 +165,10 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3599 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 3599
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
 (17 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -203,13 +188,10 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=10 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 10
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
 (12 rows)
 
 RESET enable_seqscan;
@@ -260,10 +242,8 @@ QUERY PLAN
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 :PREFIX
@@ -278,10 +258,8 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 -- test interaction with runtime exclusion
@@ -298,10 +276,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX
@@ -317,10 +293,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 -- test constraint exclusion
@@ -338,7 +312,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 :PREFIX
@@ -355,7 +328,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -372,13 +344,10 @@ QUERY PLAN
                  Order: metrics."time" DESC
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 :PREFIX
@@ -392,13 +361,10 @@ QUERY PLAN
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -412,11 +378,8 @@ QUERY PLAN
            ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                       Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Heap Fetches: 0
 (11 rows)
 
 :PREFIX
@@ -430,13 +393,10 @@ QUERY PLAN
                  Order: metrics."time" DESC
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 -- test query with time_bucket
@@ -450,11 +410,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY time_bucket
@@ -468,11 +425,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: time_bucket('@ 1 day'::interval, metrics."time")
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -512,11 +466,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: date_trunc('day'::text, metrics."time")
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY date_trunc
@@ -530,11 +481,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: date_trunc('day'::text, metrics."time")
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -577,13 +525,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -603,13 +548,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < now())
-               Heap Fetches: 100
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -628,13 +570,10 @@ QUERY PLAN
    Order: metrics."time"
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3598 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 3598
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
 (11 rows)
 
 -- test subquery
@@ -657,22 +596,16 @@ QUERY PLAN
                          Order: metrics_1."time" DESC
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 5
 (26 rows)
 
 -- test ordered append with limit expression
@@ -689,11 +622,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=4 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=4 loops=1)
-               Heap Fetches: 4
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test with ordered guc disabled
@@ -708,11 +638,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -726,11 +653,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test with chunk append disabled
@@ -745,11 +669,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -763,11 +684,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 \set TEST_TABLE 'metrics_space'
@@ -795,27 +713,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test DESC for ordered chunks
@@ -831,27 +740,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -939,27 +839,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -973,23 +864,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 -- time column must be primary sort order
@@ -1007,22 +889,16 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
 (21 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -1116,24 +992,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 :PREFIX
@@ -1150,24 +1020,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 -- test interaction with runtime exclusion
@@ -1185,35 +1049,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX
@@ -1230,35 +1085,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 -- test constraint exclusion
@@ -1277,24 +1123,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
 (25 rows)
 
 :PREFIX
@@ -1312,24 +1152,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
 (25 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -1348,35 +1182,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 :PREFIX
@@ -1392,35 +1217,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -1436,27 +1252,18 @@ QUERY PLAN
                  ->  Merge Append (actual rows=1 loops=1)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (29 rows)
 
 :PREFIX
@@ -1472,35 +1279,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 -- test query with time_bucket
@@ -1516,27 +1314,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY time_bucket
@@ -1552,27 +1341,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -1620,27 +1400,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY date_trunc
@@ -1656,27 +1427,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -1726,35 +1488,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1775,35 +1528,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 60
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1852,65 +1596,47 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 3
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 1
 (70 rows)
 
 -- test ordered append with limit expression
@@ -1929,27 +1655,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=4 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 3
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (29 rows)
 
 -- test with ordered guc disabled
@@ -1964,23 +1681,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -1996,27 +1704,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test with chunk append disabled
@@ -2031,23 +1730,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -2063,27 +1753,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 \set TEST_TABLE 'metrics_compressed'

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -36,11 +36,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test DESC for ordered chunks
@@ -54,11 +51,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -135,11 +129,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -153,11 +144,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 -- time column must be primary sort order
@@ -180,13 +168,10 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3599 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 3599
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
 (17 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -206,13 +191,10 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=10 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 10
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
 (12 rows)
 
 RESET enable_seqscan;
@@ -263,10 +245,8 @@ QUERY PLAN
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 :PREFIX
@@ -281,10 +261,8 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 -- test interaction with runtime exclusion
@@ -301,10 +279,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX
@@ -320,10 +296,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 -- test constraint exclusion
@@ -341,7 +315,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 :PREFIX
@@ -358,7 +331,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -375,13 +347,10 @@ QUERY PLAN
                  Order: metrics."time" DESC
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 :PREFIX
@@ -395,13 +364,10 @@ QUERY PLAN
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -416,11 +382,8 @@ QUERY PLAN
                  ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                        Order: metrics."time"
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (12 rows)
 
 :PREFIX
@@ -435,13 +398,10 @@ QUERY PLAN
                        Order: metrics."time" DESC
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (15 rows)
 
 -- test query with time_bucket
@@ -456,11 +416,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY time_bucket
@@ -475,11 +432,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: time_bucket('@ 1 day'::interval, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -520,11 +474,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: date_trunc('day'::text, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY date_trunc
@@ -539,11 +490,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: date_trunc('day'::text, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -586,13 +534,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -612,13 +557,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < now())
-               Heap Fetches: 100
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -637,13 +579,10 @@ QUERY PLAN
    Order: metrics."time"
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3598 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 3598
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
 (11 rows)
 
 -- test subquery
@@ -666,22 +605,16 @@ QUERY PLAN
                          Order: metrics_1."time" DESC
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 5
 (26 rows)
 
 -- test ordered append with limit expression
@@ -698,11 +631,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=4 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=4 loops=1)
-               Heap Fetches: 4
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test with ordered guc disabled
@@ -717,11 +647,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -735,11 +662,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test with chunk append disabled
@@ -754,11 +678,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -772,11 +693,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 \set TEST_TABLE 'metrics_space'
@@ -804,27 +722,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test DESC for ordered chunks
@@ -840,27 +749,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -951,27 +851,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -985,23 +876,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 -- time column must be primary sort order
@@ -1019,22 +901,16 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
 (21 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -1128,24 +1004,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 :PREFIX
@@ -1162,24 +1032,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 -- test interaction with runtime exclusion
@@ -1197,35 +1061,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX
@@ -1242,35 +1097,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 -- test constraint exclusion
@@ -1289,24 +1135,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
 (25 rows)
 
 :PREFIX
@@ -1324,24 +1164,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
 (25 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -1360,35 +1194,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 :PREFIX
@@ -1404,35 +1229,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -1449,27 +1265,18 @@ QUERY PLAN
                        ->  Merge Append (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
 (30 rows)
 
 :PREFIX
@@ -1486,35 +1293,26 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
 (39 rows)
 
 -- test query with time_bucket
@@ -1531,27 +1329,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY time_bucket
@@ -1568,27 +1357,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -1637,27 +1417,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY date_trunc
@@ -1674,27 +1445,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -1744,35 +1506,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1793,35 +1546,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 60
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1870,65 +1614,47 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 3
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 1
 (70 rows)
 
 -- test ordered append with limit expression
@@ -1947,27 +1673,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=4 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 3
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (29 rows)
 
 -- test with ordered guc disabled
@@ -1982,23 +1699,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -2014,27 +1722,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test with chunk append disabled
@@ -2049,23 +1748,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -2081,27 +1771,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 \set TEST_TABLE 'metrics_compressed'

--- a/tsl/test/shared/expected/ordered_append-16.out
+++ b/tsl/test/shared/expected/ordered_append-16.out
@@ -36,11 +36,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test DESC for ordered chunks
@@ -54,11 +51,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -135,11 +129,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -153,11 +144,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 -- time column must be primary sort order
@@ -180,13 +168,10 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3599 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 3599
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
 (17 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -206,13 +191,10 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=10 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 10
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
 (12 rows)
 
 RESET enable_seqscan;
@@ -263,10 +245,8 @@ QUERY PLAN
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 :PREFIX
@@ -281,10 +261,8 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 -- test interaction with runtime exclusion
@@ -301,10 +279,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX
@@ -320,10 +296,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 -- test constraint exclusion
@@ -341,7 +315,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 :PREFIX
@@ -358,7 +331,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -375,13 +347,10 @@ QUERY PLAN
                  Order: metrics."time" DESC
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 :PREFIX
@@ -395,13 +364,10 @@ QUERY PLAN
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
-                       Heap Fetches: 0
 (14 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -416,11 +382,8 @@ QUERY PLAN
                  ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                        Order: metrics."time"
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (12 rows)
 
 :PREFIX
@@ -435,13 +398,10 @@ QUERY PLAN
                        Order: metrics."time" DESC
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (15 rows)
 
 -- test query with time_bucket
@@ -456,11 +416,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY time_bucket
@@ -475,11 +432,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: time_bucket('@ 1 day'::interval, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -520,11 +474,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: date_trunc('day'::text, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY date_trunc
@@ -539,11 +490,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: date_trunc('day'::text, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -586,13 +534,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -612,13 +557,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < now())
-               Heap Fetches: 100
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -637,13 +579,10 @@ QUERY PLAN
    Order: metrics."time"
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3598 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 3598
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
 (11 rows)
 
 -- test subquery
@@ -666,22 +605,16 @@ QUERY PLAN
                          Order: metrics_1."time" DESC
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                Index Cond: ("time" IS NOT NULL)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = $1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5 loops=1)
          Index Cond: ("time" = $1)
-         Heap Fetches: 5
 (26 rows)
 
 -- test ordered append with limit expression
@@ -698,11 +631,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=4 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=4 loops=1)
-               Heap Fetches: 4
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test with ordered guc disabled
@@ -717,11 +647,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -735,11 +662,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test with chunk append disabled
@@ -754,11 +678,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -772,11 +693,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 \set TEST_TABLE 'metrics_space'
@@ -804,27 +722,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test DESC for ordered chunks
@@ -840,27 +749,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -951,27 +851,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -985,23 +876,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 -- time column must be primary sort order
@@ -1019,22 +901,16 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
 (21 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -1128,24 +1004,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 :PREFIX
@@ -1162,24 +1032,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 -- test interaction with runtime exclusion
@@ -1197,35 +1061,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX
@@ -1242,35 +1097,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 -- test constraint exclusion
@@ -1289,24 +1135,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
 (25 rows)
 
 :PREFIX
@@ -1324,24 +1164,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
 (25 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -1360,35 +1194,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 :PREFIX
@@ -1404,35 +1229,26 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                              Index Cond: ("time" IS NOT NULL)
-                             Heap Fetches: 0
 (38 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -1449,27 +1265,18 @@ QUERY PLAN
                        ->  Merge Append (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
 (30 rows)
 
 :PREFIX
@@ -1486,35 +1293,26 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
 (39 rows)
 
 -- test query with time_bucket
@@ -1531,27 +1329,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY time_bucket
@@ -1568,27 +1357,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -1637,27 +1417,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY date_trunc
@@ -1674,27 +1445,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -1744,35 +1506,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1793,35 +1546,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 60
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1870,65 +1614,47 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 1
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
                                      Index Cond: ("time" IS NOT NULL)
-                                     Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 3
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = $1)
-               Heap Fetches: 1
 (70 rows)
 
 -- test ordered append with limit expression
@@ -1947,27 +1673,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=4 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 3
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (29 rows)
 
 -- test with ordered guc disabled
@@ -1982,23 +1699,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -2014,27 +1722,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test with chunk append disabled
@@ -2049,23 +1748,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -2081,27 +1771,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 \set TEST_TABLE 'metrics_compressed'

--- a/tsl/test/shared/expected/ordered_append-17.out
+++ b/tsl/test/shared/expected/ordered_append-17.out
@@ -36,11 +36,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test DESC for ordered chunks
@@ -54,11 +51,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -135,11 +129,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -153,11 +144,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 -- time column must be primary sort order
@@ -180,13 +168,10 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk.device_id
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3599 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 3599
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5039 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-                     Heap Fetches: 5039
 (17 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -206,13 +191,10 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=10 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 10
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
 (12 rows)
 
 RESET enable_seqscan;
@@ -263,10 +245,8 @@ QUERY PLAN
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 :PREFIX
@@ -281,10 +261,8 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               Heap Fetches: 0
 (9 rows)
 
 -- test interaction with runtime exclusion
@@ -301,10 +279,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 :PREFIX
@@ -320,10 +296,8 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-               Heap Fetches: 0
 (10 rows)
 
 -- test constraint exclusion
@@ -341,7 +315,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 :PREFIX
@@ -358,7 +331,6 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 1
 (7 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -374,11 +346,8 @@ QUERY PLAN
            ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                  Order: metrics."time" DESC
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                       Heap Fetches: 1
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Heap Fetches: 0
                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Heap Fetches: 0
 (11 rows)
 
 :PREFIX
@@ -391,11 +360,8 @@ QUERY PLAN
            ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                       Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Heap Fetches: 0
 (11 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -410,11 +376,8 @@ QUERY PLAN
                  ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                        Order: metrics."time"
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (12 rows)
 
 :PREFIX
@@ -428,11 +391,8 @@ QUERY PLAN
                  ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                        Order: metrics."time" DESC
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (12 rows)
 
 -- test query with time_bucket
@@ -447,11 +407,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY time_bucket
@@ -466,11 +423,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: time_bucket('@ 1 day'::interval, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -511,11 +465,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: date_trunc('day'::text, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY date_trunc
@@ -530,11 +481,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: date_trunc('day'::text, metrics."time")
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (10 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -577,13 +525,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -603,13 +548,10 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=100 loops=1)
                Index Cond: ("time" < now())
-               Heap Fetches: 100
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: ("time" < now())
-               Heap Fetches: 0
 (13 rows)
 
 -- test CTE
@@ -628,13 +570,10 @@ QUERY PLAN
    Order: metrics."time"
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=3598 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 3598
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=5038 loops=1)
          Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         Heap Fetches: 5038
 (11 rows)
 
 -- test subquery
@@ -656,20 +595,14 @@ QUERY PLAN
                    ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=1 loops=1)
                          Order: metrics_1."time" DESC
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                               Heap Fetches: 1
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                               Heap Fetches: 0
                          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                               Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 0
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5 loops=1)
          Index Cond: ("time" = (InitPlan 2).col1)
-         Heap Fetches: 5
 (23 rows)
 
 -- test ordered append with limit expression
@@ -686,11 +619,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=4 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=4 loops=1)
-               Heap Fetches: 4
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (11 rows)
 
 -- test with ordered guc disabled
@@ -705,11 +635,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -723,11 +650,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test with chunk append disabled
@@ -742,11 +666,8 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (9 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -760,11 +681,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=3 loops=1)
          Order: metrics."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-               Heap Fetches: 3
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 \set TEST_TABLE 'metrics_space'
@@ -792,27 +710,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test DESC for ordered chunks
@@ -828,27 +737,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test query with ORDER BY column not in targetlist
@@ -939,27 +839,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
@@ -973,23 +864,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 -- time column must be primary sort order
@@ -1007,22 +889,16 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               Heap Fetches: 1
 (21 rows)
 
 -- test equality constraint on ORDER BY prefix
@@ -1116,24 +992,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 :PREFIX
@@ -1150,24 +1020,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
 (25 rows)
 
 -- test interaction with runtime exclusion
@@ -1185,35 +1049,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 :PREFIX
@@ -1230,35 +1085,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Heap Fetches: 0
 (36 rows)
 
 -- test constraint exclusion
@@ -1277,24 +1123,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" > ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
 (25 rows)
 
 :PREFIX
@@ -1312,24 +1152,18 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (("time" < ('2000-01-08'::cstring)::timestamp with time zone) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 0
 (25 rows)
 
 -- Disable hash aggregation to get a deterministic test output
@@ -1347,27 +1181,18 @@ QUERY PLAN
                  ->  Merge Append (actual rows=1 loops=1)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (29 rows)
 
 :PREFIX
@@ -1382,27 +1207,18 @@ QUERY PLAN
                  ->  Merge Append (actual rows=1 loops=1)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Heap Fetches: 0
 (29 rows)
 
 -- test first/last (doesn't use ordered append yet)
@@ -1419,27 +1235,18 @@ QUERY PLAN
                        ->  Merge Append (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
 (30 rows)
 
 :PREFIX
@@ -1455,27 +1262,18 @@ QUERY PLAN
                        ->  Merge Append (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
 (30 rows)
 
 -- test query with time_bucket
@@ -1492,27 +1290,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY time_bucket
@@ -1529,27 +1318,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY time_bucket, device_id
@@ -1598,27 +1378,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY date_trunc
@@ -1635,27 +1406,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: (date_trunc('day'::text, _hyper_X_X_chunk."time"))
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
 (28 rows)
 
 -- test query with ORDER BY date_trunc, device_id
@@ -1705,35 +1467,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < (now() + '@ 1 mon'::interval))
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1754,35 +1507,26 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=60 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 60
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=21 loops=1)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 21
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: ("time" < now())
-                     Heap Fetches: 0
 (36 rows)
 
 -- test CTE
@@ -1830,57 +1574,39 @@ QUERY PLAN
                          ->  Merge Append (actual rows=1 loops=1)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                     Heap Fetches: 1
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                     Heap Fetches: 1
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Heap Fetches: 0
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Heap Fetches: 0
                                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=0 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=0 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 0
    ->  Merge Append (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 3
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: ("time" = (InitPlan 2).col1)
-               Heap Fetches: 1
 (61 rows)
 
 -- test ordered append with limit expression
@@ -1899,27 +1625,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=4 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
-                     Heap Fetches: 3
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (29 rows)
 
 -- test with ordered guc disabled
@@ -1934,23 +1651,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_ordered_append;
@@ -1966,27 +1674,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test with chunk append disabled
@@ -2001,23 +1700,14 @@ QUERY PLAN
    ->  Merge Append (actual rows=3 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-               Heap Fetches: 2
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
 (21 rows)
 
 RESET timescaledb.enable_chunk_append;
@@ -2033,27 +1723,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=3 loops=1)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                     Heap Fetches: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 \set TEST_TABLE 'metrics_compressed'

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -44,11 +44,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (12 rows)
@@ -74,11 +71,8 @@ QUERY PLAN
                      ->  Custom Scan (ChunkAppend) on metrics (actual rows=2 loops=1)
                            Order: metrics."time" DESC
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                 Heap Fetches: 0
 (13 rows)
 
 -- test plan with best index is chosen
@@ -96,13 +90,10 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
 (12 rows)
 
 -- test plan with best index is chosen
@@ -117,11 +108,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test LATERAL with correlated query
@@ -147,13 +135,10 @@ QUERY PLAN
                Chunks excluded during runtime: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     Heap Fetches: 3
 (16 rows)
 
 -- test LATERAL with correlated query
@@ -179,13 +164,10 @@ QUERY PLAN
                Chunks excluded during runtime: 2
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (actual rows=1 loops=2)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     Heap Fetches: 2
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (never executed)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     Heap Fetches: 0
 (16 rows)
 
 -- test startup and runtime exclusion together
@@ -211,13 +193,10 @@ QUERY PLAN
                Chunks excluded during runtime: 2
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                      Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     Heap Fetches: 3
 (16 rows)
 
 -- test startup and runtime exclusion together
@@ -263,25 +242,19 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
    ->  Materialize (actual rows=13674 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=13674 loops=1)
                Order: o2."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -306,19 +279,14 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 2
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=6 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=6 loops=1)
-                           Heap Fetches: 6
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                           Heap Fetches: 0
 (20 rows)
 
 -- test join against max query
@@ -342,13 +310,10 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
    ->  Sort (actual rows=1 loops=1)
          Sort Key: ($0)
          Sort Method: quicksort 
@@ -359,13 +324,10 @@ QUERY PLAN
                              Order: metrics."time" DESC
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
 (30 rows)
 
 RESET enable_hashjoin;
@@ -390,25 +352,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with USING
@@ -429,25 +385,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test NATURAL JOIN on time column
@@ -487,25 +437,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test RIGHT JOIN on time column
@@ -526,25 +470,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -565,25 +503,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -605,25 +537,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -644,25 +570,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column and device_id
@@ -709,24 +629,18 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
 (24 rows)
 
 -- test JOIN on time column with implicit join
@@ -748,25 +662,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -789,13 +697,10 @@ QUERY PLAN
                Order: o3."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_2 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_3 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Merge Join (actual rows=100 loops=1)
                      Merge Cond: (o1."time" = o2."time")
@@ -803,25 +708,19 @@ QUERY PLAN
                            Order: o1."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 100
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                      ->  Materialize (actual rows=100 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                                  Order: o2."time"
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (40 rows)
 
 RESET enable_seqscan;
@@ -857,27 +756,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (30 rows)
@@ -905,27 +795,18 @@ QUERY PLAN
                            ->  Merge Append (actual rows=2 loops=1)
                                  Sort Key: _hyper_X_X_chunk."time" DESC
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                       Heap Fetches: 1
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                       Heap Fetches: 1
                            ->  Merge Append (never executed)
                                  Sort Key: _hyper_X_X_chunk."time" DESC
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                            ->  Merge Append (never executed)
                                  Sort Key: _hyper_X_X_chunk."time" DESC
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
 (31 rows)
 
 -- test plan with best index is chosen
@@ -963,27 +844,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test LATERAL with correlated query
@@ -1009,35 +881,26 @@ QUERY PLAN
                      Sort Key: o_1."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_4."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=1 loops=3)
                      Sort Key: o_7."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 3
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 3
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 3
 (38 rows)
 
 -- test LATERAL with correlated query
@@ -1063,35 +926,26 @@ QUERY PLAN
                      Sort Key: o_1."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=1 loops=2)
                      Sort Key: o_4."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=1 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=1 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=1 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 2
                ->  Merge Append (never executed)
                      Sort Key: o_7."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
 (38 rows)
 
 -- test startup and runtime exclusion together
@@ -1117,35 +971,26 @@ QUERY PLAN
                      Sort Key: o_1."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_4."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=1 loops=3)
                      Sort Key: o_7."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 3
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 3
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 3
 (38 rows)
 
 -- test startup and runtime exclusion together
@@ -1172,35 +1017,26 @@ QUERY PLAN
                      Sort Key: o_1."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_4."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_7."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           Heap Fetches: 0
 (38 rows)
 
 -- test JOIN
@@ -1235,13 +1071,10 @@ QUERY PLAN
                Order: o2."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -1268,51 +1101,36 @@ QUERY PLAN
                      Sort Key: o1_1."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: o1_4."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_4 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_5 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_6 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=6 loops=1)
                      Order: o2."time"
                      ->  Merge Append (actual rows=6 loops=1)
                            Sort Key: o2_1."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2 loops=1)
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=4 loops=1)
-                                 Heap Fetches: 4
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=2 loops=1)
-                                 Heap Fetches: 2
                      ->  Merge Append (never executed)
                            Sort Key: o2_4."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_4 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_5 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_6 (never executed)
-                                 Heap Fetches: 0
                      ->  Merge Append (never executed)
                            Sort Key: o2_7."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_7 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_8 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_9 (never executed)
-                                 Heap Fetches: 0
 (54 rows)
 
 -- test join against max query
@@ -1352,35 +1170,26 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
 (51 rows)
 
 RESET enable_hashjoin;
@@ -1414,13 +1223,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with USING
@@ -1450,13 +1256,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test NATURAL JOIN on time column
@@ -1505,13 +1308,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test RIGHT JOIN on time column
@@ -1541,13 +1341,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -1577,13 +1374,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -1614,13 +1408,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -1650,13 +1441,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column and device_id
@@ -1735,13 +1523,10 @@ QUERY PLAN
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
 (21 rows)
 
 -- test JOIN on time column with implicit join
@@ -1772,13 +1557,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -1821,13 +1603,10 @@ QUERY PLAN
                                  Order: o2."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (34 rows)
 
 RESET enable_seqscan;

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -44,11 +44,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (12 rows)
@@ -75,11 +72,8 @@ QUERY PLAN
                            ->  Custom Scan (ChunkAppend) on metrics (actual rows=2 loops=1)
                                  Order: metrics."time" DESC
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
 (14 rows)
 
 -- test plan with best index is chosen
@@ -97,13 +91,10 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
 (12 rows)
 
 -- test plan with best index is chosen
@@ -118,11 +109,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test LATERAL with correlated query
@@ -149,13 +137,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 3
 (17 rows)
 
 -- test LATERAL with correlated query
@@ -182,13 +167,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (actual rows=1 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 2
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
 (17 rows)
 
 -- test startup and runtime exclusion together
@@ -215,13 +197,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 3
 (17 rows)
 
 -- test startup and runtime exclusion together
@@ -268,25 +247,19 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
    ->  Materialize (actual rows=13674 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=13674 loops=1)
                Order: o2."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -311,20 +284,15 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 2
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Result (actual rows=6 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=6 loops=1)
                            Order: o2."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=6 loops=1)
-                                 Heap Fetches: 6
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Heap Fetches: 0
 (21 rows)
 
 -- test join against max query
@@ -348,13 +316,10 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
    ->  Sort (actual rows=1 loops=1)
          Sort Key: ($0)
          Sort Method: quicksort 
@@ -365,13 +330,10 @@ QUERY PLAN
                              Order: metrics."time" DESC
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
 (30 rows)
 
 RESET enable_hashjoin;
@@ -396,25 +358,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with USING
@@ -435,25 +391,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test NATURAL JOIN on time column
@@ -493,25 +443,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test RIGHT JOIN on time column
@@ -532,25 +476,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -571,25 +509,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -611,25 +543,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -650,25 +576,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column and device_id
@@ -715,24 +635,18 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
 (24 rows)
 
 -- test JOIN on time column with implicit join
@@ -754,25 +668,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -795,13 +703,10 @@ QUERY PLAN
                Order: o3."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_2 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_3 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Merge Join (actual rows=100 loops=1)
                      Merge Cond: (o1."time" = o2."time")
@@ -809,25 +714,19 @@ QUERY PLAN
                            Order: o1."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 100
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                      ->  Materialize (actual rows=100 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                                  Order: o2."time"
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (40 rows)
 
 RESET enable_seqscan;
@@ -863,27 +762,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (30 rows)
@@ -912,27 +802,18 @@ QUERY PLAN
                                  ->  Merge Append (actual rows=2 loops=1)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                             Heap Fetches: 2
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                             Heap Fetches: 1
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                             Heap Fetches: 1
                                  ->  Merge Append (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                  ->  Merge Append (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
 (32 rows)
 
 -- test plan with best index is chosen
@@ -970,27 +851,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test LATERAL with correlated query
@@ -1017,35 +889,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
 (39 rows)
 
 -- test LATERAL with correlated query
@@ -1072,35 +935,26 @@ QUERY PLAN
                            Sort Key: o_1."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=2)
                            Sort Key: o_4."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                      ->  Merge Append (never executed)
                            Sort Key: o_7."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
 (39 rows)
 
 -- test startup and runtime exclusion together
@@ -1127,35 +981,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
 (39 rows)
 
 -- test startup and runtime exclusion together
@@ -1183,35 +1028,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
 (39 rows)
 
 -- test JOIN
@@ -1246,13 +1082,10 @@ QUERY PLAN
                Order: o2."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -1279,24 +1112,18 @@ QUERY PLAN
                      Sort Key: o1_1."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: o1_4."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_4 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_5 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_6 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Result (actual rows=6 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=6 loops=1)
@@ -1304,27 +1131,18 @@ QUERY PLAN
                            ->  Merge Append (actual rows=6 loops=1)
                                  Sort Key: o2_1."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=4 loops=1)
-                                       Heap Fetches: 4
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                            ->  Merge Append (never executed)
                                  Sort Key: o2_4."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_4 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_5 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_6 (never executed)
-                                       Heap Fetches: 0
                            ->  Merge Append (never executed)
                                  Sort Key: o2_7."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_7 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_8 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_9 (never executed)
-                                       Heap Fetches: 0
 (55 rows)
 
 -- test join against max query
@@ -1364,35 +1182,26 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
 (51 rows)
 
 RESET enable_hashjoin;
@@ -1426,13 +1235,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with USING
@@ -1462,13 +1268,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test NATURAL JOIN on time column
@@ -1517,13 +1320,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test RIGHT JOIN on time column
@@ -1553,13 +1353,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -1589,13 +1386,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -1626,13 +1420,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -1662,13 +1453,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column and device_id
@@ -1747,13 +1535,10 @@ QUERY PLAN
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 1)
-                           Heap Fetches: 0
 (21 rows)
 
 -- test JOIN on time column with implicit join
@@ -1784,13 +1569,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -1833,13 +1615,10 @@ QUERY PLAN
                                  Order: o2."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (34 rows)
 
 RESET enable_seqscan;

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -44,11 +44,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (12 rows)
@@ -75,11 +72,8 @@ QUERY PLAN
                            ->  Custom Scan (ChunkAppend) on metrics (actual rows=2 loops=1)
                                  Order: metrics."time" DESC
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
 (14 rows)
 
 -- test plan with best index is chosen
@@ -97,13 +91,10 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
 (12 rows)
 
 -- test plan with best index is chosen
@@ -118,11 +109,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test LATERAL with correlated query
@@ -149,13 +137,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 3
 (17 rows)
 
 -- test LATERAL with correlated query
@@ -182,13 +167,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (actual rows=1 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 2
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
 (17 rows)
 
 -- test startup and runtime exclusion together
@@ -215,13 +197,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 3
 (17 rows)
 
 -- test startup and runtime exclusion together
@@ -268,25 +247,19 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
    ->  Materialize (actual rows=13674 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=13674 loops=1)
                Order: o2."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -311,20 +284,15 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 2
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Result (actual rows=6 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=6 loops=1)
                            Order: o2."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=6 loops=1)
-                                 Heap Fetches: 6
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Heap Fetches: 0
 (21 rows)
 
 -- test join against max query
@@ -348,13 +316,10 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
    ->  Sort (actual rows=1 loops=1)
          Sort Key: ($0)
          Sort Method: quicksort 
@@ -365,13 +330,10 @@ QUERY PLAN
                              Order: metrics."time" DESC
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
                                    Index Cond: ("time" IS NOT NULL)
-                                   Heap Fetches: 0
 (30 rows)
 
 RESET enable_hashjoin;
@@ -396,25 +358,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with USING
@@ -435,25 +391,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test NATURAL JOIN on time column
@@ -493,25 +443,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test RIGHT JOIN on time column
@@ -532,25 +476,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -571,25 +509,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -611,25 +543,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -650,25 +576,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column and device_id
@@ -715,24 +635,18 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
 (24 rows)
 
 -- test JOIN on time column with implicit join
@@ -754,25 +668,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -795,13 +703,10 @@ QUERY PLAN
                Order: o3."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_2 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_3 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Merge Join (actual rows=100 loops=1)
                      Merge Cond: (o1."time" = o2."time")
@@ -809,25 +714,19 @@ QUERY PLAN
                            Order: o1."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 100
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                      ->  Materialize (actual rows=100 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                                  Order: o2."time"
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (40 rows)
 
 RESET enable_seqscan;
@@ -863,27 +762,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (30 rows)
@@ -912,27 +802,18 @@ QUERY PLAN
                                  ->  Merge Append (actual rows=2 loops=1)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                             Heap Fetches: 2
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                             Heap Fetches: 1
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                             Heap Fetches: 1
                                  ->  Merge Append (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                  ->  Merge Append (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
 (32 rows)
 
 -- test plan with best index is chosen
@@ -970,27 +851,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test LATERAL with correlated query
@@ -1017,35 +889,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
 (39 rows)
 
 -- test LATERAL with correlated query
@@ -1072,35 +935,26 @@ QUERY PLAN
                            Sort Key: o_1."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=2)
                            Sort Key: o_4."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                      ->  Merge Append (never executed)
                            Sort Key: o_7."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
 (39 rows)
 
 -- test startup and runtime exclusion together
@@ -1127,35 +981,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
 (39 rows)
 
 -- test startup and runtime exclusion together
@@ -1183,35 +1028,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
 (39 rows)
 
 -- test JOIN
@@ -1246,13 +1082,10 @@ QUERY PLAN
                Order: o2."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -1279,24 +1112,18 @@ QUERY PLAN
                      Sort Key: o1_1."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: o1_4."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_4 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_5 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_6 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Result (actual rows=6 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=6 loops=1)
@@ -1304,27 +1131,18 @@ QUERY PLAN
                            ->  Merge Append (actual rows=6 loops=1)
                                  Sort Key: o2_1."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=4 loops=1)
-                                       Heap Fetches: 4
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                            ->  Merge Append (never executed)
                                  Sort Key: o2_4."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_4 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_5 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_6 (never executed)
-                                       Heap Fetches: 0
                            ->  Merge Append (never executed)
                                  Sort Key: o2_7."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_7 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_8 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_9 (never executed)
-                                       Heap Fetches: 0
 (55 rows)
 
 -- test join against max query
@@ -1364,35 +1182,26 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 1
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                                          Index Cond: ("time" IS NOT NULL)
-                                         Heap Fetches: 0
 (51 rows)
 
 RESET enable_hashjoin;
@@ -1426,13 +1235,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with USING
@@ -1462,13 +1268,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test NATURAL JOIN on time column
@@ -1517,13 +1320,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test RIGHT JOIN on time column
@@ -1553,13 +1353,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -1589,13 +1386,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -1626,13 +1420,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -1662,13 +1453,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column and device_id
@@ -1747,13 +1535,10 @@ QUERY PLAN
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
 (21 rows)
 
 -- test JOIN on time column with implicit join
@@ -1784,13 +1569,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -1833,13 +1615,10 @@ QUERY PLAN
                                  Order: o2."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (34 rows)
 
 RESET enable_seqscan;

--- a/tsl/test/shared/expected/ordered_append_join-17.out
+++ b/tsl/test/shared/expected/ordered_append_join-17.out
@@ -44,11 +44,8 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                Order: metrics."time" DESC
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (12 rows)
@@ -75,11 +72,8 @@ QUERY PLAN
                            ->  Custom Scan (ChunkAppend) on metrics (actual rows=2 loops=1)
                                  Order: metrics."time" DESC
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                       Heap Fetches: 0
 (14 rows)
 
 -- test plan with best index is chosen
@@ -97,13 +91,10 @@ QUERY PLAN
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-               Heap Fetches: 0
 (12 rows)
 
 -- test plan with best index is chosen
@@ -118,11 +109,8 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
          Order: metrics."time" DESC
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               Heap Fetches: 1
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
          ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-               Heap Fetches: 0
 (9 rows)
 
 -- test LATERAL with correlated query
@@ -149,13 +137,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 3
 (17 rows)
 
 -- test LATERAL with correlated query
@@ -182,13 +167,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (actual rows=1 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 2
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           Heap Fetches: 0
 (17 rows)
 
 -- test startup and runtime exclusion together
@@ -215,13 +197,10 @@ QUERY PLAN
                      Chunks excluded during runtime: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           Heap Fetches: 3
 (17 rows)
 
 -- test startup and runtime exclusion together
@@ -268,25 +247,19 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               Heap Fetches: 5038
    ->  Materialize (actual rows=13674 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=13674 loops=1)
                Order: o2."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -311,20 +284,15 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 2
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Result (actual rows=6 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=6 loops=1)
                            Order: o2."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=6 loops=1)
-                                 Heap Fetches: 6
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Heap Fetches: 0
 (21 rows)
 
 -- test join against max query
@@ -348,13 +316,10 @@ QUERY PLAN
          Order: o1."time"
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 3598
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
          ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
                Index Cond: (device_id = 1)
-               Heap Fetches: 5038
    ->  Sort (actual rows=1 loops=1)
          Sort Key: ((InitPlan 1).col1)
          Sort Method: quicksort 
@@ -364,11 +329,8 @@ QUERY PLAN
                        ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                              Order: metrics."time" DESC
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                                   Heap Fetches: 0
 (27 rows)
 
 RESET enable_hashjoin;
@@ -393,25 +355,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with USING
@@ -432,25 +388,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test NATURAL JOIN on time column
@@ -490,25 +440,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test RIGHT JOIN on time column
@@ -529,25 +473,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -568,25 +506,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -608,25 +540,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -647,25 +573,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column and device_id
@@ -712,24 +632,18 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
 (24 rows)
 
 -- test JOIN on time column with implicit join
@@ -751,25 +665,19 @@ QUERY PLAN
                Order: o1."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                      Order: o2."time"
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (26 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -792,13 +700,10 @@ QUERY PLAN
                Order: o3."time"
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 100
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_2 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_3 (never executed)
                      Index Cond: (device_id = 3)
-                     Heap Fetches: 0
          ->  Materialize (actual rows=100 loops=1)
                ->  Merge Join (actual rows=100 loops=1)
                      Merge Cond: (o1."time" = o2."time")
@@ -806,25 +711,19 @@ QUERY PLAN
                            Order: o1."time"
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 100
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                                  Index Cond: (device_id = 1)
-                                 Heap Fetches: 0
                      ->  Materialize (actual rows=100 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
                                  Order: o2."time"
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (40 rows)
 
 RESET enable_seqscan;
@@ -860,27 +759,18 @@ QUERY PLAN
                ->  Merge Append (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                ->  Merge Append (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
                      ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
 (30 rows)
@@ -909,27 +799,18 @@ QUERY PLAN
                                  ->  Merge Append (actual rows=2 loops=1)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                             Heap Fetches: 2
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                             Heap Fetches: 1
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                             Heap Fetches: 1
                                  ->  Merge Append (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                  ->  Merge Append (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
                                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                             Heap Fetches: 0
 (32 rows)
 
 -- test plan with best index is chosen
@@ -967,27 +848,18 @@ QUERY PLAN
          ->  Merge Append (actual rows=1 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Heap Fetches: 1
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
                ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                     Heap Fetches: 0
 (27 rows)
 
 -- test LATERAL with correlated query
@@ -1014,35 +886,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 3
 (39 rows)
 
 -- test LATERAL with correlated query
@@ -1069,35 +932,26 @@ QUERY PLAN
                            Sort Key: o_1."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=2)
                            Sort Key: o_4."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=1 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 2
                      ->  Merge Append (never executed)
                            Sort Key: o_7."time"
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
                            ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Heap Fetches: 0
 (39 rows)
 
 -- test startup and runtime exclusion together
@@ -1124,35 +978,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=1 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                                 Heap Fetches: 3
 (39 rows)
 
 -- test startup and runtime exclusion together
@@ -1180,35 +1025,26 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_4."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                      ->  Merge Append (actual rows=0 loops=3)
                            Sort Key: o_7."time" DESC
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
                            ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                                 Heap Fetches: 0
 (39 rows)
 
 -- test JOIN
@@ -1243,13 +1079,10 @@ QUERY PLAN
                Order: o2."time"
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 3598
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-                     Heap Fetches: 5038
 (25 rows)
 
 RESET enable_nestloop;
@@ -1276,24 +1109,18 @@ QUERY PLAN
                      Sort Key: o1_1."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 2
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=1 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 1
                ->  Merge Append (never executed)
                      Sort Key: o1_4."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_4 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_5 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_6 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Heap Fetches: 0
          ->  Materialize (actual rows=10 loops=1)
                ->  Result (actual rows=6 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=6 loops=1)
@@ -1301,27 +1128,18 @@ QUERY PLAN
                            ->  Merge Append (actual rows=6 loops=1)
                                  Sort Key: o2_1."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=4 loops=1)
-                                       Heap Fetches: 4
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=2 loops=1)
-                                       Heap Fetches: 2
                            ->  Merge Append (never executed)
                                  Sort Key: o2_4."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_4 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_5 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_6 (never executed)
-                                       Heap Fetches: 0
                            ->  Merge Append (never executed)
                                  Sort Key: o2_7."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_7 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_8 (never executed)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_9 (never executed)
-                                       Heap Fetches: 0
 (55 rows)
 
 -- test join against max query
@@ -1360,27 +1178,18 @@ QUERY PLAN
                              ->  Merge Append (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                         Heap Fetches: 1
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                         Heap Fetches: 1
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                         Heap Fetches: 0
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                         Heap Fetches: 0
                                    ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                         Heap Fetches: 0
 (42 rows)
 
 RESET enable_hashjoin;
@@ -1414,13 +1223,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with USING
@@ -1450,13 +1256,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test NATURAL JOIN on time column
@@ -1505,13 +1308,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test RIGHT JOIN on time column
@@ -1541,13 +1341,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ON clause expression order switched
@@ -1577,13 +1374,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
@@ -1614,13 +1408,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
@@ -1650,13 +1441,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column and device_id
@@ -1735,13 +1523,10 @@ QUERY PLAN
                ->  Append (actual rows=100 loops=1)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: ((device_id = 1) AND (device_id = 1))
-                           Heap Fetches: 0
 (21 rows)
 
 -- test JOIN on time column with implicit join
@@ -1772,13 +1557,10 @@ QUERY PLAN
                      Order: o2."time"
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 100
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-                           Heap Fetches: 0
 (23 rows)
 
 -- test JOIN on time column with 3 hypertables
@@ -1821,13 +1603,10 @@ QUERY PLAN
                                  Order: o2."time"
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 100
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
                                  ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-                                       Heap Fetches: 0
 (34 rows)
 
 RESET enable_seqscan;


### PR DESCRIPTION
In #7512 we added manual `VACUUM` in all involved relations to avoid flaky output tests.

But looks like it is not working very well specially on Windows builds, so now we're replacing the output `Heap Fetches: [0-9]` for `Heap Fetches: 0` to make have a more predictable output test.

https://github.com/timescale/timescaledb/actions/runs/12166253875/job/33932077535?pr=7517#step:17:23

Disable-check: force-changelog-file
Disable-check: approval-count
