### PR TITLE
Disambiguate the merge_append_partially_compressed test

### DIFF
--- a/tsl/test/expected/merge_append_partially_compressed-14.out
+++ b/tsl/test/expected/merge_append_partially_compressed-14.out
@@ -4,7 +4,8 @@
 -- this test checks the validity of the produced plans for partially compressed chunks
 -- when injecting query_pathkeys on top of the append
 -- path that combines the uncompressed and compressed parts of a chunk.
-set enable_parallel_append to off; -- for less flaky plans
+-- We're testing the MergeAppend here which is not compatible with parallel plans.
+set max_parallel_workers_per_gather = 0;
 set timescaledb.enable_decompression_sorted_merge = off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float);
@@ -33,6 +34,7 @@ INSERT INTO ht_metrics_compressed
 SELECT time, device, device * 0.1
 FROM generate_series('2020-01-02'::timestamptz,'2020-01-18'::timestamptz,'9 hour') time,
 generate_series(1,3) device;
+VACUUM ANALYZE ht_metrics_compressed;
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time DESC, device LIMIT 1;
@@ -275,8 +277,8 @@ generate_series(1,3) device;
 
 -- index scan, no sort on top
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1; -- index scan, no resorting required
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -284,8 +286,12 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -296,8 +302,10 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_2_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -306,13 +314,15 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
              time             | device | value 
@@ -321,15 +331,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1; -- this uses the index and does not do sort on top
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -338,8 +352,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 36
          ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -348,15 +366,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
