### PR TITLE
Update existing backports in the backport script

### DIFF
--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -354,29 +354,20 @@ for commit_sha, commit_title in main_commits:
 
 def branch_has_open_pr(repo, branch):
     """Check whether the given branch has an open PR."""
-    result = run_query(
-        string.Template(
-            """
-                query {
-                  repository(name: "$repo_name", owner: "$repo_owner") {
-                    ref(qualifiedName: "$branch") {
-                      associatedPullRequests(first: 1) {
-                          nodes {
-                            closed
-                          }
-                        }
-                    }
-                  }
-                }
-          """
-        ).substitute(
-            {
-                "branch": branch,
-                "repo_name": repo.name,
-                "repo_owner": repo.owner.login,
-            }
-        )
-    )
+
+    template = """query {
+      repository(name: "$repo_name", owner: "$repo_owner") {
+        ref(qualifiedName: "$branch") {
+          associatedPullRequests(first: 1) {
+            nodes { closed }}}}}"""
+
+    params = {
+        "branch": branch,
+        "repo_name": repo.name,
+        "repo_owner": repo.owner.login,
+    }
+
+    result = run_query(string.Template(template).substitute(params))
 
     # This returns:
     # {'data': {'repository': {'ref': {'associatedPullRequests': {'nodes': [{'closed': True}]}}}}}

--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -409,6 +409,7 @@ def report_backport_not_done(original_pr, reason, details=None):
 # Set git name and email corresponding to the token user.
 token_user = github.get_user()
 os.environ["GIT_COMMITTER_NAME"] = token_user.name
+os.environ["GIT_AUTHOR_NAME"] = token_user.name
 
 # This is an email that is used by Github when you opt to hide your real email
 # address. It is required so that the commits are recognized by Github as made
@@ -417,6 +418,8 @@ os.environ["GIT_COMMITTER_NAME"] = token_user.name
 os.environ["GIT_COMMITTER_EMAIL"] = (
     f"{token_user.id}+{token_user.login}@users.noreply.github.com"
 )
+os.environ["GIT_AUTHOR_EMAIL"] = os.environ["GIT_COMMITTER_EMAIL"]
+
 print(
     f"Will commit as {os.environ['GIT_COMMITTER_NAME']} <{os.environ['GIT_COMMITTER_EMAIL']}>"
 )


### PR DESCRIPTION
Depending on the branch protection settings, we might have to update them before they can be merged, so do this automatically to minimize the required manual work.

Disable-check: force-changelog-file
Disable-check: approval-count