### PR TITLE
Implement bool compression (#7233)

### DIFF
--- a/.unreleased/pr_7700
+++ b/.unreleased/pr_7700
@@ -1,0 +1,1 @@
+Implements: #7233 Implement bool compression

--- a/sql/pre_install/insert_data.sql
+++ b/sql/pre_install/insert_data.sql
@@ -8,4 +8,5 @@ insert into _timescaledb_catalog.compression_algorithm( id, version, name, descr
 ( 1, 1, 'COMPRESSION_ALGORITHM_ARRAY', 'array'),
 ( 2, 1, 'COMPRESSION_ALGORITHM_DICTIONARY', 'dictionary'),
 ( 3, 1, 'COMPRESSION_ALGORITHM_GORILLA', 'gorilla'),
-( 4, 1, 'COMPRESSION_ALGORITHM_DELTADELTA', 'deltadelta');
+( 4, 1, 'COMPRESSION_ALGORITHM_DELTADELTA', 'deltadelta'),
+( 5, 1, 'COMPRESSION_ALGORITHM_BOOL_COMPRESS', 'boolcompress');

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -76,6 +76,8 @@ CROSSMODULE_WRAPPER(dictionary_compressor_append);
 CROSSMODULE_WRAPPER(dictionary_compressor_finish);
 CROSSMODULE_WRAPPER(array_compressor_append);
 CROSSMODULE_WRAPPER(array_compressor_finish);
+CROSSMODULE_WRAPPER(bool_compressor_append);
+CROSSMODULE_WRAPPER(bool_compressor_finish);
 CROSSMODULE_WRAPPER(create_compressed_chunk);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
@@ -395,6 +397,8 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.dictionary_compressor_finish = error_no_default_fn_pg_community,
 	.array_compressor_append = error_no_default_fn_pg_community,
 	.array_compressor_finish = error_no_default_fn_pg_community,
+	.bool_compressor_append = error_no_default_fn_pg_community,
+	.bool_compressor_finish = error_no_default_fn_pg_community,
 	.hypercore_handler = error_no_default_fn_pg_community,
 	.hypercore_proxy_handler = error_pg_community_hypercore_proxy_handler,
 	.is_compressed_tid = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -149,6 +149,8 @@ typedef struct CrossModuleFunctions
 	PGFunction dictionary_compressor_finish;
 	PGFunction array_compressor_append;
 	PGFunction array_compressor_finish;
+	PGFunction bool_compressor_append;
+	PGFunction bool_compressor_finish;
 	PGFunction hypercore_handler;
 	PGFunction hypercore_proxy_handler;
 	PGFunction is_compressed_tid;

--- a/src/guc.c
+++ b/src/guc.c
@@ -149,6 +149,7 @@ TSDLLEXPORT bool ts_guc_auto_sparse_indexes = true;
 TSDLLEXPORT bool ts_guc_default_hypercore_use_access_method = false;
 bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
+TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
 
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
@@ -738,6 +739,17 @@ _guc_init(void)
 							 "Enable segmentwise recompression functionality",
 							 "Enable segmentwise recompression",
 							 &ts_guc_enable_segmentwise_recompression,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_bool_compression"),
+							 "Enable bool compression functionality",
+							 "Enable bool compression",
+							 &ts_guc_enable_bool_compression,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -69,6 +69,7 @@ extern TSDLLEXPORT bool ts_guc_enable_delete_after_compression;
 extern TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh;
 extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
+extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
 
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel

--- a/tsl/src/compression/README.md
+++ b/tsl/src/compression/README.md
@@ -67,6 +67,13 @@ structure and does not actually compress it (though TOAST-based compression
 can be applied on top). It is the compression mechanism used when no other
 compression mechanism works. It can store any type of data.
 
+### Bool Compressor
+
+The bool compressor is a simple compression algorithm that stores boolean values
+using the simple8b_rle algorithm only, without any additional processing. During
+decompression it decompresses the data and stores it in memory as a bitmap. The
+row based iterators then walk through the bitmap.
+
 # Merging chunks while compressing #
 
 ## Setup ##

--- a/tsl/src/compression/algorithms/CMakeLists.txt
+++ b/tsl/src/compression/algorithms/CMakeLists.txt
@@ -3,5 +3,6 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/datum_serialize.c
     ${CMAKE_CURRENT_SOURCE_DIR}/deltadelta.c
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/gorilla.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/gorilla.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/bool_compress.c)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -1,0 +1,465 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include "bool_compress.h"
+#include "compression/arrow_c_data_interface.h"
+#include "compression/compression.h"
+#include "simple8b_rle.h"
+#include "simple8b_rle_bitmap.h"
+
+typedef struct BoolCompressed
+{
+	CompressedDataHeaderFields;
+	uint8 has_nulls; /* 1 if this has a NULLs bitmap after the values, 0 otherwise */
+	uint8 padding[2];
+	char values[FLEXIBLE_ARRAY_MEMBER];
+} BoolCompressed;
+
+typedef struct BoolDecompressionIterator
+{
+	DecompressionIterator base;
+	Simple8bRleBitmap values;
+	Simple8bRleBitmap nulls;
+	int32 num_elements;
+	int32 value_position;
+	int32 element_position;
+} BoolDecompressionIterator;
+
+typedef struct BoolCompressor
+{
+	Simple8bRleCompressor values;
+	Simple8bRleCompressor nulls;
+	bool has_nulls;
+} BoolCompressor;
+
+typedef struct ExtendedCompressor
+{
+	Compressor base;
+	BoolCompressor *internal;
+} ExtendedCompressor;
+
+/*
+ * Local helpers
+ */
+static void bool_compressor_append_bool(Compressor *compressor, Datum val);
+
+static void bool_compressor_append_null_value(Compressor *compressor);
+
+static void *bool_compressor_finish_and_reset(Compressor *compressor);
+
+const Compressor bool_compressor_initializer = {
+	.append_val = bool_compressor_append_bool,
+	.append_null = bool_compressor_append_null_value,
+	.finish = bool_compressor_finish_and_reset,
+};
+
+static BoolCompressed *bool_compressed_from_parts(Simple8bRleSerialized *values,
+												  Simple8bRleSerialized *nulls);
+
+static void decompression_iterator_init(BoolDecompressionIterator *iter, void *compressed,
+										Oid element_type, bool forward);
+
+static DecompressResultInternal
+bool_decompression_iterator_try_next_forward_internal(BoolDecompressionIterator *iter);
+
+static DecompressResultInternal
+bool_decompression_iterator_try_next_reverse_internal(BoolDecompressionIterator *iter);
+
+static inline DecompressResult convert_from_internal(DecompressResultInternal res_internal);
+
+/*
+ * Compressor framework functions and definitions for the bool_compress algorithm.
+ */
+
+extern BoolCompressor *
+bool_compressor_alloc(void)
+{
+	BoolCompressor *compressor = palloc0(sizeof(*compressor));
+	simple8brle_compressor_init(&compressor->values);
+	simple8brle_compressor_init(&compressor->nulls);
+	return compressor;
+}
+
+extern void
+bool_compressor_append_null(BoolCompressor *compressor)
+{
+	compressor->has_nulls = true;
+	simple8brle_compressor_append(&compressor->nulls, 1);
+}
+
+extern void
+bool_compressor_append_value(BoolCompressor *compressor, bool next_val)
+{
+	simple8brle_compressor_append(&compressor->values, next_val);
+	simple8brle_compressor_append(&compressor->nulls, 0);
+}
+
+extern void *
+bool_compressor_finish(BoolCompressor *compressor)
+{
+	Simple8bRleSerialized *values = simple8brle_compressor_finish(&compressor->values);
+	Simple8bRleSerialized *nulls = simple8brle_compressor_finish(&compressor->nulls);
+	BoolCompressed *compressed;
+
+	if (values == NULL)
+		return NULL;
+
+	compressed = bool_compressed_from_parts(values, compressor->has_nulls ? nulls : NULL);
+
+	Assert(compressed->compression_algorithm == COMPRESSION_ALGORITHM_BOOL_COMPRESS);
+	return compressed;
+}
+
+extern bool
+bool_compressed_has_nulls(const CompressedDataHeader *header)
+{
+	const BoolCompressed *ddc = (const BoolCompressed *) header;
+	return ddc->has_nulls;
+}
+
+extern DecompressResult
+bool_decompression_iterator_try_next_forward(DecompressionIterator *iter)
+{
+	Assert(iter->compression_algorithm == COMPRESSION_ALGORITHM_BOOL_COMPRESS && iter->forward);
+	Assert(iter->element_type == BOOLOID);
+	return convert_from_internal(
+		bool_decompression_iterator_try_next_forward_internal((BoolDecompressionIterator *) iter));
+}
+
+extern DecompressionIterator *
+bool_decompression_iterator_from_datum_forward(Datum bool_compressed, Oid element_type)
+{
+	BoolDecompressionIterator *iterator = palloc(sizeof(*iterator));
+	decompression_iterator_init(iterator,
+								(void *) PG_DETOAST_DATUM(bool_compressed),
+								element_type,
+								true);
+	return &iterator->base;
+}
+
+extern DecompressResult
+bool_decompression_iterator_try_next_reverse(DecompressionIterator *iter)
+{
+	Assert(iter->compression_algorithm == COMPRESSION_ALGORITHM_BOOL_COMPRESS && !iter->forward);
+	Assert(iter->element_type == BOOLOID);
+	return convert_from_internal(
+		bool_decompression_iterator_try_next_reverse_internal((BoolDecompressionIterator *) iter));
+}
+
+extern DecompressionIterator *
+bool_decompression_iterator_from_datum_reverse(Datum bool_compressed, Oid element_type)
+{
+	BoolDecompressionIterator *iterator = palloc(sizeof(*iterator));
+	decompression_iterator_init(iterator,
+								(void *) PG_DETOAST_DATUM(bool_compressed),
+								element_type,
+								false);
+	return &iterator->base;
+}
+
+extern void
+bool_compressed_send(CompressedDataHeader *header, StringInfo buffer)
+{
+	const BoolCompressed *data = (BoolCompressed *) header;
+	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_BOOL_COMPRESS);
+	pq_sendbyte(buffer, data->has_nulls);
+	simple8brle_serialized_send(buffer, (Simple8bRleSerialized *) data->values);
+	if (data->has_nulls)
+	{
+		Simple8bRleSerialized *nulls =
+			(Simple8bRleSerialized *) (((char *) data->values) +
+									   simple8brle_serialized_total_size(
+										   (Simple8bRleSerialized *) data->values));
+		simple8brle_serialized_send(buffer, nulls);
+	}
+}
+
+extern Datum
+bool_compressed_recv(StringInfo buffer)
+{
+	uint8 has_nulls;
+	Simple8bRleSerialized *values;
+	Simple8bRleSerialized *nulls = NULL;
+	BoolCompressed *compressed;
+
+	has_nulls = pq_getmsgbyte(buffer);
+	CheckCompressedData(has_nulls == 0 || has_nulls == 1);
+
+	values = simple8brle_serialized_recv(buffer);
+	if (has_nulls)
+		nulls = simple8brle_serialized_recv(buffer);
+
+	compressed = bool_compressed_from_parts(values, nulls);
+
+	PG_RETURN_POINTER(compressed);
+}
+
+extern Compressor *
+bool_compressor_for_type(Oid element_type)
+{
+	ExtendedCompressor *compressor = palloc(sizeof(*compressor));
+	switch (element_type)
+	{
+		case BOOLOID:
+			*compressor = (ExtendedCompressor){ .base = bool_compressor_initializer };
+			return &compressor->base;
+		default:
+			elog(ERROR, "invalid type for bool compressor \"%s\"", format_type_be(element_type));
+	}
+
+	pg_unreachable();
+}
+
+/*
+ * Cross-module functions for the bool_compress algorithm.
+ */
+
+extern Datum
+tsl_bool_compressor_append(PG_FUNCTION_ARGS)
+{
+	MemoryContext old_context;
+	MemoryContext agg_context;
+	BoolCompressor *compressor = (BoolCompressor *) (PG_ARGISNULL(0) ? NULL : PG_GETARG_POINTER(0));
+
+	if (!AggCheckCallContext(fcinfo, &agg_context))
+	{
+		/* cannot be called directly because of internal-type argument */
+		elog(ERROR, "tsl_bool_compressor_append called in non-aggregate context");
+	}
+
+	old_context = MemoryContextSwitchTo(agg_context);
+
+	if (compressor == NULL)
+	{
+		compressor = bool_compressor_alloc();
+		if (PG_NARGS() > 2)
+			elog(ERROR, "append expects two arguments");
+	}
+
+	if (PG_ARGISNULL(1))
+		bool_compressor_append_null(compressor);
+	else
+	{
+		bool next_val = PG_GETARG_BOOL(1);
+		bool_compressor_append_value(compressor, next_val);
+	}
+
+	MemoryContextSwitchTo(old_context);
+	PG_RETURN_POINTER(compressor);
+}
+
+extern Datum
+tsl_bool_compressor_finish(PG_FUNCTION_ARGS)
+{
+	BoolCompressor *compressor = PG_ARGISNULL(0) ? NULL : (BoolCompressor *) PG_GETARG_POINTER(0);
+	void *compressed;
+	if (compressor == NULL)
+		PG_RETURN_NULL();
+
+	compressed = bool_compressor_finish(compressor);
+	if (compressed == NULL)
+		PG_RETURN_NULL();
+	PG_RETURN_POINTER(compressed);
+}
+
+/*
+ * Local helpers
+ */
+static void
+bool_compressor_append_bool(Compressor *compressor, Datum val)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = bool_compressor_alloc();
+
+	bool_compressor_append_value(extended->internal, DatumGetBool(val) ? true : false);
+}
+
+static void
+bool_compressor_append_null_value(Compressor *compressor)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = bool_compressor_alloc();
+
+	bool_compressor_append_null(extended->internal);
+}
+
+static void *
+bool_compressor_finish_and_reset(Compressor *compressor)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	void *compressed = bool_compressor_finish(extended->internal);
+	pfree(extended->internal);
+	extended->internal = NULL;
+	return compressed;
+}
+
+static BoolCompressed *
+bool_compressed_from_parts(Simple8bRleSerialized *values, Simple8bRleSerialized *nulls)
+{
+	uint32 nulls_size = 0;
+	Size compressed_size;
+	char *compressed_data;
+	BoolCompressed *compressed;
+
+	if (nulls != NULL)
+		nulls_size = simple8brle_serialized_total_size(nulls);
+
+	compressed_size =
+		sizeof(BoolCompressed) + simple8brle_serialized_total_size(values) + nulls_size;
+
+	if (!AllocSizeIsValid(compressed_size))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("compressed size exceeds the maximum allowed (%d)", (int) MaxAllocSize)));
+
+	compressed_data = palloc(compressed_size);
+	compressed = (BoolCompressed *) compressed_data;
+	SET_VARSIZE(&compressed->vl_len_, compressed_size);
+
+	compressed->compression_algorithm = COMPRESSION_ALGORITHM_BOOL_COMPRESS;
+	compressed->has_nulls = nulls_size != 0 ? 1 : 0;
+
+	compressed_data += sizeof(*compressed);
+	compressed_data =
+		bytes_serialize_simple8b_and_advance(compressed_data,
+											 simple8brle_serialized_total_size(values),
+											 values);
+
+	if (compressed->has_nulls == 1 && nulls != NULL)
+	{
+		CheckCompressedData(nulls->num_elements > values->num_elements);
+		bytes_serialize_simple8b_and_advance(compressed_data, nulls_size, nulls);
+	}
+
+	return compressed;
+}
+
+static inline DecompressResult
+convert_from_internal(DecompressResultInternal res_internal)
+{
+	if (res_internal.is_done || res_internal.is_null)
+	{
+		return (DecompressResult){
+			.is_done = res_internal.is_done,
+			.is_null = res_internal.is_null,
+		};
+	}
+
+	return (DecompressResult){
+		.val = BoolGetDatum(res_internal.val),
+	};
+}
+
+static void
+decompression_iterator_init(BoolDecompressionIterator *iter, void *compressed, Oid element_type,
+							bool forward)
+{
+	StringInfoData si = { .data = compressed, .len = VARSIZE(compressed) };
+	BoolCompressed *header = consumeCompressedData(&si, sizeof(BoolCompressed));
+	Simple8bRleSerialized *values = bytes_deserialize_simple8b_and_advance(&si);
+
+	Assert(header->has_nulls == 0 || header->has_nulls == 1);
+	Assert(element_type == BOOLOID);
+
+	const bool has_nulls = header->has_nulls == 1;
+
+	CheckCompressedData(has_nulls == 0 || has_nulls == 1);
+
+	*iter = (BoolDecompressionIterator){
+		.base = { .compression_algorithm = COMPRESSION_ALGORITHM_BOOL_COMPRESS,
+				  .forward = forward,
+				  .element_type = element_type,
+				  .try_next = (forward ? bool_decompression_iterator_try_next_forward :
+										 bool_decompression_iterator_try_next_reverse) },
+		.values = { 0 },
+		.nulls = { 0 },
+		.num_elements = 0,
+		.value_position = 0,
+		.element_position = 0,
+	};
+
+	iter->values = simple8brle_bitmap_decompress(values);
+	iter->num_elements = iter->values.num_elements;
+
+	if (has_nulls)
+	{
+		Simple8bRleSerialized *nulls = bytes_deserialize_simple8b_and_advance(&si);
+		iter->nulls = simple8brle_bitmap_decompress(nulls);
+		iter->num_elements = iter->nulls.num_elements;
+	}
+
+	if (!forward)
+	{
+		iter->element_position = iter->num_elements - 1;
+		iter->value_position = iter->values.num_elements - 1;
+	}
+}
+
+static inline bool
+iterator_has_nulls(BoolDecompressionIterator *iter)
+{
+	return iter->nulls.num_elements > 0;
+}
+
+static DecompressResultInternal
+bool_decompression_iterator_try_next_forward_internal(BoolDecompressionIterator *iter)
+{
+	if (iter->element_position >= iter->num_elements)
+		return (DecompressResultInternal){
+			.is_done = true,
+		};
+
+	/* check nulls */
+	if (iter->nulls.num_elements > 0)
+	{
+		if (simple8brle_bitmap_get_at(&iter->nulls, iter->element_position))
+		{
+			iter->element_position++;
+			return (DecompressResultInternal){
+				.is_null = true,
+			};
+		}
+	}
+
+	bool val = simple8brle_bitmap_get_at(&iter->values, iter->value_position);
+	iter->element_position++;
+	iter->value_position++;
+
+	return (DecompressResultInternal){
+		.val = val,
+	};
+}
+
+static DecompressResultInternal
+bool_decompression_iterator_try_next_reverse_internal(BoolDecompressionIterator *iter)
+{
+	if (iter->element_position < 0)
+		return (DecompressResultInternal){
+			.is_done = true,
+		};
+
+	/* check nulls */
+	if (iter->nulls.num_elements > 0)
+	{
+		if (simple8brle_bitmap_get_at(&iter->nulls, iter->element_position))
+		{
+			iter->element_position--;
+			return (DecompressResultInternal){
+				.is_null = true,
+			};
+		}
+	}
+
+	bool val = simple8brle_bitmap_get_at(&iter->values, iter->value_position);
+	iter->element_position--;
+	iter->value_position--;
+
+	return (DecompressResultInternal){
+		.val = val,
+	};
+}

