### PR TITLE
Generalise  script to create the Changelog PR on `main`

### DIFF
--- a/scripts/release/create_minor_release_PR_commit.sh
+++ b/scripts/release/create_minor_release_PR_commit.sh
@@ -44,7 +44,7 @@ DOWNGRADE_FILE="$NEW_VERSION--$CURRENT_VERSION.sql"
 LAST_UPDATE_FILE="$LAST_VERSION--$CURRENT_VERSION.sql"
 LAST_DOWNGRADE_FILE="$CURRENT_VERSION--$LAST_VERSION.sql"
 
-RELEASE_BRANCH_EXISTS=$(git branch -a |grep 'upstream/$RELEASE_BRANCH'|wc -l|cut -d ' ' -f 8)
+RELEASE_BRANCH_EXISTS=$(git branch -a |grep -c 'upstream/$RELEASE_BRANCH'|cut -d ' ' -f 1)
 
 if [[ $RELEASE_BRANCH_EXISTS == '0' ]]; then
   echo "git branch '$RELEASE_BRANCH' does not exist in the remote repository, yet"

--- a/scripts/release/create_minor_release_PR_commit.sh
+++ b/scripts/release/create_minor_release_PR_commit.sh
@@ -44,7 +44,7 @@ DOWNGRADE_FILE="$NEW_VERSION--$CURRENT_VERSION.sql"
 LAST_UPDATE_FILE="$LAST_VERSION--$CURRENT_VERSION.sql"
 LAST_DOWNGRADE_FILE="$CURRENT_VERSION--$LAST_VERSION.sql"
 
-RELEASE_BRANCH_EXISTS=$(git branch -a |grep -c 'upstream/$RELEASE_BRANCH'|cut -d ' ' -f 1)
+RELEASE_BRANCH_EXISTS=$(git branch -a |grep -c "upstream/$RELEASE_BRANCH"|cut -d ' ' -f 1)
 
 if [[ $RELEASE_BRANCH_EXISTS == '0' ]]; then
   echo "git branch '$RELEASE_BRANCH' does not exist in the remote repository, yet"

--- a/scripts/release/create_minor_release_PR_commit.sh
+++ b/scripts/release/create_minor_release_PR_commit.sh
@@ -17,6 +17,8 @@ NEW_PATCH_VERSION="0"
 NEW_VERSION=$(head -1 version.config | cut -d ' ' -f 3 | cut -d '-' -f 1)
 RELEASE_BRANCH="${NEW_VERSION/%.$NEW_PATCH_VERSION/.x}"
 CURRENT_VERSION=$(tail -1 version.config | cut -d ' ' -f 3)
+CURRENT_MINOR_VERSION=$(echo $NEW_VERSION | cut -d '.' -f 2)
+NEW_MINOR_VERSION=$((CURRENT_MINOR_VERSION + 1))
 cd sql/updates
 
 for f in ./*
@@ -136,6 +138,15 @@ do
 done
 
 cd ..
+
+
+if [[ $RELEASE_BRANCH_EXISTS == '0' ]]; then
+  echo "---- Modifying version.config to the new versions , if current PR is for main----"
+  sed -i.bak "s/${NEW_VERSION}/${NEW_VERSION}-dev/g" version.config
+  sed -i.bak "s/${CURRENT_MINOR_VERSION}/${NEW_MINOR_VERSION}/g" version.config
+  sed -i.bak "s/${CURRENT_VERSION}/${NEW_VERSION}/g" version.config
+  rm version.config.bak
+fi
 
 git diff HEAD --name-only
 

--- a/scripts/release/create_minor_release_PR_commit.sh
+++ b/scripts/release/create_minor_release_PR_commit.sh
@@ -29,7 +29,6 @@ done
 LAST_VERSION=$(echo "$LAST_UPDATE_FILE" |cut -d '-' -f 1 |cut -d '/' -f 2)
 
 echo "CURRENT_VERSION is $CURRENT_VERSION"
-#echo "LAST_UPDATE_FILE is $LAST_UPDATE_FILE"
 echo "LAST_VERSION is $LAST_VERSION"
 echo "RELEASE_BRANCH is $RELEASE_BRANCH"
 echo "NEW_VERSION is $NEW_VERSION"
@@ -37,18 +36,27 @@ cd ~/"$SOURCES_DIR"/"$FORK_DIR"
 
 
 # Derived Variables
-#RELEASE_PR_BRANCH="release-$NEW_VERSION-$RELEASE_BRANCH"
 RELEASE_PR_BRANCH="release-$NEW_VERSION"
 UPDATE_FILE="$CURRENT_VERSION--$NEW_VERSION.sql"
 DOWNGRADE_FILE="$NEW_VERSION--$CURRENT_VERSION.sql"
 LAST_UPDATE_FILE="$LAST_VERSION--$CURRENT_VERSION.sql"
 LAST_DOWNGRADE_FILE="$CURRENT_VERSION--$LAST_VERSION.sql"
 
+RELEASE_BRANCH_EXISTS=$(git branch -a |grep 'upstream/$RELEASE_BRANCH'|wc -l|cut -d ' ' -f 8)
+
+if [[ $RELEASE_BRANCH_EXISTS == '0' ]]; then
+  echo "git branch '$RELEASE_BRANCH' does not exist in the remote repository, yet"
+  echo "We want to raise this PR against main"
+  RELEASE_BRANCH="main"
+  RELEASE_PR_BRANCH="$RELEASE_PR_BRANCH-main"
+fi
+
+echo "final RELEASE_BRANCH is $RELEASE_BRANCH"
+echo "RELEASE_PR_BRANCH is $RELEASE_PR_BRANCH"
 
 echo "---- Creating release branch $RELEASE_PR_BRANCH from $RELEASE_BRANCH, on the fork ----"
 
 git checkout -b "$RELEASE_PR_BRANCH" upstream/"$RELEASE_BRANCH"
-#git checkout -b "$RELEASE_PR_BRANCH" upstream/main
 git branch
 git pull && git diff HEAD
 


### PR DESCRIPTION
When the minor-version branch, e.g. `2.18.x` is not yet available. 

This way, we can run these steps for a new minor version release:
- create the Changelog+post-release PR on `main`, 
- create the new minor-version-branch , e.g. `2.18.x`
- create the Release PR on minor-version-branch
, with PRs being created by the same script.

Remove a couple of commented lines from the script.

Related to issue https://github.com/timescale/eng-database/issues/624

Disable-check: force-changelog-file
Disable-check: commit-count
