### PR TITLE
Use the Postgres uint64 instead of the C uint64_t

### DIFF
--- a/tsl/src/nodes/vector_agg/grouping_policy_hash.c
+++ b/tsl/src/nodes/vector_agg/grouping_policy_hash.c
@@ -330,7 +330,7 @@ gp_hash_add_batch(GroupingPolicy *gp, DecompressBatchState *batch_state)
 	/*
 	 * Add the batch rows to aggregate function states.
 	 */
-	const uint64_t *restrict filter = batch_state->vector_qual_result;
+	const uint64 *restrict filter = batch_state->vector_qual_result;
 	add_one_range(policy, batch_state, 0, n);
 
 	policy->stat_input_total_rows += batch_state->total_batch_rows;


### PR DESCRIPTION
They are nominally different on some platforms (e.g. unsigned long vs unsigned long long), so we shouldn't mix them.