### PR TITLE
Store hash value in hash table in dictionary compressor

### DIFF
--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -192,7 +192,7 @@ dictionary_compressor_append(DictionaryCompressor *compressor, Datum val)
 		// per_val->bitmap = roaring_dictionary_create();
 		dict_item->index = compressor->next_index;
 		dict_item->key = datumCopy(val, compressor->typbyval, compressor->typlen);
-		Assert(compressor->next_index < INT16_MAX - 1);
+		Assert(compressor->next_index <= INT16_MAX - 1);
 		compressor->next_index += 1;
 	}
 

--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -192,6 +192,7 @@ dictionary_compressor_append(DictionaryCompressor *compressor, Datum val)
 		// per_val->bitmap = roaring_dictionary_create();
 		dict_item->index = compressor->next_index;
 		dict_item->key = datumCopy(val, compressor->typbyval, compressor->typlen);
+		Assert(compressor->next_index < INT16_MAX - 1);
 		compressor->next_index += 1;
 	}
 

--- a/tsl/src/compression/algorithms/dictionary_hash.h
+++ b/tsl/src/compression/algorithms/dictionary_hash.h
@@ -28,8 +28,9 @@ typedef struct DictionaryHashItem
 {
 	Datum key;
 	/* hash entry status */
-	char status;
-	uint32 index;
+	uint32 hash;
+	uint16 status;
+	uint16 index;
 } DictionaryHashItem;
 
 typedef struct dictionary_hash dictionary_hash;
@@ -42,6 +43,8 @@ static bool datum_eq(dictionary_hash *tb, Datum a, Datum b);
 #define SH_KEY key
 #define SH_HASH_KEY(tb, key) datum_hash(tb, key)
 #define SH_EQUAL(tb, a, b) datum_eq(tb, a, b)
+#define SH_STORE_HASH
+#define SH_GET_HASH(tb, entry) entry->hash
 #define SH_SCOPE static inline
 #define SH_DEFINE
 #define SH_DECLARE


### PR DESCRIPTION
This speeds up the compression.

The recompression of the hackers mailing list archive is now almost 40% faster: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=4085&var-run2=4086&var-threshold=0.02&var-use_historical_thresholds=true&var-threshold_expression=2%20%2A%20percentile_cont%280.90%29&var-exact_suite_version=false&from=now-2d&to=now

Disable-check: force-changelog-file