### PR TITLE
Optimize quals on segmentby columns in ColumnarScan

### DIFF
--- a/tsl/src/hypercore/arrow_tts.h
+++ b/tsl/src/hypercore/arrow_tts.h
@@ -271,6 +271,16 @@ arrow_slot_is_consumed(const TupleTableSlot *slot)
 }
 
 static inline bool
+arrow_slot_is_first(const TupleTableSlot *slot)
+{
+	const ArrowTupleTableSlot *aslot = (const ArrowTupleTableSlot *) slot;
+
+	Assert(TTS_IS_ARROWTUPLE(slot));
+
+	return aslot->tuple_index == InvalidTupleIndex || aslot->tuple_index == 1;
+}
+
+static inline bool
 arrow_slot_is_last(const TupleTableSlot *slot)
 {
 	const ArrowTupleTableSlot *aslot = (const ArrowTupleTableSlot *) slot;

--- a/tsl/test/expected/hypercore_scans.out
+++ b/tsl/test/expected/hypercore_scans.out
@@ -1159,3 +1159,50 @@ where time <= '2022-06-02' and device = '1'::oid;
  1381.63850675326
 (1 row)
 
+--
+-- Test backwards scan with segmentby and vector quals
+--
+select count(*)-4 as myoffset from readings
+where time <= '2022-06-02' and device in (1, 2)
+\gset
+-- Get the last four values to compare with cursor fetch backward from
+-- the end
+select * from readings
+where time <= '2022-06-02' and device in (1, 2)
+offset :myoffset;
+             time             | location | device |       temp       |     humidity     
+------------------------------+----------+--------+------------------+------------------
+ Wed Jun 01 19:10:00 2022 PDT | 3        |      2 | 25.6339083021175 | 85.7531443688847
+ Wed Jun 01 20:30:00 2022 PDT | 2        |      2 | 6.02098537951642 | 56.3153986241908
+ Wed Jun 01 23:15:00 2022 PDT | 2        |      2 | 35.7529756426646 | 86.0243391529811
+ Wed Jun 01 23:40:00 2022 PDT | 3        |      2 | 3.94232546784524 |  55.454709690509
+(4 rows)
+
+begin;
+declare cur1 scroll cursor for
+select * from readings
+where time <= '2022-06-02' and device in (1, 2);
+move last cur1;
+-- move one step beyond last
+fetch forward 1 from cur1;
+ time | location | device | temp | humidity 
+------+----------+--------+------+----------
+(0 rows)
+
+-- fetch the last 4 values with two fetches
+fetch backward 2 from cur1;
+             time             | location | device |       temp       |     humidity     
+------------------------------+----------+--------+------------------+------------------
+ Wed Jun 01 23:40:00 2022 PDT | 3        |      2 | 3.94232546784524 |  55.454709690509
+ Wed Jun 01 23:15:00 2022 PDT | 2        |      2 | 35.7529756426646 | 86.0243391529811
+(2 rows)
+
+fetch backward 2 from cur1;
+             time             | location | device |       temp       |     humidity     
+------------------------------+----------+--------+------------------+------------------
+ Wed Jun 01 20:30:00 2022 PDT | 2        |      2 | 6.02098537951642 | 56.3153986241908
+ Wed Jun 01 19:10:00 2022 PDT | 3        |      2 | 25.6339083021175 | 85.7531443688847
+(2 rows)
+
+close cur1;
+commit;

--- a/tsl/test/expected/hypercore_scans.out
+++ b/tsl/test/expected/hypercore_scans.out
@@ -800,6 +800,152 @@ where time = '2022-06-01' and 4 < device;
 
 set timescaledb.enable_hypercore_scankey_pushdown=true;
 --
+-- Test non-btree operator on segmentby column and compare with btree
+-- operators.
+--
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (device <> 1)
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Filter: (device <> 1)
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(10 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+       sum        
+------------------
+ 29162.2138479675
+(1 row)
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device != 1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (device <> 1)
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Filter: (device <> 1)
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(10 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device != 1;
+       sum        
+------------------
+ 29162.2138479675
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (device <> 1)
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Filter: (device <> 1)
+               Vectorized Filter: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+(8 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+       sum        
+------------------
+ 29162.2138479675
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+--
+-- Test non-btree operator on non-segmentby column and compare with
+-- btree operators.
+--
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (temp <> '1'::double precision))
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (temp <> '1'::double precision))
+(8 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+       sum        
+------------------
+ 30543.8523547207
+(1 row)
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp != 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (temp <> '1'::double precision))
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Scankey: ("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone)
+               Vectorized Filter: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (temp <> '1'::double precision))
+(8 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp != 1;
+       sum        
+------------------
+ 30543.8523547207
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Vectorized Filter: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (temp <> '1'::double precision))
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk
+               Vectorized Filter: (("time" <= 'Thu Jun 02 00:00:00 2022 PDT'::timestamp with time zone) AND (temp <> '1'::double precision))
+(6 rows)
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+       sum        
+------------------
+ 30543.8523547207
+(1 row)
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+--
 -- Test "foo IN (1, 2)" (ScalarArrayOpExpr)
 --
 -- This is currently not transformed to scan keys because only index

--- a/tsl/test/sql/hypercore_scans.sql
+++ b/tsl/test/sql/hypercore_scans.sql
@@ -303,6 +303,64 @@ where time = '2022-06-01' and 4 < device;
 set timescaledb.enable_hypercore_scankey_pushdown=true;
 
 --
+-- Test non-btree operator on segmentby column and compare with btree
+-- operators.
+--
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device != 1;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device != 1;
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and device <> 1;
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+--
+-- Test non-btree operator on non-segmentby column and compare with
+-- btree operators.
+--
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp != 1;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp != 1;
+
+set timescaledb.enable_hypercore_scankey_pushdown=false;
+
+explain (costs off)
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+
+select sum(humidity) from readings
+where time <= '2022-06-02' and temp <> 1;
+
+set timescaledb.enable_hypercore_scankey_pushdown=true;
+
+--
 -- Test "foo IN (1, 2)" (ScalarArrayOpExpr)
 --
 -- This is currently not transformed to scan keys because only index


### PR DESCRIPTION
When filtering arrow slots in ColumnarScan, quals on segmentby columns should be executed separately from those on other columns because they don't require decompression and might filter the whole arrow slot in one go. Furthermore, the quals only need to be applied once per arrow slot since the segmentby value is the same for all compressed rows in the slot.

This will speed up scans when filters on segmentby columns cannot be pushed down to Hypercore TAM as scankeys. For example, "<column> IN (1, 2, 3)" won't be pushed down as a scankey because only index scans support scankeys with such scalar array expressions.

Disable-check: force-changelog-file
Disable-check: commit-count