### PR TITLE
Relax lock when updating job history information

### DIFF
--- a/src/bgw/job_stat_history.c
+++ b/src/bgw/job_stat_history.c
@@ -270,7 +270,7 @@ ts_bgw_job_stat_history_mark_end(BgwJob *job, JobResult result, Jsonb *edata)
 										  bgw_job_stat_history_tuple_mark_end,
 										  NULL,
 										  &context,
-										  ShareRowExclusiveLock))
+										  RowExclusiveLock))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("unable to find job history " INT64_FORMAT, new_job->job_history.id)));


### PR DESCRIPTION
In #6767 we introduced the ability to track job execution history, but looks like we exaggerated the lock level when marking the end of the job execution using `ShareRowExclusiveLock` that conflicts with autovacuum jobs that requires an `ShareUpdateExclusiveLock`, so relaxing the lock to `RowExclusiveLock` because we only update the tuple in the job execution history metadata table.

Disable-check: force-changelog-file
