### PR TITLE
Push down orderby scankeys to Hypercore TAM

### DIFF
--- a/.unreleased/pr_7653
+++ b/.unreleased/pr_7653
@@ -1,0 +1,2 @@
+Fixes: #7653 Push down orderby scankeys to Hypercore TAM
+Thanks: Timescale community members Jacob and pantonis for reporting issues with slow queries.

--- a/src/guc.c
+++ b/src/guc.c
@@ -164,6 +164,7 @@ TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh = false;
 TSDLLEXPORT char *ts_guc_hypercore_indexam_whitelist;
 TSDLLEXPORT HypercoreCopyToBehavior ts_guc_hypercore_copy_to_behavior =
 	HYPERCORE_COPY_NO_COMPRESSED_DATA;
+TSDLLEXPORT bool ts_guc_enable_hypercore_scankey_pushdown = true;
 
 /* default value of ts_guc_max_open_chunks_per_insert and
  * ts_guc_max_cached_chunks_per_hypertable will be set as their respective boot-value when the
@@ -1068,6 +1069,20 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+	DefineCustomBoolVariable(/* name= */ MAKE_EXTOPTION("enable_hypercore_scankey_pushdown"),
+							 /* short_desc= */
+							 "Push down qualifiers as scankeys when using Hypercore TAM",
+							 /* long_desc= */
+							 "Enabling this setting might lead to faster scans when "
+							 "query qualifiers match Hypercore segmentby and orderby columns.",
+							 /* valueAddr= */ &ts_guc_enable_hypercore_scankey_pushdown,
+							 /* bootValue= */ true,
+							 /* context= */ PGC_USERSET,
+							 /* flags= */ 0,
+							 /* check_hook= */ NULL,
+							 /* assign_hook= */ NULL,
+							 /* show_hook= */ NULL);
 
 	DefineCustomIntVariable(/* name= */ MAKE_EXTOPTION("debug_bgw_scheduler_exit_status"),
 							/* short_desc= */ "exit status to use when shutting down the scheduler",

--- a/src/guc.h
+++ b/src/guc.h
@@ -148,6 +148,7 @@ typedef enum HypercoreCopyToBehavior
 } HypercoreCopyToBehavior;
 
 extern TSDLLEXPORT HypercoreCopyToBehavior ts_guc_hypercore_copy_to_behavior;
+extern TSDLLEXPORT bool ts_guc_enable_hypercore_scankey_pushdown;
 
 void _guc_init(void);
 

--- a/tsl/src/hypercore/hypercore_handler.h
+++ b/tsl/src/hypercore/hypercore_handler.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <postgres.h>
+#include <access/attnum.h>
 #include <access/tableam.h>
 #include <access/xact.h>
 #include <fmgr.h>
@@ -36,9 +37,17 @@ extern int hypercore_decompress_update_segment(Relation relation, const ItemPoin
 
 typedef struct ColumnCompressionSettings
 {
+	/* Attribute name in the non-compressed relation */
 	NameData attname;
+	/* Attribute number in non-compressed relation */
 	AttrNumber attnum;
-	AttrNumber cattnum; /* Attribute number in the compressed relation */
+	/* Attribute number in the compressed relation */
+	AttrNumber cattnum;
+	/* For orderby columns, these are the attribute numbers of the the min/max
+	 * metadata columns. */
+	AttrNumber cattnum_min;
+	AttrNumber cattnum_max;
+	/* Attribute type */
 	Oid typid;
 	bool is_orderby;
 	bool is_segmentby;
@@ -67,3 +76,16 @@ typedef struct HypercoreInfo
 #define REL_IS_HYPERCORE(rel) ((rel)->rd_tableam == hypercore_routine())
 
 extern HypercoreInfo *RelationGetHypercoreInfo(Relation rel);
+
+static inline bool
+hypercore_column_has_minmax(const ColumnCompressionSettings *column)
+{
+	if (AttributeNumberIsValid(column->cattnum_min))
+	{
+		/* Both min and max should always be set together */
+		Assert(AttributeNumberIsValid(column->cattnum_max));
+		return true;
+	}
+
+	return false;
+}

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -8,11 +8,14 @@
 #include <access/sdir.h>
 #include <access/skey.h>
 #include <access/tableam.h>
+#include <c.h>
 #include <catalog/pg_attribute.h>
 #include <executor/tuptable.h>
 #include <nodes/execnodes.h>
 #include <nodes/extensible.h>
 #include <nodes/nodeFuncs.h>
+#include <nodes/nodes.h>
+#include <nodes/parsenodes.h>
 #include <nodes/pathnodes.h>
 #include <nodes/pg_list.h>
 #include <optimizer/cost.h>
@@ -28,6 +31,7 @@
 
 #include "columnar_scan.h"
 #include "compression/compression.h"
+#include "guc.h"
 #include "hypercore/arrow_tts.h"
 #include "hypercore/hypercore_handler.h"
 #include "hypercore/vector_quals.h"
@@ -49,6 +53,7 @@ typedef struct ColumnarScanState
 	ScanKey scankeys;
 	int nscankeys;
 	List *scankey_quals;
+	List *quals_orig;
 	List *vectorized_quals_orig;
 	SimpleProjInfo sprojinfo;
 } ColumnarScanState;
@@ -66,167 +71,271 @@ match_relvar(Expr *expr, Index relid)
 	return false;
 }
 
