### PR TITLE
Fix vectorized hash agg in GroupAgg mode in reverse order

### DIFF
--- a/.unreleased/hash-groupagg-bug
+++ b/.unreleased/hash-groupagg-bug
@@ -1,0 +1,1 @@
+Fixes: #7686 Potential wrong aggregation result when using vectorized aggregation with hash grouping in reverse order

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -522,7 +522,12 @@ decompress_chunk_explain(CustomScanState *node, List *ancestors, ExplainState *e
 			ExplainPropertyBool("Batch Sorted Merge", dcontext->batch_sorted_merge, es);
 		}
 
-		if (es->analyze && (es->verbose || es->format != EXPLAIN_FORMAT_TEXT))
+		if (dcontext->reverse)
+		{
+			ExplainPropertyBool("Reverse", dcontext->reverse, es);
+		}
+
+		if (es->analyze)
 		{
 			ExplainPropertyBool("Bulk Decompression",
 								chunk_state->decompress_context.enable_bulk_decompression,

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -522,12 +522,7 @@ decompress_chunk_explain(CustomScanState *node, List *ancestors, ExplainState *e
 			ExplainPropertyBool("Batch Sorted Merge", dcontext->batch_sorted_merge, es);
 		}
 
-		if (dcontext->reverse)
-		{
-			ExplainPropertyBool("Reverse", dcontext->reverse, es);
-		}
-
-		if (es->analyze)
+		if (es->analyze && (es->verbose || es->format != EXPLAIN_FORMAT_TEXT))
 		{
 			ExplainPropertyBool("Bulk Decompression",
 								chunk_state->decompress_context.enable_bulk_decompression,

--- a/tsl/src/nodes/vector_agg/grouping_policy_hash.h
+++ b/tsl/src/nodes/vector_agg/grouping_policy_hash.h
@@ -43,7 +43,9 @@ typedef struct GroupingPolicyHash GroupingPolicyHash;
  * results are emitted into the output slot. This is done in the order of unique
  * grouping key indexes, thereby preserving the incoming key order. This
  * guarantees that this policy works correctly even in a Partial GroupAggregate
- * node, even though it's not optimal performance-wise.
+ * node, even though it's not optimal performance-wise. We only support the
+ * direct order of records in batch though, not reverse. This is checked at
+ * planning time.
  */
 typedef struct GroupingPolicyHash
 {

--- a/tsl/src/nodes/vector_agg/plan.c
+++ b/tsl/src/nodes/vector_agg/plan.c
@@ -506,7 +506,7 @@ get_vectorized_grouping_type(Agg *agg, CustomScan *custom, List *resolved_target
 	 * We support hashed vectorized grouping by one fixed-size by-value
 	 * compressed column.
 	 * We can use our hash table for GroupAggregate as well, because it preserves
-	 * the input order of the keys.
+	 * the input order of the keys, but only for the direct order, not reverse.
 	 */
 	if (num_grouping_columns == 1)
 	{

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -130,6 +130,42 @@ select count(compress_chunk(x)) from show_chunks('text_table') x;
 (1 row)
 
 vacuum analyze text_table;
+select table_schema,
+       table_name,
+       column_name,
+       collation_name
+from information_schema.columns
+where table_name = 'text_table'
+order by table_schema,
+         table_name,
+         ordinal_position;
+ table_schema | table_name | column_name | collation_name 
+--------------+------------+-------------+----------------
+ public       | text_table | ts          | ¤
+ public       | text_table | a           | ¤
+(2 rows)
+
+select datname,
+       datcollate
+from pg_database
+where datname = current_database();
+        datname         | datcollate  
+------------------------+-------------
+ db_vector_agg_groupagg | en_IE.UTF-8
+(1 row)
+
+select 'different-with-nulls999' > 'different999';
+ ?column? 
+----------
+ t
+(1 row)
+
+select count(distinct a) from text_table;
+ count 
+-------
+  1504
+(1 row)
+
 explain (verbose, costs off, analyze, timing off, summary off)
 select a, count(*) from text_table group by a order by a limit 10;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -6,9 +6,9 @@
 \pset null ¤
 set max_parallel_workers_per_gather = 0;
 set enable_hashagg to off;
-set timescaledb.enable_vectorized_aggregation to off;
-set timescaledb.debug_require_vector_agg to 'forbid';
-create table groupagg(t int, s text, value int);
+--set timescaledb.enable_vectorized_aggregation to off;
+--set timescaledb.debug_require_vector_agg to 'forbid';
+create table groupagg(t int, s int, value int);
 select create_hypertable('groupagg', 't', chunk_time_interval => 10000);
 NOTICE:  adding not-null constraint to column "t"
    create_hypertable   
@@ -18,11 +18,11 @@ NOTICE:  adding not-null constraint to column "t"
 
 insert into groupagg
 select
-    xfast * 100 + xslow,
+    xslow * 10,
     case when xfast = 13 then null else xfast end,
     xfast * 7 + xslow * 3
 from generate_series(10, 99) xfast,
-    generate_series(1, 1000) xslow
+    generate_series(1, 1487) xslow
 ;
 alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 's');
@@ -33,38 +33,42 @@ select count(compress_chunk(x)) from show_chunks('groupagg') x;
 (1 row)
 
 vacuum analyze groupagg;
+set timescaledb.debug_require_vector_agg to 'require';
 select s, sum(value) from groupagg group by s order by s limit 10;
  s  |   sum   
 ----+---------
- 10 | 1571500
- 11 | 1578500
- 12 | 1585500
- 14 | 1599500
- 15 | 1606500
- 16 | 1613500
- 17 | 1620500
- 18 | 1627500
- 19 | 1634500
- 20 | 1641500
+ 10 | 3423074
+ 11 | 3433483
+ 12 | 3443892
+ 14 | 3464710
+ 15 | 3475119
+ 16 | 3485528
+ 17 | 3495937
+ 18 | 3506346
+ 19 | 3516755
+ 20 | 3527164
 (10 rows)
 
 -- The hash grouping policies do not support the GroupAggregate mode in the
 -- reverse order.
+set timescaledb.debug_require_vector_agg to 'forbid';
 select s, sum(value) from groupagg group by s order by s desc limit 10;
  s  |   sum   
 ----+---------
- ¤  | 1592500
- 99 | 2194500
- 98 | 2187500
- 97 | 2180500
- 96 | 2173500
- 95 | 2166500
- 94 | 2159500
- 93 | 2152500
- 92 | 2145500
- 91 | 2138500
+ ¤ | 3454301
+ 99 | 4349475
+ 98 | 4339066
+ 97 | 4328657
+ 96 | 4318248
+ 95 | 4307839
+ 94 | 4297430
+ 93 | 4287021
+ 92 | 4276612
+ 91 | 4266203
 (10 rows)
 
+reset timescaledb.debug_require_vector_agg;
+-- Also test the NULLS FIRST order.
 select count(decompress_chunk(x)) from show_chunks('groupagg') x;
  count 
 -------
@@ -80,22 +84,25 @@ select count(compress_chunk(x)) from show_chunks('groupagg') x;
 (1 row)
 
 vacuum analyze groupagg;
-select s , sum(value) from groupagg group by s  order by s  nulls first limit 10;
+set timescaledb.debug_require_vector_agg to 'require';
+select s, sum(value) from groupagg group by s order by s nulls first limit 10;
  s  |   sum   
 ----+---------
- ¤  | 1592500
- 10 | 1571500
- 11 | 1578500
- 12 | 1585500
- 14 | 1599500
- 15 | 1606500
- 16 | 1613500
- 17 | 1620500
- 18 | 1627500
- 19 | 1634500
+ ¤ | 3454301
+ 10 | 3423074
+ 11 | 3433483
+ 12 | 3443892
+ 14 | 3464710
+ 15 | 3475119
+ 16 | 3485528
+ 17 | 3495937
+ 18 | 3506346
+ 19 | 3516755
 (10 rows)
 
--- More tests for dictionary encoding.
+reset timescaledb.debug_require_vector_agg;
+-- More tests for dictionary encoding. This is not vectorized at the moment.
+set timescaledb.debug_require_vector_agg to 'forbid';
 create table text_table(ts int);
 select create_hypertable('text_table', 'ts', chunk_time_interval => 3);
 NOTICE:  adding not-null constraint to column "ts"
@@ -130,6 +137,7 @@ select count(compress_chunk(x)) from show_chunks('text_table') x;
 (1 row)
 
 vacuum analyze text_table;
+-- The following tests are collation-sensitive, so verify it all matches.
 select table_schema,
        table_name,
        column_name,
@@ -145,19 +153,16 @@ order by table_schema,
  public       | text_table | a           | ¤
 (2 rows)
 
-select datname,
-       datcollate
-from pg_database
-where datname = current_database();
-        datname         | datcollate  
-------------------------+-------------
- db_vector_agg_groupagg | en_IE.UTF-8
+select datcollate from pg_database where datname = current_database();
+ datcollate 
+------------
+ C
 (1 row)
 
 select 'different-with-nulls999' > 'different999';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 select count(distinct a) from text_table;
@@ -166,96 +171,37 @@ select count(distinct a) from text_table;
   1504
 (1 row)
 
-explain (verbose, costs off, analyze, timing off, summary off)
+-- Test the GroupAggregate by a text column. Not vectorized for now.
 select a, count(*) from text_table group by a order by a limit 10;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   Output: _hyper_3_7_chunk.a, (count(*))
-   ->  Finalize GroupAggregate (actual rows=10 loops=1)
-         Output: _hyper_3_7_chunk.a, count(*)
-         Group Key: _hyper_3_7_chunk.a
-         ->  Merge Append (actual rows=11 loops=1)
-               Sort Key: _hyper_3_7_chunk.a
-               ->  Partial GroupAggregate (actual rows=3 loops=1)
-                     Output: _hyper_3_7_chunk.a, PARTIAL count(*)
-                     Group Key: _hyper_3_7_chunk.a
-                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_7_chunk (actual rows=3000 loops=1)
-                           Output: _hyper_3_7_chunk.a
-                           Bulk Decompression: true
-                           ->  Index Scan using compress_hyper_4_10_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_10_chunk (actual rows=3 loops=1)
-                                 Output: compress_hyper_4_10_chunk._ts_meta_count, compress_hyper_4_10_chunk._ts_meta_min_2, compress_hyper_4_10_chunk._ts_meta_max_2, compress_hyper_4_10_chunk.ts, compress_hyper_4_10_chunk._ts_meta_min_1, compress_hyper_4_10_chunk._ts_meta_max_1, compress_hyper_4_10_chunk.a
-               ->  Partial GroupAggregate (actual rows=9 loops=1)
-                     Output: _hyper_3_9_chunk.a, PARTIAL count(*)
-                     Group Key: _hyper_3_9_chunk.a
-                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_9_chunk (actual rows=10 loops=1)
-                           Output: _hyper_3_9_chunk.a
-                           Bulk Decompression: true
-                           ->  Index Scan using compress_hyper_4_11_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_11_chunk (actual rows=1 loops=1)
-                                 Output: compress_hyper_4_11_chunk._ts_meta_count, compress_hyper_4_11_chunk._ts_meta_min_2, compress_hyper_4_11_chunk._ts_meta_max_2, compress_hyper_4_11_chunk.ts, compress_hyper_4_11_chunk._ts_meta_min_1, compress_hyper_4_11_chunk._ts_meta_max_1, compress_hyper_4_11_chunk.a
-(23 rows)
-
-select a, count(*) from text_table group by a order by a limit 10;
-       a       | count 
----------------+-------
-               |  1000
- default       |  1000
- different1    |     1
- different10   |     1
- different100  |     1
- different1000 |     1
- different101  |     1
- different102  |     1
- different103  |     1
- different104  |     1
+            a            | count 
+-------------------------+-------
+                         |  1000
+ default                 |  1000
+ different-with-nulls1   |     1
+ different-with-nulls101 |     1
+ different-with-nulls103 |     1
+ different-with-nulls105 |     1
+ different-with-nulls107 |     1
+ different-with-nulls109 |     1
+ different-with-nulls11  |     1
+ different-with-nulls111 |     1
 (10 rows)
 
 -- The hash grouping policies do not support the GroupAggregate mode in the
 -- reverse order.
-explain (verbose, costs off, analyze, timing off, summary off)
 select a, count(*) from text_table group by a order by a desc limit 10;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   Output: _hyper_3_7_chunk.a, (count(*))
-   ->  Finalize GroupAggregate (actual rows=10 loops=1)
-         Output: _hyper_3_7_chunk.a, count(*)
-         Group Key: _hyper_3_7_chunk.a
-         ->  Merge Append (actual rows=11 loops=1)
-               Sort Key: _hyper_3_7_chunk.a DESC
-               ->  Partial GroupAggregate (actual rows=2 loops=1)
-                     Output: _hyper_3_7_chunk.a, PARTIAL count(*)
-                     Group Key: _hyper_3_7_chunk.a
-                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_7_chunk (actual rows=2001 loops=1)
-                           Output: _hyper_3_7_chunk.a
-                           Reverse: true
-                           Bulk Decompression: true
-                           ->  Index Scan Backward using compress_hyper_4_10_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_10_chunk (actual rows=3 loops=1)
-                                 Output: compress_hyper_4_10_chunk._ts_meta_count, compress_hyper_4_10_chunk._ts_meta_min_2, compress_hyper_4_10_chunk._ts_meta_max_2, compress_hyper_4_10_chunk.ts, compress_hyper_4_10_chunk._ts_meta_min_1, compress_hyper_4_10_chunk._ts_meta_max_1, compress_hyper_4_10_chunk.a
-               ->  Partial GroupAggregate (actual rows=10 loops=1)
-                     Output: _hyper_3_9_chunk.a, PARTIAL count(*)
-                     Group Key: _hyper_3_9_chunk.a
-                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_9_chunk (actual rows=1509 loops=1)
-                           Output: _hyper_3_9_chunk.a
-                           Reverse: true
-                           Bulk Decompression: true
-                           ->  Index Scan Backward using compress_hyper_4_11_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_11_chunk (actual rows=2 loops=1)
-                                 Output: compress_hyper_4_11_chunk._ts_meta_count, compress_hyper_4_11_chunk._ts_meta_min_2, compress_hyper_4_11_chunk._ts_meta_max_2, compress_hyper_4_11_chunk.ts, compress_hyper_4_11_chunk._ts_meta_min_1, compress_hyper_4_11_chunk._ts_meta_max_1, compress_hyper_4_11_chunk.a
-(25 rows)
-
-select a, count(*) from text_table group by a order by a desc limit 10;
-            a            | count 
--------------------------+-------
- ¤                       |  1000
- same-with-nulls         |   500
- same                    |  1000
- different-with-nulls999 |     1
- different-with-nulls997 |     1
- different-with-nulls995 |     1
- different-with-nulls993 |     1
- different-with-nulls991 |     1
- different-with-nulls99  |     1
- different-with-nulls989 |     1
+        a        | count 
+-----------------+-------
+ ¤              |  1000
+ same-with-nulls |   500
+ same            |  1000
+ different999    |     1
+ different998    |     1
+ different997    |     1
+ different996    |     1
+ different995    |     1
+ different994    |     1
+ different993    |     1
 (10 rows)
 
 -- with NULLS FIRST
@@ -274,18 +220,18 @@ select count(compress_chunk(x)) from show_chunks('text_table') x;
 (1 row)
 
 select a, count(*) from text_table group by a order by a nulls first limit 10;
-       a       | count 
----------------+-------
- ¤             |  1000
-               |  1000
- default       |  1000
- different1    |     1
- different10   |     1
- different100  |     1
- different1000 |     1
- different101  |     1
- different102  |     1
- different103  |     1
+            a            | count 
+-------------------------+-------
+ ¤                      |  1000
+                         |  1000
+ default                 |  1000
+ different-with-nulls1   |     1
+ different-with-nulls101 |     1
+ different-with-nulls103 |     1
+ different-with-nulls105 |     1
+ different-with-nulls107 |     1
+ different-with-nulls109 |     1
+ different-with-nulls11  |     1
 (10 rows)
 
 -- TODO verify that this works with the serialized hash grouping strategy
@@ -305,18 +251,18 @@ select ts, a, count(*) from text_table group by ts, a order by ts, a limit 10;
 (10 rows)
 
 select a, ts, count(*) from text_table group by a, ts order by a desc, ts desc limit 10;
-            a            | ts | count 
--------------------------+----+-------
- ¤                       |  5 |   500
- ¤                       |  4 |   500
- same-with-nulls         |  4 |   500
- same                    |  2 |  1000
- different-with-nulls999 |  5 |     1
- different-with-nulls997 |  5 |     1
- different-with-nulls995 |  5 |     1
- different-with-nulls993 |  5 |     1
- different-with-nulls991 |  5 |     1
- different-with-nulls99  |  5 |     1
+        a        | ts | count 
+-----------------+----+-------
+ ¤              |  5 |   500
+ ¤              |  4 |   500
+ same-with-nulls |  4 |   500
+ same            |  2 |  1000
+ different999    |  3 |     1
+ different998    |  3 |     1
+ different997    |  3 |     1
+ different996    |  3 |     1
+ different995    |  3 |     1
+ different994    |  3 |     1
 (10 rows)
 
 reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -1,0 +1,288 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Check that the vectorized aggregation works properly in the GroupAggregate
+-- mode.
+\pset null ¤
+set max_parallel_workers_per_gather = 0;
+set enable_hashagg to off;
+set timescaledb.enable_vectorized_aggregation to off;
+set timescaledb.debug_require_vector_agg to 'forbid';
+create table groupagg(t int, s text, value int);
+select create_hypertable('groupagg', 't', chunk_time_interval => 10000);
+NOTICE:  adding not-null constraint to column "t"
+   create_hypertable   
+-----------------------
+ (1,public,groupagg,t)
+(1 row)
+
+insert into groupagg
+select
+    xfast * 100 + xslow,
+    case when xfast = 13 then null else xfast end,
+    xfast * 7 + xslow * 3
+from generate_series(10, 99) xfast,
+    generate_series(1, 1000) xslow
+;
+alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 's');
+select count(compress_chunk(x)) from show_chunks('groupagg') x;
+ count 
+-------
+     2
+(1 row)
+
+vacuum analyze groupagg;
+select s, sum(value) from groupagg group by s order by s limit 10;
+ s  |   sum   
+----+---------
+ 10 | 1571500
+ 11 | 1578500
+ 12 | 1585500
+ 14 | 1599500
+ 15 | 1606500
+ 16 | 1613500
+ 17 | 1620500
+ 18 | 1627500
+ 19 | 1634500
+ 20 | 1641500
+(10 rows)
+
+-- The hash grouping policies do not support the GroupAggregate mode in the
+-- reverse order.
+select s, sum(value) from groupagg group by s order by s desc limit 10;
+ s  |   sum   
+----+---------
+ ¤  | 1592500
+ 99 | 2194500
+ 98 | 2187500
+ 97 | 2180500
+ 96 | 2173500
+ 95 | 2166500
+ 94 | 2159500
+ 93 | 2152500
+ 92 | 2145500
+ 91 | 2138500
+(10 rows)
+
+select count(decompress_chunk(x)) from show_chunks('groupagg') x;
+ count 
+-------
+     2
+(1 row)
+
+alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 's nulls first');
+select count(compress_chunk(x)) from show_chunks('groupagg') x;
+ count 
+-------
+     2
+(1 row)
+
+vacuum analyze groupagg;
+select s , sum(value) from groupagg group by s  order by s  nulls first limit 10;
+ s  |   sum   
+----+---------
+ ¤  | 1592500
+ 10 | 1571500
+ 11 | 1578500
+ 12 | 1585500
+ 14 | 1599500
+ 15 | 1606500
+ 16 | 1613500
+ 17 | 1620500
+ 18 | 1627500
+ 19 | 1634500
+(10 rows)
+
+-- More tests for dictionary encoding.
+create table text_table(ts int);
+select create_hypertable('text_table', 'ts', chunk_time_interval => 3);
+NOTICE:  adding not-null constraint to column "ts"
+    create_hypertable    
+-------------------------
+ (3,public,text_table,t)
+(1 row)
+
+alter table text_table set (timescaledb.compress);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "text_table" is set to ""
+NOTICE:  default order by for hypertable "text_table" is set to "ts DESC"
+insert into text_table select 0 /*, default */ from generate_series(1, 1000) x;
+select count(compress_chunk(x)) from show_chunks('text_table') x;
+ count 
+-------
+     1
+(1 row)
+
+alter table text_table add column a text default 'default';
+alter table text_table set (timescaledb.compress,
+    timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a');
+insert into text_table select 1, '' from generate_series(1, 1000) x;
+insert into text_table select 2, 'same' from generate_series(1, 1000) x;
+insert into text_table select 3, 'different' || x from generate_series(1, 1000) x;
+insert into text_table select 4, case when x % 2 = 0 then null else 'same-with-nulls' end from generate_series(1, 1000) x;
+insert into text_table select 5, case when x % 2 = 0 then null else 'different-with-nulls' || x end from generate_series(1, 1000) x;
+select count(compress_chunk(x)) from show_chunks('text_table') x;
+ count 
+-------
+     2
+(1 row)
+
+vacuum analyze text_table;
+explain (verbose, costs off, analyze, timing off, summary off)
+select a, count(*) from text_table group by a order by a limit 10;
+                                                                                                                                                     QUERY PLAN                                                                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   Output: _hyper_3_7_chunk.a, (count(*))
+   ->  Finalize GroupAggregate (actual rows=10 loops=1)
+         Output: _hyper_3_7_chunk.a, count(*)
+         Group Key: _hyper_3_7_chunk.a
+         ->  Merge Append (actual rows=11 loops=1)
+               Sort Key: _hyper_3_7_chunk.a
+               ->  Partial GroupAggregate (actual rows=3 loops=1)
+                     Output: _hyper_3_7_chunk.a, PARTIAL count(*)
+                     Group Key: _hyper_3_7_chunk.a
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_7_chunk (actual rows=3000 loops=1)
+                           Output: _hyper_3_7_chunk.a
+                           Bulk Decompression: true
+                           ->  Index Scan using compress_hyper_4_10_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_10_chunk (actual rows=3 loops=1)
+                                 Output: compress_hyper_4_10_chunk._ts_meta_count, compress_hyper_4_10_chunk._ts_meta_min_2, compress_hyper_4_10_chunk._ts_meta_max_2, compress_hyper_4_10_chunk.ts, compress_hyper_4_10_chunk._ts_meta_min_1, compress_hyper_4_10_chunk._ts_meta_max_1, compress_hyper_4_10_chunk.a
+               ->  Partial GroupAggregate (actual rows=9 loops=1)
+                     Output: _hyper_3_9_chunk.a, PARTIAL count(*)
+                     Group Key: _hyper_3_9_chunk.a
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_9_chunk (actual rows=10 loops=1)
+                           Output: _hyper_3_9_chunk.a
+                           Bulk Decompression: true
+                           ->  Index Scan using compress_hyper_4_11_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_11_chunk (actual rows=1 loops=1)
+                                 Output: compress_hyper_4_11_chunk._ts_meta_count, compress_hyper_4_11_chunk._ts_meta_min_2, compress_hyper_4_11_chunk._ts_meta_max_2, compress_hyper_4_11_chunk.ts, compress_hyper_4_11_chunk._ts_meta_min_1, compress_hyper_4_11_chunk._ts_meta_max_1, compress_hyper_4_11_chunk.a
+(23 rows)
+
+select a, count(*) from text_table group by a order by a limit 10;
+       a       | count 
+---------------+-------
+               |  1000
+ default       |  1000
+ different1    |     1
+ different10   |     1
+ different100  |     1
+ different1000 |     1
+ different101  |     1
+ different102  |     1
+ different103  |     1
+ different104  |     1
+(10 rows)
+
+-- The hash grouping policies do not support the GroupAggregate mode in the
+-- reverse order.
+explain (verbose, costs off, analyze, timing off, summary off)
+select a, count(*) from text_table group by a order by a desc limit 10;
+                                                                                                                                                     QUERY PLAN                                                                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   Output: _hyper_3_7_chunk.a, (count(*))
+   ->  Finalize GroupAggregate (actual rows=10 loops=1)
+         Output: _hyper_3_7_chunk.a, count(*)
+         Group Key: _hyper_3_7_chunk.a
+         ->  Merge Append (actual rows=11 loops=1)
+               Sort Key: _hyper_3_7_chunk.a DESC
+               ->  Partial GroupAggregate (actual rows=2 loops=1)
+                     Output: _hyper_3_7_chunk.a, PARTIAL count(*)
+                     Group Key: _hyper_3_7_chunk.a
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_7_chunk (actual rows=2001 loops=1)
+                           Output: _hyper_3_7_chunk.a
+                           Reverse: true
+                           Bulk Decompression: true
+                           ->  Index Scan Backward using compress_hyper_4_10_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_10_chunk (actual rows=3 loops=1)
+                                 Output: compress_hyper_4_10_chunk._ts_meta_count, compress_hyper_4_10_chunk._ts_meta_min_2, compress_hyper_4_10_chunk._ts_meta_max_2, compress_hyper_4_10_chunk.ts, compress_hyper_4_10_chunk._ts_meta_min_1, compress_hyper_4_10_chunk._ts_meta_max_1, compress_hyper_4_10_chunk.a
+               ->  Partial GroupAggregate (actual rows=10 loops=1)
+                     Output: _hyper_3_9_chunk.a, PARTIAL count(*)
+                     Group Key: _hyper_3_9_chunk.a
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_9_chunk (actual rows=1509 loops=1)
+                           Output: _hyper_3_9_chunk.a
+                           Reverse: true
+                           Bulk Decompression: true
+                           ->  Index Scan Backward using compress_hyper_4_11_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on _timescaledb_internal.compress_hyper_4_11_chunk (actual rows=2 loops=1)
+                                 Output: compress_hyper_4_11_chunk._ts_meta_count, compress_hyper_4_11_chunk._ts_meta_min_2, compress_hyper_4_11_chunk._ts_meta_max_2, compress_hyper_4_11_chunk.ts, compress_hyper_4_11_chunk._ts_meta_min_1, compress_hyper_4_11_chunk._ts_meta_max_1, compress_hyper_4_11_chunk.a
+(25 rows)
+
+select a, count(*) from text_table group by a order by a desc limit 10;
+            a            | count 
+-------------------------+-------
+ ¤                       |  1000
+ same-with-nulls         |   500
+ same                    |  1000
+ different-with-nulls999 |     1
+ different-with-nulls997 |     1
+ different-with-nulls995 |     1
+ different-with-nulls993 |     1
+ different-with-nulls991 |     1
+ different-with-nulls99  |     1
+ different-with-nulls989 |     1
+(10 rows)
+
+-- with NULLS FIRST
+select count(decompress_chunk(x)) from show_chunks('text_table') x;
+ count 
+-------
+     2
+(1 row)
+
+alter table text_table set (timescaledb.compress,
+    timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a nulls first');
+select count(compress_chunk(x)) from show_chunks('text_table') x;
+ count 
+-------
+     2
+(1 row)
+
+select a, count(*) from text_table group by a order by a nulls first limit 10;
+       a       | count 
+---------------+-------
+ ¤             |  1000
+               |  1000
+ default       |  1000
+ different1    |     1
+ different10   |     1
+ different100  |     1
+ different1000 |     1
+ different101  |     1
+ different102  |     1
+ different103  |     1
+(10 rows)
+
+-- TODO verify that this works with the serialized hash grouping strategy
+select ts, a, count(*) from text_table group by ts, a order by ts, a limit 10;
+ ts |       a       | count 
+----+---------------+-------
+  0 | default       |  1000
+  1 |               |  1000
+  2 | same          |  1000
+  3 | different1    |     1
+  3 | different10   |     1
+  3 | different100  |     1
+  3 | different1000 |     1
+  3 | different101  |     1
+  3 | different102  |     1
+  3 | different103  |     1
+(10 rows)
+
+select a, ts, count(*) from text_table group by a, ts order by a desc, ts desc limit 10;
+            a            | ts | count 
+-------------------------+----+-------
+ ¤                       |  5 |   500
+ ¤                       |  4 |   500
+ same-with-nulls         |  4 |   500
+ same                    |  2 |  1000
+ different-with-nulls999 |  5 |     1
+ different-with-nulls997 |  5 |     1
+ different-with-nulls995 |  5 |     1
+ different-with-nulls993 |  5 |     1
+ different-with-nulls991 |  5 |     1
+ different-with-nulls99  |  5 |     1
+(10 rows)
+
+reset max_parallel_workers_per_gather;
+reset timescaledb.debug_require_vector_agg;
+reset enable_hashagg;

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Check that the vectorized aggregation works properly in the GroupAggregate
 -- mode.
-\pset null ¤
+\pset null $
 set max_parallel_workers_per_gather = 0;
 set enable_hashagg to off;
 --set timescaledb.enable_vectorized_aggregation to off;
@@ -55,7 +55,7 @@ set timescaledb.debug_require_vector_agg to 'forbid';
 select s, sum(value) from groupagg group by s order by s desc limit 10;
  s  |   sum   
 ----+---------
- ¤ | 3454301
+  $ | 3454301
  99 | 4349475
  98 | 4339066
  97 | 4328657
@@ -88,7 +88,7 @@ set timescaledb.debug_require_vector_agg to 'require';
 select s, sum(value) from groupagg group by s order by s nulls first limit 10;
  s  |   sum   
 ----+---------
- ¤ | 3454301
+  $ | 3454301
  10 | 3423074
  11 | 3433483
  12 | 3443892
@@ -149,14 +149,14 @@ order by table_schema,
          ordinal_position;
  table_schema | table_name | column_name | collation_name 
 --------------+------------+-------------+----------------
- public       | text_table | ts          | ¤
- public       | text_table | a           | ¤
+ public       | text_table | ts          | $
+ public       | text_table | a           | $
 (2 rows)
 
 select datcollate from pg_database where datname = current_database();
  datcollate 
 ------------
- C
+ C.UTF-8
 (1 row)
 
 select 'different-with-nulls999' > 'different999';
@@ -192,7 +192,7 @@ select a, count(*) from text_table group by a order by a limit 10;
 select a, count(*) from text_table group by a order by a desc limit 10;
         a        | count 
 -----------------+-------
- ¤              |  1000
+ $               |  1000
  same-with-nulls |   500
  same            |  1000
  different999    |     1
@@ -222,7 +222,7 @@ select count(compress_chunk(x)) from show_chunks('text_table') x;
 select a, count(*) from text_table group by a order by a nulls first limit 10;
             a            | count 
 -------------------------+-------
- ¤                      |  1000
+ $                       |  1000
                          |  1000
  default                 |  1000
  different-with-nulls1   |     1
@@ -253,8 +253,8 @@ select ts, a, count(*) from text_table group by ts, a order by ts, a limit 10;
 select a, ts, count(*) from text_table group by a, ts order by a desc, ts desc limit 10;
         a        | ts | count 
 -----------------+----+-------
- ¤              |  5 |   500
- ¤              |  4 |   500
+ $               |  5 |   500
+ $               |  4 |   500
  same-with-nulls |  4 |   500
  same            |  2 |  1000
  different999    |  3 |     1

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -137,40 +137,6 @@ select count(compress_chunk(x)) from show_chunks('text_table') x;
 (1 row)
 
 vacuum analyze text_table;
--- The following tests are collation-sensitive, so verify it all matches.
-select table_schema,
-       table_name,
-       column_name,
-       collation_name
-from information_schema.columns
-where table_name = 'text_table'
-order by table_schema,
-         table_name,
-         ordinal_position;
- table_schema | table_name | column_name | collation_name 
---------------+------------+-------------+----------------
- public       | text_table | ts          | $
- public       | text_table | a           | $
-(2 rows)
-
-select datcollate from pg_database where datname = current_database();
- datcollate 
-------------
- C.UTF-8
-(1 row)
-
-select 'different-with-nulls999' > 'different999';
- ?column? 
-----------
- f
-(1 row)
-
-select count(distinct a) from text_table;
- count 
--------
-  1504
-(1 row)
-
 -- Test the GroupAggregate by a text column. Not vectorized for now.
 select a, count(*) from text_table group by a order by a limit 10;
             a            | count 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TEST_FILES
     skip_scan.sql
     transparent_decompression_join_index.sql
     vector_agg_functions.sql
+    vector_agg_groupagg.sql
     vector_agg_param.sql
     vectorized_aggregation.sql)
 

--- a/tsl/test/sql/vector_agg_groupagg.sql
+++ b/tsl/test/sql/vector_agg_groupagg.sql
@@ -5,7 +5,7 @@
 -- Check that the vectorized aggregation works properly in the GroupAggregate
 -- mode.
 
-\pset null ¤
+\pset null $
 
 set max_parallel_workers_per_gather = 0;
 set enable_hashagg to off;

--- a/tsl/test/sql/vector_agg_groupagg.sql
+++ b/tsl/test/sql/vector_agg_groupagg.sql
@@ -10,19 +10,19 @@
 set max_parallel_workers_per_gather = 0;
 set enable_hashagg to off;
 
-set timescaledb.enable_vectorized_aggregation to off;
-set timescaledb.debug_require_vector_agg to 'forbid';
+--set timescaledb.enable_vectorized_aggregation to off;
+--set timescaledb.debug_require_vector_agg to 'forbid';
 
-create table groupagg(t int, s text, value int);
+create table groupagg(t int, s int, value int);
 select create_hypertable('groupagg', 't', chunk_time_interval => 10000);
 
 insert into groupagg
 select
-    xfast * 100 + xslow,
+    xslow * 10,
     case when xfast = 13 then null else xfast end,
     xfast * 7 + xslow * 3
 from generate_series(10, 99) xfast,
-    generate_series(1, 1000) xslow
+    generate_series(1, 1487) xslow
 ;
 
 alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
@@ -31,24 +31,29 @@ select count(compress_chunk(x)) from show_chunks('groupagg') x;
 vacuum analyze groupagg;
 
 
+set timescaledb.debug_require_vector_agg to 'require';
 select s, sum(value) from groupagg group by s order by s limit 10;
 
 -- The hash grouping policies do not support the GroupAggregate mode in the
 -- reverse order.
+set timescaledb.debug_require_vector_agg to 'forbid';
 select s, sum(value) from groupagg group by s order by s desc limit 10;
+reset timescaledb.debug_require_vector_agg;
 
-
-
+-- Also test the NULLS FIRST order.
 select count(decompress_chunk(x)) from show_chunks('groupagg') x;
 alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 's nulls first');
 select count(compress_chunk(x)) from show_chunks('groupagg') x;
 vacuum analyze groupagg;
 
-select s , sum(value) from groupagg group by s  order by s  nulls first limit 10;
+set timescaledb.debug_require_vector_agg to 'require';
+select s, sum(value) from groupagg group by s order by s nulls first limit 10;
+reset timescaledb.debug_require_vector_agg;
 
 
--- More tests for dictionary encoding.
+-- More tests for dictionary encoding. This is not vectorized at the moment.
+set timescaledb.debug_require_vector_agg to 'forbid';
 create table text_table(ts int);
 select create_hypertable('text_table', 'ts', chunk_time_interval => 3);
 alter table text_table set (timescaledb.compress);
@@ -69,7 +74,7 @@ insert into text_table select 5, case when x % 2 = 0 then null else 'different-w
 select count(compress_chunk(x)) from show_chunks('text_table') x;
 vacuum analyze text_table;
 
-
+-- The following tests are collation-sensitive, so verify it all matches.
 select table_schema,
        table_name,
        column_name,
@@ -80,26 +85,19 @@ order by table_schema,
          table_name,
          ordinal_position;
 
-select datname,
-       datcollate
-from pg_database
-where datname = current_database();
+select datcollate from pg_database where datname = current_database();
 
 select 'different-with-nulls999' > 'different999';
 
 select count(distinct a) from text_table;
 
 
-explain (verbose, costs off, analyze, timing off, summary off)
-select a, count(*) from text_table group by a order by a limit 10;
+-- Test the GroupAggregate by a text column. Not vectorized for now.
 select a, count(*) from text_table group by a order by a limit 10;
 
 -- The hash grouping policies do not support the GroupAggregate mode in the
 -- reverse order.
-explain (verbose, costs off, analyze, timing off, summary off)
 select a, count(*) from text_table group by a order by a desc limit 10;
-select a, count(*) from text_table group by a order by a desc limit 10;
-
 
 
 -- with NULLS FIRST

--- a/tsl/test/sql/vector_agg_groupagg.sql
+++ b/tsl/test/sql/vector_agg_groupagg.sql
@@ -74,23 +74,6 @@ insert into text_table select 5, case when x % 2 = 0 then null else 'different-w
 select count(compress_chunk(x)) from show_chunks('text_table') x;
 vacuum analyze text_table;
 
--- The following tests are collation-sensitive, so verify it all matches.
-select table_schema,
-       table_name,
-       column_name,
-       collation_name
-from information_schema.columns
-where table_name = 'text_table'
-order by table_schema,
-         table_name,
-         ordinal_position;
-
-select datcollate from pg_database where datname = current_database();
-
-select 'different-with-nulls999' > 'different999';
-
-select count(distinct a) from text_table;
-
 
 -- Test the GroupAggregate by a text column. Not vectorized for now.
 select a, count(*) from text_table group by a order by a limit 10;

--- a/tsl/test/sql/vector_agg_groupagg.sql
+++ b/tsl/test/sql/vector_agg_groupagg.sql
@@ -30,6 +30,7 @@ alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby =
 select count(compress_chunk(x)) from show_chunks('groupagg') x;
 vacuum analyze groupagg;
 
+
 select s, sum(value) from groupagg group by s order by s limit 10;
 
 -- The hash grouping policies do not support the GroupAggregate mode in the
@@ -67,6 +68,27 @@ insert into text_table select 5, case when x % 2 = 0 then null else 'different-w
 
 select count(compress_chunk(x)) from show_chunks('text_table') x;
 vacuum analyze text_table;
+
+
+select table_schema,
+       table_name,
+       column_name,
+       collation_name
+from information_schema.columns
+where table_name = 'text_table'
+order by table_schema,
+         table_name,
+         ordinal_position;
+
+select datname,
+       datcollate
+from pg_database
+where datname = current_database();
+
+select 'different-with-nulls999' > 'different999';
+
+select count(distinct a) from text_table;
+
 
 explain (verbose, costs off, analyze, timing off, summary off)
 select a, count(*) from text_table group by a order by a limit 10;

--- a/tsl/test/sql/vector_agg_groupagg.sql
+++ b/tsl/test/sql/vector_agg_groupagg.sql
@@ -1,0 +1,98 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Check that the vectorized aggregation works properly in the GroupAggregate
+-- mode.
+
+\pset null ¤
+
+set max_parallel_workers_per_gather = 0;
+set enable_hashagg to off;
+
+set timescaledb.enable_vectorized_aggregation to off;
+set timescaledb.debug_require_vector_agg to 'forbid';
+
+create table groupagg(t int, s text, value int);
+select create_hypertable('groupagg', 't', chunk_time_interval => 10000);
+
+insert into groupagg
+select
+    xfast * 100 + xslow,
+    case when xfast = 13 then null else xfast end,
+    xfast * 7 + xslow * 3
+from generate_series(10, 99) xfast,
+    generate_series(1, 1000) xslow
+;
+
+alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 's');
+select count(compress_chunk(x)) from show_chunks('groupagg') x;
+vacuum analyze groupagg;
+
+select s, sum(value) from groupagg group by s order by s limit 10;
+
+-- The hash grouping policies do not support the GroupAggregate mode in the
+-- reverse order.
+select s, sum(value) from groupagg group by s order by s desc limit 10;
+
+
+
+select count(decompress_chunk(x)) from show_chunks('groupagg') x;
+alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 's nulls first');
+select count(compress_chunk(x)) from show_chunks('groupagg') x;
+vacuum analyze groupagg;
+
+select s , sum(value) from groupagg group by s  order by s  nulls first limit 10;
+
+
+-- More tests for dictionary encoding.
+create table text_table(ts int);
+select create_hypertable('text_table', 'ts', chunk_time_interval => 3);
+alter table text_table set (timescaledb.compress);
+
+insert into text_table select 0 /*, default */ from generate_series(1, 1000) x;
+select count(compress_chunk(x)) from show_chunks('text_table') x;
+
+alter table text_table add column a text default 'default';
+alter table text_table set (timescaledb.compress,
+    timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a');
+
+insert into text_table select 1, '' from generate_series(1, 1000) x;
+insert into text_table select 2, 'same' from generate_series(1, 1000) x;
+insert into text_table select 3, 'different' || x from generate_series(1, 1000) x;
+insert into text_table select 4, case when x % 2 = 0 then null else 'same-with-nulls' end from generate_series(1, 1000) x;
+insert into text_table select 5, case when x % 2 = 0 then null else 'different-with-nulls' || x end from generate_series(1, 1000) x;
+
+select count(compress_chunk(x)) from show_chunks('text_table') x;
+vacuum analyze text_table;
+
+explain (verbose, costs off, analyze, timing off, summary off)
+select a, count(*) from text_table group by a order by a limit 10;
+select a, count(*) from text_table group by a order by a limit 10;
+
+-- The hash grouping policies do not support the GroupAggregate mode in the
+-- reverse order.
+explain (verbose, costs off, analyze, timing off, summary off)
+select a, count(*) from text_table group by a order by a desc limit 10;
+select a, count(*) from text_table group by a order by a desc limit 10;
+
+
+
+-- with NULLS FIRST
+select count(decompress_chunk(x)) from show_chunks('text_table') x;
+alter table text_table set (timescaledb.compress,
+    timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a nulls first');
+select count(compress_chunk(x)) from show_chunks('text_table') x;
+
+select a, count(*) from text_table group by a order by a nulls first limit 10;
+
+
+-- TODO verify that this works with the serialized hash grouping strategy
+select ts, a, count(*) from text_table group by ts, a order by ts, a limit 10;
+select a, ts, count(*) from text_table group by a, ts order by a desc, ts desc limit 10;
+
+reset max_parallel_workers_per_gather;
+reset timescaledb.debug_require_vector_agg;
+reset enable_hashagg;


### PR DESCRIPTION
The hash grouping strategies do not preserve the input order when the compressed batches need to be reversed. Disable them in this case.