### PR TITLE
Fix wrong origin returned by cagg_get_bucket_function_info

### DIFF
--- a/tsl/test/expected/cagg_migrate_function-14.out
+++ b/tsl/test/expected/cagg_migrate_function-14.out
@@ -170,7 +170,7 @@ SELECT mat_hypertable_id,
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                                    bucket_func                                    | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+-----------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);
@@ -206,7 +206,7 @@ CALL _timescaledb_functions.cagg_migrate_to_time_bucket(:'CAGG_NAME');
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);

--- a/tsl/test/expected/cagg_migrate_function-15.out
+++ b/tsl/test/expected/cagg_migrate_function-15.out
@@ -170,7 +170,7 @@ SELECT mat_hypertable_id,
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                                    bucket_func                                    | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+-----------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);
@@ -206,7 +206,7 @@ CALL _timescaledb_functions.cagg_migrate_to_time_bucket(:'CAGG_NAME');
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);

--- a/tsl/test/expected/cagg_migrate_function-16.out
+++ b/tsl/test/expected/cagg_migrate_function-16.out
@@ -170,7 +170,7 @@ SELECT mat_hypertable_id,
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                                    bucket_func                                    | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+-----------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);
@@ -206,7 +206,7 @@ CALL _timescaledb_functions.cagg_migrate_to_time_bucket(:'CAGG_NAME');
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);

--- a/tsl/test/expected/cagg_migrate_function-17.out
+++ b/tsl/test/expected/cagg_migrate_function-17.out
@@ -170,7 +170,7 @@ SELECT mat_hypertable_id,
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                                    bucket_func                                    | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+-----------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | timescaledb_experimental.time_bucket_ng(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);
@@ -206,7 +206,7 @@ CALL _timescaledb_functions.cagg_migrate_to_time_bucket(:'CAGG_NAME');
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function WHERE mat_hypertable_id = :mat_hypertable_id;
  mat_hypertable_id |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 -------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Fri Jan 03 16:00:00 2020 PST |               |                 | t
+                 5 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 7 days     | Sat Jan 04 00:00:00 2020 PST |               |                 | t
 (1 row)
 
 SELECT pg_get_viewdef(:'partial_view', true);

--- a/tsl/test/expected/cagg_query-14.out
+++ b/tsl/test/expected/cagg_query-14.out
@@ -1041,7 +1041,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1055,7 +1055,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_query-15.out
+++ b/tsl/test/expected/cagg_query-15.out
@@ -1041,7 +1041,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1055,7 +1055,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_query-16.out
+++ b/tsl/test/expected/cagg_query-16.out
@@ -1035,7 +1035,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1049,7 +1049,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_query-17.out
+++ b/tsl/test/expected/cagg_query-17.out
@@ -1035,7 +1035,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1049,7 +1049,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_query_using_merge-15.out
+++ b/tsl/test/expected/cagg_query_using_merge-15.out
@@ -1043,7 +1043,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1057,7 +1057,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_query_using_merge-16.out
+++ b/tsl/test/expected/cagg_query_using_merge-16.out
@@ -1037,7 +1037,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1051,7 +1051,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_query_using_merge-17.out
+++ b/tsl/test/expected/cagg_query_using_merge-17.out
@@ -1037,7 +1037,7 @@ psql:include/cagg_query_common.sql:483: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
  user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
@@ -1051,7 +1051,7 @@ psql:include/cagg_query_common.sql:491: NOTICE:  refreshing continuous aggregate
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
  user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Sat Jan 01 00:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -378,10 +378,10 @@ ORDER BY user_view_name;
 -----------------------------+---------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
  integer_ht_cagg             | time_bucket(integer,integer)                                                          | 1            |                              |               |                 | t
  integer_ht_cagg_offset      | time_bucket(integer,integer,integer)                                                  | 1            |                              | 10            |                 | t
- temperature_4h              | time_bucket(interval,timestamp without time zone)                                     | @ 4 hours    | Fri Dec 31 16:00:00 1999 PST |               |                 | t
- temperature_tz_4h           | time_bucket(interval,timestamp with time zone)                                        | @ 4 hours    | Fri Dec 31 16:00:00 1999 PST |               |                 | t
- temperature_tz_4h_ts        | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval) | @ 4 hours    | Fri Dec 31 16:00:00 1999 PST |               | Europe/Berlin   | f
- temperature_tz_4h_ts_offset | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval) | @ 4 hours    | Fri Dec 31 16:00:00 1999 PST | @ 1 hour      | Europe/Berlin   | f
+ temperature_4h              | time_bucket(interval,timestamp without time zone)                                     | @ 4 hours    |                              |               |                 | t
+ temperature_tz_4h           | time_bucket(interval,timestamp with time zone)                                        | @ 4 hours    |                              |               |                 | t
+ temperature_tz_4h_ts        | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval) | @ 4 hours    |                              |               | Europe/Berlin   | f
+ temperature_tz_4h_ts_offset | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval) | @ 4 hours    |                              | @ 1 hour      | Europe/Berlin   | f
  temperature_tz_4h_ts_origin | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval) | @ 4 hours    | Mon Jan 01 00:00:00 2001 PST |               | Europe/Berlin   | f
 (7 rows)
 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -168,9 +168,12 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
     merge_compress.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
+  list(APPEND TEST_TEMPLATES cagg_query_using_merge.sql.in)
+endif()
+
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
   list(APPEND TEST_FILES cagg_planning.sql hypercore_parallel.sql)
-  list(APPEND TEST_TEMPLATES cagg_query_using_merge.sql.in)
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))


### PR DESCRIPTION
In #7042 we refactored the code for getting the time bucket function info to read information from the stored query tree on Postgres metadata.

But when an origin was not specified it was returning a wrong value instead of NULL. Fixed it by properly dealing with non-defined origin and also simplified a bit the code to process time bucket parameters.

Disable-check: force-changelog-file