+typedef struct QualProcessState
+{
+	const HypercoreInfo *hcinfo;
+	Index relid;
+	/*
+	 * The original quals are split into scankey quals, vectorized and
+	 * non-vectorized (regular) quals.
+	 */
+	List *scankey_quals;
+	List *vectorized_quals;
+	List *nonvectorized_quals;
+
+	/* Scankeys created from scankey_quals */
+	ScanKey scankeys;
+	unsigned int scankeys_capacity;
+	unsigned int nscankeys;
+} QualProcessState;
+
 /*
- * Utility function to extract quals that can be used as scankeys. The
- * remaining "normal" quals are optionally collected in the corresponding
- * argument.
+ * Process OP-like expression.
  *
- * Returns:
+ * Returns true if the qual should be kept as a regular qual filter in the
+ * scan, or false if it should not be kept.
  *
- * 1. A list of scankey quals if scankeys is NULL, or
- *
- * 2. NIL if scankeys is non-NULL.
- *
+ * Note that only scankeys on segmentby columns can completely replace a
+ * qual. Scankeys on other (compressed) columns will be transformed into
+ * scankeys on metadata columns, and those filters are not 100% accurate so
+ * the original qual must be kept.
+ */
+static bool
+process_opexpr(QualProcessState *qpi, OpExpr *opexpr)
+{
+	Expr *leftop, *rightop, *expr = NULL;
+	Var *relvar = NULL;
+	Datum scanvalue = 0;
+	bool argfound = false;
+	Oid opno = opexpr->opno;
+	Oid vartype_left = InvalidOid;
+	Oid vartype_right = InvalidOid;
+	Oid vartype = InvalidOid;
+
+	/* OpExpr always has 1 or 2 arguments */
+	Assert(is_opclause(opexpr) &&
+		   (list_length(opexpr->args) == 1 || list_length(opexpr->args) == 2));
+
+	if (opexpr->opresulttype != BOOLOID)
+		return true;
+
+	if (list_length(opexpr->args) != 2)
+		return true;
+
+	leftop = (Expr *) get_leftop(opexpr);
+	rightop = (Expr *) get_rightop(opexpr);
+
+	/* Strip any relabeling */
+	if (IsA(leftop, RelabelType))
+	{
+		vartype_left = ((RelabelType *) leftop)->resulttype;
+		leftop = ((RelabelType *) leftop)->arg;
+	}
+	if (IsA(rightop, RelabelType))
+	{
+		vartype_right = ((RelabelType *) rightop)->resulttype;
+		rightop = ((RelabelType *) rightop)->arg;
+	}
+
+	/*
+	 * Find a Var reference in either left or right operand. If an operand was
+	 * relabeled, the vartype must be the original relabel result type instead
+	 * of the Var's type.
+	 */
+	if (match_relvar(leftop, qpi->relid))
+	{
+		relvar = castNode(Var, leftop);
+		expr = rightop;
+		vartype = OidIsValid(vartype_left) ? vartype_left : relvar->vartype;
+	}
+	else if (match_relvar(rightop, qpi->relid))
+	{
+		relvar = castNode(Var, rightop);
+		expr = leftop;
+		vartype = OidIsValid(vartype_right) ? vartype_right : relvar->vartype;
+		opno = get_commutator(opexpr->opno);
+	}
+	else
+	{
+		/* If neither right nor left argument is a variable, we
+		 * don't use it as scan key */
+		return true;
+	}
+
+	if (!OidIsValid(opno) || !op_strict(opno))
+		return true;
+
+	Assert(expr != NULL);
+
+	if (IsA(expr, Const))
+	{
+		Const *c = castNode(Const, expr);
+		scanvalue = c->constvalue;
+		argfound = true;
+	}
+
+	const ColumnCompressionSettings *ccs =
+		&qpi->hcinfo->columns[AttrNumberGetAttrOffset(relvar->varattno)];
+
+	/* Add a scankey if this is a segmentby column or the column
+	 * has min/max metadata */
+	if (argfound && (ccs->is_segmentby || hypercore_column_has_minmax(ccs)))
+	{
+		TypeCacheEntry *tce = lookup_type_cache(vartype, TYPECACHE_BTREE_OPFAMILY);
+		int op_strategy = get_op_opfamily_strategy(opno, tce->btree_opf);
+
+		if (op_strategy != InvalidStrategy)
+		{
+			Oid op_lefttype;
+			Oid op_righttype;
+
+			get_op_opfamily_properties(opno,
+									   tce->btree_opf,
+									   false,
+									   &op_strategy,
+									   &op_lefttype,
+									   &op_righttype);
+
+			Assert(relvar != NULL);
+
+			if (qpi->scankeys != NULL)
+			{
+				ScanKeyEntryInitialize(&qpi->scankeys[qpi->nscankeys++],
+									   0,
+									   relvar->varattno,
+									   op_strategy,
+									   op_righttype,
+									   opexpr->inputcollid,
+									   opexpr->opfuncid,
+									   scanvalue);
+			}
+
+			qpi->scankey_quals = lappend(qpi->scankey_quals, opexpr);
+
+			return !ccs->is_segmentby;
+		}
+	}
+
+	return true;
+}
+
+/*
+ * Utility function to extract quals that can be used as scankeys.
+
  * Thus, this function is designed to be called over two passes: one at plan
  * time to split the quals into scankey quals and remaining quals, and one at
  * execution time to populate a scankey array with the scankey quals found in
  * the first pass.
  *
- * The scankey quals returned in pass 1 is used for EXPLAIN.
+ * The scankey quals collected in pass 1 is used for EXPLAIN.
+ *
+ * Returns the remaining quals that cannot be made into scankeys. The scankey
+ * quals are returned in the QualProcessInfo.
  */
 static List *
