### PR TITLE
Fix ExplainHook breaking call chain

### DIFF
--- a/.unreleased/pr_7694
+++ b/.unreleased/pr_7694
@@ -1,0 +1,1 @@
+Fixes: #7694 Fix ExplainHook breaking call chain


### PR DESCRIPTION
Hooks in postgres are supposed to be chained and call the previous
hook in your own added hooks. Not calling previous hook will prevent
other extensions from having working hooks.

Disable-check: force-changelog-file
