### PR TITLE
Add support for merging compressed chunks

### DIFF
--- a/.unreleased/pr_7669
+++ b/.unreleased/pr_7669
@@ -1,0 +1,1 @@
+Implements: #7669 Add support for merging compressed chunks

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -50,11 +50,11 @@
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/palloc.h>
+#include <utils/rel.h>
 #include <utils/snapmgr.h>
 #include <utils/syscache.h>
 #include <utils/tuplestore.h>
 
-#include "annotations.h"
 #include "cache.h"
 #include "chunk.h"
 #include "debug_point.h"
@@ -212,8 +212,11 @@ typedef struct RelationMergeInfo
 {
 	Oid relid;
 	struct VacuumCutoffs cutoffs;
-	const Chunk *chunk;
+	Chunk *chunk;
 	Relation rel;
+	char relpersistence;
+	bool isresult;
+	bool iscompressed_rel;
 } RelationMergeInfo;
 
 typedef enum MergeLockUpgrade
@@ -246,9 +249,10 @@ compute_rel_vacuum_cutoffs(Relation rel, struct VacuumCutoffs *cutoffs)
 
 static void
 merge_chunks_finish(Oid new_relid, RelationMergeInfo *relinfos, int nrelids,
-					TransactionId freeze_limit, MultiXactId multi_cutoff, char relpersistence,
 					MergeLockUpgrade lock_upgrade)
 {
+	RelationMergeInfo *result_minfo = NULL;
+
 	/*
 	 * The relations being merged are currently locked in ExclusiveLock, which
 	 * means other readers can have locks. To delete the relations, we first
@@ -258,6 +262,13 @@ merge_chunks_finish(Oid new_relid, RelationMergeInfo *relinfos, int nrelids,
 	for (int i = 0; i < nrelids; i++)
 	{
 		Oid relid = relinfos[i].relid;
+
+		if (relinfos[i].isresult)
+			result_minfo = &relinfos[i];
+
+		/* If merging internal compressed relations, not all chunks have one */
+		if (!OidIsValid(relid))
+			continue;
 
 		switch (lock_upgrade)
 		{
@@ -279,29 +290,43 @@ merge_chunks_finish(Oid new_relid, RelationMergeInfo *relinfos, int nrelids,
 		}
 	}
 
-	finish_heap_swap(relinfos[0].relid,
+	Ensure(result_minfo != NULL, "no chunk to merge into found");
+	struct VacuumCutoffs *cutoffs = &result_minfo->cutoffs;
+
+	finish_heap_swap(result_minfo->relid,
 					 new_relid,
 					 false, /* system catalog */
 					 false /* swap toast by content */,
 					 false, /* check constraints */
 					 true,	/* internal? */
-					 freeze_limit,
-					 multi_cutoff,
-					 relpersistence);
+					 cutoffs->FreezeLimit,
+					 cutoffs->MultiXactCutoff,
+					 result_minfo->relpersistence);
+
+	/* Don't need to drop objects for internal compressed relations, they are
+	 * dropped when the main chunk is dropped. */
+	if (result_minfo->iscompressed_rel)
+		return;
+
+	if (ts_chunk_is_compressed(result_minfo->chunk))
+		ts_chunk_set_partial(result_minfo->chunk);
 
 	/*
-	 * Delete all the merged relations except the first one, since we are
+	 * Delete all the merged relations except the result one, since we are
 	 * keeping it for the heap swap.
 	 */
 	ObjectAddresses *objects = new_object_addresses();
 
-	for (int i = 1; i < nrelids; i++)
+	for (int i = 0; i < nrelids; i++)
 	{
 		Oid relid = relinfos[i].relid;
 		ObjectAddress object = {
 			.classId = RelationRelationId,
 			.objectId = relid,
 		};
+
+		if (!OidIsValid(relid) || relinfos[i].isresult)
+			continue;
 
 		/* Cannot drop if relation is still open */
 		Assert(relinfos[i].rel == NULL);
@@ -481,10 +506,6 @@ chunk_update_constraints(const Chunk *chunk, const Hypercube *new_cube)
 			.waitpolicy = LockWaitBlock,
 			.lockmode = LockTupleShare,
 		};
-
-		/* The new slice has merged range, but still old ID. Should match with
-		 * the old slice. */
-		Assert(old_slice->fd.id == new_slice->fd.id);
 
 		/* If nothing changed in this dimension, move on to the next */
 		if (ts_dimension_slices_equal(old_slice, new_slice))
@@ -682,11 +703,15 @@ pg17_workaround_init(Relation rel, RelationMergeInfo *relinfos, int nrelids)
 	for (int i = 0; i < nrelids; i++)
 	{
 		blockoff[i] = (BlockNumber) totalblocks;
-		totalblocks += RelationGetNumberOfBlocks(relinfos[i].rel);
 
-		/* Ensure the offsets don't overflow. For the merge itself, it is
-		 * assumed that the write will fail when writing too many blocks */
-		Ensure(totalblocks <= MaxBlockNumber, "max number of blocks exceeded for merge");
+		if (relinfos[i].rel)
+		{
+			totalblocks += smgrnblocks(RelationGetSmgr(relinfos[i].rel), MAIN_FORKNUM);
+
+			/* Ensure the offsets don't overflow. For the merge itself, it is
+			 * assumed that the write will fail when writing too many blocks */
+			Ensure(totalblocks <= MaxBlockNumber, "max number of blocks exceeded for merge");
+		}
 	}
 }
 
@@ -710,6 +735,122 @@ get_relmergeinfo(RelationMergeInfo *relinfos, int nrelids, int i)
 #define pg17_workaround_cleanup(rel)
 #define get_relmergeinfo(relinfos, nrelids, i) &(relinfos)[i]
 #endif