-process_scan_key_quals(const HypercoreInfo *hsinfo, Index relid, const List *quals,
-					   List **remaining_quals, ScanKey scankeys, unsigned scankeys_capacity)
+process_scan_key_quals(QualProcessState *qpi, const List *quals)
 {
-	List *scankey_quals = NIL;
-	unsigned nkeys = 0;
 	ListCell *lc;
-
-	Assert(scankeys == NULL || (scankeys_capacity >= (unsigned) list_length(quals)));
+	List *remaining_quals = NIL;
 
 	foreach (lc, quals)
 	{
 		Expr *qual = lfirst(lc);
-		bool scankey_found = false;
+		bool keep_qual = true;
 
-		/* ignore volatile expressions */
-		if (contain_volatile_functions((Node *) qual))
+		if (!contain_volatile_functions((Node *) qual))
 		{
-			if (remaining_quals != NULL)
-				*remaining_quals = lappend(*remaining_quals, qual);
-			continue;
-		}
-
-		switch (nodeTag(qual))
-		{
-			case T_OpExpr:
+			switch (nodeTag(qual))
 			{
-				OpExpr *opexpr = castNode(OpExpr, qual);
-				Oid opno = opexpr->opno;
-				Expr *leftop, *rightop, *expr = NULL;
-				Var *relvar = NULL;
-				Datum scanvalue = 0;
-				bool argfound = false;
-
-				if (list_length(opexpr->args) != 2)
+				case T_OpExpr:
+					keep_qual = process_opexpr(qpi, castNode(OpExpr, qual));
 					break;
-
-				leftop = linitial(opexpr->args);
-				rightop = lsecond(opexpr->args);
-
-				/* Strip any relabeling */
-				if (IsA(leftop, RelabelType))
-					leftop = ((RelabelType *) leftop)->arg;
-				if (IsA(rightop, RelabelType))
-					rightop = ((RelabelType *) rightop)->arg;
-
-				if (match_relvar(leftop, relid))
-				{
-					relvar = castNode(Var, leftop);
-					expr = rightop;
-				}
-				else if (match_relvar(rightop, relid))
-				{
-					relvar = castNode(Var, rightop);
-					expr = leftop;
-					opno = get_commutator(opno);
-				}
-				else
-				{
-					/* If neither right nor left argument is a variable, we
-					 * don't use it as scan key */
+				case T_ScalarArrayOpExpr:
+					/*
+					 * Currently cannot pushing down "foo IN (1, 3)". The
+					 * expression can be transformed into a scankey, but it
+					 * only works for index scans.
+					 */
 					break;
-				}
-
-				if (!OidIsValid(opno) || !op_strict(opno))
+				case T_NullTest:
+					/*
+					 * "foo IS NULL"
+					 *
+					 * Not pushed down currently.
+					 */
 					break;
-
-				Assert(expr != NULL);
-
-				if (IsA(expr, Const))
-				{
-					Const *c = castNode(Const, expr);
-					scanvalue = c->constvalue;
-					argfound = true;
-				}
-
-				bool is_segmentby =
-					hsinfo->columns[AttrNumberGetAttrOffset(relvar->varattno)].is_segmentby;
-				if (argfound && is_segmentby)
-				{
-					TypeCacheEntry *tce =
-						lookup_type_cache(relvar->vartype, TYPECACHE_BTREE_OPFAMILY);
-					int op_strategy = get_op_opfamily_strategy(opno, tce->btree_opf);
-
-					if (op_strategy != InvalidStrategy)
-					{
-						Oid op_lefttype;
-						Oid op_righttype;
-
-						scankey_found = true;
-						get_op_opfamily_properties(opno,
-												   tce->btree_opf,
-												   false,
-												   &op_strategy,
-												   &op_lefttype,
-												   &op_righttype);
-
-						Assert(relvar != NULL);
-
-						if (scankeys != NULL)
-						{
-							ScanKeyEntryInitialize(&scankeys[nkeys++],
-												   0 /* flags */,
-												   relvar->varattno, /* attribute number to scan */
-												   op_strategy,		 /* op's strategy */
-												   op_righttype,	 /* strategy subtype */
-												   opexpr->inputcollid, /* collation */
-												   opexpr->opfuncid,	/* reg proc to use */
-												   scanvalue);			/* constant */
-						}
-						else
-						{
-							scankey_quals = lappend(scankey_quals, qual);
-						}
-					}
-				}
-				break;
+				default:
+					break;
 			}
-			default:
-				break;
 		}
 
-		if (!scankey_found && remaining_quals != NULL)
-			*remaining_quals = lappend(*remaining_quals, qual);
+		if (keep_qual)
+			remaining_quals = lappend(remaining_quals, qual);
 	}
 
-	return scankey_quals;
+	return remaining_quals;
 }
 
