### PR TITLE
Respect other extensions' ExecutorStart hooks

### DIFF
--- a/.unreleased/pr_7712
+++ b/.unreleased/pr_7712
@@ -1,0 +1,1 @@
+Fixes: #7712 Respect other extensions' ExecutorStart hooks


### PR DESCRIPTION
A fix for #7667.

When we override ExecutorStart hook that has been set by another extension we have to chain-call it not to disrupt other extension's integrity.