### PR TITLE
Remove redundant PG17 entry from build matrix

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test-ignored.yaml
+++ b/.github/workflows/linux-32bit-build-and-test-ignored.yaml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
-      pg17_latest: ${{ steps.setter.outputs.PG17_LATEST }}
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -38,9 +37,6 @@ jobs:
       matrix:
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
         build_type: [ Debug ]
-        include:
-          - pg: ${{ fromJson(needs.config.outputs.pg17_latest) }}
-            build_type: Debug
     steps:
       - run: |
           echo "No build required"

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
-      pg17_latest: ${{ steps.setter.outputs.PG17_LATEST }}
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -56,9 +55,6 @@ jobs:
       matrix:
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
         build_type: [ Debug ]
-        include:
-          - pg: ${{ fromJson(needs.config.outputs.pg17_latest) }}
-            build_type: Debug
       fail-fast: false
 
     steps:


### PR DESCRIPTION
PG17 is included by default now so we dont need to explicitly add it to matrix anymore.

Disable-check: force-changelog-file