### PR TITLE
Allow more workflows to be triggered by github ui

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -17,6 +17,7 @@ name: ABI Test
       - trigger/abi
   pull_request:
     paths: .github/workflows/abi.yaml
+  workflow_dispatch:
 jobs:
   config:
     runs-on: ubuntu-latest

--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -12,6 +12,7 @@ name: APT ARM64 packages
     branches:
     - release_test
     - trigger/package_test
+  workflow_dispatch:
 jobs:
   apt_tests:
     name: APT ARM64 ${{ matrix.image }} PG${{ matrix.pg }}

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -12,6 +12,7 @@ name: APT packages
     branches:
     - release_test
     - trigger/package_test
+  workflow_dispatch:
 jobs:
   apt_tests:
     name: APT ${{ matrix.image }} PG${{ matrix.pg }} ${{ matrix.license }}

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -6,6 +6,7 @@ name: Coverity
   push:
     branches:
       - coverity_scan
+  workflow_dispatch:
 jobs:
 
   coverity:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -15,6 +15,7 @@ name: Test Docker images
     branches:
     - release_test
     - trigger/package_test
+  workflow_dispatch:
 jobs:
   docker_tests:
     name: ${{ matrix.image }}

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -11,6 +11,7 @@ name: Homebrew
     - release_test
     - trigger/package_test
     - trigger/homebrew_test
+  workflow_dispatch:
 
 jobs:
   homebrew:

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -12,6 +12,7 @@ name: Libfuzzer
     paths:
       - .github/workflows/libfuzzer.yaml
       - 'tsl/test/fuzzing/compression/**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -12,6 +12,7 @@ name: RPM packages
     branches:
     - release_test
     - trigger/package_test
+  workflow_dispatch:
 
 jobs:
   rpm_tests:

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -11,6 +11,7 @@ name: Sanitizer test
       - trigger/sanitizer
   pull_request:
     paths: .github/workflows/sanitizer-build-and-test.yaml
+  workflow_dispatch:
 
 env:
   name: "Sanitizer"

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -13,6 +13,8 @@ name: ABI Test Against Snapshot
       - trigger/snapshot-abi
   pull_request:
     paths: .github/workflows/snapshot-abi.yaml
+  workflow_dispatch:
+
 jobs:
   config:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -5,6 +5,8 @@ name: Test Update and Downgrade
       - main
       - prerelease_test
   pull_request:
+  workflow_dispatch:
+
 jobs:
   update_test:
     name: Update test PG${{ matrix.pg }}

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -20,6 +20,7 @@ name: Regression Windows
       - 'LICENSE*'
       - NOTICE
       - 'bootstrap*'
+  workflow_dispatch:
 jobs:
   config:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -12,6 +12,7 @@ name: Windows Packages
     branches:
     - release_test
     - trigger/windows_packages
+  workflow_dispatch:
 
 jobs:
   config:


### PR DESCRIPTION
This is mostly to allow triggering package tests directly from
github UI but no harm enabling it for a couple more.

Disable-check: force-changelog-file
