### PR TITLE
Sync sql/updates/2.18.0--2.17.2.sql with release branch

### DIFF
--- a/sql/updates/2.18.0--2.17.2.sql
+++ b/sql/updates/2.18.0--2.17.2.sql
@@ -1,8 +1,8 @@
 -- Hypercore AM
 DROP ACCESS METHOD IF EXISTS hypercore_proxy;
-DROP FUNCTION IF EXISTS @extschema@.ts_hypercore_proxy_handler;
+DROP FUNCTION IF EXISTS ts_hypercore_proxy_handler;
 DROP ACCESS METHOD IF EXISTS hypercore;
-DROP FUNCTION IF EXISTS @extschema@.ts_hypercore_handler;
+DROP FUNCTION IF EXISTS ts_hypercore_handler;
 DROP FUNCTION IF EXISTS _timescaledb_debug.is_compressed_tid;
 
 DROP FUNCTION IF EXISTS @extschema@.compress_chunk(uncompressed_chunk REGCLASS,	if_not_compressed BOOLEAN, recompress BOOLEAN, hypercore_use_access_method BOOL);


### PR DESCRIPTION
The downgrade script for 2.17.2 that was merged into main branch
was different from the one in 2.18.0 due to merge error. This
patch syncs the downgrade script with the version used in 2.18.0
release.
