### PR TITLE
Add error for DELETE triggers with transition tables

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -240,6 +240,7 @@ Hypertable *
 ts_hypertable_from_tupleinfo(const TupleInfo *ti)
 {
 	Hypertable *h = MemoryContextAllocZero(ti->mctx, sizeof(Hypertable));
+	char relkind;
 
 	ts_hypertable_formdata_fill(&h->fd, ti);
 	h->main_table_relid =
@@ -248,6 +249,9 @@ ts_hypertable_from_tupleinfo(const TupleInfo *ti)
 	h->chunk_cache =
 		ts_subspace_store_init(h->space, ti->mctx, ts_guc_max_cached_chunks_per_hypertable);
 	h->chunk_sizing_func = get_chunk_sizing_func_oid(&h->fd);
+
+	if (OidIsValid(h->main_table_relid))
+		ts_get_rel_info(h->main_table_relid, &h->amoid, &relkind);
 
 	if (ts_guc_enable_chunk_skipping)
 	{

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -51,6 +51,7 @@ typedef struct Hypertable
 	FormData_hypertable fd;
 	Oid main_table_relid;
 	Oid chunk_sizing_func;
+	Oid amoid;
 	Hyperspace *space;
 	SubspaceStore *chunk_cache;
 	ChunkRangeSpace *range_space;

--- a/tsl/test/expected/compression_trigger.out
+++ b/tsl/test/expected/compression_trigger.out
@@ -1,0 +1,193 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- This is copied from hypercore_trigger.sql
+set client_min_messages to warning;
+create table readings(
+       metric_id serial,
+       created_at timestamptz not null unique,
+       location_id smallint,	--segmentby attribute with index
+       owner_id bigint,		--segmentby attribute without index
+       device_id bigint,	--non-segmentby attribute
+       temp float8,
+       humidity float4
+);
+select create_hypertable('readings', by_range('created_at'));
+ create_hypertable 
+-------------------
+ (1,t)
+(1 row)
+
+select setseed(1);
+ setseed 
+---------
+ 
+(1 row)
+
+insert into readings(created_at, location_id, device_id, owner_id, temp, humidity)
+select t, ceil(random()*10), ceil(random()*30), ceil(random() * 5), random()*40, random()*100
+from generate_series('2022-06-01'::timestamptz, '2022-07-01', '5m') t;
+alter table readings set (
+	  timescaledb.compress,
+	  timescaledb.compress_orderby = 'created_at',
+	  timescaledb.compress_segmentby = 'location_id, owner_id'
+);
+select compress_chunk(show_chunks('readings'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(6 rows)
+
+create table saved_rows (like readings, new_row bool not null, kind text);
+create function save_transition_table() returns trigger as $$
+begin
+   case tg_op
+   	when 'INSERT' then
+	     insert into saved_rows select n.*, true, tg_op from new_table n;
+	when 'DELETE' then
+	     insert into saved_rows select o.*, false, tg_op from old_table o;
+	when 'UPDATE' then
+	     insert into saved_rows select n.*, true, tg_op from new_table n;
+	     insert into saved_rows select o.*, false, tg_op from old_table o;
+   end case;
+   return null;
+end;
+$$ language plpgsql;
+create trigger save_insert_transition_table_trg
+       after insert on readings
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+insert into readings(created_at, location_id, device_id, owner_id, temp, humidity)
+values ('2022-06-01 00:01:23', 999, 666, 111, 3.14, 3.14),
+       ('2022-06-01 00:02:23', 999, 666, 112, 3.14, 3.14);
+select * from saved_rows order by metric_id;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+      8642 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | t       | INSERT
+      8643 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14 | t       | INSERT
+(2 rows)
+
+truncate saved_rows;
+select compress_chunk(show_chunks('readings'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(6 rows)
+
+copy readings(created_at, location_id, device_id, owner_id, temp, humidity) from stdin with (format csv);
+select * from saved_rows order by metric_id;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+      8644 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | t       | INSERT
+(1 row)
+
+truncate saved_rows;
+select compress_chunk(show_chunks('readings'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(6 rows)
+
+create trigger save_update_transition_table_trg
+       after update on readings
+       referencing new table as new_table old table as old_table
+       for each statement execute function save_transition_table();
+select * from readings where location_id = 999 order by metric_id;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity 
+-----------+------------------------------+-------------+----------+-----------+------+----------
+      8642 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14
+      8643 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14
+      8644 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14
+(3 rows)
+
+update readings set humidity = 99.99 where location_id = 999;
+select * from saved_rows order by metric_id;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+      8642 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
+      8642 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | f       | UPDATE
+      8643 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |    99.99 | t       | UPDATE
+      8643 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14 | f       | UPDATE
+      8644 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
+      8644 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | f       | UPDATE
+(6 rows)
+
+truncate saved_rows;
+select compress_chunk(show_chunks('readings'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(6 rows)
+
+-- This is not supported since it is possible to delete an entire
+-- segment without executing the trigger.
+\set ON_ERROR_STOP 0
+create trigger save_delete_transition_table_trg
+       after delete on readings
+       referencing old table as old_table
+       for each statement execute function save_transition_table();
+ERROR:  DELETE triggers with transition tables not supported
+\set ON_ERROR_STOP 1
+-- Test that we get an error when enabling compression and have a
+-- delete trigger with a transition table. We allow transition tables
+-- for update and insert triggers.
+create table test2(
+       created_at timestamptz not null unique,
+       location_id bigint,
+       temp float8
+);
+select create_hypertable('test2', by_range('created_at'));
+ create_hypertable 
+-------------------
+ (3,t)
+(1 row)
+
+create trigger save_test2_insert_trg
+       after insert on test2
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+create trigger save_test2_update_trg
+       after update on test2
+       referencing new table as new_table old table as old_table
+       for each statement execute function save_transition_table();
+create trigger save_test2_delete_trg
+       after delete on test2
+       referencing old table as old_table
+       for each statement execute function save_transition_table();
+-- This should fail
+\set ON_ERROR_STOP 0
+alter table test2 set (
+	  timescaledb.compress,
+	  timescaledb.compress_orderby = 'created_at',
+	  timescaledb.compress_segmentby = 'location_id'
+);
+ERROR:  DELETE triggers with transition tables not supported
+\set ON_ERROR_STOP 1
+-- drop the delete trigger
+drop trigger save_test2_delete_trg on test2;
+-- This should now succeed.
+alter table test2 set (
+	  timescaledb.compress,
+	  timescaledb.compress_orderby = 'created_at',
+	  timescaledb.compress_segmentby = 'location_id'
+);

--- a/tsl/test/expected/hypercore_trigger.out
+++ b/tsl/test/expected/hypercore_trigger.out
@@ -111,6 +111,9 @@ select format('%I.%I', chunk_schema, chunk_name)::regclass as chunk2
  where format('%I.%I', hypertable_schema, hypertable_name)::regclass = :'hypertable'::regclass
  order by chunk2 asc
  limit 1 offset 1 \gset
+-- Set the hypercore access method on the hypertable for transition
+-- tables to work properly.
+alter table :hypertable set access method hypercore;
 create table saved_rows (like :chunk1, new_row bool not null, kind text);
 create table count_stmt (inserts int, updates int, deletes int);
 create function save_row() returns trigger as $$
@@ -371,7 +374,7 @@ create trigger save_insert_transition_table_trg
 insert into readings(created_at, location_id, device_id, owner_id, temp, humidity)
 select created_at, location_id, device_id, owner_id, temp, humidity from sample
 order by created_at limit 2;
-select * from saved_rows;
+select * from saved_rows order by metric_id;
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
 -----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
      11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | t       | INSERT
@@ -379,19 +382,60 @@ select * from saved_rows;
 (2 rows)
 
 truncate saved_rows;
+-- Compress the data again to make sure that it is fully compressed.
+select compress_chunk(show_chunks(:'hypertable'), hypercore_use_access_method => true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_13_chunk
+ _timescaledb_internal._hyper_1_15_chunk
+ _timescaledb_internal._hyper_1_17_chunk
+ _timescaledb_internal._hyper_1_19_chunk
+(10 rows)
+
 copy readings(created_at, location_id, device_id, owner_id, temp, humidity) from stdin with (format csv);
-select * from saved_rows;
+select * from saved_rows order by metric_id;
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
 -----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
      11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | t       | INSERT
 (1 row)
 
 truncate saved_rows;
+-- Compress the data again to make sure that it is fully compressed.
+select compress_chunk(show_chunks(:'hypertable'), hypercore_use_access_method => true);
+NOTICE:  chunk "_hyper_1_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_3_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_4_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_5_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_6_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_13_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_15_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_17_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_19_chunk" is already compressed
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_13_chunk
+ _timescaledb_internal._hyper_1_15_chunk
+ _timescaledb_internal._hyper_1_17_chunk
+ _timescaledb_internal._hyper_1_19_chunk
+(10 rows)
+
 create trigger save_update_transition_table_trg
        after update on readings
        referencing new table as new_table old table as old_table
        for each statement execute function save_transition_table();
-select * from readings where location_id = 999;
+select * from readings where location_id = 999 order by metric_id;
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity 
 -----------+------------------------------+-------------+----------+-----------+------+----------
      11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14
@@ -400,23 +444,48 @@ select * from readings where location_id = 999;
 (3 rows)
 
 update readings set humidity = 99.99 where location_id = 999;
-select * from saved_rows;
+select * from saved_rows order by metric_id;
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
 -----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
      11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
-     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |    99.99 | t       | UPDATE
-     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
      11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | f       | UPDATE
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |    99.99 | t       | UPDATE
      11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14 | f       | UPDATE
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
      11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | f       | UPDATE
 (6 rows)
 
 truncate saved_rows;
+-- Compress the data again to make sure that it is fully compressed.
+select compress_chunk(show_chunks(:'hypertable'), hypercore_use_access_method => true);
+NOTICE:  chunk "_hyper_1_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_3_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_4_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_5_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_6_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_13_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_15_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_17_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_19_chunk" is already compressed
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_13_chunk
+ _timescaledb_internal._hyper_1_15_chunk
+ _timescaledb_internal._hyper_1_17_chunk
+ _timescaledb_internal._hyper_1_19_chunk
+(10 rows)
+
 create trigger save_delete_transition_table_trg
        after delete on readings
        referencing old table as old_table
        for each statement execute function save_transition_table();
-select * from readings where location_id = 999;
+select * from readings where location_id = 999 order by metric_id;
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity 
 -----------+------------------------------+-------------+----------+-----------+------+----------
      11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99
@@ -425,7 +494,7 @@ select * from readings where location_id = 999;
 (3 rows)
 
 delete from readings where location_id = 999;
-select * from saved_rows;
+select * from saved_rows order by metric_id;
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
 -----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
      11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | f       | DELETE

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_FILES
     compression_settings.sql
     compression_sorted_merge_columns.sql
     compression_sorted_merge_distinct.sql
+    compression_trigger.sql
     decompress_index.sql
     foreign_keys.sql
     move.sql

--- a/tsl/test/sql/compression_trigger.sql
+++ b/tsl/test/sql/compression_trigger.sql
@@ -1,0 +1,143 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- This is copied from hypercore_trigger.sql
+
+set client_min_messages to warning;
+
+create table readings(
+       metric_id serial,
+       created_at timestamptz not null unique,
+       location_id smallint,	--segmentby attribute with index
+       owner_id bigint,		--segmentby attribute without index
+       device_id bigint,	--non-segmentby attribute
+       temp float8,
+       humidity float4
+);
+
+select create_hypertable('readings', by_range('created_at'));
+
+select setseed(1);
+
+insert into readings(created_at, location_id, device_id, owner_id, temp, humidity)
+select t, ceil(random()*10), ceil(random()*30), ceil(random() * 5), random()*40, random()*100
+from generate_series('2022-06-01'::timestamptz, '2022-07-01', '5m') t;
+
+alter table readings set (
+	  timescaledb.compress,
+	  timescaledb.compress_orderby = 'created_at',
+	  timescaledb.compress_segmentby = 'location_id, owner_id'
+);
+
+select compress_chunk(show_chunks('readings'));
+
+create table saved_rows (like readings, new_row bool not null, kind text);
+
+create function save_transition_table() returns trigger as $$
+begin
+   case tg_op
+   	when 'INSERT' then
+	     insert into saved_rows select n.*, true, tg_op from new_table n;
+	when 'DELETE' then
+	     insert into saved_rows select o.*, false, tg_op from old_table o;
+	when 'UPDATE' then
+	     insert into saved_rows select n.*, true, tg_op from new_table n;
+	     insert into saved_rows select o.*, false, tg_op from old_table o;
+   end case;
+   return null;
+end;
+$$ language plpgsql;
+
+create trigger save_insert_transition_table_trg
+       after insert on readings
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+
+insert into readings(created_at, location_id, device_id, owner_id, temp, humidity)
+values ('2022-06-01 00:01:23', 999, 666, 111, 3.14, 3.14),
+       ('2022-06-01 00:02:23', 999, 666, 112, 3.14, 3.14);
+
+select * from saved_rows order by metric_id;
+
+truncate saved_rows;
+
+select compress_chunk(show_chunks('readings'));
+
+copy readings(created_at, location_id, device_id, owner_id, temp, humidity) from stdin with (format csv);
+"2022-06-01 00:01:35",999,666,111,3.14,3.14
+\.
+
+select * from saved_rows order by metric_id;
+
+truncate saved_rows;
+
+select compress_chunk(show_chunks('readings'));
+
+create trigger save_update_transition_table_trg
+       after update on readings
+       referencing new table as new_table old table as old_table
+       for each statement execute function save_transition_table();
+
+select * from readings where location_id = 999 order by metric_id;
+
+update readings set humidity = 99.99 where location_id = 999;
+
+select * from saved_rows order by metric_id;
+
+truncate saved_rows;
+
+select compress_chunk(show_chunks('readings'));
+
+-- This is not supported since it is possible to delete an entire
+-- segment without executing the trigger.
+\set ON_ERROR_STOP 0
+create trigger save_delete_transition_table_trg
+       after delete on readings
+       referencing old table as old_table
+       for each statement execute function save_transition_table();
+\set ON_ERROR_STOP 1
+
+-- Test that we get an error when enabling compression and have a
+-- delete trigger with a transition table. We allow transition tables
+-- for update and insert triggers.
+create table test2(
+       created_at timestamptz not null unique,
+       location_id bigint,
+       temp float8
+);
+
+select create_hypertable('test2', by_range('created_at'));
+
+create trigger save_test2_insert_trg
+       after insert on test2
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+create trigger save_test2_update_trg
+       after update on test2
+       referencing new table as new_table old table as old_table
+       for each statement execute function save_transition_table();
+create trigger save_test2_delete_trg
+       after delete on test2
+       referencing old table as old_table
+       for each statement execute function save_transition_table();
+
+
+-- This should fail
+\set ON_ERROR_STOP 0
+alter table test2 set (
+	  timescaledb.compress,
+	  timescaledb.compress_orderby = 'created_at',
+	  timescaledb.compress_segmentby = 'location_id'
+);
+\set ON_ERROR_STOP 1
+
+-- drop the delete trigger
+drop trigger save_test2_delete_trg on test2;
+
+-- This should now succeed.
+alter table test2 set (
+	  timescaledb.compress,
+	  timescaledb.compress_orderby = 'created_at',
+	  timescaledb.compress_segmentby = 'location_id'
+);


### PR DESCRIPTION
DELETE triggers cannot be supported for compressed tables not using the hypercore table access method since it can delete an entire compressed segment and a transition table is not built for this case, so generating an error instead.

This commit also adds a bunch of tests for triggers with transition tables for normal compressed tables and extend the hypercore trigger tests.

Disable-check: force-changelog-file