--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -400,12 +400,6 @@ decompression_iterator_init(BoolDecompressionIterator *iter, void *compressed, O
 	}
 }
 
-static inline bool
-iterator_has_nulls(BoolDecompressionIterator *iter)
-{
-	return iter->nulls.num_elements > 0;
-}
-
 static DecompressResultInternal
 bool_decompression_iterator_try_next_forward_internal(BoolDecompressionIterator *iter)
 {

--- a/tsl/src/compression/algorithms/bool_compress.h
+++ b/tsl/src/compression/algorithms/bool_compress.h
@@ -1,0 +1,65 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+/*
+ * bool_compress is used to encode boolean values using the simple8b_rle algorithm.
+ * In essence, it is a simplified version of the delta-delta compression, by removing
+ * the delta-delta and zig-zag encoding steps.
+ */
+
+#include <postgres.h>
+#include <fmgr.h>
+#include <lib/stringinfo.h>
+
+#include "compression/compression.h"
+
+typedef struct BoolCompressor BoolCompressor;
+typedef struct BoolCompressed BoolCompressed;
+typedef struct BoolDecompressionIterator BoolDecompressionIterator;
+
+/*
+ * Compressor framework functions and definitions for the bool_compress algorithm.
+ */
+
+extern BoolCompressor *bool_compressor_alloc(void);
+extern void bool_compressor_append_null(BoolCompressor *compressor);
+extern void bool_compressor_append_value(BoolCompressor *compressor, bool next_val);
+extern void *bool_compressor_finish(BoolCompressor *compressor);
+extern bool bool_compressed_has_nulls(const CompressedDataHeader *header);
+
+extern DecompressResult bool_decompression_iterator_try_next_forward(DecompressionIterator *iter);
+
+extern DecompressionIterator *bool_decompression_iterator_from_datum_forward(Datum bool_compressed,
+																			 Oid element_type);
+
+extern DecompressResult bool_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
+
+extern DecompressionIterator *bool_decompression_iterator_from_datum_reverse(Datum bool_compressed,
+																			 Oid element_type);
+
+extern void bool_compressed_send(CompressedDataHeader *header, StringInfo buffer);
+
+extern Datum bool_compressed_recv(StringInfo buf);
+
+extern Compressor *bool_compressor_for_type(Oid element_type);
+
+#define BOOL_COMPRESS_ALGORITHM_DEFINITION                                                         \
+	{                                                                                              \
+		.iterator_init_forward = bool_decompression_iterator_from_datum_forward,                   \
+		.iterator_init_reverse = bool_decompression_iterator_from_datum_reverse,                   \
+		.decompress_all = NULL, .compressed_data_send = bool_compressed_send,                      \
+		.compressed_data_recv = bool_compressed_recv,                                              \
+		.compressor_for_type = bool_compressor_for_type,                                           \
+		.compressed_data_storage = TOAST_STORAGE_EXTERNAL,                                         \
+	}
+
+/*
+ * Cross-module functions for the bool_compress algorithm.
+ */
+
+extern Datum tsl_bool_compressor_append(PG_FUNCTION_ARGS);
+extern Datum tsl_bool_compressor_finish(PG_FUNCTION_ARGS);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -19,6 +19,7 @@
 #include "compat/compat.h"
 
 #include "algorithms/array.h"
+#include "algorithms/bool_compress.h"
 #include "algorithms/deltadelta.h"
 #include "algorithms/dictionary.h"
 #include "algorithms/gorilla.h"
@@ -47,6 +48,7 @@ static const CompressionAlgorithmDefinition definitions[_END_COMPRESSION_ALGORIT
 	[COMPRESSION_ALGORITHM_DICTIONARY] = DICTIONARY_ALGORITHM_DEFINITION,
 	[COMPRESSION_ALGORITHM_GORILLA] = GORILLA_ALGORITHM_DEFINITION,
 	[COMPRESSION_ALGORITHM_DELTADELTA] = DELTA_DELTA_ALGORITHM_DEFINITION,
+	[COMPRESSION_ALGORITHM_BOOL_COMPRESS] = BOOL_COMPRESS_ALGORITHM_DEFINITION,
 };
 
 static NameData compression_algorithm_name[] = {
@@ -55,6 +57,7 @@ static NameData compression_algorithm_name[] = {
 	[COMPRESSION_ALGORITHM_DICTIONARY] = { "DICTIONARY" },
 	[COMPRESSION_ALGORITHM_GORILLA] = { "GORILLA" },
 	[COMPRESSION_ALGORITHM_DELTADELTA] = { "DELTADELTA" },
+	[COMPRESSION_ALGORITHM_BOOL_COMPRESS] = { "BOOLCOMPRESS" },
 };
 
 Name
@@ -1802,6 +1805,9 @@ tsl_compressed_data_info(PG_FUNCTION_ARGS)
 		case COMPRESSION_ALGORITHM_ARRAY:
 			has_nulls = array_compressed_has_nulls(header);
 			break;
+		case COMPRESSION_ALGORITHM_BOOL_COMPRESS:
+			has_nulls = bool_compressed_has_nulls(header);
+			break;
 		default:
 			elog(ERROR, "unknown compression algorithm %d", header->compression_algorithm);
 			break;
@@ -1855,6 +1861,12 @@ compression_get_default_algorithm(Oid typeoid)
 
 		case NUMERICOID:
 			return COMPRESSION_ALGORITHM_ARRAY;
+
+		case BOOLOID:
+			if (ts_guc_enable_bool_compression)
+				return COMPRESSION_ALGORITHM_BOOL_COMPRESS;
+			else
+				return COMPRESSION_ALGORITHM_ARRAY;
 
 		default:
 		{

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -193,6 +193,7 @@ typedef enum CompressionAlgorithm
 	COMPRESSION_ALGORITHM_DICTIONARY,
 	COMPRESSION_ALGORITHM_GORILLA,
 	COMPRESSION_ALGORITHM_DELTADELTA,
+	COMPRESSION_ALGORITHM_BOOL_COMPRESS,
 
 	/* When adding an algorithm also add a static assert statement below */
 	/* end of real values */
@@ -314,13 +315,14 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 	StaticAssertStmt(COMPRESSION_ALGORITHM_DICTIONARY == 2, "algorithm index has changed");
 	StaticAssertStmt(COMPRESSION_ALGORITHM_GORILLA == 3, "algorithm index has changed");
 	StaticAssertStmt(COMPRESSION_ALGORITHM_DELTADELTA == 4, "algorithm index has changed");
+	StaticAssertStmt(COMPRESSION_ALGORITHM_BOOL_COMPRESS == 5, "algorithm index has changed");
 
 	/*
 	 * This should change when adding a new algorithm after adding the new
 	 * algorithm to the assert list above. This statement prevents adding a
 	 * new algorithm without updating the asserts above
 	 */
-	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS == 5,
+	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS == 6,
 					 "number of algorithms have changed, the asserts should be updated");
 }
 

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -17,6 +17,7 @@
 #include "chunk.h"
 #include "chunk_api.h"
 #include "compression/algorithms/array.h"
+#include "compression/algorithms/bool_compress.h"
 #include "compression/algorithms/deltadelta.h"
 #include "compression/algorithms/dictionary.h"
 #include "compression/algorithms/gorilla.h"
@@ -166,6 +167,8 @@ CrossModuleFunctions tsl_cm_functions = {
 	.dictionary_compressor_finish = tsl_dictionary_compressor_finish,
 	.array_compressor_append = tsl_array_compressor_append,
 	.array_compressor_finish = tsl_array_compressor_finish,
+	.bool_compressor_append = tsl_bool_compressor_append,
+	.bool_compressor_finish = tsl_bool_compressor_finish,
 	.process_compress_table = tsl_process_compress_table,
 	.process_altertable_cmd = tsl_process_altertable_cmd,
 	.process_rename_cmd = tsl_process_rename_cmd,

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -1538,6 +1538,217 @@ CREATE TABLE base_texts AS SELECT row_number() OVER() as rn, NULLIF(NULLIF(NULLI
 (1 row)
 
 DROP TABLE base_texts;
+----------------------
+-- Bool Compression --
+----------------------
+SELECT
+  $$
+  select item from base_bools order by rn
+  $$ AS "QUERY"
+\gset
+\set TABLE_NAME base_bools
+\set TYPE boolean
+\set COMPRESSION_CMD _timescaledb_internal.compress_bool(item)
+\set DECOMPRESS_FORWARD_CMD _timescaledb_internal.decompress_forward(c::_timescaledb_internal.compressed_data, NULL::boolean)
+\set DECOMPRESS_REVERSE_CMD _timescaledb_internal.decompress_reverse(c::_timescaledb_internal.compressed_data, NULL::boolean)
+-- bool test, flipping values betweem true and false, no nulls
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, (item%2=0)::boolean as item FROM (SELECT generate_series(1, 1000) item) sub;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+  algorithm   | has_nulls | compressed size 
+--------------+-----------+-----------------
+ BOOLCOMPRESS | f         |             152
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_bools;
+-- bool test, all true values, no nulls
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, true as item FROM (SELECT generate_series(1, 1000) item) sub;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+  algorithm   | has_nulls | compressed size 
+--------------+-----------+-----------------
+ BOOLCOMPRESS | f         |              29
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_bools;
+-- bool test, all false, no nulls
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, false as item FROM (SELECT generate_series(1, 1000) item) sub;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+  algorithm   | has_nulls | compressed size 
+--------------+-----------+-----------------
+ BOOLCOMPRESS | f         |              29
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_bools;
+-- a single true element
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, true as item FROM (SELECT generate_series(1, 1) item) sub;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+  algorithm   | has_nulls | compressed size 
+--------------+-----------+-----------------
+ BOOLCOMPRESS | f         |              29
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_bools;
+-- all true, except every 43rd value is null
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, ((NULLIF(i, (CASE WHEN i%43=0 THEN i ELSE -1 END)))>0)::boolean item FROM generate_series(1, 1000) i;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+  algorithm   | has_nulls | compressed size 
+--------------+-----------+-----------------
+ BOOLCOMPRESS | t         |             176
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_bools;
+-- all false, except every 29th value is null
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, ((NULLIF(i, (CASE WHEN i%29=0 THEN i ELSE -1 END)))<0)::boolean item FROM generate_series(1, 1000) i;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+  algorithm   | has_nulls | compressed size 
+--------------+-----------+-----------------
+ BOOLCOMPRESS | t         |             176
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_bools;
 -----------------------------------------------
 -- Interesting corrupt data found by fuzzing --
 -----------------------------------------------

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -370,6 +370,51 @@ CREATE TABLE base_texts AS SELECT row_number() OVER() as rn, NULLIF(NULLIF(NULLI
 \ir include/compression_test.sql
 DROP TABLE base_texts;
 
+----------------------
+-- Bool Compression --
+----------------------
+
+SELECT
+  $$
+  select item from base_bools order by rn
+  $$ AS "QUERY"
+\gset
+\set TABLE_NAME base_bools
+\set TYPE boolean
+\set COMPRESSION_CMD _timescaledb_internal.compress_bool(item)
+\set DECOMPRESS_FORWARD_CMD _timescaledb_internal.decompress_forward(c::_timescaledb_internal.compressed_data, NULL::boolean)
+\set DECOMPRESS_REVERSE_CMD _timescaledb_internal.decompress_reverse(c::_timescaledb_internal.compressed_data, NULL::boolean)
+
+-- bool test, flipping values betweem true and false, no nulls
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, (item%2=0)::boolean as item FROM (SELECT generate_series(1, 1000) item) sub;
+\ir include/compression_test.sql
+DROP TABLE base_bools;
+
+-- bool test, all true values, no nulls
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, true as item FROM (SELECT generate_series(1, 1000) item) sub;
+\ir include/compression_test.sql
+DROP TABLE base_bools;
+
+-- bool test, all false, no nulls
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, false as item FROM (SELECT generate_series(1, 1000) item) sub;
+\ir include/compression_test.sql
+DROP TABLE base_bools;
+
+-- a single true element
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, true as item FROM (SELECT generate_series(1, 1) item) sub;
+\ir include/compression_test.sql
+DROP TABLE base_bools;
+
+-- all true, except every 43rd value is null
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, ((NULLIF(i, (CASE WHEN i%43=0 THEN i ELSE -1 END)))>0)::boolean item FROM generate_series(1, 1000) i;
+\ir include/compression_test.sql
+DROP TABLE base_bools;
+
+-- all false, except every 29th value is null
+CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, ((NULLIF(i, (CASE WHEN i%29=0 THEN i ELSE -1 END)))<0)::boolean item FROM generate_series(1, 1000) i;
+\ir include/compression_test.sql
+DROP TABLE base_bools;
+
 -----------------------------------------------
 -- Interesting corrupt data found by fuzzing --
 -----------------------------------------------

--- a/tsl/test/sql/include/compression_utils.sql
+++ b/tsl/test/sql/include/compression_utils.sql
@@ -74,6 +74,16 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.array_compressor_finish(interna
    AS :MODULE_PATHNAME, 'ts_array_compressor_finish'
    LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.bool_compressor_append(internal, ANYELEMENT)
+   RETURNS internal
+   AS :MODULE_PATHNAME, 'ts_bool_compressor_append'
+   LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.bool_compressor_finish(internal)
+   RETURNS _timescaledb_internal.compressed_data
+   AS :MODULE_PATHNAME, 'ts_bool_compressor_finish'
+   LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
 CREATE AGGREGATE _timescaledb_internal.compress_deltadelta(BIGINT) (
     STYPE = internal,
     SFUNC = _timescaledb_internal.deltadelta_compressor_append,
@@ -102,6 +112,12 @@ CREATE AGGREGATE _timescaledb_internal.compress_array(ANYELEMENT) (
     STYPE = internal,
     SFUNC = _timescaledb_internal.array_compressor_append,
     FINALFUNC = _timescaledb_internal.array_compressor_finish
+);
+
+CREATE AGGREGATE _timescaledb_internal.compress_bool(boolean) (
+    STYPE = internal,
+    SFUNC = _timescaledb_internal.bool_compressor_append,
+    FINALFUNC = _timescaledb_internal.bool_compressor_finish
 );
 
 \set ECHO all

--- a/tsl/test/src/compression_sql_test.c
+++ b/tsl/test/src/compression_sql_test.c
@@ -36,6 +36,10 @@ get_compression_algorithm(char *name)
 	{
 		return COMPRESSION_ALGORITHM_DICTIONARY;
 	}
+	else if (pg_strcasecmp(name, "boolcompress") == 0)
+	{
+		return COMPRESSION_ALGORITHM_BOOL_COMPRESS;
+	}
 
 	ereport(ERROR, (errmsg("unknown compression algorithm %s", name)));
 	return _INVALID_COMPRESSION_ALGORITHM;


### PR DESCRIPTION
Reusing the existing Simple8bRLE algorithm for bools. I added a new compression type specifically for this case called 'boolcompress'.

A new GUC is introduced so we can revert to the previous, array compression for bools: `timescaledb.enable_bool_compression`. It defaults to `true`.

To disable bool compression set the GUC:

`timescaledb.enable_bool_compression=false`