+
+/* Update table stats */
+
+static void
+update_relstats(Relation catrel, Relation rel, double ntuples)
+{
+	HeapTuple reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(RelationGetRelid(rel)));
+	if (!HeapTupleIsValid(reltup))
+		elog(ERROR, "cache lookup failed for relation %u", RelationGetRelid(rel));
+	Form_pg_class relform = (Form_pg_class) GETSTRUCT(reltup);
+	BlockNumber num_pages = RelationGetNumberOfBlocks(rel);
+	relform->relpages = num_pages;
+	relform->reltuples = ntuples;
+
+	CatalogTupleUpdate(catrel, &reltup->t_self, reltup);
+	heap_freetuple(reltup);
+}
+
+static double
+copy_table_data(Relation fromrel, Relation torel, struct VacuumCutoffs *cutoffs,
+				struct VacuumCutoffs *merged_cutoffs)
+{
+	const TableAmRoutine *tableam = NULL;
+	double num_tuples = 0.0;
+	double tups_vacuumed = 0.0;
+	double tups_recently_dead = 0.0;
+
+	if (ts_is_hypercore_am(fromrel->rd_rel->relam))
+	{
+		tableam = fromrel->rd_tableam;
+		fromrel->rd_tableam = GetHeapamTableAmRoutine();
+	}
+
+	table_relation_copy_for_cluster(fromrel,
+									torel,
+									NULL,
+									false,
+									cutoffs->OldestXmin,
+									&cutoffs->FreezeLimit,
+									&cutoffs->MultiXactCutoff,
+									&num_tuples,
+									&tups_vacuumed,
+									&tups_recently_dead);
+
+	elog(LOG,
+		 "merged rows from \"%s\" into \"%s\": tuples %lf vacuumed %lf recently dead %lf",
+		 RelationGetRelationName(fromrel),
+		 RelationGetRelationName(torel),
+		 num_tuples,
+		 tups_vacuumed,
+		 tups_recently_dead);
+
+	if (TransactionIdPrecedes(merged_cutoffs->FreezeLimit, cutoffs->FreezeLimit))
+		merged_cutoffs->FreezeLimit = cutoffs->FreezeLimit;
+
+	if (MultiXactIdPrecedes(merged_cutoffs->MultiXactCutoff, cutoffs->MultiXactCutoff))
+		merged_cutoffs->MultiXactCutoff = cutoffs->MultiXactCutoff;
+
+	if (tableam != NULL)
+		fromrel->rd_tableam = tableam;
+
+	/* Close the relations before the heap swap, but keep the locks until
+	 * end of transaction. */
+	table_close(fromrel, NoLock);
+
+	return num_tuples;
+}
+
+static Oid
+merge_relinfos(RelationMergeInfo *relinfos, int nrelids, int mergeindex)
+{
+	RelationMergeInfo *result_minfo = &relinfos[mergeindex];
+	Relation result_rel = result_minfo->rel;
+
+	if (result_rel == NULL)
+		return InvalidOid;
+
+	Oid tablespace = result_rel->rd_rel->reltablespace;
+	struct VacuumCutoffs *merged_cutoffs = &result_minfo->cutoffs;
+
+	/* Create the transient heap that will receive the re-ordered data */
+	Oid new_relid = make_new_heap_compat(RelationGetRelid(result_rel),
+										 tablespace,
+										 result_rel->rd_rel->relam,
+										 result_minfo->relpersistence,
+										 ExclusiveLock);
+	Relation new_rel = table_open(new_relid, AccessExclusiveLock);
+	double total_num_tuples = 0.0;
+
+	pg17_workaround_init(new_rel, relinfos, nrelids);
+
+	/* Step 3: write the data from all the rels into a new merged heap */
+	for (int i = 0; i < nrelids; i++)
+	{
+		RelationMergeInfo *relinfo = get_relmergeinfo(relinfos, nrelids, i);
+		struct VacuumCutoffs *cutoffs_i = &relinfo->cutoffs;
+		double num_tuples = 0.0;
+
+		if (relinfo->rel)
+		{
+			num_tuples = copy_table_data(relinfo->rel, new_rel, cutoffs_i, merged_cutoffs);
+			total_num_tuples += num_tuples;
+			relinfo->rel = NULL;
+		}
+	}
+
+	pg17_workaround_cleanup(new_rel);
+
+	/* Update table stats */
+	Relation relRelation = table_open(RelationRelationId, RowExclusiveLock);
+	update_relstats(relRelation, new_rel, total_num_tuples);
+	table_close(new_rel, NoLock);
+	table_close(relRelation, RowExclusiveLock);
+
+	return new_relid;
+}
 
 /*
  * Merge N chunk relations into one chunk based on Oids.
@@ -759,10 +900,12 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 	bool *nulls;
 	int nrelids;
 	RelationMergeInfo *relinfos;
+	RelationMergeInfo *crelinfos; /* For compressed relations */
 	int32 hypertable_id = INVALID_HYPERTABLE_ID;
 	Hypercube *merged_cube = NULL;
 	const Hypercube *prev_cube = NULL;
 	const MergeLockUpgrade lock_upgrade = merge_chunks_lock_upgrade_mode();
+	int mergeindex = -1;
 
 	PreventCommandIfReadOnly("merge_chunks");
 
@@ -785,6 +928,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 				 errmsg("must specify at least two chunks to merge")));
 
 	relinfos = palloc0(sizeof(struct RelationMergeInfo) * nrelids);
+	crelinfos = palloc0(sizeof(struct RelationMergeInfo) * nrelids);
 
 	/* Sort relids array in order to find duplicates and lock relations in
 	 * consistent order to avoid deadlocks. It doesn't matter that we don't
@@ -796,9 +940,9 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 	for (int i = 0; i < nrelids; i++)
 	{
 		Oid relid = DatumGetObjectId(relids[i]);
-		const Chunk *chunk;
+		RelationMergeInfo *relinfo = &relinfos[i];
+		Chunk *chunk;
 		Relation rel;
-		Oid amoid;
 
 		if (nulls[i] || !OidIsValid(relid))
 			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid relation")));
@@ -886,11 +1030,21 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("cannot merge OSM chunks")));
 
+		/*
+		 * Lock also internal compressed relation, if it exists.
+		 *
+		 * Don't fill in its MergeRelInfo until we sort relations in partition
+		 * order below, because the compressed relations need to be in the
+		 * same order.
+		 */
 		if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("merging compressed chunks is not yet supported"),
