### PR TITLE
Block TAM rewrites with incompatible GUC setting

### DIFF
--- a/.unreleased/pr_7746
+++ b/.unreleased/pr_7746
@@ -1,0 +1,1 @@
+Fixes: #7747 Block TAM rewrites with incompatible GUC setting

--- a/src/guc.c
+++ b/src/guc.c
@@ -98,13 +98,16 @@ static const struct config_enum_entry loglevel_options[] = {
  *
  * (2) = hypercore, enabled for compressed tables and those using Hypercore
  *       TAM. This is useful mostly for debugging/testing and as a fallback.
+ *       Only available in debug builds.
  */
 static const struct config_enum_entry transparent_decompression_options[] = {
 	{ "on", 1, false },
 	{ "true", 1, false },
 	{ "off", 0, false },
 	{ "false", 0, false },
+#ifdef TS_DEBUG
 	{ TS_HYPERCORE_TAM_NAME, 2, false },
+#endif
 	{ NULL, 0, false }
 };
 

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -1063,3 +1063,26 @@ select * from amrels where relparent = 'test5'::regclass;
  _timescaledb_internal._hyper_10_47_chunk | heap      | test5
 (2 rows)
 
+-- Check that operations that rewrite the relation are blocked with
+-- invalid setting of transparent decompression GUC
+\set ON_ERROR_STOP 0
+select count(*) from :chunk;
+ count 
+-------
+     1
+(1 row)
+
+set timescaledb.enable_transparent_decompression='hypercore';
+select decompress_chunk(:'chunk');
+ERROR:  operation not compatible with current setting of timescaledb.enable_transparent_decompression
+alter table :chunk set access method heap;
+ERROR:  operation not compatible with current setting of timescaledb.enable_transparent_decompression
+vacuum full :chunk;
+ERROR:  operation not compatible with current setting of timescaledb.enable_transparent_decompression
+select count(*) from :chunk;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -144,7 +144,8 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND TEST_FILES bgw_scheduler_control.sql hypercore.sql)
+    list(APPEND TEST_FILES bgw_scheduler_control.sql hypercore.sql
+         hypercore_create.sql hypercore_scans.sql)
   endif()
   list(
     APPEND
@@ -155,7 +156,6 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
     hypercore_columnar.sql
     hypercore_constraints.sql
     hypercore_copy.sql
-    hypercore_create.sql
     hypercore_cursor.sql
     hypercore_ddl.sql
     hypercore_delete.sql
@@ -166,7 +166,6 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
     hypercore_join.sql
     hypercore_merge.sql
     hypercore_policy.sql
-    hypercore_scans.sql
     hypercore_stats.sql
     hypercore_trigger.sql
     hypercore_types.sql

--- a/tsl/test/sql/hypercore_create.sql
+++ b/tsl/test/sql/hypercore_create.sql
@@ -512,3 +512,14 @@ select ch as chunk from show_chunks('test5') ch limit 1 \gset
 alter table test5 set (timescaledb.compress);
 select compress_chunk(:'chunk');
 select * from amrels where relparent = 'test5'::regclass;
+
+-- Check that operations that rewrite the relation are blocked with
+-- invalid setting of transparent decompression GUC
+\set ON_ERROR_STOP 0
+select count(*) from :chunk;
+set timescaledb.enable_transparent_decompression='hypercore';
+select decompress_chunk(:'chunk');
+alter table :chunk set access method heap;
+vacuum full :chunk;
+select count(*) from :chunk;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
The GUC timescaledb.enable_transparent_decompression can be set to 'hypercore' when using Hypercore TAM in order to get a DecompressChunk plan. This will make a scan read only non-compressed data from the TAM, and is used for debugging. Howver, the setting can be dangerous if a chunk is rewritten by decompression or vaccum full, leading to
data loss. Therefore, block rewrite operations on Hypercore TAM when the GUC is set to 'hypercore'. Also remove the possibility to use this GUC value entirely in release builds.

Disable-check: force-changelog-file
