### PR TITLE
Allow EXPLAIN in read-only mode

### DIFF
--- a/.unreleased/pr_7637
+++ b/.unreleased/pr_7637
@@ -1,0 +1,2 @@
+Fixes: #7637 Allow EXPLAIN in read-only mode
+Thanks: @ikalafat for reporting the error

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4859,6 +4859,7 @@ process_ddl_command_start(ProcessUtilityArgs *args)
 			handler = preprocess_execute;
 			break;
 		case T_ExplainStmt:
+			check_read_only = false;
 			handler = process_explain_start;
 			break;
 

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -8,7 +8,84 @@
 -- create_hypertable()
 --
 CREATE TABLE test_table(time bigint NOT NULL, device int);
+-- EXPLAIN should work in read-only mode, when enabling in transaction.
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (COSTS OFF) SELECT * FROM test_table;
+       QUERY PLAN       
+------------------------
+ Seq Scan on test_table
+(1 row)
+
+ROLLBACK;
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (ANALYZE ON, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT * FROM test_table;
+                   QUERY PLAN                   
+------------------------------------------------
+ Seq Scan on test_table (actual rows=0 loops=1)
+(1 row)
+
+ROLLBACK;
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (COSTS OFF) INSERT INTO test_table VALUES (1, 1);
+      QUERY PLAN      
+----------------------
+ Insert on test_table
+   ->  Result
+(2 rows)
+
+ROLLBACK;
+-- This should give an error since we are using ANALYZE and a DML. The
+-- read-only is checked when executing the actual INSERT statement,
+-- not inside our code.
+\set ON_ERROR_STOP 0
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (ANALYZE ON, COSTS OFF, TIMING OFF, SUMMARY OFF) INSERT INTO test_table VALUES (1, 1);
+ERROR:  cannot execute INSERT in a read-only transaction
+ROLLBACK;
+\set ON_ERROR_STOP 1
 SET default_transaction_read_only TO on;
+-- EXPLAIN should work in read-only mode, even when using the default.
+START TRANSACTION;
+EXPLAIN (COSTS OFF) SELECT * FROM test_table;
+       QUERY PLAN       
+------------------------
+ Seq Scan on test_table
+(1 row)
+
+ROLLBACK;
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (ANALYZE ON, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT * FROM test_table;
+                   QUERY PLAN                   
+------------------------------------------------
+ Seq Scan on test_table (actual rows=0 loops=1)
+(1 row)
+
+ROLLBACK;
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (COSTS OFF) INSERT INTO test_table VALUES (1, 1);
+      QUERY PLAN      
+----------------------
+ Insert on test_table
+   ->  Result
+(2 rows)
+
+ROLLBACK;
+-- This should give an error since we are using ANALYZE and a DML. The
+-- read-only is checked when executing the actual INSERT statement,
+-- not inside our code.
+\set ON_ERROR_STOP 0
+START TRANSACTION;
+SET transaction_read_only TO on;
+EXPLAIN (ANALYZE ON, COSTS OFF, TIMING OFF, SUMMARY OFF) INSERT INTO test_table VALUES (1, 1);
+ERROR:  cannot execute INSERT in a read-only transaction
+ROLLBACK;
+\set ON_ERROR_STOP 1
 \set ON_ERROR_STOP 0
 SELECT * FROM create_hypertable('test_table', 'time');
 ERROR:  cannot execute create_hypertable() in a read-only transaction


### PR DESCRIPTION
Using `EXPLAIN` when `transaction_read_only` is set to `on` fails with an error. This is fixed by explicitly setting the `check_read_only` flag.

Fixes #7635 