### PR TITLE
Adjust windows package test CI

### DIFF
--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -18,10 +18,6 @@ jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
-      pg14_earliest: ${{ steps.config.outputs.pg14_abi_min }}
-      pg15_earliest: ${{ steps.config.outputs.pg15_abi_min }}
-      pg16_earliest: ${{ steps.config.outputs.pg16_abi_min }}
-      pg17_earliest: ${{ steps.config.outputs.pg17_abi_min }}
       pg14_latest: ${{ steps.config.outputs.pg14_latest }}
       pg15_latest: ${{ steps.config.outputs.pg15_latest }}
       pg16_latest: ${{ steps.config.outputs.pg16_latest }}
@@ -35,38 +31,22 @@ jobs:
       run: python .github/gh_config_reader.py
 
   build:
-    name: Windows package PG${{ matrix.test }}
+    name: Windows package PG${{ matrix.pkg_version }}
     runs-on: ${{ matrix.os }}
     needs: config
     strategy:
       fail-fast: false
       matrix:
         os: [ windows-2019 ]
-        test: [ "14min", "14max", "15min", "15max", "16min", "16max", "17min", "17max" ]
+        pg: [ "14", "15", "16", "17" ]
         include:
-          - test: 14min
-            pg: 14
-            pkg_version: ${{ fromJson(needs.config.outputs.pg14_earliest) }}.1
-          - test: 14max
-            pg: 14
-            pkg_version: 14.10.0 # hardcoded since 14.11 is not available yet
-          - test: 15min
-            pg: 15
-            pkg_version: ${{ fromJson(needs.config.outputs.pg15_earliest) }}.1
-          - test: 15max
-            pg: 15
-            pkg_version: 15.5.0 # hardcoded since 15.6 is not available yet
-          - test: 16min
-            pg: 16
-            pkg_version: ${{ fromJson(needs.config.outputs.pg16_earliest) }}.0
-          - test: 16max
-            pg: 16
-            pkg_version: 16.1.0 # hardcoded since 16.2 is not available yet
-          - test: 17min
-            pg: 17
-            pkg_version: ${{ fromJson(needs.config.outputs.pg17_earliest) }}.0
-          - test: 17max
-            pg: 17
+          - pg: 14
+            pkg_version: ${{ fromJson(needs.config.outputs.pg14_latest) }}.0
+          - pg: 15
+            pkg_version: ${{ fromJson(needs.config.outputs.pg15_latest) }}.0
+          - pg: 16
+            pkg_version: ${{ fromJson(needs.config.outputs.pg16_latest) }}.0
+          - pg: 17
             pkg_version: ${{ fromJson(needs.config.outputs.pg17_latest) }}.0
     env:
       # PostgreSQL configuration


### PR DESCRIPTION
Since we depend on the openssl version of the postgres installer
to match the openssl version we built against and we can't ensure
stability of that version in the postgres installer we only test
windows package against the latest available postgres version.

Disable-check: force-changelog-file
Disable-check: commit-count
