### PR TITLE
Pinned Ubuntu version in package workflow to 22.04

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -15,7 +15,7 @@ name: APT ARM64 packages
 jobs:
   apt_tests:
     name: APT ARM64 ${{ matrix.image }} PG${{ matrix.pg }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub Actions using `ubuntu-latest` have been changed to use `ubuntu-24.04` instead by default (https://github.com/actions/runner-images/issues/10636) which breaks our APT-ARM64 package workflow. This pins the version back to `ubuntu-22.04` to avoid this.

Disable-check: force-changelog-file