### PR TITLE
Fix NULL handling for in-memory tuple filtering

### DIFF
--- a/.unreleased/pr_7557
+++ b/.unreleased/pr_7557
@@ -1,0 +1,1 @@
+Fixes: #7557 Fix NULL handling for in-memory tuple filtering 

--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -30,6 +30,8 @@ typedef struct tuple_filtering_constraints
 	bool nullsnotdistinct;
 } tuple_filtering_constraints;
 
+bool slot_key_test(TupleTableSlot *slot, ScanKey skey);
+
 ScanKeyData *build_mem_scankeys_from_slot(Oid ht_relid, CompressionSettings *settings,
 										  Relation out_rel,
 										  tuple_filtering_constraints *constraints,

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -13,6 +13,7 @@
 #include <utils/typcache.h>
 
 #include "compression.h"
+#include "compression_dml.h"
 #include "create.h"
 #include "guc.h"
 #include "hypercore/hypercore_handler.h"
@@ -515,20 +516,6 @@ update_orderby_scankeys(TupleTableSlot *uncompressed_slot, CompressedSegmentInfo
 		orderby_scankeys[max_index].sk_flags = is_null ? SK_ISNULL : 0;
 		orderby_scankeys[max_index].sk_argument = val;
 	}
-}
-
-static bool
-slot_key_test(TupleTableSlot *compressed_slot, ScanKey key)
-{
-	Datum val;
-	bool is_null;
-	val = slot_getattr(compressed_slot, key->sk_attno, &is_null);
-
-	/* NULL values only match the value is NULL */
-	if (key->sk_flags & SK_ISNULL)
-		return is_null;
-
-	return DatumGetBool(FunctionCall2Coll(&key->sk_func, key->sk_collation, val, key->sk_argument));
 }
 
 static enum Batch_match_result

--- a/tsl/test/shared/expected/compression_nulls_not_distinct.out
+++ b/tsl/test/shared/expected/compression_nulls_not_distinct.out
@@ -6,17 +6,19 @@
 -- only exists since then. once we drop support for PG14, this test
 -- can be moved to non-shared compression_conflicts test
 set timescaledb.debug_compression_path_info to on;
-CREATE TABLE nulls_not_distinct(time timestamptz not null, device text, value float);
-CREATE UNIQUE INDEX ON nulls_not_distinct (time, device) NULLS NOT DISTINCT;
+CREATE TABLE nulls_not_distinct(time timestamptz not null, device text, label text, value float);
+CREATE UNIQUE INDEX ON nulls_not_distinct (time, device, label) NULLS NOT DISTINCT;
 SELECT table_name FROM create_hypertable('nulls_not_distinct', 'time');
      table_name     
  nulls_not_distinct
 (1 row)
 
 ALTER TABLE nulls_not_distinct SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
-NOTICE:  default order by for hypertable "nulls_not_distinct" is set to ""time" DESC"
-INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
-INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+NOTICE:  default order by for hypertable "nulls_not_distinct" is set to ""time" DESC, label"
+INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', 'l1', i FROM generate_series(1,6000) g(i);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 'l1', 1);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', 'd2', NULL, 1);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.10', 'd2', 'l1', 1);
 SELECT count(compress_chunk(c)) FROM show_chunks('nulls_not_distinct') c;
 INFO:  using tuplesort to scan rows from "_hyper_X_X_chunk" for compression
  count 
@@ -25,9 +27,16 @@ INFO:  using tuplesort to scan rows from "_hyper_X_X_chunk" for compression
 
 -- shouldn't succeed because nulls are not distinct
 \set ON_ERROR_STOP 0
-INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
-INFO:  Using index scan with scan keys: index 1, heap 2, memory 1. 
-ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_nulls_not_distinct_time_device_idx"
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 'l1', 1);
+INFO:  Using index scan with scan keys: index 1, heap 4, memory 2. 
+ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_nulls_not_distinct_time_device_label_idx"
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', 'd2', NULL, 1);
+INFO:  Using index scan with scan keys: index 1, heap 2, memory 2. 
+ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_nulls_not_distinct_time_device_label_idx"
 \set ON_ERROR_STOP 1
+-- should insert without error, no conflict
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', 'd2', 'l1', 1);
+INFO:  Using index scan with scan keys: index 1, heap 4, memory 2. 
+INFO:  Number of compressed rows fetched from index: 1. Number of compressed rows filtered by heap filters: 0.
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE nulls_not_distinct;

--- a/tsl/test/shared/sql/compression_nulls_not_distinct.sql
+++ b/tsl/test/shared/sql/compression_nulls_not_distinct.sql
@@ -9,20 +9,26 @@
 -- can be moved to non-shared compression_conflicts test
 
 set timescaledb.debug_compression_path_info to on;
-CREATE TABLE nulls_not_distinct(time timestamptz not null, device text, value float);
-CREATE UNIQUE INDEX ON nulls_not_distinct (time, device) NULLS NOT DISTINCT;
+CREATE TABLE nulls_not_distinct(time timestamptz not null, device text, label text, value float);
+CREATE UNIQUE INDEX ON nulls_not_distinct (time, device, label) NULLS NOT DISTINCT;
 SELECT table_name FROM create_hypertable('nulls_not_distinct', 'time');
 ALTER TABLE nulls_not_distinct SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
 
-INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
-INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+INSERT INTO nulls_not_distinct SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', 'l1', i FROM generate_series(1,6000) g(i);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 'l1', 1);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', 'd2', NULL, 1);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.10', 'd2', 'l1', 1);
 
 SELECT count(compress_chunk(c)) FROM show_chunks('nulls_not_distinct') c;
 
 -- shouldn't succeed because nulls are not distinct
 \set ON_ERROR_STOP 0
-INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 1);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', NULL, 'l1', 1);
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', 'd2', NULL, 1);
 \set ON_ERROR_STOP 1
+
+-- should insert without error, no conflict
+INSERT INTO nulls_not_distinct VALUES ('2024-01-01 0:00:00.5', 'd2', 'l1', 1);
 
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE nulls_not_distinct;


### PR DESCRIPTION
During DML decompression, we filter out batches that don't need decompression using in-memory filtering which filters compressed tuples using scankeys. Those scankeys were not detecting NULL values correctly for unique constraints which use NULLS NOT DISTINCT setting. This change uses existing codebase to properly detect those tuples when using SK_ISNULL flag.