### PR TITLE
Silence compiler warning about macro arguments

### DIFF
--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -708,7 +708,7 @@ get_relmergeinfo(RelationMergeInfo *relinfos, int nrelids, int i)
 #else
 #define pg17_workaround_init(rel, relinfos, nrelids)
 #define pg17_workaround_cleanup(rel)
-#define get_relmergeinfo(relinfos, nrelids, i) &relinfos[i]
+#define get_relmergeinfo(relinfos, nrelids, i) &(relinfos)[i]
 #endif
 
 /*


### PR DESCRIPTION
get_relmergeinfo macro produced the following warning:
macro argument should be enclosed in parentheses [bugprone-macro-parentheses,-warnings-as-errors]

Disable-check: force-changelog-file
Disable-check: approval-count
