### PR TITLE
Modify `ORDER BY` clause in flaky test

### DIFF
--- a/tsl/test/expected/hypercore_index_btree.out
+++ b/tsl/test/expected/hypercore_index_btree.out
@@ -986,7 +986,7 @@ where c.oid = :'unique_chunk'::regclass;
  _hyper_7_19_chunk | hypercore
 (1 row)
 
-select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time;
+select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time, value;
  is_compressed_tid |             time             | value 
 -------------------+------------------------------+-------
  t                 | Mon Jan 01 01:00:00 2024 PST |     1
@@ -1008,11 +1008,11 @@ select compress_chunk(:'unique_chunk');
 (1 row)
 
 -- Everything's compressed
-select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time;
+select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time, value;
  is_compressed_tid |             time             | value 
 -------------------+------------------------------+-------
- t                 | Mon Jan 01 01:00:00 2024 PST |     3
  t                 | Mon Jan 01 01:00:00 2024 PST |     1
+ t                 | Mon Jan 01 01:00:00 2024 PST |     3
  t                 | Mon Jan 01 02:00:00 2024 PST |     2
 (3 rows)
 

--- a/tsl/test/sql/hypercore_index_btree.sql
+++ b/tsl/test/sql/hypercore_index_btree.sql
@@ -441,7 +441,7 @@ select c.relname, a.amname from pg_class c
 inner join pg_am a ON (c.relam = a.oid)
 where c.oid = :'unique_chunk'::regclass;
 
-select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time;
+select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time, value;
 
 -- Unique index creation should work but fail on uniqueness check
 \set ON_ERROR_STOP 0
@@ -452,7 +452,7 @@ create unique index time_key on uniquetable (time);
 select compress_chunk(:'unique_chunk');
 
 -- Everything's compressed
-select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time;
+select _timescaledb_debug.is_compressed_tid(ctid), * from :unique_chunk order by time, value;
 
 -- Unique index creation should still fail
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
Modifies the `ORDER BY` clause in the `hypercore_index_btree` test to guarantee the ordering of the query result.