### PR TITLE
Fix downgrade path for 2.18.0

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -37,12 +37,11 @@ jobs:
         PATH="/usr/lib/postgresql/${{ matrix.pg }}/bin:$PATH"
         ./scripts/test_updates.sh
 
-#    Temporary disabled downgrade for 2.18.0 
-#    - name: Downgrade tests PG${{ matrix.pg }}
-#      if: always()
-#      run: |
-#        PATH="/usr/lib/postgresql/${{ matrix.pg }}/bin:$PATH"
-#        ./scripts/test_downgrade.sh
+    - name: Downgrade tests PG${{ matrix.pg }}
+      if: always()
+      run: |
+        PATH="/usr/lib/postgresql/${{ matrix.pg }}/bin:$PATH"
+        ./scripts/test_downgrade.sh
 
     - name: Update diff
       if: failure()

--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -172,6 +172,10 @@ function(generate_downgrade_script)
     _epilog_files
     IGNORE_ERRORS)
 
+  if(_downgrade_TARGET_VERSION VERSION_EQUAL 2.18.0)
+    list(TRANSFORM _epilog_files REPLACE "^.*/hypercore.sql" "${CMAKE_CURRENT_SOURCE_DIR}/pre_install/tam.functions.sql")
+  endif()
+
   foreach(_downgrade_file ${_downgrade_PRE_FILES})
     get_filename_component(_downgrade_filename ${_downgrade_file} NAME)
     configure_file(${_downgrade_file} ${_downgrade_INPUT_DIRECTORY}/${_downgrade_filename} COPYONLY)


### PR DESCRIPTION
This patch adjusts the downgrade script generation to not include
incompatible files from the 2.18.0 release that would break script
generation and replaces them with a working version. This adjustment
can be removed after we release of 2.18.1.
This patch also reenables the downgrade test.

Disable-check: force-changelog-file
Disable-check: approval-count