-static List *
-extract_scankey_quals(const HypercoreInfo *hsinfo, Index relid, const List *quals,
-					  List **remaining_quals)
+/*
+ * Classify quals into the following:
+ *
+ * 1. Scankey quals: quals that can be pushed down to the TAM as
+ *    scankeys. This includes most quals on segmentby columns, and orderby
+ *    columns that have min/max metadata.
+ *
+ * 2. Vectorized quals: quals that can be executed as vectorized filters.
+ *
+ * 3. Non-vectorized quals: regular quals that should be executed in the
+ *    columnar scan node.
+ *
+ * Note that category (3) might include quals from category (1) (scankeys)
+ * because some scankeys that apply to compressed columns that have min/max
+ * metadata might not exclude all data, so the regular quals need to be
+ * applied after.
+ */
+static void
+classify_quals(QualProcessState *qpi, const VectorQualInfo *vqinfo, List *quals)
 {
-	return process_scan_key_quals(hsinfo, relid, quals, remaining_quals, NULL, 0);
+	ListCell *lc;
+	List *nonscankey_quals = quals;
+
+	Assert(qpi->hcinfo && qpi->relid > 0);
+
+	if (ts_guc_enable_hypercore_scankey_pushdown)
+		nonscankey_quals = process_scan_key_quals(qpi, quals);
+
+	foreach (lc, nonscankey_quals)
+	{
+		Node *source_qual = lfirst(lc);
+		Node *vectorized_qual = vector_qual_make(source_qual, vqinfo);
+
+		if (vectorized_qual)
+		{
+			TS_DEBUG_LOG("qual identified as vectorizable: %s", nodeToString(vectorized_qual));
+			qpi->vectorized_quals = lappend(qpi->vectorized_quals, vectorized_qual);
+		}
+		else
+		{
+			TS_DEBUG_LOG("qual identified as non-vectorized qual: %s", nodeToString(source_qual));
+			qpi->nonvectorized_quals = lappend(qpi->nonvectorized_quals, source_qual);
+		}
+	}
 }
 
 static ScanKey
