### PR TITLE
Add GUC for TAM arrow cache size

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -165,6 +165,7 @@ TSDLLEXPORT char *ts_guc_hypercore_indexam_whitelist;
 TSDLLEXPORT HypercoreCopyToBehavior ts_guc_hypercore_copy_to_behavior =
 	HYPERCORE_COPY_NO_COMPRESSED_DATA;
 TSDLLEXPORT bool ts_guc_enable_hypercore_scankey_pushdown = true;
+TSDLLEXPORT int ts_guc_hypercore_arrow_cache_max_entries;
 
 /* default value of ts_guc_max_open_chunks_per_insert and
  * ts_guc_max_cached_chunks_per_hypertable will be set as their respective boot-value when the
@@ -1083,6 +1084,23 @@ _guc_init(void)
 							 /* check_hook= */ NULL,
 							 /* assign_hook= */ NULL,
 							 /* show_hook= */ NULL);
+
+	DefineCustomIntVariable(/* name= */ MAKE_EXTOPTION("hypercore_arrow_cache_max_entries"),
+							/* short_desc= */ "max number of entries in arrow data cache",
+							/* long_desc= */
+							"The max number of decompressed arrow segments that can be "
+							"cached before entries are evicted. This mainly affects the "
+							"performance of index scans on the Hypercore TAM "
+							"when segments are accessed in non-sequential order.",
+							/* valueAddr= */ &ts_guc_hypercore_arrow_cache_max_entries,
+							/* bootValue= */ 25000,
+							/* minValue= */ 1,
+							/* maxValue= */ INT_MAX,
+							/* context= */ PGC_USERSET,
+							/* flags= */ 0,
+							/* check_hook= */ NULL,
+							/* assign_hook= */ NULL,
+							/* show_hook= */ NULL);
 
 	DefineCustomIntVariable(/* name= */ MAKE_EXTOPTION("debug_bgw_scheduler_exit_status"),
 							/* short_desc= */ "exit status to use when shutting down the scheduler",

--- a/src/guc.h
+++ b/src/guc.h
@@ -149,6 +149,7 @@ typedef enum HypercoreCopyToBehavior
 
 extern TSDLLEXPORT HypercoreCopyToBehavior ts_guc_hypercore_copy_to_behavior;
 extern TSDLLEXPORT bool ts_guc_enable_hypercore_scankey_pushdown;
+extern TSDLLEXPORT int ts_guc_hypercore_arrow_cache_max_entries;
 
 void _guc_init(void);
 

--- a/tsl/src/hypercore/arrow_cache.h
+++ b/tsl/src/hypercore/arrow_cache.h
@@ -53,7 +53,7 @@ typedef struct ArrowColumnCache
 	size_t arrow_column_cache_lru_count; /* Arrow column cache LRU list count */
 	dlist_head arrow_column_cache_lru;	 /* Arrow column cache LRU list */
 	HTAB *htab;							 /* Arrow column cache */
-	uint16 maxsize;
+	size_t maxsize;
 } ArrowColumnCache;
 
 typedef struct ArrowTupleTableSlot ArrowTupleTableSlot;

--- a/tsl/test/expected/hypercore.out
+++ b/tsl/test/expected/hypercore.out
@@ -12,7 +12,7 @@ show timescaledb.hypercore_indexam_whitelist;
 -- user.
 grant all on schema _timescaledb_internal to :ROLE_DEFAULT_PERM_USER;
 set role :ROLE_DEFAULT_PERM_USER;
-SET timescaledb.arrow_cache_maxsize = 4;
+SET timescaledb.hypercore_arrow_cache_max_entries = 4;
 CREATE TABLE readings(
        time timestamptz UNIQUE,
        location int,

--- a/tsl/test/sql/hypercore.sql
+++ b/tsl/test/sql/hypercore.sql
@@ -9,7 +9,7 @@ show timescaledb.hypercore_indexam_whitelist;
 grant all on schema _timescaledb_internal to :ROLE_DEFAULT_PERM_USER;
 set role :ROLE_DEFAULT_PERM_USER;
 
-SET timescaledb.arrow_cache_maxsize = 4;
+SET timescaledb.hypercore_arrow_cache_max_entries = 4;
 
 CREATE TABLE readings(
        time timestamptz UNIQUE,


### PR DESCRIPTION
The arrow cache is used to cache decompressed arrow segments and is mostly useful for index scans that access values across segments in non-segment order.

The fixed cache size was set too small for index scans on bigger data sets. Therefore, increase the default size and make it configurable via a GUC.

Disable-check: force-changelog-file