-(33 rows)
+(45 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1;
              time             | device | value 
@@ -365,8 +387,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1; -- this also uses the index and does not do sort on top
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time"
@@ -374,8 +396,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
                      Sort Method: top-N heapsort 
@@ -386,8 +412,10 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_2_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time"
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -396,13 +424,15 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1;
              time             | device | value 
@@ -447,8 +477,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
@@ -457,8 +487,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -469,8 +499,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -481,8 +511,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -490,58 +520,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
--- Test direct ordered select from a single partially compressed chunk
-select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
-:PREFIX
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
-               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
-(5 rows)
-
-:PREFIX
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
-(5 rows)
-
+-- -- Test direct ordered select from a single partially compressed chunk
+-- -- Note that this currently doesn't work: https://github.com/timescale/timescaledb/issues/7084
+-- select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -731,7 +722,6 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC LI
                      ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (14 rows)
 
-set max_parallel_workers_per_gather = 0; -- parallel plan different on Windows
 set enable_hashagg to off; -- different on PG13
 :PREFIX
 SELECT x1, x2, max(time) FROM (SELECT * FROM test1 ORDER BY time, x1, x2 LIMIT 10) t
@@ -757,7 +747,6 @@ GROUP BY x1, x2, time ORDER BY time limit 10;
                                  ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (17 rows)
 
-reset max_parallel_workers_per_gather;
 reset enable_hashagg;
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;
@@ -967,10 +956,10 @@ INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
@@ -979,8 +968,8 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
 (2 rows)
 
 -- make them partially compressed
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test2;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1014,15 +1003,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1055,15 +1044,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1097,15 +1086,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
@@ -1138,15 +1127,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
@@ -1179,15 +1168,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -----------------------------
@@ -1216,10 +1205,10 @@ INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
@@ -1230,8 +1219,8 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
 (4 rows)
 
 -- make them partially compressed
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test3;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1275,15 +1264,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1326,15 +1315,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1378,15 +1367,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
@@ -1429,15 +1418,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
@@ -1480,14 +1469,17 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
+reset enable_indexscan;
+reset timescaledb.enable_decompression_sorted_merge;
+reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-14.out
+++ b/tsl/test/expected/merge_append_partially_compressed-14.out
@@ -182,8 +182,8 @@ generate_series(1,3) device;
 (32 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -194,8 +194,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -207,8 +207,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -219,8 +219,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -228,8 +228,8 @@ generate_series(1,3) device;
 (41 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time, device DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time", ht_metrics_compressed.device DESC
@@ -240,8 +240,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
                      Sort Method: top-N heapsort 
@@ -253,8 +253,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -265,8 +265,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
@@ -489,6 +489,58 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
+
+-- Test direct ordered select from a single partially compressed chunk
+select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+:PREFIX
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
+(5 rows)
+
+:PREFIX
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=2 loops=1)
+               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+(5 rows)
 
 CREATE TABLE test1 (
 time timestamptz NOT NULL,

--- a/tsl/test/expected/merge_append_partially_compressed-15.out
+++ b/tsl/test/expected/merge_append_partially_compressed-15.out
@@ -76,39 +76,25 @@ generate_series(1,3) device;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
-         ->  Sort (actual rows=1 loops=1)
+   ->  Gather Merge (actual rows=1 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
-               ->  Result (actual rows=81 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=84 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=84 loops=1)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
-(33 rows)
+               Worker 0:  Sort Method: quicksort 
+               ->  Result (actual rows=162 loops=2)
+                     ->  Append (actual rows=162 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=40 loops=2)
+                                 ->  Parallel Seq Scan on compress_hyper_2_4_chunk (actual rows=2 loops=2)
+                           ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=27 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=42 loops=2)
+                                 ->  Parallel Seq Scan on compress_hyper_2_5_chunk (actual rows=2 loops=2)
+                           ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=28 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=15 loops=2)
+                                 ->  Parallel Seq Scan on compress_hyper_2_6_chunk (actual rows=2 loops=2)
+                           ->  Parallel Seq Scan on _hyper_1_3_chunk (actual rows=9 loops=2)
+(19 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time desc limit 10;
                                              QUERY PLAN                                             
@@ -188,8 +174,8 @@ generate_series(1,3) device;
 (35 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -200,8 +186,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -213,8 +199,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -225,8 +211,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -234,8 +220,8 @@ generate_series(1,3) device;
 (41 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time, device DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time", ht_metrics_compressed.device DESC
@@ -246,8 +232,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
                      Sort Method: top-N heapsort 
@@ -259,8 +245,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -271,8 +257,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
@@ -496,6 +482,58 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
+-- Test direct ordered select from a single partially compressed chunk
+select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+:PREFIX
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
+(5 rows)
+
+:PREFIX
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=2 loops=1)
+               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+(5 rows)
+
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -525,165 +563,117 @@ ANALYZE test1;
 -- requires resorting, no pushdown can happen
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC LIMIT 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time" DESC
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time" DESC
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time" DESC
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 -- requires resorting
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST LIMIT 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time" DESC, test1.x3
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 -- all these require resorting, no pushdown can happen
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NULLS LAST LIMIT 10;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time" DESC, test1.x3, test1.x4
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 DESC NULLS FIRST LIMIT 10;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time" DESC, test1.x3, test1.x4 DESC
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST LIMIT 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time"
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time"
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST LIMIT 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time", test1.x3 DESC
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC NULLS FIRST LIMIT 10;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time", test1.x3 DESC, test1.x4 DESC
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC LIMIT 10;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-         Order: test1."time" NULLS FIRST, test1.x3 DESC NULLS LAST, test1.x4
-         ->  Merge Append (actual rows=5 loops=1)
-               Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
-               ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(14 rows)
+   ->  Sort (actual rows=5 loops=1)
+         Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(8 rows)
 
 set max_parallel_workers_per_gather = 0; -- parallel plan different on Windows
 set enable_hashagg to off; -- different on PG13
@@ -716,93 +706,73 @@ reset max_parallel_workers_per_gather;
 reset enable_hashagg;
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
+   ->  Sort (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk.x4, _hyper_3_7_chunk."time"
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk.x4, _hyper_3_7_chunk."time"
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk.x4, _hyper_3_7_chunk."time"
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(12 rows)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x4 LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
+   ->  Sort (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(12 rows)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3 LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
+   ->  Sort (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(12 rows)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3, x4 LIMIT 10;
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
+   ->  Sort (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(12 rows)
+(8 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x4 DESC LIMIT 10; -- no pushdown because orderby does not match
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
+   ->  Sort (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4 DESC
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4 DESC
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=5 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4 DESC
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(12 rows)
+(8 rows)
 
 -- queries with pushdown
 :PREFIX
@@ -922,10 +892,10 @@ INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
@@ -934,8 +904,8 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
 (2 rows)
 
 -- make them partially compressed
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test2;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -969,15 +939,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1010,15 +980,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1026,123 +996,93 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Append (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=10 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
-(21 rows)
+(11 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Append (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=10 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
-(21 rows)
+(11 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Append (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=10 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=4 loops=1)
-               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
-(21 rows)
+(11 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -----------------------------
@@ -1171,10 +1111,10 @@ INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
@@ -1185,8 +1125,8 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
 (4 rows)
 
 -- make them partially compressed
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test3;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1230,15 +1170,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1281,15 +1221,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1297,152 +1237,104 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Append (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=10 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x3
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x3
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
-(31 rows)
+(15 rows)
 
 SELECT * FROM test3 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Append (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=10 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk.x4
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk.x4
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
-(31 rows)
+(15 rows)
 
 SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Append (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
-               Sort Method: quicksort 
+         Sort Method: quicksort 
+         ->  Append (actual rows=10 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk."time"
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk."time"
-               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
-(31 rows)
+(15 rows)
 
 SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 

--- a/tsl/test/expected/merge_append_partially_compressed-15.out
+++ b/tsl/test/expected/merge_append_partially_compressed-15.out
@@ -4,7 +4,8 @@
 -- this test checks the validity of the produced plans for partially compressed chunks
 -- when injecting query_pathkeys on top of the append
 -- path that combines the uncompressed and compressed parts of a chunk.
-set enable_parallel_append to off; -- for less flaky plans
+-- We're testing the MergeAppend here which is not compatible with parallel plans.
+set max_parallel_workers_per_gather = 0;
 set timescaledb.enable_decompression_sorted_merge = off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float);
@@ -33,6 +34,7 @@ INSERT INTO ht_metrics_compressed
 SELECT time, device, device * 0.1
 FROM generate_series('2020-01-02'::timestamptz,'2020-01-18'::timestamptz,'9 hour') time,
 generate_series(1,3) device;
+VACUUM ANALYZE ht_metrics_compressed;
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time DESC, device LIMIT 1;
@@ -76,25 +78,39 @@ generate_series(1,3) device;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Gather Merge (actual rows=1 loops=1)
-         Workers Planned: 1
-         Workers Launched: 1
-         ->  Sort (actual rows=0 loops=2)
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
+         ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
-               Worker 0:  Sort Method: quicksort 
-               ->  Result (actual rows=162 loops=2)
-                     ->  Append (actual rows=162 loops=2)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=40 loops=2)
-                                 ->  Parallel Seq Scan on compress_hyper_2_4_chunk (actual rows=2 loops=2)
-                           ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=27 loops=2)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=42 loops=2)
-                                 ->  Parallel Seq Scan on compress_hyper_2_5_chunk (actual rows=2 loops=2)
-                           ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=28 loops=2)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=15 loops=2)
-                                 ->  Parallel Seq Scan on compress_hyper_2_6_chunk (actual rows=2 loops=2)
-                           ->  Parallel Seq Scan on _hyper_1_3_chunk (actual rows=9 loops=2)
-(19 rows)
+               ->  Result (actual rows=81 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Result (actual rows=84 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=84 loops=1)
+                           ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Result (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+(33 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time desc limit 10;
                                              QUERY PLAN                                             
@@ -267,8 +283,8 @@ generate_series(1,3) device;
 
 -- index scan, no sort on top
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1; -- index scan, no resorting required
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -276,8 +292,12 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -288,8 +308,10 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_2_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -298,13 +320,15 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
              time             | device | value 
@@ -313,15 +337,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1; -- this uses the index and does not do sort on top
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -330,8 +358,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 36
          ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -340,15 +372,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
-(33 rows)
+(45 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1;
              time             | device | value 
@@ -357,8 +393,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1; -- this also uses the index and does not do sort on top
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time"
@@ -366,8 +402,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
                      Sort Method: top-N heapsort 
@@ -378,8 +418,10 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_2_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time"
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -388,13 +430,15 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1;
              time             | device | value 
@@ -439,8 +483,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
@@ -449,8 +493,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -461,8 +505,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -473,8 +517,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -482,58 +526,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
--- Test direct ordered select from a single partially compressed chunk
-select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
-:PREFIX
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
-               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
-(5 rows)
-
-:PREFIX
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
-(5 rows)
-
+-- -- Test direct ordered select from a single partially compressed chunk
+-- -- Note that this currently doesn't work: https://github.com/timescale/timescaledb/issues/7084
+-- select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -563,119 +568,166 @@ ANALYZE test1;
 -- requires resorting, no pushdown can happen
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC LIMIT 10;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time" DESC
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time" DESC
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time" DESC
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 -- requires resorting
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST LIMIT 10;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time" DESC, test1.x3
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 -- all these require resorting, no pushdown can happen
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NULLS LAST LIMIT 10;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time" DESC, test1.x3, test1.x4
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 DESC NULLS FIRST LIMIT 10;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time" DESC, test1.x3, test1.x4 DESC
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" DESC, _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST LIMIT 10;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time"
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time"
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time"
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time"
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST LIMIT 10;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time", test1.x3 DESC
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC NULLS FIRST LIMIT 10;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time", test1.x3 DESC, test1.x4 DESC
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3 DESC, _hyper_3_7_chunk.x4 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC LIMIT 10;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                     ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+   ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+         Order: test1."time" NULLS FIRST, test1.x3 DESC NULLS LAST, test1.x4
+         ->  Merge Append (actual rows=5 loops=1)
+               Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time" NULLS FIRST, _hyper_3_7_chunk.x3 DESC NULLS LAST, _hyper_3_7_chunk.x4
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(14 rows)
 
-set max_parallel_workers_per_gather = 0; -- parallel plan different on Windows
 set enable_hashagg to off; -- different on PG13
 :PREFIX
 SELECT x1, x2, max(time) FROM (SELECT * FROM test1 ORDER BY time, x1, x2 LIMIT 10) t
@@ -702,77 +754,96 @@ GROUP BY x1, x2, time ORDER BY time limit 10;
                                        ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (18 rows)
 
-reset max_parallel_workers_per_gather;
 reset enable_hashagg;
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk.x4, _hyper_3_7_chunk."time"
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk.x4, _hyper_3_7_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk.x4, _hyper_3_7_chunk."time"
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+(12 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x4 LIMIT 10;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+(12 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3 LIMIT 10;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+(12 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3, x4 LIMIT 10;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x3, _hyper_3_7_chunk.x4
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+(12 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x4 DESC LIMIT 10; -- no pushdown because orderby does not match
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
          Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4 DESC
-         Sort Method: quicksort 
-         ->  Append (actual rows=5 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4 DESC
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk.x5, _hyper_3_7_chunk."time", _hyper_3_7_chunk.x4 DESC
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(8 rows)
+(12 rows)
 
 -- queries with pushdown
 :PREFIX
@@ -996,17 +1067,27 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
-         Sort Method: quicksort 
-         ->  Append (actual rows=10 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
-(11 rows)
+(21 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -1024,20 +1105,30 @@ SELECT * FROM test2 ORDER BY x1, x2, x3 LIMIT 10;
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
-         Sort Method: quicksort 
-         ->  Append (actual rows=10 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
-(11 rows)
+(21 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -1055,20 +1146,30 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
-         Sort Method: quicksort 
-         ->  Append (actual rows=10 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=4 loops=1)
+               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
                      ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
-(11 rows)
+(21 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -1237,21 +1338,37 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
-         Sort Method: quicksort 
-         ->  Append (actual rows=10 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x3
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
-(15 rows)
+(31 rows)
 
 SELECT * FROM test3 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -1269,24 +1386,40 @@ SELECT * FROM test3 ORDER BY x1, x2, x3 LIMIT 10;
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
-         Sort Method: quicksort 
-         ->  Append (actual rows=10 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk.x4
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
-(15 rows)
+(31 rows)
 
 SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -1304,24 +1437,40 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
-         Sort Method: quicksort 
-         ->  Append (actual rows=10 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk."time"
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
-(15 rows)
+(31 rows)
 
 SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -1338,3 +1487,6 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
  Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
+reset enable_indexscan;
+reset timescaledb.enable_decompression_sorted_merge;
+reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-16.out
+++ b/tsl/test/expected/merge_append_partially_compressed-16.out
@@ -4,7 +4,8 @@
 -- this test checks the validity of the produced plans for partially compressed chunks
 -- when injecting query_pathkeys on top of the append
 -- path that combines the uncompressed and compressed parts of a chunk.
-set enable_parallel_append to off; -- for less flaky plans
+-- We're testing the MergeAppend here which is not compatible with parallel plans.
+set max_parallel_workers_per_gather = 0;
 set timescaledb.enable_decompression_sorted_merge = off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float);
@@ -33,6 +34,7 @@ INSERT INTO ht_metrics_compressed
 SELECT time, device, device * 0.1
 FROM generate_series('2020-01-02'::timestamptz,'2020-01-18'::timestamptz,'9 hour') time,
 generate_series(1,3) device;
+VACUUM ANALYZE ht_metrics_compressed;
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time DESC, device LIMIT 1;
@@ -281,8 +283,8 @@ generate_series(1,3) device;
 
 -- index scan, no sort on top
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1; -- index scan, no resorting required
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -290,8 +292,12 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -302,8 +308,10 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_2_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -312,13 +320,15 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
              time             | device | value 
@@ -327,15 +337,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1; -- this uses the index and does not do sort on top
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -344,8 +358,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 36
          ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -354,15 +372,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
-(33 rows)
+(45 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1;
              time             | device | value 
@@ -371,8 +393,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1; -- this also uses the index and does not do sort on top
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time"
@@ -380,8 +402,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
                      Sort Method: top-N heapsort 
@@ -392,8 +418,10 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_2_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time"
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -402,13 +430,15 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1;
              time             | device | value 
@@ -453,8 +483,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
@@ -463,8 +493,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -475,8 +505,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -487,8 +517,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -496,58 +526,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
--- Test direct ordered select from a single partially compressed chunk
-select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
-:PREFIX
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
-               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
-(5 rows)
-
-:PREFIX
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
-(5 rows)
-
+-- -- Test direct ordered select from a single partially compressed chunk
+-- -- Note that this currently doesn't work: https://github.com/timescale/timescaledb/issues/7084
+-- select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -737,7 +728,6 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC LI
                      ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (14 rows)
 
-set max_parallel_workers_per_gather = 0; -- parallel plan different on Windows
 set enable_hashagg to off; -- different on PG13
 :PREFIX
 SELECT x1, x2, max(time) FROM (SELECT * FROM test1 ORDER BY time, x1, x2 LIMIT 10) t
@@ -764,7 +754,6 @@ GROUP BY x1, x2, time ORDER BY time limit 10;
                                        ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (18 rows)
 
-reset max_parallel_workers_per_gather;
 reset enable_hashagg;
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;
@@ -974,10 +963,10 @@ INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
@@ -986,8 +975,8 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
 (2 rows)
 
 -- make them partially compressed
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test2;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1021,15 +1010,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1062,15 +1051,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1104,15 +1093,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
@@ -1145,15 +1134,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
@@ -1186,15 +1175,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -----------------------------
@@ -1223,10 +1212,10 @@ INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
@@ -1237,8 +1226,8 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
 (4 rows)
 
 -- make them partially compressed
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test3;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1282,15 +1271,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1333,15 +1322,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1385,15 +1374,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
@@ -1436,15 +1425,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
@@ -1487,14 +1476,17 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
+reset enable_indexscan;
+reset timescaledb.enable_decompression_sorted_merge;
+reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-16.out
+++ b/tsl/test/expected/merge_append_partially_compressed-16.out
@@ -188,8 +188,8 @@ generate_series(1,3) device;
 (35 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -200,8 +200,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -213,8 +213,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -225,8 +225,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -234,8 +234,8 @@ generate_series(1,3) device;
 (41 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time, device DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time", ht_metrics_compressed.device DESC
@@ -246,8 +246,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
                      Sort Method: top-N heapsort 
@@ -259,8 +259,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -271,8 +271,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
@@ -495,6 +495,58 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
+
+-- Test direct ordered select from a single partially compressed chunk
+select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+:PREFIX
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
+(5 rows)
+
+:PREFIX
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=2 loops=1)
+               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+(5 rows)
 
 CREATE TABLE test1 (
 time timestamptz NOT NULL,

--- a/tsl/test/expected/merge_append_partially_compressed-17.out
+++ b/tsl/test/expected/merge_append_partially_compressed-17.out
@@ -4,7 +4,8 @@
 -- this test checks the validity of the produced plans for partially compressed chunks
 -- when injecting query_pathkeys on top of the append
 -- path that combines the uncompressed and compressed parts of a chunk.
-set enable_parallel_append to off; -- for less flaky plans
+-- We're testing the MergeAppend here which is not compatible with parallel plans.
+set max_parallel_workers_per_gather = 0;
 set timescaledb.enable_decompression_sorted_merge = off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float);
@@ -33,6 +34,7 @@ INSERT INTO ht_metrics_compressed
 SELECT time, device, device * 0.1
 FROM generate_series('2020-01-02'::timestamptz,'2020-01-18'::timestamptz,'9 hour') time,
 generate_series(1,3) device;
+VACUUM ANALYZE ht_metrics_compressed;
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time DESC, device LIMIT 1;
@@ -281,8 +283,8 @@ generate_series(1,3) device;
 
 -- index scan, no sort on top
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1; -- index scan, no resorting required
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -290,8 +292,12 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -302,8 +308,10 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_2_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -312,13 +320,15 @@ generate_series(1,3) device;
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
              time             | device | value 
@@ -327,15 +337,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1; -- this uses the index and does not do sort on top
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -344,8 +358,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 36
          ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -354,15 +372,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                      Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Filter: (device = 3)
+                           Rows Removed by Filter: 2
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
-(33 rows)
+(45 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC LIMIT 1;
              time             | device | value 
@@ -371,8 +393,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
 (1 row)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1; -- this also uses the index and does not do sort on top
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time"
@@ -380,8 +402,12 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-                           Index Cond: (device = 3)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                                 Filter: (device = 3)
+                                 Rows Removed by Filter: 2
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
                      Sort Method: top-N heapsort 
@@ -392,8 +418,10 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_2_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time"
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -402,13 +430,15 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                           Index Cond: (device = 3)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
-(35 rows)
+(43 rows)
 
 SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC LIMIT 1;
              time             | device | value 
@@ -453,8 +483,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
@@ -463,8 +493,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -475,8 +505,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -487,8 +517,8 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                           Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
@@ -496,58 +526,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
--- Test direct ordered select from a single partially compressed chunk
-select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
-:PREFIX
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
-               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
- Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
-(5 rows)
-
-:PREFIX
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Merge Append (actual rows=5 loops=1)
-         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-(9 rows)
-
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-             time             | device | value 
-------------------------------+--------+-------
- Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
- Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
-(5 rows)
-
+-- -- Test direct ordered select from a single partially compressed chunk
+-- -- Note that this currently doesn't work: https://github.com/timescale/timescaledb/issues/7084
+-- select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -737,7 +728,6 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC LI
                      ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (14 rows)
 
-set max_parallel_workers_per_gather = 0; -- parallel plan different on Windows
 set enable_hashagg to off; -- different on PG13
 :PREFIX
 SELECT x1, x2, max(time) FROM (SELECT * FROM test1 ORDER BY time, x1, x2 LIMIT 10) t
@@ -764,7 +754,6 @@ GROUP BY x1, x2, time ORDER BY time limit 10;
                                        ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (18 rows)
 
-reset max_parallel_workers_per_gather;
 reset enable_hashagg;
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;
@@ -974,10 +963,10 @@ INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
@@ -986,8 +975,8 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
 (2 rows)
 
 -- make them partially compressed
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test2;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1021,15 +1010,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1062,15 +1051,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1104,15 +1093,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
@@ -1145,15 +1134,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
@@ -1186,15 +1175,15 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -----------------------------
@@ -1223,10 +1212,10 @@ INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
@@ -1237,8 +1226,8 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
 (4 rows)
 
 -- make them partially compressed
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 ANALYZE test3;
 set enable_indexscan = off;
 -- queries where sort is pushed down
@@ -1282,15 +1271,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
@@ -1333,15 +1322,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 -- queries where sort is not pushed down
@@ -1385,15 +1374,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x3 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
@@ -1436,15 +1425,15 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
@@ -1487,14 +1476,17 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 16:02:01 1999 PST |  1 |  2 |  9 |  9 |  0
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
- Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 16:02:01 2000 PST |  1 |  2 |  1 |  1 |  0
- Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  4 |  4 |  0
+ Sun Jan 09 16:00:00 2000 PST |  1 |  2 |  5 |  5 |  0
+ Sun Jan 09 16:02:01 2000 PST |  1 |  2 | 10 | 10 |  0
+ Sun Jan 09 19:00:00 2000 PST |  1 |  2 |  8 |  8 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  2 |  2 |  0
+ Sun Jan 09 17:00:00 2000 PST |  1 |  3 |  6 |  6 |  0
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  3 |  3 |  0
+ Sun Jan 09 18:00:00 2000 PST |  2 |  1 |  7 |  7 |  0
 (10 rows)
 
+reset enable_indexscan;
+reset timescaledb.enable_decompression_sorted_merge;
+reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-17.out
+++ b/tsl/test/expected/merge_append_partially_compressed-17.out
@@ -188,8 +188,8 @@ generate_series(1,3) device;
 (35 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
@@ -200,8 +200,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -213,8 +213,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -225,8 +225,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -234,8 +234,8 @@ generate_series(1,3) device;
 (41 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY time, device DESC LIMIT 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time", ht_metrics_compressed.device DESC
@@ -246,8 +246,8 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=3 loops=1)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
                      Sort Method: top-N heapsort 
@@ -259,8 +259,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -271,8 +271,8 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+                                 Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
@@ -495,6 +495,58 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
+
+-- Test direct ordered select from a single partially compressed chunk
+select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+:PREFIX
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time"
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 00:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 06:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 09:00:00 2020 PST |      1 |   0.1
+ Thu Jan 02 12:00:00 2020 PST |      1 |   0.1
+(5 rows)
+
+:PREFIX
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=4 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Sort (actual rows=2 loops=1)
+               Sort Key: _hyper_1_1_chunk.device DESC, _hyper_1_1_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
+(9 rows)
+
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 08 12:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 09:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 06:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+ Wed Jan 08 00:00:00 2020 PST |      3 |   0.3
+(5 rows)
 
 CREATE TABLE test1 (
 time timestamptz NOT NULL,

--- a/tsl/test/sql/merge_append_partially_compressed.sql.in
+++ b/tsl/test/sql/merge_append_partially_compressed.sql.in
@@ -6,8 +6,8 @@
 -- when injecting query_pathkeys on top of the append
 -- path that combines the uncompressed and compressed parts of a chunk.
 
-set enable_parallel_append to off; -- for less flaky plans
-
+-- We're testing the MergeAppend here which is not compatible with parallel plans.
+set max_parallel_workers_per_gather = 0;
 set timescaledb.enable_decompression_sorted_merge = off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 
@@ -26,6 +26,8 @@ INSERT INTO ht_metrics_compressed
 SELECT time, device, device * 0.1
 FROM generate_series('2020-01-02'::timestamptz,'2020-01-18'::timestamptz,'9 hour') time,
 generate_series(1,3) device;
+
+VACUUM ANALYZE ht_metrics_compressed;
 
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down
@@ -47,18 +49,19 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY device, time DESC LIMIT 1; -- with pushdown
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
 
--- Test direct ordered select from a single partially compressed chunk
-select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
-
-:PREFIX
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-
-SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
-
-:PREFIX
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
-
-SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+-- -- Test direct ordered select from a single partially compressed chunk
+-- -- Note that this currently doesn't work: https://github.com/timescale/timescaledb/issues/7084
+-- select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+--
+-- :PREFIX
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+--
+-- SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
 
 
 CREATE TABLE test1 (
@@ -114,14 +117,12 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC N
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC LIMIT 10;
 
-set max_parallel_workers_per_gather = 0; -- parallel plan different on Windows
 set enable_hashagg to off; -- different on PG13
 
 :PREFIX
 SELECT x1, x2, max(time) FROM (SELECT * FROM test1 ORDER BY time, x1, x2 LIMIT 10) t
 GROUP BY x1, x2, time ORDER BY time limit 10;
 
-reset max_parallel_workers_per_gather;
 reset enable_hashagg;
 
 :PREFIX
@@ -261,3 +262,8 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4 LIMIT 10;
 :PREFIX SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 
+reset enable_indexscan;
+
+
+reset timescaledb.enable_decompression_sorted_merge;
+reset max_parallel_workers_per_gather;

--- a/tsl/test/sql/merge_append_partially_compressed.sql.in
+++ b/tsl/test/sql/merge_append_partially_compressed.sql.in
@@ -47,6 +47,20 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY device, time DESC LIMIT 1; -- with pushdown
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
 
+-- Test direct ordered select from a single partially compressed chunk
+select * from show_chunks('ht_metrics_compressed') chunk order by chunk limit 1 \gset
+
+:PREFIX
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+
+SELECT * FROM :chunk ORDER BY device, time LIMIT 5;
+
+:PREFIX
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+
+SELECT * FROM :chunk ORDER BY device DESC, time DESC LIMIT 5;
+
+
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -172,15 +186,15 @@ INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 
 SELECT compress_chunk(i) FROM show_chunks('test2') i;
 -- make them partially compressed
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 
 ANALYZE test2;
 
@@ -220,15 +234,15 @@ INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 01:00:00-00', 1,
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2, 1, 3, 3, 0);
 INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 -- chunk 2
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 2, 2, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 3, 3, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 4, 4, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:00:00-00', 1, 2, 5, 5, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 01:00:00-00', 1, 3, 6, 6, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 02:00:00-00', 2, 1, 7, 7, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 03:00:00-00', 1, 2, 8, 8, 0);
 
 SELECT compress_chunk(i) FROM show_chunks('test3') i;
 -- make them partially compressed
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2, 1, 1, 0);
-INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 1, 1, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-01 00:02:01-00', 1, 2,  9,  9, 0);
+INSERT INTO test3 (time, x1, x2, x3, x4, x5) values('2000-01-10 00:02:01-00', 1, 2, 10, 10, 0);
 
 ANALYZE test3;
 


### PR DESCRIPTION
Make the column sets used for ordering unique, otherwise the resulting order depends on the plan.

Disable-check: force-changelog-file