### PR TITLE
Fix flaky bgw scheduler test

### DIFF
--- a/tsl/test/expected/bgw_scheduler_restart.out
+++ b/tsl/test/expected/bgw_scheduler_restart.out
@@ -64,10 +64,11 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+\c
 SHOW timescaledb.bgw_scheduler_restart_time;
  timescaledb.bgw_scheduler_restart_time 
 ----------------------------------------
- 1min
+ 10s
 (1 row)
 
 -- Launcher is running, so we need to restart it for the scheduler

--- a/tsl/test/sql/bgw_scheduler_restart.sql
+++ b/tsl/test/sql/bgw_scheduler_restart.sql
@@ -59,6 +59,7 @@ SHOW timescaledb.bgw_scheduler_restart_time;
 ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '10s';
 ALTER SYSTEM SET timescaledb.debug_bgw_scheduler_exit_status TO 1;
 SELECT pg_reload_conf();
+\c
 SHOW timescaledb.bgw_scheduler_restart_time;
 
 -- Launcher is running, so we need to restart it for the scheduler


### PR DESCRIPTION
- **Fix flaky bgw scheduler test**

Disable-check: force-changelog-file
Disable-check: approval-count
