### PR TITLE
Skip function_telemetry.c when telemetry is disabled

### DIFF
--- a/sql/pre_install/tam.functions.sql.gen
+++ b/sql/pre_install/tam.functions.sql.gen
@@ -1,0 +1,10 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE OR REPLACE FUNCTION ts_hypercore_handler(internal) RETURNS table_am_handler
+AS '$libdir/timescaledb-2.18.0', 'ts_hypercore_handler' LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION ts_hypercore_proxy_handler(internal) RETURNS index_am_handler
+AS '$libdir/timescaledb-2.18.0', 'ts_hypercore_proxy_handler' LANGUAGE C;
+

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -4,8 +4,11 @@ set(SOURCES
     bgw_counter.c
     bgw_launcher.c
     bgw_interface.c
-    function_telemetry.c
     lwlocks.c)
+
+if(USE_TELEMETRY)
+  list(APPEND SOURCES function_telemetry.c)
+endif()
 
 set(TEST_SOURCES ${PROJECT_SOURCE_DIR}/test/src/symbol_conflict.c)
 

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -1,10 +1,5 @@
-set(SOURCES
-    loader.c
-    bgw_message_queue.c
-    bgw_counter.c
-    bgw_launcher.c
-    bgw_interface.c
-    lwlocks.c)
+set(SOURCES loader.c bgw_message_queue.c bgw_counter.c bgw_launcher.c
+            bgw_interface.c lwlocks.c)
 
 if(USE_TELEMETRY)
   list(APPEND SOURCES function_telemetry.c)

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -37,7 +37,9 @@
 #include "loader/bgw_interface.h"
 #include "loader/bgw_launcher.h"
 #include "loader/bgw_message_queue.h"
+#ifdef USE_TELEMETRY
 #include "loader/function_telemetry.h"
+#endif
 #include "loader/loader.h"
 #include "loader/lwlocks.h"
 
@@ -546,7 +548,9 @@ timescaledb_shmem_startup_hook(void)
 	ts_bgw_counter_shmem_startup();
 	ts_bgw_message_queue_shmem_startup();
 	ts_lwlocks_shmem_startup();
+#ifdef USE_TELEMETRY
 	ts_function_telemetry_shmem_startup();
+#endif
 }
 
 /*
@@ -565,7 +569,9 @@ timescaledb_shmem_request_hook(void)
 	ts_bgw_counter_shmem_alloc();
 	ts_bgw_message_queue_alloc();
 	ts_lwlocks_shmem_alloc();
+#ifdef USE_TELEMETRY
 	ts_function_telemetry_shmem_alloc();
+#endif
 }
 
 static void


### PR DESCRIPTION
This avoids allocating the telemetry hash table, which saves a little shared memory.

Disable-check: force-changelog-file
Disable-check: loader-change
