### PR TITLE
Support ALTER COLUMN SET NOT NULL on compressed chunks

### DIFF
--- a/.unreleased/pr_7707
+++ b/.unreleased/pr_7707
@@ -1,0 +1,1 @@
+Implements: #7707 Support ALTER COLUMN SET NOT NULL on compressed chunks

--- a/sql/pre_install/types.functions.sql
+++ b/sql/pre_install/types.functions.sql
@@ -39,6 +39,11 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.compressed_data_info(_timescal
     LANGUAGE C STRICT IMMUTABLE
     AS '@MODULE_PATHNAME@', 'ts_compressed_data_info';
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data)
+    RETURNS BOOL
+    LANGUAGE C STRICT IMMUTABLE
+    AS '@MODULE_PATHNAME@', 'ts_compressed_data_has_nulls';
+
 CREATE OR REPLACE FUNCTION _timescaledb_functions.dimension_info_in(cstring)
     RETURNS _timescaledb_internal.dimension_info
     LANGUAGE C STRICT IMMUTABLE

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,8 @@
 ALTER TABLE _timescaledb_internal.bgw_job_stat_history
     ALTER COLUMN succeeded DROP NOT NULL,
     ALTER COLUMN succeeded DROP DEFAULT;
+
+CREATE FUNCTION _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data)
+    RETURNS BOOL
+    LANGUAGE C STRICT IMMUTABLE
+    AS '@MODULE_PATHNAME@', 'ts_update_placeholder';

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -3,3 +3,6 @@ UPDATE _timescaledb_internal.bgw_job_stat_history SET succeeded = FALSE WHERE su
 ALTER TABLE _timescaledb_internal.bgw_job_stat_history
     ALTER COLUMN succeeded SET NOT NULL,
     ALTER COLUMN succeeded SET DEFAULT FALSE;
+
+DROP FUNCTION IF EXISTS _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data);
+

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -68,6 +68,7 @@ CROSSMODULE_WRAPPER(compressed_data_recv);
 CROSSMODULE_WRAPPER(compressed_data_in);
 CROSSMODULE_WRAPPER(compressed_data_out);
 CROSSMODULE_WRAPPER(compressed_data_info);
+CROSSMODULE_WRAPPER(compressed_data_has_nulls);
 CROSSMODULE_WRAPPER(deltadelta_compressor_append);
 CROSSMODULE_WRAPPER(deltadelta_compressor_finish);
 CROSSMODULE_WRAPPER(gorilla_compressor_append);

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -122,6 +122,7 @@ typedef struct CrossModuleFunctions
 	PGFunction compressed_data_in;
 	PGFunction compressed_data_out;
 	PGFunction compressed_data_info;