-create_scankeys_from_quals(const HypercoreInfo *hsinfo, Index relid, const List *quals)
+create_scankeys_from_quals(const HypercoreInfo *hcinfo, Index relid, const List *quals)
 {
 	unsigned capacity = list_length(quals);
-	ScanKey scankeys = palloc0(sizeof(ScanKeyData) * capacity);
-	process_scan_key_quals(hsinfo, relid, quals, NULL, scankeys, capacity);
-	return scankeys;
+	QualProcessState qpi = {
+		.hcinfo = hcinfo,
+		.relid = relid,
+		.scankeys = palloc0(sizeof(ScanKeyData) * capacity),
+		.scankeys_capacity = capacity,
+	};
+
+	process_scan_key_quals(&qpi, quals);
+
+	return qpi.scankeys;
 }
 
 static pg_attribute_always_inline TupleTableSlot *
@@ -746,6 +855,7 @@ columnar_scan_state_create(CustomScan *cscan)
 #if PG16_GE
 	cstate->css.slotOps = &TTSOpsArrowTuple;
 #endif
+	cstate->quals_orig = list_concat_copy(cstate->vectorized_quals_orig, cscan->scan.plan.qual);
 
 	return (Node *) cstate;
 }
@@ -764,7 +874,7 @@ is_columnar_scan(const CustomScan *scan)
 typedef struct VectorQualInfoHypercore
 {
 	VectorQualInfo vqinfo;
-	const HypercoreInfo *hsinfo;
+	const HypercoreInfo *hcinfo;
 } VectorQualInfoHypercore;
 
 static bool *
@@ -793,19 +903,17 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_p
 	CustomScan *columnar_scan_plan = makeNode(CustomScan);
 	RangeTblEntry *rte = planner_rt_fetch(rel->relid, root);
 	Relation relation = RelationIdGetRelation(rte->relid);
-	HypercoreInfo *hsinfo = RelationGetHypercoreInfo(relation);
-	List *vectorized_quals = NIL;
-	List *nonvectorized_quals = NIL;
-	List *scankey_quals = NIL;
-	List *remaining_quals = NIL;
-	ListCell *lc;
-
+	HypercoreInfo *hcinfo = RelationGetHypercoreInfo(relation);
+	QualProcessState qpi = {
+		.hcinfo = hcinfo,
+		.relid = rel->relid,
+	};
 	VectorQualInfoHypercore vqih = {
 		.vqinfo = {
 			.rti = rel->relid,
-			.vector_attrs = columnar_scan_build_vector_attrs(hsinfo->columns, hsinfo->num_columns),
+			.vector_attrs = columnar_scan_build_vector_attrs(hcinfo->columns, hcinfo->num_columns),
 		},
-		.hsinfo = hsinfo,
+		.hcinfo = hcinfo,
 	};
 	Assert(best_path->path.parent->rtekind == RTE_RELATION);
 
@@ -816,38 +924,11 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_p
 	/* output target list */
 	columnar_scan_plan->scan.plan.targetlist = tlist;
 
-	/* Reduce RestrictInfo list to bare expressions; ignore pseudoconstants */
 	scan_clauses = extract_actual_clauses(scan_clauses, false);
+	classify_quals(&qpi, &vqih.vqinfo, scan_clauses);
 
