### PR TITLE
Fix flaky job crash log TAP test

### DIFF
--- a/tsl/test/t/001_job_crash_log.pl
+++ b/tsl/test/t/001_job_crash_log.pl
@@ -65,7 +65,7 @@ is($node->poll_query_until('postgres', 'SELECT 1', '1'),
 	1, "reconnected after SIGQUIT");
 
 my $errlog = $node->safe_psql('postgres',
-	'select count(*) from _timescaledb_internal.bgw_job_stat_history where job_id = 1000 and succeeded = false'
+	'select count(*) from _timescaledb_internal.bgw_job_stat_history where job_id = 1000 and succeeded is false'
 );
 is($errlog, "1", "there is a row for the crash in the error log");
 


### PR DESCRIPTION
In #7630 we fixed wrong crash error messages on job history. It was fixed by removing the `NOT NULL` constraint from `succeeded` column when the launcher insert the job history row that is updated by the worker when the job actually start to run.

Fixed the TAP test to properly deal with nulls on the `succeeded` column when checking for failed executions.

Flaky execution:
https://github.com/timescale/timescaledb/actions/runs/13391680375/job/37400633002?pr=7719#step:16:701

Disable-check: force-changelog-file