+	PGFunction compressed_data_has_nulls;
 	bool (*process_compress_table)(AlterTableCmd *cmd, Hypertable *ht,
 								   WithClauseResult *with_clause_options);
 	void (*process_altertable_cmd)(Hypertable *ht, const AlterTableCmd *cmd);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -300,6 +300,7 @@ extern Datum tsl_compressed_data_recv(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_in(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_out(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_info(PG_FUNCTION_ARGS);
+extern Datum tsl_compressed_data_has_nulls(PG_FUNCTION_ARGS);
 
 static void
 pg_attribute_unused() assert_num_compression_algorithms_sane(void)

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -158,6 +158,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.compressed_data_in = tsl_compressed_data_in,
 	.compressed_data_out = tsl_compressed_data_out,
 	.compressed_data_info = tsl_compressed_data_info,
+	.compressed_data_has_nulls = tsl_compressed_data_has_nulls,
 	.deltadelta_compressor_append = tsl_deltadelta_compressor_append,
 	.deltadelta_compressor_finish = tsl_deltadelta_compressor_finish,
 	.gorilla_compressor_append = tsl_gorilla_compressor_append,

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -2543,7 +2543,7 @@ SELECT count(*) FROM test2 WHERE i IS NULL;
 
 \set ON_ERROR_STOP 0
 ALTER TABLE test2 ALTER COLUMN i SET NOT NULL;
-ERROR:  operation not supported on compressed chunks not using the "hypercore" table access method
+ERROR:  column "i" of relation "_hyper_44_181_chunk" contains null values
 DELETE FROM test2 WHERE i IS NULL;
 SELECT count(*) FROM test2 WHERE i IS NULL;
  count 
@@ -2552,5 +2552,104 @@ SELECT count(*) FROM test2 WHERE i IS NULL;
 (1 row)
 
 ALTER TABLE test2 ALTER COLUMN i SET NOT NULL;
-ERROR:  operation not supported on compressed chunks not using the "hypercore" table access method
 \set ON_ERROR_STOP 1
+-- test set not null
+CREATE TABLE test_notnull(time timestamptz, device text, value float);
+SELECT create_hypertable('test_notnull','time');
+     create_hypertable      
+----------------------------
+ (46,public,test_notnull,t)
+(1 row)
+
+ALTER TABLE test_notnull SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO test_notnull VALUES ('2025-01-01','d1',NULL);
+INSERT INTO test_notnull VALUES ('2025-01-01',NULL,NULL);
+-- should fail since we have NULL value
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ERROR:  column "value" of relation "_hyper_46_238_chunk" contains null values
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ERROR:  column "device" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+SELECT compress_chunk(show_chunks('test_notnull'));
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_46_238_chunk
+(1 row)
+
+-- should fail since we have NULL value
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ERROR:  column "value" of relation "_hyper_46_238_chunk" contains null values
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ERROR:  column "device" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+UPDATE test_notnull SET value = 1;
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN value DROP NOT NULL;
+SELECT compress_chunk(show_chunks('test_notnull'));
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_46_238_chunk
+(1 row)
+
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN value DROP NOT NULL;
+-- device still has NULL
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ERROR:  column "device" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+UPDATE test_notnull SET device = 'd1';
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN device DROP NOT NULL;
+SELECT compress_chunk(show_chunks('test_notnull'));
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_46_238_chunk
+(1 row)
+
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN device DROP NOT NULL;
+-- test partial compressed chunks
+-- NULL in uncompressed part only
+INSERT INTO test_notnull VALUES ('2025-01-01',NULL,NULL);
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ERROR:  column "device" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+-- NULL in compressed part only
+SELECT compress_chunk(show_chunks('test_notnull'));
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_46_238_chunk
+(1 row)
+
+INSERT INTO test_notnull VALUES ('2025-01-01','d1',2);
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ERROR:  column "device" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+-- test added columns and defaults
+ALTER TABLE test_notnull ADD COLUMN c1 int;
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN c1 SET NOT NULL;
+ERROR:  column "c1" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+ALTER TABLE test_notnull ADD COLUMN c2 int DEFAULT 42;
+ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN c2 DROP NOT NULL;
+-- test column with default and explicit NULL
+UPDATE test_notnull SET c2 = NULL;
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+ERROR:  column "c2" of relation "_hyper_46_238_chunk" contains null values
+\set ON_ERROR_STOP 1
+SELECT compress_chunk(show_chunks('test_notnull'));
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_46_238_chunk
+(1 row)
+
+-- broken atm due to bug in default handling in compression
+ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -52,6 +52,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.chunk_status(regclass)
  _timescaledb_functions.chunks_local_size(name,name)
  _timescaledb_functions.compressed_chunk_local_stats(name,name)
+ _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data)
  _timescaledb_functions.compressed_data_in(cstring)
  _timescaledb_functions.compressed_data_info(_timescaledb_internal.compressed_data)
  _timescaledb_functions.compressed_data_out(_timescaledb_internal.compressed_data)

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -1078,3 +1078,77 @@ DELETE FROM test2 WHERE i IS NULL;
 SELECT count(*) FROM test2 WHERE i IS NULL;
 ALTER TABLE test2 ALTER COLUMN i SET NOT NULL;
 \set ON_ERROR_STOP 1
+
+-- test set not null
+CREATE TABLE test_notnull(time timestamptz, device text, value float);
+SELECT create_hypertable('test_notnull','time');
+ALTER TABLE test_notnull SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+
+INSERT INTO test_notnull VALUES ('2025-01-01','d1',NULL);
+INSERT INTO test_notnull VALUES ('2025-01-01',NULL,NULL);
+
+-- should fail since we have NULL value
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+SELECT compress_chunk(show_chunks('test_notnull'));
+-- should fail since we have NULL value
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+UPDATE test_notnull SET value = 1;
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN value DROP NOT NULL;
+SELECT compress_chunk(show_chunks('test_notnull'));
+
+ALTER TABLE test_notnull ALTER COLUMN value SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN value DROP NOT NULL;
+-- device still has NULL
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+UPDATE test_notnull SET device = 'd1';
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN device DROP NOT NULL;
+SELECT compress_chunk(show_chunks('test_notnull'));
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN device DROP NOT NULL;
+
+-- test partial compressed chunks
+-- NULL in uncompressed part only
+INSERT INTO test_notnull VALUES ('2025-01-01',NULL,NULL);
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+-- NULL in compressed part only
+SELECT compress_chunk(show_chunks('test_notnull'));
+INSERT INTO test_notnull VALUES ('2025-01-01','d1',2);
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN device SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+-- test added columns and defaults
+ALTER TABLE test_notnull ADD COLUMN c1 int;
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN c1 SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+ALTER TABLE test_notnull ADD COLUMN c2 int DEFAULT 42;
+ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+ALTER TABLE test_notnull ALTER COLUMN c2 DROP NOT NULL;
+
+-- test column with default and explicit NULL
+UPDATE test_notnull SET c2 = NULL;
+\set ON_ERROR_STOP 0
+ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+\set ON_ERROR_STOP 1
+SELECT compress_chunk(show_chunks('test_notnull'));
+-- broken atm due to bug in default handling in compression
+ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+


### PR DESCRIPTION
This patch adds support for ALTER TABLE ALTER COLUMN SET NOT NULL
to compressed chunks. The statement will be allowed when no NULL
values for the specific column are present in compressed chunks.