### PR TITLE
Move function from under a wrong ifdef

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -39,6 +39,14 @@ ts_function_telemetry_on()
 	return ts_guc_telemetry_level > TELEMETRY_NO_FUNCTIONS;
 }
 
+static const struct config_enum_entry telemetry_level_options[] = {
+	{ "off", TELEMETRY_OFF, false },
+	{ "no_functions", TELEMETRY_NO_FUNCTIONS, false },
+	{ "basic", TELEMETRY_BASIC, false },
+	{ NULL, 0, false }
+};
+#endif
+
 bool
 ts_is_whitelisted_indexam(const char *amname)
 {
@@ -66,14 +74,6 @@ ts_is_whitelisted_indexam(const char *amname)
 	list_free(namelist);
 	return false;
 }
-
-static const struct config_enum_entry telemetry_level_options[] = {
-	{ "off", TELEMETRY_OFF, false },
-	{ "no_functions", TELEMETRY_NO_FUNCTIONS, false },
-	{ "basic", TELEMETRY_BASIC, false },
-	{ NULL, 0, false }
-};
-#endif
 
 /* Copied from contrib/auto_explain/auto_explain.c */
 static const struct config_enum_entry loglevel_options[] = {


### PR DESCRIPTION
Somehow the hypercore supported am function ended up under
 #ifdef TELEMETRY, so some rare build configurations are failing.


Disable-check: force-changelog-file

Since this is a cosmetic change in Hypercore:
Disable-check: approval-count