### PR TITLE
Improve metadata for PR 7637

### DIFF
--- a/.unreleased/pr_7637
+++ b/.unreleased/pr_7637
@@ -1,2 +1,2 @@
 Fixes: #7637 Allow EXPLAIN in read-only mode
-Thanks: @ikalafat for reporting the error
+Thanks: @ikalafat for reporting a problem with EXPLAIN in read-only mode


### PR DESCRIPTION
Since we split the fixes and thanks messages into separate sections
in the changelog the context between fix and thanks will be lost so
the thanks note should repeat any required context

Disable-check: force-changelog-file