-	foreach (lc, scan_clauses)
-	{
-		Node *source_qual = lfirst(lc);
-		Node *vectorized_qual = vector_qual_make(source_qual, &vqih.vqinfo);
-
-		if (vectorized_qual)
-		{
-			TS_DEBUG_LOG("qual identified as vectorizable: %s", nodeToString(vectorized_qual));
-			vectorized_quals = lappend(vectorized_quals, vectorized_qual);
-		}
-		else
-		{
-			TS_DEBUG_LOG("qual identified as non-vectorized qual: %s", nodeToString(source_qual));
-			nonvectorized_quals = lappend(nonvectorized_quals, source_qual);
-		}
-	}
-
-	/* Need to split the nonvectorized quals into scankey quals and remaining
-	 * quals before ExecInitQual() in CustomScanState::begin() since the qual
-	 * execution state is created from the remaining quals. Note that it is
-	 * not possible to create the scankeys themselves here because the only
-	 * way to pass those on to the scan state is via custom_private. And
-	 * anything that goes into custom_private needs to be a Node that is
-	 * printable with nodeToString(). */
-	scankey_quals =
-		extract_scankey_quals(vqih.hsinfo, rel->relid, nonvectorized_quals, &remaining_quals);
-
-	columnar_scan_plan->scan.plan.qual = remaining_quals;
-	columnar_scan_plan->custom_exprs = list_make2(vectorized_quals, scankey_quals);
+	columnar_scan_plan->scan.plan.qual = qpi.nonvectorized_quals;
+	columnar_scan_plan->custom_exprs = list_make2(qpi.vectorized_quals, qpi.scankey_quals);
 
 	RelationClose(relation);
 

--- a/tsl/test/expected/hypercore_dump_restore.out
+++ b/tsl/test/expected/hypercore_dump_restore.out
@@ -176,10 +176,12 @@ select * from hyperdump where time < '2022-06-03';
 ------------------------------------------------------------------------------------------------
  Append
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Scankey: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
          Vectorized Filter: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
    ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Scankey: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
          Vectorized Filter: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
-(5 rows)
+(7 rows)
 
 reindex table hyperdump;
 explain (costs off)
@@ -188,10 +190,12 @@ select * from hyperdump where time < '2022-06-03';
 ------------------------------------------------------------------------------------------------
  Append
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Scankey: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
          Vectorized Filter: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
    ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Scankey: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
          Vectorized Filter: ("time" < 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone)
-(5 rows)
+(7 rows)
 
 select format('\! diff -u --label "hypercore original" --label "hypercore restored" %s %s', :'TEST_RESULTS_ORIGINAL', :'TEST_RESULTS_RESTORED') as "DIFF_CMD" \gset
 -- Original output and restored output should be the same, i.e., no

