### PR TITLE
Don't abort additional INSERTs when hitting first conflict

### DIFF
--- a/.unreleased/pr_7673
+++ b/.unreleased/pr_7673
@@ -1,0 +1,2 @@
+Fixes: #7673 Don't abort additional INSERTs when hitting first conflict
+Thanks: @bjornuppeke for reporting a problem with INSERT INTO ... ON CONFLICT DO NOTHING on compressed chunks

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -728,7 +728,7 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 			cds->skip_current_tuple = false;
 			if (node->ps.instrument)
 				node->ps.instrument->ntuples2++;
-			return NULL;
+			continue;
 		}
 
 		/* No more tuples to process? */

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -748,3 +748,33 @@ VALUES
   (41, 1609478100000, 'val1')
 ON CONFLICT DO NOTHING;
 INFO:  Using index scan with scan keys: index 1, heap 4, memory 2. 
+INFO:  Using index scan with scan keys: index 1, heap 4, memory 2. 
+RESET timescaledb.debug_compression_path_info;
+-- gh issue #7672
+-- check additional INSERTS after hitting ON CONFLICT clause still go through
+CREATE TABLE test_i7672(time timestamptz, device text, primary key(time,device));
+SELECT create_hypertable('test_i7672', 'time');
+    create_hypertable     
+--------------------------
+ (13,public,test_i7672,t)
+(1 row)
+
+ALTER TABLE test_i7672 SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device');
+INSERT INTO test_i7672 VALUES ('2025-01-01','d1');
+SELECT count(*) FROM (SELECT compress_chunk(show_chunks('test_i7672'))) c;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO test_i7672 VALUES
+('2025-01-01','d1'),
+('2025-01-01','d2')
+ON CONFLICT DO NOTHING;
+SELECT * FROM test_i7672 t ORDER BY t;
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | d1
+ Wed Jan 01 00:00:00 2025 PST | d2
+(2 rows)
+


### PR DESCRIPTION
When an INSERT with ON CONFLICT DO NOTHING hits the first conflicts
it would abort additional INSERTS following the INSERT triggering
the DO NOTHING clause leading to missed INSERTs.

Fixes #7672

Disable-check: approval-count