-					 errhint("Decompress the chunks before merging.")));
+		{
+			Oid crelid = ts_chunk_get_relid(chunk->fd.compressed_chunk_id, false);
+			LockRelationOid(crelid, AccessExclusiveLock);
+
+			if (mergeindex == -1)
+				mergeindex = i;
+		}
 
 		if (ts_chunk_is_frozen(chunk))
 			ereport(ERROR,
@@ -921,18 +1075,25 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 		 * It might not be possible to merge two chunks with different
 		 * storage, so better safe than sorry for now.
 		 */
-		amoid = rel->rd_rel->relam;
+		Oid amoid = rel->rd_rel->relam;
 
-		if (amoid != HEAP_TABLE_AM_OID)
+		if (amoid != HEAP_TABLE_AM_OID && !ts_is_hypercore_am(amoid))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("access method \"%s\" is not supported for merge",
 							get_am_name(amoid))));
 
-		relinfos[i].relid = relid;
-		relinfos[i].rel = rel;
-		relinfos[i].chunk = chunk;
+		relinfo->relid = relid;
+		relinfo->rel = rel;
+		relinfo->chunk = chunk;
+		relinfo->relpersistence = rel->rd_rel->relpersistence;
 	}
+
+	/* No compressed chunk found, so use index 0 for resulting merged chunk */
+	if (mergeindex == -1)
+		mergeindex = 0;
+
+	relinfos[mergeindex].isresult = true;
 
 	/* Sort rels in partition order (in case of chunks). This is necessary to
 	 * validate that a merge is possible. */
@@ -961,118 +1122,61 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 
 		prev_cube = chunk->cube;
 		compute_rel_vacuum_cutoffs(relinfos[i].rel, &relinfos[i].cutoffs);
+
+		/*
+		 * Fill in the compressed mergerelinfo array here after final sort of
+		 * rels so that the two arrays have the same order.
+		 */
+		if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		{
+			RelationMergeInfo *crelinfo = &crelinfos[i];
+
+			crelinfo->chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
+			crelinfo->relid = crelinfo->chunk->table_id;
+			crelinfo->rel = table_open(crelinfo->relid, AccessExclusiveLock);
+			crelinfo->isresult = relinfos[i].isresult;
+			crelinfo->iscompressed_rel = true;
+			crelinfo->relpersistence = crelinfo->rel->rd_rel->relpersistence;
+			compute_rel_vacuum_cutoffs(crelinfos[i].rel, &crelinfos[i].cutoffs);
+		}
+
+		/* Need to update the index of the result (merged) relation after
+		 * resort */
+		if (relinfos[i].isresult)
+			mergeindex = i;
 	}
 
 	/*
-	 * Keep the first of the ordered relations. It will receive a heap
-	 * swap.
+	 * Now merge all the data into a new temporary heap relation. Do it
+	 * separately for the non-compressed and compressed relations.
 	 */
-	Relation result_rel = relinfos[0].rel;
-	/* These will be our final cutoffs for the merged relation */
-	struct VacuumCutoffs *cutoffs = &relinfos[0].cutoffs;
+	Oid new_relid = merge_relinfos(relinfos, nrelids, mergeindex);
+	Oid new_crelid = merge_relinfos(crelinfos, nrelids, mergeindex);
 
-	Oid tablespace = result_rel->rd_rel->reltablespace;
-	char relpersistence = result_rel->rd_rel->relpersistence;
-
-	/* Create the transient heap that will receive the re-ordered data */
-	Oid new_relid = make_new_heap_compat(RelationGetRelid(result_rel),
-										 tablespace,
-										 result_rel->rd_rel->relam,
-										 relpersistence,
-										 ExclusiveLock);
-	Relation new_rel = table_open(new_relid, AccessExclusiveLock);
-	double total_num_tuples = 0.0;
-
-	pg17_workaround_init(new_rel, relinfos, nrelids);
-
-	/* Step 3: write the data from all the rels into a new merged heap */
-	for (int i = 0; i < nrelids; i++)
-	{
-		RelationMergeInfo *relinfo = get_relmergeinfo(relinfos, nrelids, i);
-		struct VacuumCutoffs *cutoffs_i = &relinfo->cutoffs;
-		Relation rel = relinfo->rel;
-
-		double num_tuples = 0.0;
-		double tups_vacuumed = 0.0;
-		double tups_recently_dead = 0.0;
-
-		table_relation_copy_for_cluster(rel,
-										new_rel,
-										NULL,
-										false,
-										cutoffs_i->OldestXmin,
-										&cutoffs_i->FreezeLimit,
-										&cutoffs_i->MultiXactCutoff,
-										&num_tuples,
-										&tups_vacuumed,
-										&tups_recently_dead);
-
-		elog(LOG,
-			 "merged rows from \"%s\" into \"%s\": tuples %lf vacuumed %lf recently dead %lf",
-			 RelationGetRelationName(rel),
-			 RelationGetRelationName(result_rel),
-			 num_tuples,
-			 tups_vacuumed,
-			 tups_recently_dead);
-
-		total_num_tuples += num_tuples;
-
-		if (TransactionIdPrecedes(cutoffs->FreezeLimit, cutoffs_i->FreezeLimit))
-			cutoffs->FreezeLimit = cutoffs_i->FreezeLimit;
-
-		if (MultiXactIdPrecedes(cutoffs->MultiXactCutoff, cutoffs_i->MultiXactCutoff))
-			cutoffs->MultiXactCutoff = cutoffs_i->MultiXactCutoff;
-
-		/* Close the relations before the heap swap, but keep the locks until
-		 * end of transaction. */
-		table_close(rel, NoLock);
-		relinfo->rel = NULL;
-	}
-
-	pg17_workaround_cleanup(new_rel);
-
-	/* Update table stats */
-	Relation relRelation = table_open(RelationRelationId, RowExclusiveLock);
-	HeapTuple reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(new_relid));
-	if (!HeapTupleIsValid(reltup))
-		elog(ERROR, "cache lookup failed for relation %u", new_relid);
-	Form_pg_class relform = (Form_pg_class) GETSTRUCT(reltup);
-	BlockNumber num_pages = RelationGetNumberOfBlocks(new_rel);
-	relform->relpages = num_pages;
-	relform->reltuples = total_num_tuples;
-
-	CatalogTupleUpdate(relRelation, &reltup->t_self, reltup);
-	heap_freetuple(reltup);
-	table_close(relRelation, RowExclusiveLock);
+	/* Make new table stats visible */
 	CommandCounterIncrement();
