### PR TITLE
Fix the umash build

### DIFF
--- a/tsl/src/import/CMakeLists.txt
+++ b/tsl/src/import/CMakeLists.txt
@@ -8,8 +8,6 @@ if(SOURCES)
   # Disable clang-tidy for imported code
   add_library(target_no_static_code_analysis OBJECT ${SOURCES})
   set_target_properties(target_no_static_code_analysis PROPERTIES C_CLANG_TIDY
-                                                                  "")
-
-  target_link_libraries(${TSL_LIBRARY_NAME}
-                        $<TARGET_OBJECTS:target_no_static_code_analysis>)
+  target_sources(${TSL_LIBRARY_NAME}
+                 PRIVATE $<TARGET_OBJECTS:target_no_static_code_analysis>)
 endif()

--- a/tsl/src/import/CMakeLists.txt
+++ b/tsl/src/import/CMakeLists.txt
@@ -8,6 +8,7 @@ if(SOURCES)
   # Disable clang-tidy for imported code
   add_library(target_no_static_code_analysis OBJECT ${SOURCES})
   set_target_properties(target_no_static_code_analysis PROPERTIES C_CLANG_TIDY
+                                                                  "")
   target_sources(${TSL_LIBRARY_NAME}
                  PRIVATE $<TARGET_OBJECTS:target_no_static_code_analysis>)
 endif()


### PR DESCRIPTION
Apparently the proper way to use the object libraries in cmake is to add them to target_sources, not target_link_libraries.

The failing workflow: https://github.com/timescale/timescaledb/actions/runs/13271561042/job/37052078190

Some references:
https://cprieto.com/posts/2020/06/cmake-and-object-libraries.html

https://cmake.org/pipermail/cmake/2018-June/067721.html

Disable-check: force-changelog-file