### PR TITLE
Block dropping internal compressed chunks with `drop_chunk()`

### DIFF
--- a/.unreleased/pr_7695
+++ b/.unreleased/pr_7695
@@ -1,0 +1,1 @@
+Fixes: #7695 Block dropping internal compressed chunks with `drop_chunk()`

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4044,6 +4044,14 @@ ts_chunk_drop_single_chunk(PG_FUNCTION_ARGS)
 															   true);
 	Assert(ch != NULL);
 	ts_chunk_validate_chunk_status_for_operation(ch, CHUNK_DROP, true /*throw_error */);
+
+	if (ts_chunk_contains_compressed_data(ch))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("dropping compressed chunks not supported"),
+				 errhint("Please drop the corresponding chunk on the uncompressed hypertable "
+						 "instead.")));
+
 	/* do not drop any chunk dependencies */
 	ts_chunk_drop(ch, DROP_RESTRICT, LOG);
 	PG_RETURN_BOOL(true);

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -367,6 +367,8 @@ WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 \set ON_ERROR_STOP 0
 DROP TABLE :COMPRESSED_CHUNK_NAME;
 ERROR:  dropping compressed chunks not supported
+SELECT _timescaledb_functions.drop_chunk(:'COMPRESSED_CHUNK_NAME');
+ERROR:  dropping compressed chunks not supported
 \set ON_ERROR_STOP 1
 SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -226,6 +226,7 @@ WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 
 \set ON_ERROR_STOP 0
 DROP TABLE :COMPRESSED_CHUNK_NAME;
+SELECT _timescaledb_functions.drop_chunk(:'COMPRESSED_CHUNK_NAME');
 \set ON_ERROR_STOP 1
 
 SELECT


### PR DESCRIPTION
Follow up on this [SDC](https://github.com/timescale/Support-Dev-Collab/issues/2570)

Dropping internal compressed chunks is blocked on DDL level (with process utility hook), but is still possible with `_timescaledb_functions.drop_chunk` function. This patch adds a simple check to prevent that.