### PR TITLE
Fix collation issue in VectorAgg test

### DIFF
--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -122,7 +122,7 @@ select count(compress_chunk(x)) from show_chunks('text_table') x;
      1
 (1 row)
 
-alter table text_table add column a text default 'default';
+alter table text_table add column a text collate "POSIX" default 'default';
 alter table text_table set (timescaledb.compress,
     timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a');
 insert into text_table select 1, '' from generate_series(1, 1000) x;

--- a/tsl/test/sql/vector_agg_groupagg.sql
+++ b/tsl/test/sql/vector_agg_groupagg.sql
@@ -61,7 +61,7 @@ alter table text_table set (timescaledb.compress);
 insert into text_table select 0 /*, default */ from generate_series(1, 1000) x;
 select count(compress_chunk(x)) from show_chunks('text_table') x;
 
-alter table text_table add column a text default 'default';
+alter table text_table add column a text collate "POSIX" default 'default';
 alter table text_table set (timescaledb.compress,
     timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a');
 


### PR DESCRIPTION
The vector_agg_groupagg test has queries that can return data in a different order depending on the locale of the system.

To fix this, add a fixed collation to the test table definition.