### PR TITLE
Refresh cagg uses min value for dimension when start_time is NULL

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -34,3 +34,107 @@ LANGUAGE C VOLATILE;
 
 UPDATE _timescaledb_catalog.hypertable SET chunk_sizing_func_schema = '_timescaledb_functions' WHERE chunk_sizing_func_schema = '_timescaledb_internal' AND chunk_sizing_func_name = 'calculate_chunk_interval';
 
+CREATE OR REPLACE PROCEDURE
+_timescaledb_functions.policy_compression_execute(
+  job_id              INTEGER,
+  htid                INTEGER,
+  lag                 ANYELEMENT,
+  maxchunks           INTEGER,
+  verbose_log         BOOLEAN,
+  recompress_enabled  BOOLEAN,
+  use_creation_time   BOOLEAN,
+  useam               BOOLEAN = NULL)
+AS $$
+DECLARE
+  htoid       REGCLASS;
+  chunk_rec   RECORD;
+  numchunks_compressed   INTEGER := 1;
+  _message     text;
+  _detail      text;
+  _sqlstate    text;
+  -- fully compressed chunk status
+  status_fully_compressed int := 1;
+  -- chunk status bits:
+  bit_compressed int := 1;
+  bit_compressed_unordered int := 2;
+  bit_frozen int := 4;
+  bit_compressed_partial int := 8;
+  creation_lag INTERVAL := NULL;
+  chunks_failure INTEGER := 0;
+BEGIN
+
+  -- procedures with SET clause cannot execute transaction
+  -- control so we adjust search_path in procedure body
+  SET LOCAL search_path TO pg_catalog, pg_temp;
+
+  SELECT format('%I.%I', schema_name, table_name) INTO htoid
+  FROM _timescaledb_catalog.hypertable
+  WHERE id = htid;
+
+  -- for the integer cases, we have to compute the lag w.r.t
+  -- the integer_now function and then pass on to show_chunks
+  IF pg_typeof(lag) IN ('BIGINT'::regtype, 'INTEGER'::regtype, 'SMALLINT'::regtype) THEN
+    -- cannot have use_creation_time set with this
+    IF use_creation_time IS TRUE THEN
+        RAISE EXCEPTION 'job % cannot use creation time with integer_now function', job_id;
+    END IF;
+    lag := _timescaledb_functions.subtract_integer_from_now(htoid, lag::BIGINT);
+  END IF;
+
+  -- if use_creation_time has been specified then the lag needs to be used with the
+  -- "compress_created_before" argument. Otherwise the usual "older_than" argument
+  -- is good enough
+  IF use_creation_time IS TRUE THEN
+    creation_lag := lag;
+    lag := NULL;
+  END IF;
+
+  FOR chunk_rec IN
+    SELECT
+      show.oid, ch.schema_name, ch.table_name, ch.status
+    FROM
+      @extschema@.show_chunks(htoid, older_than => lag, created_before => creation_lag) AS show(oid)
+      INNER JOIN pg_class pgc ON pgc.oid = show.oid
+      INNER JOIN pg_namespace pgns ON pgc.relnamespace = pgns.oid
+      INNER JOIN _timescaledb_catalog.chunk ch ON ch.table_name = pgc.relname AND ch.schema_name = pgns.nspname AND ch.hypertable_id = htid
+    WHERE NOT ch.dropped
+    AND NOT ch.osm_chunk
+    -- Checking for chunks which are not fully compressed and not frozen
+    AND ch.status != status_fully_compressed
+    AND ch.status & bit_frozen = 0
+  LOOP
+    BEGIN
+      IF chunk_rec.status = bit_compressed OR recompress_enabled IS TRUE THEN
+        PERFORM @extschema@.compress_chunk(chunk_rec.oid, hypercore_use_access_method => useam);
+        numchunks_compressed := numchunks_compressed + 1;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+          _message = MESSAGE_TEXT,
+          _detail = PG_EXCEPTION_DETAIL,
+          _sqlstate = RETURNED_SQLSTATE;
+      RAISE WARNING 'compressing chunk "%" failed when compression policy is executed', chunk_rec.oid::regclass::text
+          USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
+                ERRCODE = _sqlstate;
+      chunks_failure := chunks_failure + 1;
+    END;
+    COMMIT;
+    -- SET LOCAL is only active until end of transaction.
+    -- While we could use SET at the start of the function we do not
+    -- want to bleed out search_path to caller, so we do SET LOCAL
+    -- again after COMMIT
+    SET LOCAL search_path TO pg_catalog, pg_temp;
+    IF verbose_log THEN
+       RAISE LOG 'job % completed processing chunk %.%', job_id, chunk_rec.schema_name, chunk_rec.table_name;
+    END IF;
+    IF maxchunks > 0 AND numchunks_compressed >= maxchunks THEN
+         EXIT;
+    END IF;
+  END LOOP;
+
+  IF chunks_failure > 0 THEN
+    RAISE EXCEPTION 'compression policy failure'
+      USING DETAIL = format('Failed to compress %L chunks. Successfully compressed %L chunks.', chunks_failure, numchunks_compressed);
+  END IF;
+END;
+$$ LANGUAGE PLPGSQL;


### PR DESCRIPTION
When the refresh_continuous_aggregate window's start is NULL, use the min value in the hypertable to determine the beginning of the range instead of the min value for the partition column.

We do this only if enable_tiered_reads is set to false.