### PR TITLE
Restart scheduler on error

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -54,6 +54,16 @@ default_ignored_tests = {
     "memoize",
 }
 
+# Tests that we do not run as part of a Flake tests
+flaky_exclude_tests = {
+    # Not executed as a flake test since it easily exhausts available
+    # background worker slots.
+    "bgw_launcher",
+    # Not executed as a flake test since it takes a very long time and
+    # easily interferes with other tests.
+    "bgw_scheduler_restart",
+}
+
 
 # helper functions to generate matrix entries
 # the release and apache config inherit from the
@@ -306,13 +316,14 @@ elif len(sys.argv) > 2:
             sys.exit(1)
 
     if tests:
-        to_run = list(tests) * 20
+        to_run = [t for t in list(tests) if t not in flaky_exclude_tests] * 20
         random.shuffle(to_run)
+        installcheck_args = f'TESTS="{" ".join(to_run)}"'
         m["include"].append(
             build_debug_config(
                 {
                     "coverage": False,
-                    "installcheck_args": f'TESTS="{" ".join(to_run)}"',
+                    "installcheck_args": installcheck_args,
                     "name": "Flaky Check Debug",
                     "pg": PG16_LATEST,
                     "pginstallcheck": False,
@@ -323,7 +334,7 @@ elif len(sys.argv) > 2:
             build_debug_config(
                 {
                     "coverage": False,
-                    "installcheck_args": f'TESTS="{" ".join(to_run)}"',
+                    "installcheck_args": installcheck_args,
                     "name": "Flaky Check Debug",
                     "pg": PG17_LATEST,
                     "pginstallcheck": False,

--- a/.unreleased/pr_7527
+++ b/.unreleased/pr_7527
@@ -1,0 +1,1 @@
+Fixes: #7527 Restart scheduler on error

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -655,6 +655,12 @@ RelationGetSmgr(Relation rel)
 	GenerationContextCreate(parent, name, blockSize)
 #endif
 
+#if PG16_GE
+#define pgstat_get_local_beentry_by_index_compat(idx) pgstat_get_local_beentry_by_index(idx)
+#else
+#define pgstat_get_local_beentry_by_index_compat(idx) pgstat_fetch_stat_local_beentry(idx)
+#endif
+
 /*
  * PG16 adds a new parameter to DefineIndex, total_parts, that takes
  * in the total number of direct and indirect partitions of the relation.

--- a/src/guc.c
+++ b/src/guc.c
@@ -183,6 +183,20 @@ bool ts_guc_debug_require_batch_sorted_merge = false;
 
 bool ts_guc_debug_allow_cagg_with_deprecated_funcs = false;
 
+/*
+ * Exit code for the scheduler.
+ *
+ * Normally it exits with a zero which means that it will not restart. If an
+ * error is raised, it exits with error code 1, which will trigger a
+ * restart.
+ *
+ * This variable exists to be able to trigger a restart for a normal exit,
+ * which is useful when debugging.
+ *
+ * See backend/postmaster/bgworker.c
+ */
+int ts_debug_bgw_scheduler_exit_status = 0;
+
 #ifdef TS_DEBUG
 bool ts_shutdown_bgw = false;
 char *ts_current_timestamp_mock = NULL;
@@ -1054,6 +1068,19 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+	DefineCustomIntVariable(/* name= */ MAKE_EXTOPTION("debug_bgw_scheduler_exit_status"),
+							/* short_desc= */ "exit status to use when shutting down the scheduler",
+							/* long_desc= */ "this is for debugging purposes",
+							/* valueAddr= */ &ts_debug_bgw_scheduler_exit_status,
+							/* bootValue= */ 0,
+							/* minValue= */ 0,
+							/* maxValue= */ 255,
+							/* context= */ PGC_SIGHUP,
+							/* flags= */ 0,
+							/* check_hook= */ NULL,
+							/* assign_hook= */ NULL,
+							/* show_hook= */ NULL);
 
 #ifdef TS_DEBUG
 	DefineCustomBoolVariable(/* name= */ MAKE_EXTOPTION("shutdown_bgw_scheduler"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -92,6 +92,12 @@ extern TSDLLEXPORT bool ts_guc_auto_sparse_indexes;
 extern TSDLLEXPORT bool ts_guc_enable_columnarscan;
 extern TSDLLEXPORT int ts_guc_bgw_log_level;
 
+/*
+ * Exit code to use when scheduler exits.
+ *
+ * Used for debugging.
+ */
+extern TSDLLEXPORT int ts_debug_bgw_scheduler_exit_status;
 #ifdef TS_DEBUG
 extern bool ts_shutdown_bgw;
 extern char *ts_current_timestamp_mock;

--- a/src/loader/bgw_launcher.h
+++ b/src/loader/bgw_launcher.h
@@ -8,7 +8,12 @@
 #include <postgres.h>
 #include <fmgr.h>
 
-extern void ts_bgw_cluster_launcher_register(void);
+#define TS_BGW_TYPE_LAUNCHER "TimescaleDB Background Worker Launcher"
+#define TS_BGW_TYPE_SCHEDULER "TimescaleDB Background Worker Scheduler"
+
+extern int ts_guc_bgw_scheduler_restart_time_sec;
+
+extern void ts_bgw_cluster_launcher_init(void);
 
 /*called by postmaster at launcher bgw startup*/
 TSDLLEXPORT extern Datum ts_bgw_cluster_launcher_main(PG_FUNCTION_ARGS);

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -591,7 +591,7 @@ _PG_init(void)
 	timescaledb_shmem_request_hook();
 #endif
 
-	ts_bgw_cluster_launcher_register();
+	ts_bgw_cluster_launcher_init();
 	ts_bgw_counter_setup_gucs();
 	ts_bgw_interface_register_api_version();
 

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -21,11 +21,12 @@ CREATE DATABASE :TEST_DBNAME_2;
 -- Further Note: PG 9.6 changed what appeared in pg_stat_activity, so the launcher doesn't actually show up.
 -- we can still test its interactions with its children, but can't test some of the things specific to the launcher.
 -- So we've added some bits about the version number as needed.
-CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME') as single_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME_2') as single_2_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
-FROM pg_stat_activity;
+CREATE VIEW worker_counts as
+SELECT count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Launcher') as launcher,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME') as single_scheduler,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME_2') as single_2_scheduler,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
+  FROM pg_stat_activity;
 CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER, template1_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
@@ -103,7 +104,7 @@ SELECT wait_worker_counts(1,0,1,0);
 -- Now let's restart the scheduler in test db 2 and make sure our backend_start changed
 SELECT backend_start as orig_backend_start
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 -- We'll do this in a txn so that we can see that the worker locks on our txn before continuing
 BEGIN;
@@ -122,7 +123,7 @@ SELECT wait_worker_counts(1,0,1,0);
 SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed,
 (wait_event = 'virtualxid') wait_event_changed
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2';
  backend_start_changed | wait_event_changed 
 -----------------------+--------------------
@@ -138,7 +139,7 @@ SELECT wait_worker_counts(1,0,1,0);
 
 SELECT (wait_event IS DISTINCT FROM 'virtualxid') wait_event_changed
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2';
  wait_event_changed 
 --------------------
@@ -187,7 +188,7 @@ SELECT wait_worker_counts(1,0,1,0);
 -- make sure start is idempotent
 SELECT backend_start as orig_backend_start
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 -- Since we're doing idempotency tests, we're also going to exercise our queue and start 20 times
 SELECT _timescaledb_functions.start_background_workers() as start_background_workers, * FROM generate_series(1,20);
@@ -227,7 +228,7 @@ FOR i in 1..5
 LOOP
 SELECT (backend_start = $1::timestamptz) backend_start_unchanged
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = $2 into r;
 if(r) THEN
   PERFORM pg_sleep(0.1);
@@ -274,7 +275,7 @@ SELECT wait_worker_counts(1,0,1,0);
 -- Now let's restart the scheduler and make sure our backend_start changed
 SELECT backend_start as orig_backend_start
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 BEGIN;
 DROP EXTENSION timescaledb;
@@ -294,7 +295,7 @@ FOR i in 1..10
 LOOP
 SELECT (backend_start > $1::timestamptz) backend_start_changed
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = $2 into r;
 if(NOT r) THEN
   PERFORM pg_sleep(0.1);
@@ -315,9 +316,9 @@ SELECT wait_greater(:'orig_backend_start',:'TEST_DBNAME_2');
 -- Make sure canceling the launcher backend causes a restart of schedulers
 SELECT backend_start as orig_backend_start
 FROM pg_stat_activity
-WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+WHERE backend_type = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
-SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE backend_type = 'TimescaleDB Background Worker Launcher';
  pg_cancel_backend 
 -------------------
  t
@@ -445,11 +446,12 @@ ALTER ROLE :ROLE_DEFAULT_PERM_USER WITH NOSUPERUSER;
 -- Further Note: PG 9.6 changed what appeared in pg_stat_activity, so the launcher doesn't actually show up.
 -- we can still test its interactions with its children, but can't test some of the things specific to the launcher.
 -- So we've added some bits about the version number as needed.
-CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME') as single_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME_2') as single_2_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
-FROM pg_stat_activity;
+CREATE VIEW worker_counts as
+SELECT count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Launcher') as launcher,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME') as single_scheduler,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME_2') as single_2_scheduler,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
+  FROM pg_stat_activity;
 CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER, template1_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
@@ -602,7 +604,7 @@ SELECT _timescaledb_functions.stop_background_workers();
  t
 (1 row)
 
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type = 'TimescaleDB Background Worker Launcher';
  pg_terminate_backend 
 ----------------------
  t

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -29,6 +29,9 @@ set(PG_IGNORE_TESTS
     sanity_check
     type_sanity
     create_am
+    # Ignoring because it spawns different number of workers in different
+    # versions.
+    select_parallel
     psql)
 
 # Modify the test schedule to ignore some tests

--- a/test/sql/include/bgw_launcher_utils.sql
+++ b/test/sql/include/bgw_launcher_utils.sql
@@ -8,11 +8,12 @@
 -- we can still test its interactions with its children, but can't test some of the things specific to the launcher.
 -- So we've added some bits about the version number as needed.
 
-CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME') as single_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME_2') as single_2_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
-FROM pg_stat_activity;
+CREATE VIEW worker_counts as
+SELECT count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Launcher') as launcher,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME') as single_scheduler,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = :'TEST_DBNAME_2') as single_2_scheduler,
+       count(*) filter (WHERE backend_type = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
+  FROM pg_stat_activity;
 
 CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER, template1_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$

--- a/tsl/test/expected/bgw_scheduler_control.out
+++ b/tsl/test/expected/bgw_scheduler_control.out
@@ -99,7 +99,7 @@ SELECT * FROM cleaned_bgw_log;
       4 | DB Scheduler     | [TESTING] Wait until (RANDOM), started at (RANDOM)
       0 | test_job_1b      | Execute job 1
       1 | test_job_1b      | job 1000 (test_job_1b) exiting with success: execution time (RANDOM) ms
-      5 | DB Scheduler     | database scheduler for database (RANDOM) exiting
+      5 | DB Scheduler     | scheduler for database (RANDOM) exiting with exit status 0
 (8 rows)
 
 ALTER DATABASE :TEST_DBNAME RESET timescaledb.bgw_log_level;

--- a/tsl/test/expected/bgw_scheduler_restart.out
+++ b/tsl/test/expected/bgw_scheduler_restart.out
@@ -1,0 +1,191 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE VIEW tsdb_bgw AS
+       SELECT datname, pid, backend_type, application_name
+         FROM pg_stat_activity
+        WHERE backend_type LIKE '%TimescaleDB%'
+     ORDER BY datname, backend_type, application_name;
+-- Wait for at least one background worker matching pattern to have
+-- started.
+CREATE PROCEDURE wait_for_some_started(
+       min_time double precision,
+       timeout double precision,
+       pattern text
+) AS $$
+DECLARE
+   backend_count int;
+BEGIN
+    FOR i IN 0..(timeout / min_time)::int
+    LOOP
+        PERFORM pg_sleep(min_time);
+        SELECT count(*) INTO backend_count FROM tsdb_bgw WHERE backend_type LIKE pattern;
+        IF backend_count > 0 THEN
+            RETURN;
+        END IF;
+    END LOOP;
+    RAISE EXCEPTION 'backend matching % did not start before timeout', pattern;
+END;
+$$ LANGUAGE plpgsql;
+-- Wait for the number of background workers matching pattern to be
+-- zero.
+CREATE PROCEDURE wait_for_all_stopped(
+       min_time double precision,
+       timeout double precision,
+       pattern text
+) AS $$
+DECLARE
+   backend_count int;
+BEGIN
+    FOR i IN 0..(timeout / min_time)::int
+    LOOP
+        PERFORM pg_sleep(min_time);
+        SELECT count(*) INTO backend_count FROM tsdb_bgw WHERE backend_type LIKE pattern;
+        IF backend_count = 0 THEN
+            RETURN;
+        END IF;
+    END LOOP;
+    RAISE EXCEPTION 'backend matching % did not start before timeout', pattern;
+END;
+$$ LANGUAGE plpgsql;
+-- Show the default scheduler restart time
+SHOW timescaledb.bgw_scheduler_restart_time;
+ timescaledb.bgw_scheduler_restart_time 
+----------------------------------------
+ 1min
+(1 row)
+
+ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '10s';
+ALTER SYSTEM SET timescaledb.debug_bgw_scheduler_exit_status TO 1;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SHOW timescaledb.bgw_scheduler_restart_time;
+ timescaledb.bgw_scheduler_restart_time 
+----------------------------------------
+ 1min
+(1 row)
+
+-- Launcher is running, so we need to restart it for the scheduler
+-- restart time to take effect.
+SELECT datname, application_name FROM tsdb_bgw;
+ datname |            application_name            
+---------+----------------------------------------
+         | TimescaleDB Background Worker Launcher
+(1 row)
+
+SELECT pg_terminate_backend(pid) FROM tsdb_bgw
+ WHERE backend_type LIKE '%Launcher%';
+ pg_terminate_backend 
+----------------------
+ t
+(1 row)
+
+-- It will restart automatically, but we wait for it to start.
+CALL wait_for_some_started(1, 50, '%Launcher%');
+-- Verify that launcher is running. If it is not, the rest of the test
+-- will fail.
+SELECT datname, application_name FROM tsdb_bgw;
+         datname          |            application_name             
+--------------------------+-----------------------------------------
+ db_bgw_scheduler_restart | TimescaleDB Background Worker Scheduler
+                          | TimescaleDB Background Worker Launcher
+(2 rows)
+
+-- Now we can start the background workers.
+SELECT _timescaledb_functions.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+(1 row)
+
+-- They should start immediately, but let's wait for them to start.
+CALL wait_for_some_started(1, 50, '%Scheduler%');
+-- Check that the schedulers are running. If they are not, the rest of
+-- the test is meaningless.
+SELECT datname, application_name FROM tsdb_bgw;
+         datname          |            application_name             
+--------------------------+-----------------------------------------
+ db_bgw_scheduler_restart | TimescaleDB Background Worker Scheduler
+                          | TimescaleDB Background Worker Launcher
+(2 rows)
+
+-- Kill the schedulers and check that they restart.
+SELECT pg_terminate_backend(pid) FROM tsdb_bgw
+ WHERE datname = :'TEST_DBNAME' AND backend_type LIKE '%Scheduler%';
+ pg_terminate_backend 
+----------------------
+ t
+(1 row)
+
+-- Wait for scheduler to exit, they should exit immediately.
+CALL wait_for_all_stopped(1, 50, '%Scheduler%');
+-- Check that the schedulers really exited.
+SELECT datname, application_name FROM tsdb_bgw;
+ datname |            application_name            
+---------+----------------------------------------
+         | TimescaleDB Background Worker Launcher
+(1 row)
+
+-- Wait for scheduler to restart.
+CALL wait_for_some_started(10, 100, '%Scheduler%');
+-- Make sure that the launcher and schedulers are running. Otherwise
+-- the test will fail.
+SELECT datname, application_name FROM tsdb_bgw;
+         datname          |            application_name             
+--------------------------+-----------------------------------------
+ db_bgw_scheduler_restart | TimescaleDB Background Worker Scheduler
+                          | TimescaleDB Background Worker Launcher
+(2 rows)
+
+-- Now, we had a previous bug where killing the launcher at this point
+-- would leave the schedulers running (because the launcher did not
+-- have a handle for them) and when launcher is restarting, it would
+-- start more schedulers, leaving two schedulers per database.
+-- Get the PID of the launcher to be able to compare it after the restart
+SELECT pid AS orig_pid FROM tsdb_bgw WHERE backend_type LIKE '%Launcher%' \gset
+-- Kill the launcher. Since there are new restarted schedulers, the
+-- handle could not be used to terminate them, and they would be left
+-- running.
+SELECT pg_terminate_backend(pid) FROM tsdb_bgw
+ WHERE backend_type LIKE '%Launcher%';
+ pg_terminate_backend 
+----------------------
+ t
+(1 row)
+
+-- Launcher will restart immediately, but we wait one second to give
+-- it a chance to start.
+CALL wait_for_some_started(1, 50, '%Launcher%');
+-- Check that the launcher is running and that there are exactly one
+-- scheduler per database. Here the old schedulers are killed, so it
+-- will be schedulers with a different PID than the ones before the
+-- launcher was killed, but we are not showing this here.
+SELECT (pid != :orig_pid) AS different_pid,
+       datname,
+       application_name
+  FROM tsdb_bgw;
+ different_pid |         datname          |            application_name             
+---------------+--------------------------+-----------------------------------------
+ t             | db_bgw_scheduler_restart | TimescaleDB Background Worker Scheduler
+ t             |                          | TimescaleDB Background Worker Launcher
+(2 rows)
+
+ALTER SYSTEM RESET timescaledb.bgw_scheduler_restart_time;
+ALTER SYSTEM RESET timescaledb.debug_bgw_scheduler_exit_status;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -73,6 +73,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     bgw_job_stat_history_errors.sql
     bgw_job_stat_history_errors_permissions.sql
     bgw_db_scheduler_fixed.sql
+    bgw_scheduler_restart.sql
     bgw_reorder_drop_chunks.sql
     scheduler_fixed.sql
     compress_bgw_reorder_drop_chunks.sql
@@ -185,6 +186,7 @@ set(SOLO_TESTS
     # log level.
     bgw_custom
     bgw_scheduler_control
+    bgw_scheduler_restart
     bgw_db_scheduler
     bgw_job_stat_history_errors_permissions
     bgw_job_stat_history_errors

--- a/tsl/test/sql/bgw_scheduler_restart.sql
+++ b/tsl/test/sql/bgw_scheduler_restart.sql
@@ -1,0 +1,135 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE VIEW tsdb_bgw AS
+       SELECT datname, pid, backend_type, application_name
+         FROM pg_stat_activity
+        WHERE backend_type LIKE '%TimescaleDB%'
+     ORDER BY datname, backend_type, application_name;
+
+-- Wait for at least one background worker matching pattern to have
+-- started.
+CREATE PROCEDURE wait_for_some_started(
+       min_time double precision,
+       timeout double precision,
+       pattern text
+) AS $$
+DECLARE
+   backend_count int;
+BEGIN
+    FOR i IN 0..(timeout / min_time)::int
+    LOOP
+        PERFORM pg_sleep(min_time);
+        SELECT count(*) INTO backend_count FROM tsdb_bgw WHERE backend_type LIKE pattern;
+        IF backend_count > 0 THEN
+            RETURN;
+        END IF;
+    END LOOP;
+    RAISE EXCEPTION 'backend matching % did not start before timeout', pattern;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Wait for the number of background workers matching pattern to be
+-- zero.
+CREATE PROCEDURE wait_for_all_stopped(
+       min_time double precision,
+       timeout double precision,
+       pattern text
+) AS $$
+DECLARE
+   backend_count int;
+BEGIN
+    FOR i IN 0..(timeout / min_time)::int
+    LOOP
+        PERFORM pg_sleep(min_time);
+        SELECT count(*) INTO backend_count FROM tsdb_bgw WHERE backend_type LIKE pattern;
+        IF backend_count = 0 THEN
+            RETURN;
+        END IF;
+    END LOOP;
+    RAISE EXCEPTION 'backend matching % did not start before timeout', pattern;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Show the default scheduler restart time
+SHOW timescaledb.bgw_scheduler_restart_time;
+ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '10s';
+ALTER SYSTEM SET timescaledb.debug_bgw_scheduler_exit_status TO 1;
+SELECT pg_reload_conf();
+SHOW timescaledb.bgw_scheduler_restart_time;
+
+-- Launcher is running, so we need to restart it for the scheduler
+-- restart time to take effect.
+SELECT datname, application_name FROM tsdb_bgw;
+SELECT pg_terminate_backend(pid) FROM tsdb_bgw
+ WHERE backend_type LIKE '%Launcher%';
+
+-- It will restart automatically, but we wait for it to start.
+CALL wait_for_some_started(1, 50, '%Launcher%');
+
+-- Verify that launcher is running. If it is not, the rest of the test
+-- will fail.
+SELECT datname, application_name FROM tsdb_bgw;
+
+-- Now we can start the background workers.
+SELECT _timescaledb_functions.start_background_workers();
+
+-- They should start immediately, but let's wait for them to start.
+CALL wait_for_some_started(1, 50, '%Scheduler%');
+
+-- Check that the schedulers are running. If they are not, the rest of
+-- the test is meaningless.
+SELECT datname, application_name FROM tsdb_bgw;
+
+-- Kill the schedulers and check that they restart.
+SELECT pg_terminate_backend(pid) FROM tsdb_bgw
+ WHERE datname = :'TEST_DBNAME' AND backend_type LIKE '%Scheduler%';
+
+-- Wait for scheduler to exit, they should exit immediately.
+CALL wait_for_all_stopped(1, 50, '%Scheduler%');
+
+-- Check that the schedulers really exited.
+SELECT datname, application_name FROM tsdb_bgw;
+
+-- Wait for scheduler to restart.
+CALL wait_for_some_started(10, 100, '%Scheduler%');
+
+-- Make sure that the launcher and schedulers are running. Otherwise
+-- the test will fail.
+SELECT datname, application_name FROM tsdb_bgw;
+
+-- Now, we had a previous bug where killing the launcher at this point
+-- would leave the schedulers running (because the launcher did not
+-- have a handle for them) and when launcher is restarting, it would
+-- start more schedulers, leaving two schedulers per database.
+
+-- Get the PID of the launcher to be able to compare it after the restart
+SELECT pid AS orig_pid FROM tsdb_bgw WHERE backend_type LIKE '%Launcher%' \gset
+
+-- Kill the launcher. Since there are new restarted schedulers, the
+-- handle could not be used to terminate them, and they would be left
+-- running.
+SELECT pg_terminate_backend(pid) FROM tsdb_bgw
+ WHERE backend_type LIKE '%Launcher%';
+
+-- Launcher will restart immediately, but we wait one second to give
+-- it a chance to start.
+CALL wait_for_some_started(1, 50, '%Launcher%');
+
+-- Check that the launcher is running and that there are exactly one
+-- scheduler per database. Here the old schedulers are killed, so it
+-- will be schedulers with a different PID than the ones before the
+-- launcher was killed, but we are not showing this here.
+SELECT (pid != :orig_pid) AS different_pid,
+       datname,
+       application_name
+  FROM tsdb_bgw;
+
+ALTER SYSTEM RESET timescaledb.bgw_scheduler_restart_time;
+ALTER SYSTEM RESET timescaledb.debug_bgw_scheduler_exit_status;
+SELECT pg_reload_conf();
+
+SELECT _timescaledb_functions.stop_background_workers();


### PR DESCRIPTION
If the scheduler receives an error, it will never restart again since `bgw_restart_time` is set to `BGW_NEVER_RESTART`, which will prevent all jobs from executing.

This commit adds the GUC `timescaledb.bgw_scheduler_restart_time` that can be set to the restart time for the scheduler. It defaults to 60 seconds, which is the default restart interval for background workers PostgreSQL defines.

It also adds `timescaledb.debug_bgw_scheduler_exit_status` to be able to shutdown the scheduler with a non-zero exit status, which allows the restart functionality to be tested.

It also ensures that `backend_type` is explicitly set up rather than  copied from `application_name` and add some more information to `application_name`. It also updates the tests to use `backend_type` where applicable.

Disable-check: loader-change
