### PR TITLE
Optimize conflict do update (upserts) on Hypercore TAM

### DIFF
--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -132,6 +132,9 @@ typedef struct CrossModuleFunctions
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(const ChunkInsertState *state, TupleTableSlot *slot);
 	bool (*decompress_target_segments)(HypertableModifyState *ht_state);
+	int (*hypercore_decompress_update_segment)(Relation relation, const ItemPointer ctid,
+											   TupleTableSlot *slot, Snapshot snapshot,
+											   ItemPointer new_tid);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -168,22 +168,16 @@ ts_chunk_dispatch_decompress_batches_for_insert(ChunkDispatch *dispatch, ChunkIn
 {
 	if (cis->chunk_compressed)
 	{
-		OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
-
-		if (cis->use_tam && onconflict_action != ONCONFLICT_UPDATE)
-		{
-			/* With our own TAM, a unique index covers both the compressed and
-			 * non-compressed data, so there is no need to decompress anything
-			 * when doing inserts. */
-		}
 		/*
 		 * If this is an INSERT into a compressed chunk with UNIQUE or
 		 * PRIMARY KEY constraints we need to make sure any batches that could
 		 * potentially lead to a conflict are in the decompressed chunk so
 		 * postgres can do proper constraint checking.
 		 */
-		else if (ts_cm_functions->decompress_batches_for_insert)
+		if (ts_cm_functions->decompress_batches_for_insert)
 		{
+			OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
+
 			ts_cm_functions->decompress_batches_for_insert(cis, slot);
 
 			/* mark rows visible */
@@ -445,7 +439,8 @@ chunk_dispatch_exec(CustomScanState *node)
 												   on_chunk_insert_state_changed,
 												   state);
 
-	ts_chunk_dispatch_decompress_batches_for_insert(dispatch, cis, slot);
+	if (!cis->use_tam)
+		ts_chunk_dispatch_decompress_batches_for_insert(dispatch, cis, slot);
 
 	MemoryContextSwitchTo(old);
 

--- a/tsl/src/hypercore/hypercore_handler.h
+++ b/tsl/src/hypercore/hypercore_handler.h
@@ -30,6 +30,9 @@ extern void hypercore_xact_event(XactEvent event, void *arg);
 extern bool hypercore_set_truncate_compressed(bool onoff);
 extern void hypercore_scan_set_skip_compressed(TableScanDesc scan, bool skip);
 extern void hypercore_skip_compressed_data_for_relation(Oid relid);
+extern int hypercore_decompress_update_segment(Relation relation, const ItemPointer ctid,
+											   TupleTableSlot *slot, Snapshot snapshot,
+											   ItemPointer new_ctid);
 
 typedef struct ColumnCompressionSettings
 {

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -175,6 +175,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.decompress_target_segments = decompress_target_segments,
 	.hypercore_handler = hypercore_handler,
 	.hypercore_proxy_handler = hypercore_proxy_handler,
+	.hypercore_decompress_update_segment = hypercore_decompress_update_segment,
 	.is_compressed_tid = tsl_is_compressed_tid,
 	.ddl_command_start = tsl_ddl_command_start,
 	.ddl_command_end = tsl_ddl_command_end,


### PR DESCRIPTION
When a conflict-do-update statement executes on a Hypercore TAM table, the conflicting TID (and slot) can point to a "row" in a compressed segment. Therefore, it is possible to directly decompress the conflicting segment before executing the update statement.

In contrast, the existing on-conflict handling for compression doesn't have a unique index that points to the conflicting tuple, so it first needs to scan for a conflicting segment on the compressed chunk, which might, in some cases, be a full sequence scan on the compressed chunk, and decompression of the segments that might conflict.

On a synthetic test case, the improvements to upserts are significant, about 32x faster execution time for a single row upsert, while buffers read is reduced by 2220x. This makes the upsert performance on par with that of non-compressed hypertables.

Disable-check: force-changelog-file
Disable-check: approval-count