### PR TITLE
Improve transaction check in refresh_cagg

### DIFF
--- a/.unreleased/pr_7566
+++ b/.unreleased/pr_7566
@@ -1,0 +1,2 @@
+Fixes: #7566 Improve transaction check in CAgg refresh
+Thanks: @staticlibs for sending PR to improve transaction check in CAgg refresh

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -93,6 +93,7 @@ void _process_utility_fini(void);
 static ProcessUtility_hook_type prev_ProcessUtility_hook;
 
 static bool expect_chunk_modification = false;
+static ProcessUtilityContext last_process_utility_context = PROCESS_UTILITY_TOPLEVEL;
 static DDLResult process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht);
 static DDLResult process_altertable_reset_options(AlterTableCmd *cmd, Hypertable *ht);
 
@@ -111,6 +112,13 @@ prev_ProcessUtility(ProcessUtilityArgs *args)
 		 args->queryEnv,
 		 args->dest,
 		 args->completion_tag);
+
+	/*
+	 * Reset the last_process_utility_context value that is saved at the
+	 * entrance of the TS ProcessUtility hook and can be used for transaction
+	 * checks inside refresh_cagg and other procedures.
+	 */
+	ts_process_utility_context_reset();
 }
 
 static void
@@ -5048,6 +5056,8 @@ timescaledb_ddl_command_start(PlannedStmt *pstmt, const char *query_string, bool
 							  QueryEnvironment *queryEnv, DestReceiver *dest,
 							  QueryCompletion *completion_tag)
 {
+	last_process_utility_context = context;
+
 	ProcessUtilityArgs args = { .query_string = query_string,
 								.context = context,
 								.params = params,
@@ -5171,6 +5181,19 @@ extern void
 ts_process_utility_set_expect_chunk_modification(bool expect)
 {
 	expect_chunk_modification = expect;
+}
+
+bool
+ts_process_utility_is_context_nonatomic(void)
+{
+	ProcessUtilityContext context = last_process_utility_context;
+	return context == PROCESS_UTILITY_TOPLEVEL || context == PROCESS_UTILITY_QUERY_NONATOMIC;
+}
+
+void
+ts_process_utility_context_reset(void)
+{
+	last_process_utility_context = PROCESS_UTILITY_TOPLEVEL;
 }
 
 static void

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -36,3 +36,56 @@ typedef enum
 typedef DDLResult (*ts_process_utility_handler_t)(ProcessUtilityArgs *args);
 
 extern void ts_process_utility_set_expect_chunk_modification(bool expect);
+
+/*
+ * Procedures that use multiple transactions cannot be run in a transaction
+ * block (from a function, from dynamic SQL) or in a subtransaction (from a
+ * procedure block with an EXCEPTION clause). Such procedures use
+ * PreventInTransactionBlock function to check whether they can be run.
+ *
+ * Though currently such checks are incomplete, because
+ * PreventInTransactionBlock requires isTopLevel argument to throw a
+ * consistent error when the call originates from a function. This
+ * isTopLevel flag (that is a bit poorly named - see below) is not readily
+ * available inside C procedures. The source of truth for it -
+ * ProcessUtilityContext parameter is passed to ProcessUtility hooks, but
+ * is not included with the function calls. There is an undocumented
+ * SPI_inside_nonatomic_context function, that would have been sufficient
+ * for isTopLevel flag, but it currently returns false when SPI connection
+ * is absent (that is a valid scenario when C procedures are called from
+ * top-lelev SQL instead of PLPG procedures or DO blocks) so it cannot be
+ * used.
+ *
+ * To work around this the value of ProcessUtilityContext parameter is
+ * saved when TS ProcessUtility hook is entered and can be accessed from
+ * C procedures using new ts_process_utility_is_context_nonatomic function.
+ * The result is called "non-atomic" instead of "top-level" because the way
+ * how isTopLevel flag is determined from the ProcessUtilityContext value
+ * in standard_ProcessUtility is insufficient for C procedures - it
+ * excludes PROCESS_UTILITY_QUERY_NONATOMIC value (used when called from
+ * PLPG procedure without an EXCEPTION clause) that is a valid use case for
+ * C procedures with transactions. See details in the description of
+ * ExecuteCallStmt function.
+ *
+ * It is expected that calls to C procedures are done with CALL and always
+ * pass though the ProcessUtility hook. The ProcessUtilityContext
+ * parameter is set to PROCESS_UTILITY_TOPLEVEL value by default. In
+ * unlikely case when a C procedure is called without passing through
+ * ProcessUtility hook and the call is done in atomic context, then
+ * PreventInTransactionBlock checks will pass, but SPI_commit will fail
+ * when checking that all current active snapshots are portal-owned
+ * snapshots (the same behaviour that was observed before this change).
+ * In atomic context there will be an additional snapshot set in
+ * _SPI_execute_plan, see the snapshot handling invariants description
+ * in that function.
+ */
+extern TSDLLEXPORT bool ts_process_utility_is_context_nonatomic(void);
+
+/*
+ * Currently in TS ProcessUtility hook the saved ProcessUtilityContext
+ * value is reset back to PROCESS_UTILITY_TOPLEVEL on normal exit but
+ * is NOT reset in case of ereport exit. C procedures can call this
+ * function to reset the saved value before doing the checks that can
+ * result in ereport exit.
+ */
+extern TSDLLEXPORT void ts_process_utility_context_reset(void);

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -535,3 +535,68 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 COMMIT;
+-- refresh_continuous_aggregate can run two transactions, thus it cannot be
+-- called in a transaction block (from a function, from dynamic SQL) or in a
+-- subtransaction (from a procedure block with an EXCEPTION clause). Though it
+-- does NOT require a top level context and can be called from a procedure
+-- block without an EXCEPTION clause.
+-- DO block
+DO $$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+END; $$;
+psql:include/cagg_refresh_common.sql:347: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+-- Procedure without subtransaction
+CREATE OR REPLACE PROCEDURE refresh_cagg_proc_normal()
+LANGUAGE PLPGSQL AS
+$$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+END; $$;
+CALL refresh_cagg_proc_normal();
+psql:include/cagg_refresh_common.sql:357: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+\set ON_ERROR_STOP 0
+-- Procedure with subtransaction
+CREATE OR REPLACE PROCEDURE refresh_cagg_proc_subtransaction()
+LANGUAGE PLPGSQL AS
+$$
+DECLARE
+  errmsg TEXT;
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS errmsg = MESSAGE_TEXT;
+  RAISE EXCEPTION '%', errmsg;
+END; $$;
+CALL refresh_cagg_proc_subtransaction();
+psql:include/cagg_refresh_common.sql:374: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
+-- Function
+CREATE OR REPLACE FUNCTION refresh_cagg_fun()
+RETURNS INT LANGUAGE PLPGSQL AS
+$$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+  RETURN 1;
+END; $$;
+SELECT * from  refresh_cagg_fun();
+psql:include/cagg_refresh_common.sql:385: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+-- Dynamic SQL
+DO $$
+BEGIN
+  EXECUTE $inner$
+      CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+  $inner$;
+END; $$;
+psql:include/cagg_refresh_common.sql:393: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+-- Trigger
+CREATE TABLE refresh_cagg_trigger_table(a int);
+CREATE FUNCTION refresh_cagg_trigger_fun()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+END; $$;
+CREATE TRIGGER refresh_cagg_trigger AFTER INSERT ON refresh_cagg_trigger_table
+EXECUTE FUNCTION refresh_cagg_trigger_fun();
+INSERT INTO refresh_cagg_trigger_table VALUES(1);
+psql:include/cagg_refresh_common.sql:407: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_refresh_using_merge.out
+++ b/tsl/test/expected/cagg_refresh_using_merge.out
@@ -536,6 +536,71 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 COMMIT;
+-- refresh_continuous_aggregate can run two transactions, thus it cannot be
+-- called in a transaction block (from a function, from dynamic SQL) or in a
+-- subtransaction (from a procedure block with an EXCEPTION clause). Though it
+-- does NOT require a top level context and can be called from a procedure
+-- block without an EXCEPTION clause.
+-- DO block
+DO $$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+END; $$;
+psql:include/cagg_refresh_common.sql:347: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+-- Procedure without subtransaction
+CREATE OR REPLACE PROCEDURE refresh_cagg_proc_normal()
+LANGUAGE PLPGSQL AS
+$$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+END; $$;
+CALL refresh_cagg_proc_normal();
+psql:include/cagg_refresh_common.sql:357: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+\set ON_ERROR_STOP 0
+-- Procedure with subtransaction
+CREATE OR REPLACE PROCEDURE refresh_cagg_proc_subtransaction()
+LANGUAGE PLPGSQL AS
+$$
+DECLARE
+  errmsg TEXT;
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS errmsg = MESSAGE_TEXT;
+  RAISE EXCEPTION '%', errmsg;
+END; $$;
+CALL refresh_cagg_proc_subtransaction();
+psql:include/cagg_refresh_common.sql:374: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
+-- Function
+CREATE OR REPLACE FUNCTION refresh_cagg_fun()
+RETURNS INT LANGUAGE PLPGSQL AS
+$$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+  RETURN 1;
+END; $$;
+SELECT * from  refresh_cagg_fun();
+psql:include/cagg_refresh_common.sql:385: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+-- Dynamic SQL
+DO $$
+BEGIN
+  EXECUTE $inner$
+      CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+  $inner$;
+END; $$;
+psql:include/cagg_refresh_common.sql:393: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+-- Trigger
+CREATE TABLE refresh_cagg_trigger_table(a int);
+CREATE FUNCTION refresh_cagg_trigger_fun()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+  CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
+END; $$;
+CREATE TRIGGER refresh_cagg_trigger AFTER INSERT ON refresh_cagg_trigger_table
+EXECUTE FUNCTION refresh_cagg_trigger_fun();
+INSERT INTO refresh_cagg_trigger_table VALUES(1);
+psql:include/cagg_refresh_common.sql:407: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+\set ON_ERROR_STOP 1
 -- Additional tests for MERGE refresh
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 10 other objects


### PR DESCRIPTION
Intro: Hi, I was investigating an issue with `portal snapshots (0) did not account for all active snapshots (1)` error inside another Postgres extension ([wdb-97](https://github.com/wiltondb/wiltondb/issues/97), unrelated to Timescale) and stumbled upon the #6533 issue in Timescale that was reporting the same error. Decided to have a deeper look into it.

This PR allows better error messages to be reported from `refresh_continuous_aggregate` when it is called from an atomic (no transaction allowed) context. One of the following messages:

 - `ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block`
 - `ERROR:  refresh_continuous_aggregate() cannot be executed from a function`

is reported now instead of: `ERROR: portal snapshots (N) did not account for all active snapshots (N+1)`. There are no other changes to `refresh_continuous_aggregate` logic.

Longer description, also included in `process_utility.h`:

Procedures that use multiple transactions cannot be run in a transaction block (from a function, from dynamic SQL) or in a subtransaction (from a procedure block with an `EXCEPTION` clause). Such procedures use [PreventInTransactionBlock](https://github.com/postgres/postgres/blob/759620716adb347c1d8c8b2e6f7d88b947a54c98/src/backend/access/transam/xact.c#L3559) function to check whether they can be run.

Though currently [such checks](https://github.com/timescale/timescaledb/blob/27c4c02d71e309ea5e1d525a431fa28c9bfdf604/tsl/src/continuous_aggs/refresh.c#L792) are incomplete, because `PreventInTransactionBlock` requires `isTopLevel` argument to throw a consistent error when the call originates from a function. This `isTopLevel` flag (that is a bit poorly named - see below) is not readily available inside C procedures. The source of truth for it - `ProcessUtilityContext` parameter is [passed to ProcessUtility hooks](https://github.com/timescale/timescaledb/blob/27c4c02d71e309ea5e1d525a431fa28c9bfdf604/src/process_utility.c#L5030), but is not included with the function calls. There is an undocumented [SPI_inside_nonatomic_context](https://github.com/postgres/postgres/blob/759620716adb347c1d8c8b2e6f7d88b947a54c98/src/backend/executor/spi.c#L577) function, that would have been sufficient for `isTopLevel` flag, but it currently returns false when SPI connection is absent (that is a valid scenario when C procedures are called from top-level SQL instead of PLPG procedures or `DO` blocks) so it cannot be used.

To work around this the value of `ProcessUtilityContext` parameter is saved when TS ProcessUtility hook is entered and can be accessed from C procedures using new `ts_process_utility_is_context_nonatomic` function. The result is called "non-atomic" instead of "top-level" because the way how [isTopLevel flag is determined from the ProcessUtilityContext value in standard_ProcessUtility](https://github.com/postgres/postgres/blob/759620716adb347c1d8c8b2e6f7d88b947a54c98/src/backend/tcop/utility.c#L550) is insufficient for C procedures - it excludes `PROCESS_UTILITY_QUERY_NONATOMIC` value (used when called from PLPG procedure without an `EXCEPTION` clause) that is a valid use case for C procedures with transactions. See details in the [description of ExecuteCallStmt function](https://github.com/postgres/postgres/blob/759620716adb347c1d8c8b2e6f7d88b947a54c98/src/backend/commands/functioncmds.c#L2159).

It is expected that calls to C procedures are done with `CALL` and always pass though the `ProcessUtility` hook. The `ProcessUtilityContext` parameter is set to `PROCESS_UTILITY_TOPLEVEL` value by default. In unlikely case when a C procedure is called without passing through `ProcessUtility` hook and the call is done in atomic context, then `PreventInTransactionBlock` checks will pass, but [SPI_commit will fail when checking that all current active snapshots are portal-owned snapshots](https://github.com/postgres/postgres/blob/759620716adb347c1d8c8b2e6f7d88b947a54c98/src/backend/utils/mmgr/portalmem.c#L1290) (the same behaviour that was observed before this change). In atomic context there will be an additional snapshot set in `_SPI_execute_plan`, see the [snapshot handling invariants description in that function](https://github.com/postgres/postgres/blob/759620716adb347c1d8c8b2e6f7d88b947a54c98/src/backend/executor/spi.c#L2434).

With initial version of this PR, in TS `ProcessUtility` hook the saved `ProcessUtilityContext` value is reset back to `PROCESS_UTILITY_TOPLEVEL` on normal exit but is NOT reset in case of `ereport` exit. C procedures can call `ts_process_utility_context_reset` function to reset the saved value before doing the checks that can result in `ereport` exit. The scenario when more thorough reset may be necessary - when subsequent calls after the failed atomic call are not passed through the `ProcessUtility` hook - seems to be unlikely.
 
Closes #6533.

Disable-check: commit-count
