### PR TITLE
Remove some dead code from downgrade script generation

### DIFF
--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -137,21 +137,9 @@ function(generate_downgrade_script)
   endforeach()
 
   # Fetch manifest with list of files for the prolog and epilog from the target
-  # version, if we are in a version that supports downgrades.  Otherwise, take
-  # the one in the current version.
-  #
-  # We have a specific exception where we allow a missing manifest for the first
-  # version that supports downgrades and assume that the files to include are
-  # the same in the target version as the current one.
-  if(_downgrade_TARGET_VERSION VERSION_GREATER 2.3)
-    git_versioned_get(VERSION ${_downgrade_TARGET_VERSION} FILES
-                      ${CMAKE_SOURCE_DIR}/cmake/ScriptFiles.cmake)
-  else()
-    file(MAKE_DIRECTORY
-         "${CMAKE_BINARY_DIR}/v${_downgrade_TARGET_VERSION}/cmake")
-    file(COPY "${CMAKE_SOURCE_DIR}/cmake/ScriptFiles.cmake"
-         DESTINATION "${CMAKE_BINARY_DIR}/v${_downgrade_TARGET_VERSION}/cmake")
-  endif()
+  # version.
+  git_versioned_get(VERSION ${_downgrade_TARGET_VERSION} FILES
+                    ${CMAKE_SOURCE_DIR}/cmake/ScriptFiles.cmake)
 
   # This will include the variables in this scope, but not in the parent scope
   # so we can read them locally without affecting the parent scope.


### PR DESCRIPTION
Since we only support generating downgrade script for the previous
version anything targeting versions before 2.18 will never be
executed in current context. So we can safely remove the code that
deals with version before 2.3.

Disable-check: force-changelog-file
Disable-check: approval-count