### PR TITLE
Trigger the backports when a release branch is updated

### DIFF
--- a/.github/workflows/backport-trigger.yaml
+++ b/.github/workflows/backport-trigger.yaml
@@ -1,6 +1,6 @@
 # A helper workflow to trigger the run of the backport workflow on the main
 # branch, when a release branch or the main branch were changed.
-
+name: Trigger the Backport Workflow
 "on":
   push:
     branches:
@@ -13,7 +13,11 @@ jobs:
   backport_trigger:
     runs-on: ubuntu-latest
     steps:
-      - env:
+      - name: Checkout TimescaleDB
+        uses: actions/checkout@v4
+
+      - name: Trigger the Backport Workflow
+        env:
           GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
         run: |
           gh workflow run backport.yaml --ref main

--- a/.github/workflows/backport-trigger.yaml
+++ b/.github/workflows/backport-trigger.yaml
@@ -1,0 +1,20 @@
+# A helper workflow to trigger the run of the backport workflow on the main
+# branch, when a release branch or the main branch were changed.
+
+"on":
+  push:
+    branches:
+      - main
+      - ?.*.x
+  pull_request:
+    paths: .github/workflows/backport-trigger.yaml
+
+jobs:
+  backport_trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+        run: |
+          gh workflow run backport.yaml --ref main
+

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,11 +7,9 @@ on:
     - cron: '0 12 * * 1-5'
   workflow_dispatch:
   push:
+    # This is also triggered from backport-trigger.yaml when the release branches
+    # are updated.
     branches:
-      # Ideally we want to create a backport PR as soon as the fix is merged
-      # into the main branch
-      - main
-
       # You can run and debug new versions of the backport script by pushing it
       # to this branch. workflow_dispatch can only be run through github cli for
       # branches that are not main, so it's inconvenient.


### PR DESCRIPTION
This will help update the pending backport PR to the latest version of the release branch.

GitHub doesn't provide a built-in possibility to trigger a workflow on the main branch when another branch has changed. For example, if we had a "push: ?.*.x" condition, it would trigger the backport workflow on the release branch itself, which is not what we need. So we have to use a helper workflow instead.

Disable-check: approval-count
Disable-check: force-changelog-file