### PR TITLE
Backport to 2.18.x: #7630: Fix wrong crash error message on job history

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -317,7 +317,7 @@ CREATE TABLE _timescaledb_internal.bgw_job_stat_history (
   pid INTEGER,
   execution_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   execution_finish TIMESTAMPTZ,
-  succeeded boolean NOT NULL DEFAULT FALSE,
+  succeeded boolean,
   data jsonb,
   -- table constraints
   CONSTRAINT bgw_job_stat_history_pkey PRIMARY KEY (id)

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,3 @@
+ALTER TABLE _timescaledb_internal.bgw_job_stat_history
+    ALTER COLUMN succeeded DROP NOT NULL,
+    ALTER COLUMN succeeded DROP DEFAULT;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,5 @@
+UPDATE _timescaledb_internal.bgw_job_stat_history SET succeeded = FALSE WHERE succeeded IS NULL;
+
+ALTER TABLE _timescaledb_internal.bgw_job_stat_history
+    ALTER COLUMN succeeded SET NOT NULL,
+    ALTER COLUMN succeeded SET DEFAULT FALSE;

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -650,7 +650,7 @@ ts_bgw_job_stat_mark_start(BgwJob *job)
 	job->job_history.execution_start = ts_timer_get_current_timestamp();
 	job->job_history.id = INVALID_BGW_JOB_STAT_HISTORY_ID;
 
-	ts_bgw_job_stat_history_mark_start(job);
+	ts_bgw_job_stat_history_update(JOB_STAT_HISTORY_UPDATE_START, job, JOB_SUCCESS, NULL);
 
 	pgstat_report_activity(STATE_IDLE, NULL);
 }
@@ -674,7 +674,7 @@ ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result, Jsonb *edata)
 				 errmsg("unable to find job statistics for job %d", job->fd.id)));
 	}
 
-	ts_bgw_job_stat_history_mark_end(job, result, edata);
+	ts_bgw_job_stat_history_update(JOB_STAT_HISTORY_UPDATE_END, job, result, edata);
 
 	pgstat_report_activity(STATE_IDLE, NULL);
 }
@@ -693,7 +693,7 @@ ts_bgw_job_stat_mark_crash_reported(BgwJob *job, JobResult result)
 				 errmsg("unable to find job statistics for job %d", job->fd.id)));
 	}
 
-	ts_bgw_job_stat_history_mark_end(job, result, NULL);
+	ts_bgw_job_stat_history_update(JOB_STAT_HISTORY_UPDATE_END, job, result, NULL);
 
 	pgstat_report_activity(STATE_IDLE, NULL);
 }

--- a/src/bgw/job_stat_history.h
+++ b/src/bgw/job_stat_history.h
@@ -11,5 +11,12 @@
 
 #define INVALID_BGW_JOB_STAT_HISTORY_ID 0
 
-extern void ts_bgw_job_stat_history_mark_start(BgwJob *job);
-extern void ts_bgw_job_stat_history_mark_end(BgwJob *job, JobResult result, Jsonb *edata);
+typedef enum BgwJobStatHistoryUpdateType
+{
+	JOB_STAT_HISTORY_UPDATE_START,
+	JOB_STAT_HISTORY_UPDATE_END,
+	JOB_STAT_HISTORY_UPDATE_PID,
+} BgwJobStatHistoryUpdateType;
+
+extern void ts_bgw_job_stat_history_update(BgwJobStatHistoryUpdateType update_type, BgwJob *job,
+										   JobResult result, Jsonb *edata);

--- a/src/utils.h
+++ b/src/utils.h
@@ -330,17 +330,20 @@ ts_datum_set_text_from_cstring(const AttrNumber attno, NullableDatum *datums, co
 }
 
 static inline void
-ts_datum_set_bool(const AttrNumber attno, NullableDatum *datums, const bool value)
+ts_datum_set_bool(const AttrNumber attno, NullableDatum *datums, const bool value,
+				  const bool isnull)
 {
-	datums[AttrNumberGetAttrOffset(attno)].value = BoolGetDatum(value);
-	datums[AttrNumberGetAttrOffset(attno)].isnull = false;
+	if (!isnull)
+		datums[AttrNumberGetAttrOffset(attno)].value = BoolGetDatum(value);
+	datums[AttrNumberGetAttrOffset(attno)].isnull = isnull;
 }
 
 static inline void
 ts_datum_set_int32(const AttrNumber attno, NullableDatum *datums, const int32 value,
 				   const bool isnull)
 {
-	datums[AttrNumberGetAttrOffset(attno)].value = Int32GetDatum(value);
+	if (!isnull)
+		datums[AttrNumberGetAttrOffset(attno)].value = Int32GetDatum(value);
 	datums[AttrNumberGetAttrOffset(attno)].isnull = isnull;
 }
 