-
-	table_close(new_rel, NoLock);
 
 	DEBUG_WAITPOINT("merge_chunks_before_heap_swap");
 
-	/* Step 4: Keep one of the original rels but transplant the merged heap
-	 * into it using a heap swap. Then close and delete the remaining merged
-	 * rels. */
-	merge_chunks_finish(new_relid,
-						relinfos,
-						nrelids,
-						cutoffs->FreezeLimit,
-						cutoffs->MultiXactCutoff,
-						relpersistence,
-						lock_upgrade);
+	merge_chunks_finish(new_relid, relinfos, nrelids, lock_upgrade);
+
+	if (OidIsValid(new_crelid))
+		merge_chunks_finish(new_crelid, crelinfos, nrelids, lock_upgrade);
 
 	/* Step 5: Update the dimensional metadata and constraints for the chunk
 	 * we are keeping. */
 	if (merged_cube)
 	{
-		Assert(relinfos[0].chunk);
-		chunk_update_constraints(relinfos[0].chunk, merged_cube);
+		RelationMergeInfo *result_minfo = &relinfos[mergeindex];
+		Assert(result_minfo->chunk);
+		chunk_update_constraints(result_minfo->chunk, merged_cube);
 		ts_hypercube_free(merged_cube);
 	}
 
 	pfree(relids);
 	pfree(nulls);
 	pfree(relinfos);
