### PR TITLE
Release 2.18.2

### DIFF
--- a/.unreleased/hash-groupagg-bug
+++ b/.unreleased/hash-groupagg-bug
@@ -1,1 +1,0 @@
-Fixes: #7686 Potential wrong aggregation result when using vectorized aggregation with hash grouping in reverse order

--- a/.unreleased/pr_7694
+++ b/.unreleased/pr_7694
@@ -1,1 +1,0 @@
-Fixes: #7694 Fix ExplainHook breaking call chain

--- a/.unreleased/pr_7695
+++ b/.unreleased/pr_7695
@@ -1,1 +1,0 @@
-Fixes: #7695 Block dropping internal compressed chunks with `drop_chunk()`

--- a/.unreleased/pr_7711
+++ b/.unreleased/pr_7711
@@ -1,2 +1,0 @@
-Fixes: #7711 License error when using hypercore handler
-Thanks: @jflambert for reporting an bug on license error show in autovacuum

--- a/.unreleased/pr_7712
+++ b/.unreleased/pr_7712
@@ -1,3 +1,0 @@
-Fixes: #7712 Respect other extensions' ExecutorStart hooks
-
-Thanks: @davidmehren and @jflambert for reporting an issue with extension hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.18.2 (2025-02-19)
+
+This release contains performance improvements and bug fixes since
+the 2.18.1 release. We recommend that you upgrade at the next
+available opportunity.
+
+**Bugfixes**
+* #7686 Potential wrong aggregation result when using vectorized aggregation with hash grouping in reverse order
+* #7694 Fix ExplainHook breaking call chain
+* #7695 Block dropping internal compressed chunks with `drop_chunk()`
+* #7711 License error when using hypercore handler
+* #7712 Respect other extensions' ExecutorStart hooks
+
+**Thanks**
+* @davidmehren and @jflambert for reporting an issue with extension hooks
+* @jflambert for reporting a bug with license errors shown in autovacuum
+
 ## 2.18.1 (2025-02-10)
 
 This release contains performance improvements and bug fixes since

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -47,11 +47,12 @@ set(MOD_FILES
     updates/2.17.0--2.17.1.sql
     updates/2.17.1--2.17.2.sql
     updates/2.17.2--2.18.0.sql
-    updates/2.18.0--2.18.1.sql)
+    updates/2.18.0--2.18.1.sql
+    updates/2.18.1--2.18.2.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config
-set(CURRENT_REV_FILE 2.18.1--2.18.0.sql)
+set(CURRENT_REV_FILE 2.18.2--2.18.1.sql)
 # Files for generating old downgrade scripts. This should only include files for
 # downgrade from one version to its previous version since we do not support
 # skipping versions when downgrading.
@@ -94,7 +95,8 @@ set(OLD_REV_FILES
     2.17.1--2.17.0.sql
     2.17.2--2.17.1.sql
     2.18.0--2.17.2.sql
-    2.18.1--2.18.0.sql)
+    2.18.1--2.18.0.sql
+    2.18.2--2.18.1.sql)
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")
 set(LOADER_PATHNAME "$libdir/timescaledb")

--- a/sql/updates/2.18.1--2.18.2.sql
+++ b/sql/updates/2.18.1--2.18.2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE _timescaledb_internal.bgw_job_stat_history
+    ALTER COLUMN succeeded DROP NOT NULL,
+    ALTER COLUMN succeeded DROP DEFAULT;

--- a/sql/updates/2.18.2--2.18.1.sql
+++ b/sql/updates/2.18.2--2.18.1.sql
@@ -1,0 +1,5 @@
+UPDATE _timescaledb_internal.bgw_job_stat_history SET succeeded = FALSE WHERE succeeded IS NULL;
+
+ALTER TABLE _timescaledb_internal.bgw_job_stat_history
+    ALTER COLUMN succeeded SET NOT NULL,
+    ALTER COLUMN succeeded SET DEFAULT FALSE;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,0 @@
-ALTER TABLE _timescaledb_internal.bgw_job_stat_history
-    ALTER COLUMN succeeded DROP NOT NULL,
-    ALTER COLUMN succeeded DROP DEFAULT;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,5 +1,0 @@
-UPDATE _timescaledb_internal.bgw_job_stat_history SET succeeded = FALSE WHERE succeeded IS NULL;
-
-ALTER TABLE _timescaledb_internal.bgw_job_stat_history
-    ALTER COLUMN succeeded SET NOT NULL,
-    ALTER COLUMN succeeded SET DEFAULT FALSE;

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
-version = 2.18.1
-update_from_version = 2.18.0
-downgrade_to_version = 2.18.0
+version = 2.18.2
+update_from_version = 2.18.1
+downgrade_to_version = 2.18.1


### PR DESCRIPTION
This release contains performance improvements and bug fixes since the 2.18.1 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* #7686 Potential wrong aggregation result when using vectorized aggregation with hash grouping in reverse order
* #7694 Fix ExplainHook breaking call chain
* #7695 Block dropping internal compressed chunks with `drop_chunk()`
* #7711 License error when using hypercore handler
* #7712 Respect other extensions' ExecutorStart hooks

**Thanks**
* @davidmehren and @jflambert for reporting an issue with extension hooks
* @jflambert for reporting a bug with license errors shown in autovacuum