@@ -348,7 +351,8 @@ static inline void
 ts_datum_set_int64(const AttrNumber attno, NullableDatum *datums, const int64 value,
 				   const bool isnull)
 {
-	datums[AttrNumberGetAttrOffset(attno)].value = Int64GetDatum(value);
+	if (!isnull)
+		datums[AttrNumberGetAttrOffset(attno)].value = Int64GetDatum(value);
 	datums[AttrNumberGetAttrOffset(attno)].isnull = isnull;
 }
 
@@ -356,7 +360,8 @@ static inline void
 ts_datum_set_timestamptz(const AttrNumber attno, NullableDatum *datums, const TimestampTz value,
 						 const bool isnull)
 {
-	datums[AttrNumberGetAttrOffset(attno)].value = TimestampTzGetDatum(value);
+	if (!isnull)
+		datums[AttrNumberGetAttrOffset(attno)].value = TimestampTzGetDatum(value);
 	datums[AttrNumberGetAttrOffset(attno)].isnull = isnull;
 }
 

--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -40,7 +40,7 @@ create_cagg_validate_query_datum(TupleDesc tupdesc, const bool is_valid_query,
 
 	tupdesc = BlessTupleDesc(tupdesc);
 
-	ts_datum_set_bool(Anum_cagg_validate_query_valid, datums, is_valid_query);
+	ts_datum_set_bool(Anum_cagg_validate_query_valid, datums, is_valid_query, false);
 	ts_datum_set_text_from_cstring(Anum_cagg_validate_query_error_level,
 								   datums,
 								   edata->elevel > 0 ? error_severity(edata->elevel) : NULL);
@@ -861,7 +861,10 @@ create_cagg_get_bucket_function_datum(TupleDesc tupdesc, ContinuousAggsBucketFun
 	ts_datum_set_text_from_cstring(Anum_cagg_bucket_function_timezone,
 								   datums,
 								   bf->bucket_time_timezone);
-	ts_datum_set_bool(Anum_cagg_bucket_function_fixed_width, datums, bf->bucket_fixed_interval);
+	ts_datum_set_bool(Anum_cagg_bucket_function_fixed_width,
+					  datums,
+					  bf->bucket_fixed_interval,
+					  false);
 
 	Assert(tupdesc->natts == Natts_cagg_validate_query);
 	tuple = ts_heap_form_tuple(tupdesc, datums);

--- a/tsl/test/expected/bgw_job_stat_history.out
+++ b/tsl/test/expected/bgw_job_stat_history.out
@@ -28,12 +28,6 @@ SELECT _timescaledb_functions.start_background_workers();
  t
 (1 row)
 
-SELECT pg_sleep(6);
- pg_sleep 
-----------
- 
-(1 row)
-
 SELECT add_job('custom_job_ok', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_1 \gset
 SELECT add_job('custom_job_error', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_2 \gset
 SELECT test.wait_for_job_to_run(:job_id_1, 1);
@@ -81,6 +75,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- Reconnect to make sure the GUC is set
+\c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
  scheduled 
 -----------

--- a/tsl/test/expected/bgw_job_stat_history_errors.out
+++ b/tsl/test/expected/bgw_job_stat_history_errors.out
@@ -25,6 +25,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- Reconnect to make sure the GUC is set
+\c :TEST_DBNAME :ROLE_SUPERUSER
 -- test a concurrent update
 CREATE OR REPLACE PROCEDURE custom_proc1(jobid int, config jsonb) LANGUAGE PLPGSQL AS
 $$
@@ -102,6 +104,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- Reconnect to make sure the GUC is set
+\c :TEST_DBNAME :ROLE_SUPERUSER
 -- test the retention job
 SELECT next_start FROM alter_job(3, next_start => '2060-01-01 00:00:00+00'::timestamptz);
           next_start          
@@ -152,6 +156,34 @@ SELECT _timescaledb_functions.stop_background_workers();
  t
 (1 row)
 
+-- Job didn't finish yet and Crash detected
+DELETE FROM _timescaledb_internal.bgw_job_stat_history;
+INSERT INTO _timescaledb_internal.bgw_job_stat_history(job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES (1, NULL, NULL, '2000-01-01 00:00:00+00'::timestamptz, NULL, '{}'), -- Crash server detected
+(2, 2222, false, '2000-01-01 00:00:00+00'::timestamptz, NULL, '{}'), -- Didn't finished yet
+(3, 3333, false, '2000-01-01 00:00:00+00'::timestamptz, '2000-01-01 01:00:00+00'::timestamptz, '{}'), -- Finish with ERROR
+(4, 4444, true, '2000-01-01 00:00:00+00'::timestamptz, '2000-01-01 01:00:00+00'::timestamptz, '{}'); -- Finish with SUCCESS
+SELECT job_id, pid, succeeded, start_time, finish_time, config, err_message
+FROM timescaledb_information.job_history
+ORDER BY job_id;
+ job_id | pid  | succeeded |          start_time          |         finish_time          | config |             err_message             
+--------+------+-----------+------------------------------+------------------------------+--------+-------------------------------------
+      1 |      |           | Fri Dec 31 16:00:00 1999 PST |                              |        | job crash detected, see server logs
+      2 | 2222 | f         | Fri Dec 31 16:00:00 1999 PST |                              |        | 
+      3 | 3333 | f         | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 17:00:00 1999 PST |        | 
+      4 | 4444 | t         | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 17:00:00 1999 PST |        | 
+(4 rows)
+
+SELECT job_id, pid, start_time, finish_time, err_message
+FROM timescaledb_information.job_errors
+ORDER BY job_id;
+ job_id | pid  |          start_time          |         finish_time          |             err_message             
+--------+------+------------------------------+------------------------------+-------------------------------------
+      1 |      | Fri Dec 31 16:00:00 1999 PST |                              | job crash detected, see server logs
+      2 | 2222 | Fri Dec 31 16:00:00 1999 PST |                              | 
+      3 | 3333 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 17:00:00 1999 PST | 
+(3 rows)
+
 DELETE FROM _timescaledb_internal.bgw_job_stat;
 DELETE FROM _timescaledb_internal.bgw_job_stat_history;
 DELETE FROM _timescaledb_config.bgw_job CASCADE;
@@ -196,6 +228,12 @@ END;
 $TEST$;
 INFO:  Waiting for the 26 jobs to run
 SELECT count(*) > 0 FROM timescaledb_information.job_history WHERE succeeded IS FALSE AND err_message ~ 'failed to start job';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM timescaledb_information.job_errors WHERE err_message ~ 'failed to start job';
  ?column? 
 ----------
  t

--- a/tsl/test/expected/bgw_job_stat_history_errors_permissions.out
+++ b/tsl/test/expected/bgw_job_stat_history_errors_permissions.out
@@ -13,6 +13,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE OR REPLACE PROCEDURE job_fail(jobid int, config jsonb)
 AS $$
@@ -75,36 +76,47 @@ SELECT pg_sleep(6);
 \set finish '2000-01-01 00:00:10+00'
 INSERT INTO _timescaledb_internal.bgw_job_stat_history(job_id, pid, succeeded, execution_start, execution_finish, data) VALUES
        (11111, 12345, false, :'start'::timestamptz, :'finish'::timestamptz, '{"error_data": {"message": "not an error"}}'),
-       (22222, 45678, false, :'start'::timestamptz, :'finish'::timestamptz, '{}');
+       (22222, 45678, false, :'start'::timestamptz, NULL, '{}'), -- Started and didn't finished yet
+       (33333, NULL, NULL, :'start'::timestamptz, NULL, NULL); -- Crash detected cause not assigned an PID
 -- We check the log as different users and should only see what we
 -- have permissions to see. We only bother about jobs at 1000 or
 -- larger since the standard jobs are flaky.
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
-FROM timescaledb_information.job_errors WHERE job_id >= 1000;
- job_id | proc_schema | proc_name | sqlerrcode |     err_message      
---------+-------------+-----------+------------+----------------------
-   1000 | public      | job_fail  | P0001      | raising an exception
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
-FROM timescaledb_information.job_errors WHERE job_id >= 1000;
- job_id | proc_schema |  proc_name   | sqlerrcode |                     err_message                     
---------+-------------+--------------+------------+-----------------------------------------------------
-   1002 | public      | custom_proc2 | 40001      | could not serialize access due to concurrent update
-(1 row)
-
-SET ROLE :ROLE_SUPERUSER;
-SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
-FROM timescaledb_information.job_errors WHERE job_id >= 1000;
+FROM timescaledb_information.job_errors WHERE job_id >= 1000
+ORDER BY job_id;
  job_id | proc_schema |  proc_name   | sqlerrcode |                     err_message                     
 --------+-------------+--------------+------------+-----------------------------------------------------
    1000 | public      | job_fail     | P0001      | raising an exception
    1002 | public      | custom_proc2 | 40001      | could not serialize access due to concurrent update
   11111 |             |              |            | not an error
-  22222 |             |              |            | job crash detected, see server logs
+  22222 |             |              |            | 
 (4 rows)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
+FROM timescaledb_information.job_errors WHERE job_id >= 1000
+ORDER BY job_id;
+ job_id | proc_schema |  proc_name   | sqlerrcode |                     err_message                     
+--------+-------------+--------------+------------+-----------------------------------------------------
+   1000 | public      | job_fail     | P0001      | raising an exception
+   1002 | public      | custom_proc2 | 40001      | could not serialize access due to concurrent update
+  11111 |             |              |            | not an error
+  22222 |             |              |            | 
+(4 rows)
+
+SET ROLE :ROLE_SUPERUSER;
+SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
+FROM timescaledb_information.job_errors WHERE job_id >= 1000
+ORDER BY job_id;
+ job_id | proc_schema |  proc_name   | sqlerrcode |                     err_message                     
+--------+-------------+--------------+------------+-----------------------------------------------------
+   1000 | public      | job_fail     | P0001      | raising an exception
+   1002 | public      | custom_proc2 | 40001      | could not serialize access due to concurrent update
+  11111 |             |              |            | not an error
+  22222 |             |              |            | 
+  33333 |             |              |            | job crash detected, see server logs
+(5 rows)
 
 SELECT delete_job(:custom_proc2_id);
  delete_job 
@@ -122,6 +134,13 @@ SELECT delete_job(:job_fail_id);
  delete_job 
 ------------
  
+(1 row)
+
+ALTER SYSTEM RESET DEFAULT_TRANSACTION_ISOLATION;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/sql/bgw_job_stat_history.sql
+++ b/tsl/test/sql/bgw_job_stat_history.sql
@@ -23,7 +23,6 @@ SHOW timescaledb.enable_job_execution_logging;
 
 -- Start Background Workers
 SELECT _timescaledb_functions.start_background_workers();
-SELECT pg_sleep(6);
 
 SELECT add_job('custom_job_ok', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_1 \gset
 SELECT add_job('custom_job_error', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_2 \gset
@@ -44,6 +43,9 @@ ORDER BY job_id;
 -- Log all executions
 ALTER SYSTEM SET timescaledb.enable_job_execution_logging TO ON;
 SELECT pg_reload_conf();
+
+-- Reconnect to make sure the GUC is set
+\c :TEST_DBNAME :ROLE_SUPERUSER
 
 SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
 SELECT scheduled FROM alter_job(:job_id_2, next_start => now());


### PR DESCRIPTION
Currently while a job is running we set `pid = SchedulerPid`, `succeed = false` and `execution_finish=NOW()` and it leads to confusion when querying either `timescaledb_information.job_errors` or `timescaledb_information.job_history` views showing in the `err_message = job crash detected, see server logs`. This information is wrong and create confusion.

Fixed it by setting `succeed=NULL` and `pid=NULL` when the scheduler launch the job and then when the job worker start to work then set `pid=MyProcPid` (the worker PID) meaning that the job started and didn't finished yet, and at the end of the execution we set `succeed=TRUE or FALSE` and the `execution_finish=NOW()` to mark the end of the job execution. Also adjusted the views to expose the information properly.

(cherry picked from commit 6063464f6)