+	pfree(crelinfos);
 
 	PG_RETURN_VOID();
 }

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -30,6 +30,14 @@ select create_hypertable('mergeme', 'time', 'device', 3, chunk_time_interval => 
  (1,public,mergeme,t)
 (1 row)
 
+-- Create helper view for chunk information
+create view chunk_info as
+select relname as chunk, amname as tam, pg_get_expr(conbin, ch) checkconstraint
+from pg_class cl
+join pg_am am on (cl.relam = am.oid)
+join show_chunks('mergeme') ch on (cl.oid = ch)
+join pg_constraint con on (con.conrelid = ch)
+where con.contype = 'c';
 --
 -- Insert data to create two chunks with same time ranges like this:
 -- _______
@@ -41,12 +49,15 @@ select create_hypertable('mergeme', 'time', 'device', 3, chunk_time_interval => 
 -- |_____|
 ---
 insert into mergeme values ('2024-01-01', 1, 1.0), ('2024-01-01', 2, 2.0);
-select "Constraint", "Columns", "Expr" from test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
-  Constraint  | Columns  |                                                                      Expr                                                                      
---------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------
- constraint_1 | {time}   | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
- constraint_2 | {device} | (_timescaledb_functions.get_partition_hash(device) < 715827882)
-(2 rows)
+-- Show chunks and check constraints
+select * from chunk_info;
+      chunk       | tam  |                                                                checkconstraint                                                                 
+------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_1_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_2_chunk | heap | ((_timescaledb_functions.get_partition_hash(device) >= 715827882) AND (_timescaledb_functions.get_partition_hash(device) < 1431655764))
+ _hyper_1_2_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+(4 rows)
 
 -- Show partition layout
 select * from partitions;
@@ -81,24 +92,18 @@ select * from partitions;
  _hyper_1_1_chunk | device      | -9223372036854775808 |       1431655764
 (2 rows)
 
-select "Constraint", "Columns", "Expr" from test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
-  Constraint  | Columns  |                                                                      Expr                                                                      
---------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------
- constraint_1 | {time}   | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
- constraint_2 | {device} | (_timescaledb_functions.get_partition_hash(device) < 1431655764)
-(2 rows)
-
 select count(*) as num_orphaned_slices from orphaned_slices;
  num_orphaned_slices 
 ---------------------
                    0
 (1 row)
 
-select * from show_chunks('mergeme');
-              show_chunks               
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
-(1 row)
+select * from chunk_info;
+      chunk       | tam  |                                                                checkconstraint                                                                 
+------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 1431655764)
+ _hyper_1_1_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+(2 rows)
 
 select * from mergeme;
              time             | device | temp 
@@ -172,22 +177,16 @@ select * from partitions;
 
 -- Note that no space partition CHECK constraint is added because it
 -- now covers the entire range from -inf to +inf.
-select "Constraint", "Columns", "Expr" from test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
-  Constraint  | Columns |                                                                      Expr                                                                      
---------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------
- constraint_1 | {time}  | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
-(1 row)
-
 select count(*) as num_orphaned_slices from orphaned_slices;
  num_orphaned_slices 
 ---------------------
                    0
 (1 row)
 
-select * from show_chunks('mergeme');
-              show_chunks               
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
+select * from chunk_info;
+      chunk       | tam  |                                                                checkconstraint                                                                 
+------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
 (1 row)
 
 select * from mergeme;
@@ -266,31 +265,238 @@ select compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
  _timescaledb_internal._hyper_1_3_chunk
 (1 row)
 
-\set ON_ERROR_STOP 0
--- Currently cannot merge compressed chunks
-call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_2_chunk');
-ERROR:  merging compressed chunks is not yet supported
-call merge_chunks('_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_3_chunk');
-ERROR:  merging compressed chunks is not yet supported
-\set ON_ERROR_STOP 1
--- Currently cannot merge chunks using Hypercore TAM
-alter table _timescaledb_internal._hyper_1_1_chunk set access method hypercore;
-alter table _timescaledb_internal._hyper_1_3_chunk set access method hypercore;
-select relname, amname from pg_class cl
-join pg_am am on (cl.relam = am.oid)
-where cl.oid in ('_timescaledb_internal._hyper_1_1_chunk'::regclass, '_timescaledb_internal._hyper_1_3_chunk'::regclass);
-     relname      |  amname   
-------------------+-----------
- _hyper_1_1_chunk | hypercore
- _hyper_1_3_chunk | hypercore
-(2 rows)
+-- Test merging compressed chunks
+begin;
+select * from chunk_info;
+      chunk       | tam  |                                                                checkconstraint                                                                 
+------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_1_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_2_chunk | heap | ((_timescaledb_functions.get_partition_hash(device) >= 715827882) AND (_timescaledb_functions.get_partition_hash(device) < 1431655764))
+ _hyper_1_2_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | heap | (_timescaledb_functions.get_partition_hash(device) >= 1431655764)
+ _hyper_1_3_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(10 rows)
 
-\set ON_ERROR_STOP 0
-call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_2_chunk');
-ERROR:  merging compressed chunks is not yet supported
-call merge_chunks('_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_3_chunk');
-ERROR:  merging compressed chunks is not yet supported
-\set ON_ERROR_STOP 1
+call merge_chunks('{_timescaledb_internal._hyper_1_1_chunk, _timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+      chunk       | tam  |                                                                checkconstraint                                                                 
+------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(5 rows)
+
+select count(*) as num_orphaned_slices from orphaned_slices;
+ num_orphaned_slices 
+---------------------
+                   0
+(1 row)
+
+select * from mergeme;
+             time             | device | temp 
+------------------------------+--------+------
+ Mon Jan 01 00:00:00 2024 PST |      1 |    1
+ Mon Jan 01 00:00:00 2024 PST |      3 |    3
+ Mon Jan 01 00:00:00 2024 PST |      2 |    2
+ Tue Jan 02 00:00:00 2024 PST |      1 |    4
+ Thu Jan 04 00:00:00 2024 PST |      1 |    5
+(5 rows)
+
+rollback;
+-- Test mixing hypercore TAM with compression without TAM
+alter table _timescaledb_internal._hyper_1_1_chunk set access method hypercore;
+select * from chunk_info;
+      chunk       |    tam    |                                                                checkconstraint                                                                 
+------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | hypercore | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_1_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_2_chunk | heap      | ((_timescaledb_functions.get_partition_hash(device) >= 715827882) AND (_timescaledb_functions.get_partition_hash(device) < 1431655764))
+ _hyper_1_2_chunk | heap      | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) >= 1431655764)
+ _hyper_1_3_chunk | heap      | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap      | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap      | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(10 rows)
+
+begin;
+select sum(temp) from mergeme;
+ sum 
+-----
+  15
+(1 row)
+
+call merge_chunks('{_timescaledb_internal._hyper_1_1_chunk, _timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+      chunk       |    tam    |                                                                checkconstraint                                                                 
+------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap      | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap      | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(5 rows)
+
+select count(*) as num_orphaned_slices from orphaned_slices;
+ num_orphaned_slices 
+---------------------
+                   0
+(1 row)
+
+select sum(temp) from mergeme;
+ sum 
+-----
+  15
+(1 row)
+
+rollback;
+select * from chunk_info;
+      chunk       |    tam    |                                                                checkconstraint                                                                 
+------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | hypercore | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_1_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_2_chunk | heap      | ((_timescaledb_functions.get_partition_hash(device) >= 715827882) AND (_timescaledb_functions.get_partition_hash(device) < 1431655764))
+ _hyper_1_2_chunk | heap      | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) >= 1431655764)
+ _hyper_1_3_chunk | heap      | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap      | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap      | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(10 rows)
+
+-- Only Hypercore TAM and non-compressed chunks
+alter table _timescaledb_internal._hyper_1_3_chunk set access method hypercore;
+begin;
+select sum(temp) from mergeme;
+ sum 
+-----
+  15
+(1 row)
+
+call merge_chunks('{_timescaledb_internal._hyper_1_1_chunk, _timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+      chunk       |    tam    |                                                                checkconstraint                                                                 
+------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap      | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap      | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(5 rows)
+
+select count(*) as num_orphaned_slices from orphaned_slices;
+ num_orphaned_slices 
+---------------------
+                   0
+(1 row)
+
+select sum(temp) from mergeme;
+ sum 
+-----
+  15
+(1 row)
+
+-- Test that indexes work after merge
+set timescaledb.enable_columnarscan = false;
+set enable_seqscan = false;
+analyze mergeme;
+explain (costs off)
+select * from mergeme where device = 1;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_1_1_chunk_mergeme_device_time_idx on _hyper_1_1_chunk
+         Index Cond: (device = 1)
+   ->  Index Scan using _hyper_1_4_chunk_mergeme_device_time_idx on _hyper_1_4_chunk
+         Index Cond: (device = 1)
+   ->  Index Scan using _hyper_1_5_chunk_mergeme_device_time_idx on _hyper_1_5_chunk
+         Index Cond: (device = 1)
+(7 rows)
+
+select * from mergeme where device = 1;
+             time             | device | temp 
+------------------------------+--------+------
+ Mon Jan 01 00:00:00 2024 PST |      1 |    1
+ Tue Jan 02 00:00:00 2024 PST |      1 |    4
+ Thu Jan 04 00:00:00 2024 PST |      1 |    5
+(3 rows)
+
+select * from _timescaledb_internal._hyper_1_1_chunk where device = 1;
+             time             | device | temp 
+------------------------------+--------+------
+ Mon Jan 01 00:00:00 2024 PST |      1 |    1
+(1 row)
+
+reset timescaledb.enable_columnarscan;
+reset enable_seqscan;
+rollback;
+---
+--- Merge hypercore TAM into compressed chunk without TAM
+---
+begin;
+select * from chunk_info;
+      chunk       |    tam    |                                                                checkconstraint                                                                 
+------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | hypercore | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_1_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_2_chunk | heap      | ((_timescaledb_functions.get_partition_hash(device) >= 715827882) AND (_timescaledb_functions.get_partition_hash(device) < 1431655764))
+ _hyper_1_2_chunk | heap      | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | hypercore | (_timescaledb_functions.get_partition_hash(device) >= 1431655764)
+ _hyper_1_3_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap      | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap      | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(10 rows)
+
+select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
+select sum(temp) from mergeme;
+ sum 
+-----
+  15
+(1 row)
+
+call merge_chunks('{_timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+      chunk       |    tam    |                                                                checkconstraint                                                                 
+------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | hypercore | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_1_chunk | hypercore | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_2_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) >= 715827882)
+ _hyper_1_2_chunk | heap      | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_4_chunk | heap      | (("time" >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Tue Jan 02 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_5_chunk | heap      | (_timescaledb_functions.get_partition_hash(device) < 715827882)
+ _hyper_1_5_chunk | heap      | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(8 rows)
+
+select count(*) as num_orphaned_slices from orphaned_slices;
+ num_orphaned_slices 
+---------------------
+                   0
+(1 row)
+
+select sum(temp) from mergeme;
+ sum 
+-----
+  15
+(1 row)
+
+rollback;
 ---
 -- Test some error cases when merging chunks with non-chunks or chunks
 -- from other hypertables
@@ -325,7 +531,7 @@ select * from mergeme_too where device=1;
 select * from show_chunks('mergeme_too');
               show_chunks               
 ----------------------------------------
- _timescaledb_internal._hyper_3_8_chunk
+ _timescaledb_internal._hyper_3_9_chunk
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -337,7 +543,7 @@ ERROR:  can only merge hypertable chunks
 call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', 'mergeme_mat');
 ERROR:  cannot merge non-table relations
 -- Merge chunks from different hypertables
-call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_3_8_chunk');
+call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_3_9_chunk');
 ERROR:  cannot merge chunks across different hypertables
 -- Merge with unsupported access method
 alter table _timescaledb_internal._hyper_1_1_chunk set access method testam;
@@ -382,6 +588,14 @@ select setseed(0.2);
 insert into mergeme (time, device, temp)
 select t, ceil(random()*10), random()*40
 from generate_series('2024-01-01'::timestamptz, '2024-01-04', '0.5s') t;
+-- Compress two chunks, one using access method
+select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+alter table _timescaledb_internal._hyper_1_2_chunk set access method hypercore;
 -- Show partitions before merge
 select * from partitions;
     table_name     | column_name |     range_start      |      range_end      
@@ -389,27 +603,27 @@ select * from partitions;
  _hyper_1_1_chunk  | time        |     1704067200000000 |    1704153600000000
  _hyper_1_3_chunk  | time        |     1704067200000000 |    1704153600000000
  _hyper_1_2_chunk  | time        |     1704067200000000 |    1704153600000000
+ _hyper_1_11_chunk | time        |     1704153600000000 |    1704240000000000
  _hyper_1_10_chunk | time        |     1704153600000000 |    1704240000000000
- _hyper_1_9_chunk  | time        |     1704153600000000 |    1704240000000000
  _hyper_1_4_chunk  | time        |     1704153600000000 |    1704240000000000
- _hyper_1_11_chunk | time        |     1704240000000000 |    1704326400000000
- _hyper_1_13_chunk | time        |     1704240000000000 |    1704326400000000
  _hyper_1_12_chunk | time        |     1704240000000000 |    1704326400000000
- _hyper_1_15_chunk | time        |     1704326400000000 |    1704412800000000
+ _hyper_1_14_chunk | time        |     1704240000000000 |    1704326400000000
+ _hyper_1_13_chunk | time        |     1704240000000000 |    1704326400000000
+ _hyper_1_16_chunk | time        |     1704326400000000 |    1704412800000000
  _hyper_1_5_chunk  | time        |     1704326400000000 |    1704412800000000
- _hyper_1_14_chunk | time        |     1704326400000000 |    1704412800000000
+ _hyper_1_15_chunk | time        |     1704326400000000 |    1704412800000000
  _hyper_1_4_chunk  | device      | -9223372036854775808 |           715827882
  _hyper_1_1_chunk  | device      | -9223372036854775808 |           715827882
  _hyper_1_5_chunk  | device      | -9223372036854775808 |           715827882
- _hyper_1_11_chunk | device      | -9223372036854775808 |           715827882
- _hyper_1_9_chunk  | device      |            715827882 |          1431655764
+ _hyper_1_12_chunk | device      | -9223372036854775808 |           715827882
+ _hyper_1_10_chunk | device      |            715827882 |          1431655764
  _hyper_1_2_chunk  | device      |            715827882 |          1431655764
- _hyper_1_14_chunk | device      |            715827882 |          1431655764
- _hyper_1_12_chunk | device      |            715827882 |          1431655764
- _hyper_1_15_chunk | device      |           1431655764 | 9223372036854775807
- _hyper_1_10_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_15_chunk | device      |            715827882 |          1431655764
+ _hyper_1_13_chunk | device      |            715827882 |          1431655764
+ _hyper_1_16_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_11_chunk | device      |           1431655764 | 9223372036854775807
  _hyper_1_3_chunk  | device      |           1431655764 | 9223372036854775807
- _hyper_1_13_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_14_chunk | device      |           1431655764 | 9223372036854775807
 (24 rows)
 
 -- Merge all chunks until only 1 remains
@@ -419,7 +633,7 @@ select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  518406 | 2854401 | 10373952.7510
 (1 row)
 
-call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_4_chunk','_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_11_chunk']);
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_4_chunk','_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_12_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  count  |   sum   |     round     
 --------+---------+---------------
@@ -432,24 +646,24 @@ select * from partitions;
  _hyper_1_2_chunk  | time        |     1704067200000000 |    1704153600000000
  _hyper_1_3_chunk  | time        |     1704067200000000 |    1704153600000000
  _hyper_1_1_chunk  | time        |     1704067200000000 |    1704412800000000
+ _hyper_1_11_chunk | time        |     1704153600000000 |    1704240000000000
  _hyper_1_10_chunk | time        |     1704153600000000 |    1704240000000000
- _hyper_1_9_chunk  | time        |     1704153600000000 |    1704240000000000
- _hyper_1_12_chunk | time        |     1704240000000000 |    1704326400000000
  _hyper_1_13_chunk | time        |     1704240000000000 |    1704326400000000
+ _hyper_1_14_chunk | time        |     1704240000000000 |    1704326400000000
+ _hyper_1_16_chunk | time        |     1704326400000000 |    1704412800000000
  _hyper_1_15_chunk | time        |     1704326400000000 |    1704412800000000
- _hyper_1_14_chunk | time        |     1704326400000000 |    1704412800000000
  _hyper_1_1_chunk  | device      | -9223372036854775808 |           715827882
- _hyper_1_12_chunk | device      |            715827882 |          1431655764
- _hyper_1_14_chunk | device      |            715827882 |          1431655764
- _hyper_1_9_chunk  | device      |            715827882 |          1431655764
+ _hyper_1_13_chunk | device      |            715827882 |          1431655764
+ _hyper_1_15_chunk | device      |            715827882 |          1431655764
+ _hyper_1_10_chunk | device      |            715827882 |          1431655764
  _hyper_1_2_chunk  | device      |            715827882 |          1431655764
  _hyper_1_3_chunk  | device      |           1431655764 | 9223372036854775807
- _hyper_1_15_chunk | device      |           1431655764 | 9223372036854775807
- _hyper_1_10_chunk | device      |           1431655764 | 9223372036854775807
- _hyper_1_13_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_16_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_11_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_14_chunk | device      |           1431655764 | 9223372036854775807
 (18 rows)
 
-call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_9_chunk','_timescaledb_internal._hyper_1_12_chunk', '_timescaledb_internal._hyper_1_14_chunk']);
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_10_chunk','_timescaledb_internal._hyper_1_13_chunk', '_timescaledb_internal._hyper_1_15_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  count  |   sum   |     round     
 --------+---------+---------------
@@ -462,18 +676,18 @@ select * from partitions;
  _hyper_1_3_chunk  | time        |     1704067200000000 |    1704153600000000
  _hyper_1_1_chunk  | time        |     1704067200000000 |    1704412800000000
  _hyper_1_2_chunk  | time        |     1704067200000000 |    1704412800000000
- _hyper_1_10_chunk | time        |     1704153600000000 |    1704240000000000
- _hyper_1_13_chunk | time        |     1704240000000000 |    1704326400000000
- _hyper_1_15_chunk | time        |     1704326400000000 |    1704412800000000
+ _hyper_1_11_chunk | time        |     1704153600000000 |    1704240000000000
+ _hyper_1_14_chunk | time        |     1704240000000000 |    1704326400000000
+ _hyper_1_16_chunk | time        |     1704326400000000 |    1704412800000000
  _hyper_1_1_chunk  | device      | -9223372036854775808 |           715827882
  _hyper_1_2_chunk  | device      |            715827882 |          1431655764
- _hyper_1_15_chunk | device      |           1431655764 | 9223372036854775807
- _hyper_1_13_chunk | device      |           1431655764 | 9223372036854775807
- _hyper_1_10_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_16_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_14_chunk | device      |           1431655764 | 9223372036854775807
+ _hyper_1_11_chunk | device      |           1431655764 | 9223372036854775807
  _hyper_1_3_chunk  | device      |           1431655764 | 9223372036854775807
 (12 rows)
 
-call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_internal._hyper_1_10_chunk','_timescaledb_internal._hyper_1_13_chunk', '_timescaledb_internal._hyper_1_15_chunk']);
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_internal._hyper_1_11_chunk','_timescaledb_internal._hyper_1_14_chunk', '_timescaledb_internal._hyper_1_16_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  count  |   sum   |     round     
 --------+---------+---------------
@@ -504,4 +718,10 @@ select * from partitions;
  _hyper_1_1_chunk | time        |     1704067200000000 |    1704412800000000
  _hyper_1_1_chunk | device      | -9223372036854775808 | 9223372036854775807
 (2 rows)
+
+select * from chunk_info;
+      chunk       | tam  |                                                                checkconstraint                                                                 
+------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | (("time" >= 'Sun Dec 31 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 16:00:00 2024 PST'::timestamp with time zone))
+(1 row)
 

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -25,11 +25,21 @@ select ds.id, cc.constraint_name from _timescaledb_catalog.dimension_slice ds
 left join _timescaledb_catalog.chunk_constraint cc on (ds.id = cc.dimension_slice_id)
 where cc.constraint_name is null;
 
+
 -----------------
 -- Setup table --
 -----------------
 create table mergeme (time timestamptz not null, device int, temp float);
 select create_hypertable('mergeme', 'time', 'device', 3, chunk_time_interval => interval '1 day');
+
+-- Create helper view for chunk information
+create view chunk_info as
+select relname as chunk, amname as tam, pg_get_expr(conbin, ch) checkconstraint
+from pg_class cl
+join pg_am am on (cl.relam = am.oid)
+join show_chunks('mergeme') ch on (cl.oid = ch)
+join pg_constraint con on (con.conrelid = ch)
+where con.contype = 'c';
 
 --
 -- Insert data to create two chunks with same time ranges like this:
@@ -43,8 +53,8 @@ select create_hypertable('mergeme', 'time', 'device', 3, chunk_time_interval => 
 ---
 insert into mergeme values ('2024-01-01', 1, 1.0), ('2024-01-01', 2, 2.0);
 
-
-select "Constraint", "Columns", "Expr" from test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
+-- Show chunks and check constraints
+select * from chunk_info;
 
 -- Show partition layout
 select * from partitions;
@@ -55,9 +65,8 @@ call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_intern
 select * from _timescaledb_internal._hyper_1_1_chunk;
 select reltuples from pg_class where oid='_timescaledb_internal._hyper_1_1_chunk'::regclass;
 select * from partitions;
-select "Constraint", "Columns", "Expr" from test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
 select count(*) as num_orphaned_slices from orphaned_slices;
-select * from show_chunks('mergeme');
+select * from chunk_info;
 select * from mergeme;
 rollback;
 
@@ -107,9 +116,8 @@ call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_
 select * from partitions;
 -- Note that no space partition CHECK constraint is added because it
 -- now covers the entire range from -inf to +inf.
-select "Constraint", "Columns", "Expr" from test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
 select count(*) as num_orphaned_slices from orphaned_slices;
-select * from show_chunks('mergeme');
+select * from chunk_info;
 select * from mergeme;
 rollback;
 
@@ -155,24 +163,65 @@ alter table mergeme set (timescaledb.compress_orderby='time', timescaledb.compre
 select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 select compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
 
-\set ON_ERROR_STOP 0
--- Currently cannot merge compressed chunks
-call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_2_chunk');
-call merge_chunks('_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_3_chunk');
-\set ON_ERROR_STOP 1
+-- Test merging compressed chunks
+begin;
+select * from chunk_info;
+call merge_chunks('{_timescaledb_internal._hyper_1_1_chunk, _timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+select count(*) as num_orphaned_slices from orphaned_slices;
+select * from mergeme;
+rollback;
 
--- Currently cannot merge chunks using Hypercore TAM
+-- Test mixing hypercore TAM with compression without TAM
 alter table _timescaledb_internal._hyper_1_1_chunk set access method hypercore;
+select * from chunk_info;
+
+begin;
+select sum(temp) from mergeme;
+call merge_chunks('{_timescaledb_internal._hyper_1_1_chunk, _timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+select count(*) as num_orphaned_slices from orphaned_slices;
+select sum(temp) from mergeme;
+rollback;
+
+
+select * from chunk_info;
+
+-- Only Hypercore TAM and non-compressed chunks
 alter table _timescaledb_internal._hyper_1_3_chunk set access method hypercore;
 
-select relname, amname from pg_class cl
-join pg_am am on (cl.relam = am.oid)
-where cl.oid in ('_timescaledb_internal._hyper_1_1_chunk'::regclass, '_timescaledb_internal._hyper_1_3_chunk'::regclass);
+begin;
+select sum(temp) from mergeme;
+call merge_chunks('{_timescaledb_internal._hyper_1_1_chunk, _timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+select count(*) as num_orphaned_slices from orphaned_slices;
+select sum(temp) from mergeme;
 
-\set ON_ERROR_STOP 0
-call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_2_chunk');
-call merge_chunks('_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_3_chunk');
-\set ON_ERROR_STOP 1
+-- Test that indexes work after merge
+set timescaledb.enable_columnarscan = false;
+set enable_seqscan = false;
+analyze mergeme;
+explain (costs off)
+select * from mergeme where device = 1;
+select * from mergeme where device = 1;
+select * from _timescaledb_internal._hyper_1_1_chunk where device = 1;
+reset timescaledb.enable_columnarscan;
+reset enable_seqscan;
+rollback;
+
+---
+--- Merge hypercore TAM into compressed chunk without TAM
+---
+begin;
+select * from chunk_info;
+select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+
+select sum(temp) from mergeme;
+call merge_chunks('{_timescaledb_internal._hyper_1_2_chunk, _timescaledb_internal._hyper_1_3_chunk}');
+select * from chunk_info;
+select count(*) as num_orphaned_slices from orphaned_slices;
+select sum(temp) from mergeme;
+rollback;
 
 ---
 -- Test some error cases when merging chunks with non-chunks or chunks
@@ -201,7 +250,7 @@ call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', 'mergeme_regular');
 call merge_chunks('mergeme_regular', '_timescaledb_internal._hyper_1_1_chunk');
 call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', 'mergeme_mat');
 -- Merge chunks from different hypertables
-call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_3_8_chunk');
+call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_3_9_chunk');
 
 -- Merge with unsupported access method
 alter table _timescaledb_internal._hyper_1_1_chunk set access method testam;
@@ -234,20 +283,25 @@ insert into mergeme (time, device, temp)
 select t, ceil(random()*10), random()*40
 from generate_series('2024-01-01'::timestamptz, '2024-01-04', '0.5s') t;
 
+-- Compress two chunks, one using access method
+select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+alter table _timescaledb_internal._hyper_1_2_chunk set access method hypercore;
+
 -- Show partitions before merge
 select * from partitions;
 
 -- Merge all chunks until only 1 remains
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
-call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_4_chunk','_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_11_chunk']);
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_4_chunk','_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_12_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
 select * from partitions;
-call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_9_chunk','_timescaledb_internal._hyper_1_12_chunk', '_timescaledb_internal._hyper_1_14_chunk']);
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_10_chunk','_timescaledb_internal._hyper_1_13_chunk', '_timescaledb_internal._hyper_1_15_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
 select * from partitions;
-call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_internal._hyper_1_10_chunk','_timescaledb_internal._hyper_1_13_chunk', '_timescaledb_internal._hyper_1_15_chunk']);
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_internal._hyper_1_11_chunk','_timescaledb_internal._hyper_1_14_chunk', '_timescaledb_internal._hyper_1_16_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
 select * from partitions;
 call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_2_chunk']);
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
 select * from partitions;
+select * from chunk_info;


### PR DESCRIPTION
Compressed chunks can be merged by applying the same copy+heap swap technique to the internal compressed chunks as applied to non-compressed chunks. However, it is necessary to consider cases when some chunks are compressed and some are not.

The way this is handled is to pick the first compressed chunk found among the input chunks, and then use that as the "result" chunk. In the next step all the chunks' non-compressed heaps are merged followed by all the "internal" compressed heaps. In the last step, the result chunk has its non-compressed and compressed heaps swapped with the merged ones, respectively.

In all other regards, the merging works the same as before when merging non-compressed chunks.