--- a/tsl/test/expected/hypercore_scans.out
+++ b/tsl/test/expected/hypercore_scans.out
@@ -602,3 +602,414 @@ select compress_chunk(ch, hypercore_use_access_method=>true) from show_chunks('r
 -- table.
 create temp table test_bump as
 select * from readings order by time, device;
+----------------------------------------------------------------------
+--
+-- Test scankey push-downs on orderby column. Vectorized filters (or
+-- normal qual filters) should remain on all orderby columns, but not
+-- segmentby columns.
+--
+----------------------------------------------------------------------
+--
+-- Test BETWEEN on time and equality on segmentby
+--
+explain (costs off)
+select * from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+   Scankey: (("time" >= 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone) AND ("time" <= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device = 1))
+   Vectorized Filter: (("time" >= 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone) AND ("time" <= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone))
+(3 rows)
+
+select sum(humidity) from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+       sum        
+------------------
+ 1979.06637167468
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select * from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+   Filter: (device = 1)
+   Vectorized Filter: (("time" >= 'Fri Jun 03 00:00:00 2022 PDT'::timestamp with time zone) AND ("time" <= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone))
+(3 rows)
+
+select sum(humidity) from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+       sum        
+------------------
+ 1979.06637167468
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+--
+-- Test < (LT) on time and > (GT) on segmentby
+--
+explain (costs off)
+select * from readings
+where time < '2022-06-05' and device > 5;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Scankey: (("time" < 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" < 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Scankey: (("time" < 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" < 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+(7 rows)
+
+select sum(humidity) from readings
+where time < '2022-06-05' and device > 5;
+       sum        
+------------------
+ 97096.6439132039
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select * from readings
+where time < '2022-06-05' and device > 5;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" < 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" < 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+(7 rows)
+
+select sum(humidity) from readings
+where time < '2022-06-05' and device > 5;
+       sum        
+------------------
+ 97096.6439132039
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+--
+-- Test >= (GE) on time
+--
+explain (costs off)
+select * from readings
+where time >= '2022-06-05' and device > 5;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Scankey: (("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+         Scankey: (("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_4_chunk
+         Scankey: (("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_5_chunk
+         Scankey: (("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_6_chunk
+         Scankey: (("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone) AND (device > 5))
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+(16 rows)
+
+select sum(humidity) from readings
+where time >= '2022-06-05' and device > 5;
+       sum       
+-----------------
+ 619887.78450012
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select * from readings
+where time >= '2022-06-05' and device > 5;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_4_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_5_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_6_chunk
+         Filter: (device > 5)
+         Vectorized Filter: ("time" >= 'Sun Jun 05 00:00:00 2022 PDT'::timestamp with time zone)
+(16 rows)
+
+select sum(humidity) from readings
+where time >= '2022-06-05' and device > 5;
+       sum       
+-----------------
+ 619887.78450012
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+--
+-- Test = (equality) on time
+--
+explain (costs off)
+select * from readings
+where time = '2022-06-01' and 5 < device;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Scankey: ((5 < device) AND ("time" = 'Wed Jun 01 00:00:00 2022 PDT'::timestamp with time zone))
+   Vectorized Filter: ("time" = 'Wed Jun 01 00:00:00 2022 PDT'::timestamp with time zone)
+(3 rows)
+
+select sum(humidity) from readings
+where time = '2022-06-01' and 5 < device;
+ sum 
+-----
+    
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select * from readings
+where time = '2022-06-01' and 5 < device;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (5 < device)
+   Vectorized Filter: ("time" = 'Wed Jun 01 00:00:00 2022 PDT'::timestamp with time zone)
+(3 rows)
+
+select sum(humidity) from readings
+where time = '2022-06-01' and 4 < device;
+       sum        
+------------------
+ 115.397092269175
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+--
+-- Test "foo IN (1, 2)" (ScalarArrayOpExpr)
+--
+-- This is currently not transformed to scan keys because only index
+-- scans support such keys.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and device in (1, 4);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: (device = ANY ('{1,4}'::integer[]))
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: (device = ANY ('{1,4}'::integer[]))
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(9 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device in (1, 4);
+       sum        
+------------------
+ 2113.95150227923
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and device in (1, 4);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: (device = ANY ('{1,4}'::integer[]))
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: (device = ANY ('{1,4}'::integer[]))
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(7 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device in (1, 4);
+       sum        
+------------------
+ 2113.95150227923
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+-- ScalarArrayOpExpr "foo IN (1, 2)" are pushed down to compressed
+-- chunk with transparent decompression. As noted above, with TAM,
+-- such expressions are not pushed down as scan keys because only
+-- index scans support such keys.
+set timescaledb.enable_transparent_decompression='hypercore';
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and device in (1, 4);
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         ->  Seq Scan on compress_hyper_2_7_chunk
+               Filter: ((_ts_meta_min_1 <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (device = ANY ('{1,4}'::integer[])))
+   ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         ->  Seq Scan on compress_hyper_2_8_chunk
+               Filter: ((_ts_meta_min_1 <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (device = ANY ('{1,4}'::integer[])))
+(9 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device in (1, 4);
+       sum        
+------------------
+ 2113.95150227923
+(1 row)
+
+set timescaledb.enable_transparent_decompression=true;
+--
+-- Test filter that doesn't reference a column.
+--
+select setseed(0.1);
+ setseed 
+---------
+ 
+(1 row)
+
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and ceil(random()*6)::int = 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on readings
+   Chunks excluded during startup: 0
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: ((ceil((random() * '6'::double precision)))::integer = 2)
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: ((ceil((random() * '6'::double precision)))::integer = 2)
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(10 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and ceil(random()*6)::int = 2;
+       sum        
+------------------
+ 4617.95296817946
+(1 row)
+
+--
+-- Test filter that doesn't have a Const on left or right side.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and location::int = device;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: ((location)::integer = device)
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: ((location)::integer = device)
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(9 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and location::int = device;
+       sum       
+-----------------
+ 1587.5766975512
+(1 row)
+
+--
+-- Test filter that does coercing (CoerceViaIO) type. Not pushed down
+-- as scankey.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and '1' = device::text;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: ('1'::text = (device)::text)
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Filter: ('1'::text = (device)::text)
+         Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(9 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and '1' = device::text;
+       sum        
+------------------
+ 1381.63850675326
+(1 row)
+
+--
+-- Test filter that does relabeling (RelabelType) for binary
+-- compatible types, both left and right side of expression.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and '1'::oid = device;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Scankey: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND ('1'::oid = (device)::oid))
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+         Scankey: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND ('1'::oid = (device)::oid))
+         Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(7 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and '1'::oid = device;
+       sum        
+------------------
+ 1381.63850675326
+(1 row)
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device = '1'::oid;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Scankey: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND ((device)::oid = '1'::oid))
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Scankey: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND ((device)::oid = '1'::oid))
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(8 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device = '1'::oid;
+       sum        
+------------------
+ 1381.63850675326
+(1 row)
+

--- a/tsl/test/sql/hypercore_scans.sql
+++ b/tsl/test/sql/hypercore_scans.sql
@@ -208,3 +208,186 @@ select compress_chunk(ch, hypercore_use_access_method=>true) from show_chunks('r
 -- table.
 create temp table test_bump as
 select * from readings order by time, device;
+
+----------------------------------------------------------------------
+--
+-- Test scankey push-downs on orderby column. Vectorized filters (or
+-- normal qual filters) should remain on all orderby columns, but not
+-- segmentby columns.
+--
+----------------------------------------------------------------------
+
+
+--
+-- Test BETWEEN on time and equality on segmentby
+--
+explain (costs off)
+select * from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+
+select sum(humidity) from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select * from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+
+select sum(humidity) from readings
+where time between '2022-06-03' and '2022-06-05' and device = 1;
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+--
+-- Test < (LT) on time and > (GT) on segmentby
+--
+explain (costs off)
+select * from readings
+where time < '2022-06-05' and device > 5;
+
+select sum(humidity) from readings
+where time < '2022-06-05' and device > 5;
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select * from readings
+where time < '2022-06-05' and device > 5;
+
+select sum(humidity) from readings
+where time < '2022-06-05' and device > 5;
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+--
+-- Test >= (GE) on time
+--
+explain (costs off)
+select * from readings
+where time >= '2022-06-05' and device > 5;
+
+select sum(humidity) from readings
+where time >= '2022-06-05' and device > 5;
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select * from readings
+where time >= '2022-06-05' and device > 5;
+
+select sum(humidity) from readings
+where time >= '2022-06-05' and device > 5;
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+--
+-- Test = (equality) on time
+--
+explain (costs off)
+select * from readings
+where time = '2022-06-01' and 5 < device;
+
+select sum(humidity) from readings
+where time = '2022-06-01' and 5 < device;
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select * from readings
+where time = '2022-06-01' and 5 < device;
+
+select sum(humidity) from readings
+where time = '2022-06-01' and 4 < device;
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+--
+-- Test "foo IN (1, 2)" (ScalarArrayOpExpr)
+--
+-- This is currently not transformed to scan keys because only index
+-- scans support such keys.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and device in (1, 4);
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device in (1, 4);
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and device in (1, 4);
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device in (1, 4);
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+-- ScalarArrayOpExpr "foo IN (1, 2)" are pushed down to compressed
+-- chunk with transparent decompression. As noted above, with TAM,
+-- such expressions are not pushed down as scan keys because only
+-- index scans support such keys.
+set timescaledb.enable_transparent_decompression='hypercore';
+
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and device in (1, 4);
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device in (1, 4);
+
+set timescaledb.enable_transparent_decompression=true;
+
+--
+-- Test filter that doesn't reference a column.
+--
+select setseed(0.1);
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and ceil(random()*6)::int = 2;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and ceil(random()*6)::int = 2;
+
+
+--
+-- Test filter that doesn't have a Const on left or right side.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and location::int = device;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and location::int = device;
+
+--
+-- Test filter that does coercing (CoerceViaIO) type. Not pushed down
+-- as scankey.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and '1' = device::text;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and '1' = device::text;
+
+--
+-- Test filter that does relabeling (RelabelType) for binary
+-- compatible types, both left and right side of expression.
+--
+explain (costs off)
+select * from readings
+where time <= '2022-06-02' and '1'::oid = device;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and '1'::oid = device;
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device = '1'::oid;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device = '1'::oid;


### PR DESCRIPTION
Quals on orderby columns can be pushed down to Hypercore TAM and be transformed to the corresponding min/max scankeys on the compressed relation. Previously, only quals on non-compressed segmentby columns were pushed down as scankeys.

Pushing down orderby scan keys seem to give a good performance boost for columnar scans when no index exists.

The scankey push down can be disabled with a new GUC:

`timescaledb.enable_hypercore_scankey_pushdown=false`

Closes: #7652

Disable-check: approval-count