### PR TITLE
Fix DELETE on compressed chunk with non-btree operators

### DIFF
--- a/.unreleased/pr_7645
+++ b/.unreleased/pr_7645
@@ -1,0 +1,1 @@
+Fixes: #7645 Fix DELETE on compressed chunk with non-btree operators

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -268,7 +268,8 @@ decompress_batches_for_update_delete(HypertableModifyState *ht_state, Chunk *chu
 		scankeys = build_update_delete_scankeys(comp_chunk_rel,
 												heap_filters,
 												&num_scankeys,
-												&null_columns);
+												&null_columns,
+												&delete_only);
 	}
 
 	if (matching_index_rel)
@@ -957,7 +958,16 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							break;
 						}
 						default:
-							/* Do nothing for unknown operator strategies. */
+							*heap_filters = lappend(*heap_filters,
+													make_batchfilter(column_name,
+																	 op_strategy,
+																	 collation,
+																	 opcode,
+																	 arg_value,
+																	 false, /* is_null_check */
+																	 false, /* is_null */
+																	 false	/* is_array_op */
+																	 ));
 							break;
 					}
 					continue;
@@ -1109,7 +1119,16 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							break;
 						}
 						default:
-							/* Do nothing on unknown operator strategies. */
+							*heap_filters = lappend(*heap_filters,
+													make_batchfilter(column_name,
+																	 op_strategy,
+																	 collation,
+																	 opcode,
+																	 arg_value,
+																	 false, /* is_null_check */
+																	 false, /* is_null */
+																	 true	/* is_array_op */
+																	 ));
 							break;
 					}
 					continue;

--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -45,4 +45,4 @@ ScanKeyData *build_heap_scankeys(Oid hypertable_relid, Relation in_rel, Relation
 								 CompressionSettings *settings, Bitmapset *key_columns,
 								 Bitmapset **null_columns, TupleTableSlot *slot, int *num_scankeys);
 ScanKeyData *build_update_delete_scankeys(Relation in_rel, List *heap_filters, int *num_scankeys,
-										  Bitmapset **null_columns);
+										  Bitmapset **null_columns, bool *delete_only);

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -435,9 +435,11 @@ INSERT INTO direct_delete VALUES
 ('2021-01-01', 'd1', 'r1', 1.0),
 ('2021-01-01', 'd1', 'r2', 1.0),
 ('2021-01-01', 'd1', 'r3', 1.0),
+('2021-01-01', 'd1', NULL, 1.0),
 ('2021-01-01', 'd2', 'r1', 1.0),
 ('2021-01-01', 'd2', 'r2', 1.0),
-('2021-01-01', 'd2', 'r3', 1.0);
+('2021-01-01', 'd2', 'r3', 1.0),
+('2021-01-01', 'd2', NULL, 1.0);
 SELECT count(compress_chunk(c)) FROM show_chunks('direct_delete') c;
  count 
      1
@@ -448,7 +450,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE device='d1';
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches deleted: 3
+   Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
          ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
@@ -481,6 +483,108 @@ SELECT count(*) FROM direct_delete WHERE reading='r2';
 (1 row)
 
 ROLLBACK;
+-- issue #7644
+-- make sure non-btree operators don't delete unrelated batches
+BEGIN;
+:ANALYZE DELETE FROM direct_delete WHERE reading <> 'r2';
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 8
+   Tuples decompressed: 8
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=4 loops=1)
+               Filter: (reading <> 'r2'::text)
+               Rows Removed by Filter: 4
+(8 rows)
+
+-- 4 tuples should still be there
+SELECT count(*) FROM direct_delete;
+ count 
+     4
+(1 row)
+
+ROLLBACK;
+-- test IS NULL
+BEGIN;
+:ANALYZE DELETE FROM direct_delete WHERE reading IS NULL;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 2
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=2 loops=1)
+               Filter: (reading IS NULL)
+(7 rows)
+
+-- 6 tuples should still be there
+SELECT count(*) FROM direct_delete;
+ count 
+     6
+(1 row)
+
+ROLLBACK;
+-- test IS NOT NULL
+BEGIN;
+:ANALYZE DELETE FROM direct_delete WHERE reading IS NOT NULL;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 6
+   Tuples decompressed: 6
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=6 loops=1)
+               Filter: (reading IS NOT NULL)
+(7 rows)
+
+-- 2 tuples should still be there
+SELECT count(*) FROM direct_delete;
+ count 
+     2
+(1 row)
+
+ROLLBACK;
+-- test IN
+BEGIN;
+:ANALYZE DELETE FROM direct_delete WHERE reading IN ('r1','r2');
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 4
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
+               Filter: (reading = ANY ('{r1,r2}'::text[]))
+(6 rows)
+
+-- 4 tuples should still be there
+SELECT count(*) FROM direct_delete;
+ count 
+     4
+(1 row)
+
+ROLLBACK;
+-- test IN
+BEGIN;
+:ANALYZE DELETE FROM direct_delete WHERE reading NOT IN ('r1');
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 8
+   Tuples decompressed: 8
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=4 loops=1)
+               Filter: (reading <> 'r1'::text)
+               Rows Removed by Filter: 4
+(8 rows)
+
+-- 4 tuples should still be there
+SELECT count(*) FROM direct_delete;
+ count 
+     4
+(1 row)
+
+ROLLBACK;
 -- combining constraints on segmentby columns should work
 BEGIN;
 -- should be 1 batches directly deleted
@@ -505,22 +609,22 @@ ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE value = '1.0'; ROLLBACK;
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 6
-   Tuples decompressed: 6
+   Batches decompressed: 8
+   Tuples decompressed: 8
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=6 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=8 loops=1)
                Filter: (value = '1'::double precision)
 (7 rows)
 
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1' AND value = '1.0'; ROLLBACK;
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 3
-   Tuples decompressed: 3
+   Batches decompressed: 4
+   Tuples decompressed: 4
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=4 loops=1)
                Filter: ((device = 'd1'::text) AND (value = '1'::double precision))
 (7 rows)
 
@@ -552,15 +656,16 @@ BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1'; ROLLBACK;
 WARNING:  Trigger fired
 WARNING:  Trigger fired
 WARNING:  Trigger fired
+WARNING:  Trigger fired
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 3
-   Tuples decompressed: 3
+   Batches decompressed: 4
+   Tuples decompressed: 4
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=4 loops=1)
                Filter: (device = 'd1'::text)
- Trigger direct_delete_trigger on _hyper_X_X_chunk: calls=3
+ Trigger direct_delete_trigger on _hyper_X_X_chunk: calls=4
 (8 rows)
 
 DROP TRIGGER direct_delete_trigger ON direct_delete;
@@ -569,15 +674,16 @@ BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1'; ROLLBACK;
 WARNING:  Trigger fired
 WARNING:  Trigger fired
 WARNING:  Trigger fired
+WARNING:  Trigger fired
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 3
-   Tuples decompressed: 3
+   Batches decompressed: 4
+   Tuples decompressed: 4
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=4 loops=1)
                Filter: (device = 'd1'::text)
- Trigger direct_delete_trigger on _hyper_X_X_chunk: calls=3
+ Trigger direct_delete_trigger on _hyper_X_X_chunk: calls=4
 (8 rows)
 
 DROP TRIGGER direct_delete_trigger ON direct_delete;


### PR DESCRIPTION
When deleting from compressed chunk the direct delete optimization
would ignore constraints that were not using btree operators
leading to constraints of the DELETE not being applied to the
direct delete on the compressed chunk, potentially leading to
data corruption. This patch disables the direct delete optimization
when any of the constraints can not be applied.

Fixes #7644
