### PR TITLE
Reduce lock requirements during recompression

### DIFF
--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1063,8 +1063,8 @@ static Oid
 get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 {
 	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
-	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, ShareLock);
-	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, ShareLock);
+	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
+	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, AccessShareLock);
 
 	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
 

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -22,13 +22,16 @@
 #include "guc.h"
 #include "hypercore/hypercore_handler.h"
 #include "hypercore/utils.h"
+#include "indexing.h"
 #include "recompress.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/chunk_column_stats.h"
 #include "ts_catalog/compression_settings.h"
 
 static bool fetch_uncompressed_chunk_into_tuplesort(Tuplesortstate *tuplesortstate,
-													Relation uncompressed_chunk_rel);
+													Relation uncompressed_chunk_rel,
+													Snapshot snapshot);
+static bool delete_tuple_for_recompression(Relation rel, ItemPointer tid, Snapshot snapshot);
 static void update_current_segment(CompressedSegmentInfo *current_segment, TupleTableSlot *slot,
 								   int nsegmentby_cols);
 static void create_segmentby_scankeys(CompressionSettings *settings, Relation index_rel,
@@ -126,30 +129,49 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 	 */
 	Ensure(settings->fd.orderby, "empty order by, cannot recompress segmentwise");
 
-	/* new status after recompress should simply be compressed (1)
-	 * It is ok to update this early on in the transaction as it keeps a lock
-	 * on the updated tuple in the CHUNK table potentially preventing other transaction
-	 * from updating it
-	 */
-	if (ts_chunk_clear_status(uncompressed_chunk,
-							  CHUNK_STATUS_COMPRESSED_UNORDERED | CHUNK_STATUS_COMPRESSED_PARTIAL))
-		ereport(DEBUG1,
-				(errmsg("cleared chunk status for recompression: \"%s.%s\"",
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
-
 	ereport(DEBUG1,
 			(errmsg("acquiring locks for recompression: \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),
 					NameStr(uncompressed_chunk->fd.table_name))));
 	/* lock both chunks, compressed and uncompressed */
-	/* TODO: Take RowExclusive locks instead of ExclusiveLock
-	 * Taking a weaker lock is possible but in order to use that,
-	 * we have to check row level locking results when modifying tuples
-	 * and make decisions based on them.
+	Relation uncompressed_chunk_rel =
+		table_open(uncompressed_chunk->table_id, ShareUpdateExclusiveLock);
+	Relation compressed_chunk_rel =
+		table_open(compressed_chunk->table_id, ShareUpdateExclusiveLock);
+
+	bool has_unique_constraints =
+		ts_indexing_relation_has_primary_or_unique_index(uncompressed_chunk_rel);
+	int count;
+	LOCKTAG locktag;
+	SET_LOCKTAG_RELATION(locktag, MyDatabaseId, uncompressed_chunk_id);
+
+	/*
+	 * Recompression does not block inserts but it can interfere with
+	 * constraint checking since it moves uncompressed tuples from
+	 * uncompressed chunk to compressed chunk but the INSERTs check
+	 * tuples in the opposite order.
+	 *
+	 * If there are unique constraints and multiple INSERTs happening at start
+	 * we want to just bail out so not to cause wasted work and bloat.
 	 */
-	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, ExclusiveLock);
-	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, ExclusiveLock);
+	if (has_unique_constraints)
+	{
+		GetLockConflicts(&locktag, ExclusiveLock, &count);
+
+		if (count > 1)
+		{
+			elog(WARNING,
+				 "skipping recompression of chunk %s.%s due to unique constraints and concurrent "
+				 "DML",
+				 NameStr(uncompressed_chunk->fd.schema_name),
+				 NameStr(uncompressed_chunk->fd.table_name));
+
+			table_close(uncompressed_chunk_rel, NoLock);
+			table_close(compressed_chunk_rel, NoLock);
+
+			PG_RETURN_OID(uncompressed_chunk_id);
+		}
+	}
 
 	/*
 	 * Calculate and add the column dimension ranges for the src chunk used by chunk skipping
@@ -286,8 +308,9 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 	IndexScanDesc index_scan =
 		index_beginscan(compressed_chunk_rel, index_rel, snapshot, num_segmentby, 0);
 
-	bool found_tuple =
-		fetch_uncompressed_chunk_into_tuplesort(input_tuplesortstate, uncompressed_chunk_rel);
+	bool found_tuple = fetch_uncompressed_chunk_into_tuplesort(input_tuplesortstate,
+															   uncompressed_chunk_rel,
+															   snapshot);
 	if (!found_tuple)
 		goto finish;
 	tuplesort_performsort(input_tuplesortstate);
@@ -396,9 +419,14 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 				row_decompressor_decompress_row_to_tuplesort(&decompressor,
 															 recompress_tuplesortstate);
 
-				simple_table_tuple_delete(compressed_chunk_rel,
-										  &(compressed_slot->tts_tid),
-										  snapshot);
+				if (!delete_tuple_for_recompression(compressed_chunk_rel,
+													&(compressed_slot->tts_tid),
+													snapshot))
+					ereport(ERROR,
+							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							 errmsg(
+								 "cannot proceed with recompression due to concurrent updates on "
+								 "compressed data")));
 				CommandCounterIncrement();
 
 				if (should_free)
@@ -479,9 +507,6 @@ finish:
 	pfree(index_scankeys);
 	pfree(orderby_scankeys);
 
-	/* changed chunk status, so invalidate any plans involving this chunk */
-	CacheInvalidateRelcacheByRelid(uncompressed_chunk_id);
-
 	/* Need to rebuild indexes if the relation is using hypercore
 	 * TAM. Alternatively, we could insert into indexes when inserting into
 	 * the compressed rel. */
@@ -497,6 +522,63 @@ finish:
 #else
 		reindex_relation(RelationGetRelid(uncompressed_chunk_rel), 0, &params);
 #endif
+	}
+
+	/* If we can quickly upgrade the lock, lets try updating the chunk status to fully
+	 * compressed. But we need to check if there are any uncompressed tuples in the
+	 * relation since somebody might have inserted new tuples while we were recompressing.
+	 */
+	if (ConditionalLockRelation(uncompressed_chunk_rel, ExclusiveLock))
+	{
+		TableScanDesc scan = table_beginscan(uncompressed_chunk_rel, GetLatestSnapshot(), 0, 0);
+		hypercore_scan_set_skip_compressed(scan, true);
+		ScanDirection scan_dir = uncompressed_chunk_rel->rd_tableam == hypercore_routine() ?
+									 ForwardScanDirection :
+									 BackwardScanDirection;
+		TupleTableSlot *slot = table_slot_create(uncompressed_chunk_rel, NULL);
+
+		/* Doing a backwards scan with assumption that newly inserted tuples
+		 * are most likely at the end of the heap.
+		 */
+		bool has_tuples = false;
+		if (table_scan_getnextslot(scan, scan_dir, slot))
+		{
+			has_tuples = true;
+		}
+
+		ExecDropSingleTupleTableSlot(slot);
+		table_endscan(scan);
+
+		if (!has_tuples)
+		{
+			if (ts_chunk_clear_status(uncompressed_chunk,
+									  CHUNK_STATUS_COMPRESSED_UNORDERED |
+										  CHUNK_STATUS_COMPRESSED_PARTIAL))
+				ereport(DEBUG1,
+						(errmsg("cleared chunk status for recompression: \"%s.%s\"",
+								NameStr(uncompressed_chunk->fd.schema_name),
+								NameStr(uncompressed_chunk->fd.table_name))));
+
+			/* changed chunk status, so invalidate any plans involving this chunk */
+			CacheInvalidateRelcacheByRelid(uncompressed_chunk_id);
+		}
+	}
+	else if (has_unique_constraints)
+	{
+		/*
+		 * This can be problematic since we cannot acquire ExclusiveLock meaning its
+		 * possible there are inserts going which need to check unique constraints.
+		 * Due to the reverse direction of tuple movement, concurrent recompression
+		 * and speculative insertion could potentially cause false negatives during
+		 * constraint checking. For now, our best option here is to bail.
+		 *
+		 * This can be improved by using a spin lock to wait for the ExclusiveLock
+		 * or bail out if we can't get it in time.
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+				 errmsg("cannot proceed with recompression due to concurrent DML on uncompressed "
+						"data")));
 	}
 
 	table_close(uncompressed_chunk_rel, NoLock);
@@ -572,10 +654,9 @@ match_tuple_batch(TupleTableSlot *compressed_slot, int num_orderby, ScanKey orde
 
 static bool
 fetch_uncompressed_chunk_into_tuplesort(Tuplesortstate *tuplesortstate,
-										Relation uncompressed_chunk_rel)
+										Relation uncompressed_chunk_rel, Snapshot snapshot)
 {
 	bool matching_exist = false;
-	Snapshot snapshot = GetLatestSnapshot();
 	/* Let compression TAM know it should only return tuples from the
 	 * non-compressed relation. */
 
@@ -588,9 +669,12 @@ fetch_uncompressed_chunk_into_tuplesort(Tuplesortstate *tuplesortstate,
 		matching_exist = true;
 		slot_getallattrs(slot);
 		tuplesort_puttupleslot(tuplesortstate, slot);
-		/* simple_table_tuple_delete since we don't expect concurrent
-		 * updates, have exclusive lock on the relation */
-		simple_table_tuple_delete(uncompressed_chunk_rel, &slot->tts_tid, snapshot);
+		if (!delete_tuple_for_recompression(uncompressed_chunk_rel, &slot->tts_tid, snapshot))
+			ereport(ERROR,
+					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+					 errmsg("cannot proceed with recompression due to concurrent updates on "
+							"uncompressed "
+							"data")));
 	}
 	ExecDropSingleTupleTableSlot(slot);
 	table_endscan(scan);
@@ -755,4 +839,28 @@ create_orderby_scankeys(CompressionSettings *settings, Relation index_rel,
 					 attnumCollationId(compressed_chunk_rel, second_attno),
 					 second_strategy);
 	}
+}
+
+/* Deleting a tuple for recompression if we can.
+ * If there is an unexpected result, we should just abort the operation completely.
+ * There are potential optimizations that can be done here in certain scenarios.
+ */
+static bool
+delete_tuple_for_recompression(Relation rel, ItemPointer tid, Snapshot snapshot)
+{
+	TM_Result result;
+	TM_FailureData tmfd;
+
+	result =
+		table_tuple_delete(rel,
+						   tid,
+						   GetCurrentCommandId(true),
+						   snapshot,
+						   InvalidSnapshot,
+						   true /* for now, just wait for commit/abort, that might let us proceed */
+						   ,
+						   &tmfd,
+						   true /* changingPart */);
+
+	return result == TM_Ok;
 }

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -1563,6 +1563,7 @@ step I1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step I1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1651,6 +1652,7 @@ step I1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step I1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1739,6 +1741,7 @@ step I1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step I1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1827,6 +1830,7 @@ step Iu1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step Iu1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1915,6 +1919,7 @@ step Iu1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step Iu1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2009,6 +2014,7 @@ step Iu1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step Iu1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2100,6 +2106,7 @@ step RC:
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step IN1: <... completed>
 step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2185,6 +2192,7 @@ step RC:
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
 step INu1: <... completed>
 step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2279,8 +2287,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step I1: <... completed>
-step Ic: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2306,7 +2315,7 @@ step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 
@@ -2367,8 +2376,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step I1: <... completed>
-step Ic: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2394,7 +2404,7 @@ step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 
@@ -2455,8 +2465,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step I1: <... completed>
-step Ic: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2482,7 +2493,7 @@ step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 
@@ -2543,8 +2554,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step Iu1: <... completed>
-step Ic: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2555,7 +2567,6 @@ step SA: SELECT * FROM ts_device_table;
 time|device|location|value
 ----+------+--------+-----
    0|     1|     100|   20
-   1|     1|     100|   98
    2|     1|     100|   20
    3|     1|     100|   20
    4|     1|     100|   20
@@ -2564,13 +2575,14 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
+   1|     1|     100|   98
 (10 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);
@@ -2637,8 +2649,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step Iu1: <... completed>
-step Ic: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2649,7 +2662,6 @@ step SA: SELECT * FROM ts_device_table;
 time|device|location|value
 ----+------+--------+-----
    0|     1|     100|   20
-   1|     1|     100|   98
    2|     1|     100|   20
    3|     1|     100|   20
    4|     1|     100|   20
@@ -2658,13 +2670,14 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
+   1|     1|     100|   98
 (10 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);
@@ -2731,8 +2744,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step Iu1: <... completed>
-step Ic: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2743,7 +2757,6 @@ step SA: SELECT * FROM ts_device_table;
 time|device|location|value
 ----+------+--------+-----
    0|     1|     100|   20
-   1|     1|     100|   98
    2|     1|     100|   20
    3|     1|     100|   20
    4|     1|     100|   20
@@ -2752,13 +2765,14 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
+   1|     1|     100|   98
 (10 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);
@@ -2822,8 +2836,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step IN1: <... completed>
-step INc: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2849,7 +2864,7 @@ step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 
@@ -2907,8 +2922,9 @@ step RC:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step INu1: <... completed>
-step INc: COMMIT;
 step RC: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
@@ -2919,7 +2935,6 @@ step SA: SELECT * FROM ts_device_table;
 time|device|location|value
 ----+------+--------+-----
    0|     1|     100|   20
-   1|     1|     100|   99
    2|     1|     100|   20
    3|     1|     100|   20
    4|     1|     100|   20
@@ -2928,13 +2943,14 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
+   1|     1|     100|   99
 (10 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
 status
 ------
-     1
+     9
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);

--- a/tsl/test/isolation/expected/compression_recompress.out
+++ b/tsl/test/isolation/expected/compression_recompress.out
@@ -1,6 +1,6 @@
 Parsed test spec with 3 sessions
 
-starting permutation: s1_begin s1_recompress_chunk s2_select_from_compressed_chunk s2_wait_for_select_to_finish s1_rollback
+starting permutation: s1_begin s1_recompress_chunk s2_select_from_compressed_chunk s2_wait_for_finish s1_rollback
 step s1_begin: 
    BEGIN;
 
@@ -22,13 +22,13 @@ step s2_select_from_compressed_chunk:
 t       
 (1 row)
 
-step s2_wait_for_select_to_finish: 
+step s2_wait_for_finish: 
 
 step s1_rollback: 
 	ROLLBACK;
 
 
-starting permutation: s1_compress s3_block_chunk_insert s2_insert s1_decompress s1_compress s3_release_chunk_insert
+starting permutation: s1_compress s3_block_chunk_insert s2_insert_do_nothing s1_decompress s1_compress s3_release_chunk_insert
 step s1_compress: 
    SELECT compression_status FROM chunk_compression_stats('sensor_data');
    SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
@@ -63,8 +63,10 @@ debug_waitpoint_enable
                       
 (1 row)
 
-step s2_insert: 
-   INSERT INTO sensor_data VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) ON CONFLICT (time, sensor_id) DO NOTHING;
+step s2_insert_do_nothing: 
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
  <waiting ...>
 step s1_decompress: 
    SELECT count(*) FROM (SELECT decompress_chunk(i) FROM show_chunks('sensor_data') i) i;
@@ -120,4 +122,1944 @@ debug_waitpoint_release
                        
 (1 row)
 
-step s2_insert: <... completed>
+step s2_insert_do_nothing: <... completed>
+
+starting permutation: s1_show_chunk_state s2_begin s2_insert_do_nothing s1_begin s1_recompress_chunk s2_insert_do_nothing s2_wait_for_finish s2_commit s1_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_insert_do_nothing: 
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_insert_do_nothing: 
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_insert_do_nothing s1_begin s1_recompress_chunk s2_insert_existing_do_nothing s2_wait_for_finish s2_commit s1_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_insert_do_nothing: 
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_insert_existing_do_nothing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 1.0, 1.0 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_insert_do_nothing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_insert_do_nothing: 
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_insert_existing_do_nothing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_insert_existing_do_nothing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 1.0, 1.0 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+
+starting permutation: s1_recompress_chunk s1_show_chunk_state s1_insert_for_recompression s1_show_chunk_state s2_begin s2_insert_existing_do_nothing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     1
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_insert_existing_do_nothing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 1.0, 1.0 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_upsert s1_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_upsert: 
+   INSERT INTO sensor_data 
+   VALUES ('2022-01-01 20:00'::timestamptz, 100, 9999, 9999), ('2022-01-01 21:00'::timestamptz, 101, 9999, 9999) 
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_upsert: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    2
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_upsert_existing s1_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_upsert_existing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 9999, 9999 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_upsert_existing: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    1
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_upsert s2_wait_for_finish s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_upsert: 
+   INSERT INTO sensor_data 
+   VALUES ('2022-01-01 20:00'::timestamptz, 100, 9999, 9999), ('2022-01-01 21:00'::timestamptz, 101, 9999, 9999) 
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+
+step s2_wait_for_finish: 
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    2
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_upsert_existing s2_wait_for_finish s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_upsert_existing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 9999, 9999 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+
+step s2_wait_for_finish: 
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    1
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_upsert s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_upsert: 
+   INSERT INTO sensor_data 
+   VALUES ('2022-01-01 20:00'::timestamptz, 100, 9999, 9999), ('2022-01-01 21:00'::timestamptz, 101, 9999, 9999) 
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    2
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_upsert_existing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_upsert_existing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 9999, 9999 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    1
+(1 row)
+
+
+starting permutation: s1_recompress_chunk s1_insert_for_recompression s1_show_chunk_state s2_begin s2_upsert_existing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state s2_show_updated_count
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_upsert_existing: 
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 9999, 9999 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_wait_for_finish: 
+
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    1
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s3_begin s1_begin s3_delete_uncompressed s1_recompress_chunk s2_insert_do_nothing s3_rollback s1_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_begin: 
+	BEGIN;
+
+step s1_begin: 
+   BEGIN;
+
+step s3_delete_uncompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 11;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+ <waiting ...>
+step s2_insert_do_nothing: 
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+
+step s3_rollback: 
+	ROLLBACK;
+
+step s1_recompress_chunk: <... completed>
+recompress
+----------
+         1
+(1 row)
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15842
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_delete_compressed s1_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_delete_compressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 1;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_delete_compressed: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     1
+(1 row)
+
+count
+-----
+14400
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_delete_uncompressed s1_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_delete_uncompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 11;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_delete_uncompressed: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     1
+(1 row)
+
+count
+-----
+14400
+(1 row)
+
+
+starting permutation: s1_recompress_chunk s1_insert_for_recompression s1_show_chunk_state s1_begin s1_recompress_chunk s2_delete_recompressed s1_commit s1_show_chunk_state
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_delete_recompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_delete_recompressed: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14520
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_delete_compressed s2_wait_for_finish s1_commit s1_show_chunk_state s3_release_exclusive_lock
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_delete_compressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 1;
+
+step s2_wait_for_finish: 
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14400
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_delete_uncompressed s1_commit s1_show_chunk_state s3_release_exclusive_lock
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_delete_uncompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 11;
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14400
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_recompress_chunk s3_block_exclusive_lock s1_insert_for_recompression s1_show_chunk_state s1_begin s1_recompress_chunk s2_delete_recompressed s1_commit s1_show_chunk_state s3_release_exclusive_lock
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_delete_recompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14520
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_delete_uncompressed s1_recompress_chunk s2_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_delete_uncompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 11;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+ <waiting ...>
+step s2_commit: 
+	COMMIT;
+
+step s1_recompress_chunk: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent updates on uncompressed data
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14400
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_delete_compressed s1_recompress_chunk s2_commit s1_show_chunk_state
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_delete_compressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 1;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14400
+(1 row)
+
+
+starting permutation: s1_recompress_chunk s1_insert_for_recompression s1_show_chunk_state s2_begin s2_delete_recompressed s1_recompress_chunk s2_commit s1_show_chunk_state
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_delete_recompressed: 
+	DELETE FROM sensor_data WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+ <waiting ...>
+step s2_commit: 
+	COMMIT;
+
+step s1_recompress_chunk: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent updates on compressed data
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+14520
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_update_compressed s1_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_update_compressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 1;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_update_compressed: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1440
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_update_uncompressed s1_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_update_uncompressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 11;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_update_uncompressed: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1440
+(1 row)
+
+
+starting permutation: s1_recompress_chunk s1_insert_for_recompression s1_begin s1_recompress_chunk s2_update_recompressed s1_commit s1_show_chunk_state s2_show_updated_count
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s2_update_recompressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s2_update_recompressed: <... completed>
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1380
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_update_compressed s2_wait_for_finish s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_update_compressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 1;
+
+step s2_wait_for_finish: 
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1440
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_update_uncompressed s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_update_uncompressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 11;
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1440
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_recompress_chunk s1_insert_for_recompression s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_update_recompressed s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s3_block_exclusive_lock: 
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+
+step s1_begin: 
+   BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_update_recompressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+
+step s1_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1380
+(1 row)
+
+step s3_release_exclusive_lock: 
+	ROLLBACK;
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_update_uncompressed s1_recompress_chunk s2_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_update_uncompressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 11;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+ <waiting ...>
+step s2_commit: 
+	COMMIT;
+
+step s1_recompress_chunk: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent updates on uncompressed data
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1440
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s2_begin s2_update_compressed s1_recompress_chunk s2_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_update_compressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 1;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+step s2_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1440
+(1 row)
+
+
+starting permutation: s1_recompress_chunk s1_insert_for_recompression s1_show_chunk_state s2_begin s2_update_recompressed s1_recompress_chunk s2_commit s1_show_chunk_state s2_show_updated_count
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s1_insert_for_recompression: 
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_begin: 
+	BEGIN;
+
+step s2_update_recompressed: 
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+ <waiting ...>
+step s2_commit: 
+	COMMIT;
+
+step s1_recompress_chunk: <... completed>
+ERROR:  cannot proceed with recompression due to concurrent updates on compressed data
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15900
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+ 1380
+(1 row)
+
+
+starting permutation: s1_show_chunk_state s1_begin s3_begin s1_recompress_chunk s3_recompress_chunk s1_commit s3_commit s1_show_chunk_state s2_show_updated_count
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     9
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_begin: 
+   BEGIN;
+
+step s3_begin: 
+	BEGIN;
+
+step s1_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+
+recompress
+----------
+         1
+(1 row)
+
+step s3_recompress_chunk: 
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+ <waiting ...>
+step s1_commit: 
+	COMMIT;
+
+step s3_recompress_chunk: <... completed>
+recompress
+----------
+         1
+(1 row)
+
+step s3_commit: 
+	COMMIT;
+
+step s1_show_chunk_state: 
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+
+status
+------
+     1
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s2_show_updated_count: 
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
+
+count
+-----
+    0
+(1 row)
+

--- a/tsl/test/isolation/specs/compression_recompress.spec
+++ b/tsl/test/isolation/specs/compression_recompress.spec
@@ -57,6 +57,9 @@ step "s1_recompress_chunk" {
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 }
+step "s1_commit" {
+	COMMIT;
+}
 step "s1_rollback" {
 	ROLLBACK;
 }
@@ -74,16 +77,91 @@ step "s1_decompress" {
    SELECT count(*) FROM sensor_data;
 }
 
+step "s1_show_chunk_state" {
+   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT count(*) FROM sensor_data;
+}
+
+step "s1_insert_for_recompression" {
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, 
+   5 as sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-01 00:59:59', INTERVAL '1 minute') AS g1(time)
+   ORDER BY time;
+}
+
 session "s2"
+step "s2_begin" {
+	BEGIN;
+}
+step "s2_commit" {
+	COMMIT;
+}
+	
 step "s2_select_from_compressed_chunk" {
 	SELECT sum(temperature) > 1 FROM sensor_data WHERE sensor_id = 2;
 }
 ## select should not be blocked by the recompress_chunk_segmentwise in progress
-step "s2_wait_for_select_to_finish" {
+step "s2_wait_for_finish" {
 }
 
-step "s2_insert" {
-   INSERT INTO sensor_data VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) ON CONFLICT (time, sensor_id) DO NOTHING;
+step "s2_insert_do_nothing" {
+   INSERT INTO sensor_data
+   VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+}
+
+step "s2_insert_existing_do_nothing" {
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 1.0, 1.0 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO NOTHING;
+}
+
+step "s2_upsert" {
+   INSERT INTO sensor_data 
+   VALUES ('2022-01-01 20:00'::timestamptz, 100, 9999, 9999), ('2022-01-01 21:00'::timestamptz, 101, 9999, 9999) 
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+}
+
+step "s2_upsert_existing" {
+   INSERT INTO sensor_data 
+   SELECT time, sensor_id, 9999, 9999 FROM sensor_data
+   WHERE sensor_id = 4
+   LIMIT 1
+   ON CONFLICT (time, sensor_id) DO UPDATE SET cpu = EXCLUDED.cpu, temperature = EXCLUDED.temperature;
+}
+
+step "s2_delete_compressed" {
+	DELETE FROM sensor_data WHERE sensor_id = 1;
+}
+
+step "s2_delete_uncompressed" {
+	DELETE FROM sensor_data WHERE sensor_id = 11;
+}
+
+step "s2_delete_recompressed" {
+	DELETE FROM sensor_data WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+}
+
+step "s2_update_compressed" {
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 1;
+}
+
+step "s2_update_uncompressed" {
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 11;
+}
+
+step "s2_update_recompressed" {
+	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
+}
+
+step "s2_show_updated_count" {
+	SELECT COUNT(*) FROM sensor_data WHERE cpu = 9999;
 }
 
 session "s3"
@@ -96,7 +174,90 @@ step "s3_release_chunk_insert" {
 	SELECT debug_waitpoint_release('chunk_insert_before_lock');
 }
 
+step "s3_block_exclusive_lock" {
+	BEGIN;
+	LOCK TABLE sensor_data IN ROW EXCLUSIVE MODE;
+}
+step "s3_release_exclusive_lock" {
+	ROLLBACK;
+}
 
-permutation "s1_begin" "s1_recompress_chunk" "s2_select_from_compressed_chunk" "s2_wait_for_select_to_finish" "s1_rollback"
+step "s3_begin" {
+	BEGIN;
+}
 
-permutation "s1_compress" "s3_block_chunk_insert" "s2_insert" "s1_decompress" "s1_compress" "s3_release_chunk_insert"
+step "s3_commit" {
+	COMMIT;
+}
+
+step "s3_rollback" {
+	ROLLBACK;
+}
+
+step "s3_delete_uncompressed" {
+	DELETE FROM sensor_data WHERE sensor_id = 11;
+}
+
+step "s3_recompress_chunk" {
+   SELECT count(_timescaledb_functions.recompress_chunk_segmentwise(i)) AS recompress
+   FROM show_chunks('sensor_data') i
+   LIMIT 1;
+}
+
+
+permutation "s1_begin" "s1_recompress_chunk" "s2_select_from_compressed_chunk" "s2_wait_for_finish" "s1_rollback"
+
+permutation "s1_compress" "s3_block_chunk_insert" "s2_insert_do_nothing" "s1_decompress" "s1_compress" "s3_release_chunk_insert"
+
+## test inserts and recompression
+permutation "s1_show_chunk_state" "s2_begin" "s2_insert_do_nothing" "s1_begin" "s1_recompress_chunk" "s2_insert_do_nothing" "s2_wait_for_finish" "s2_commit" "s1_commit" "s1_show_chunk_state"
+permutation "s1_show_chunk_state" "s2_begin" "s2_insert_do_nothing" "s1_begin" "s1_recompress_chunk" "s2_insert_existing_do_nothing" "s2_wait_for_finish" "s2_commit" "s1_commit" "s1_show_chunk_state"
+permutation "s1_show_chunk_state" "s2_begin" "s2_insert_do_nothing" "s1_recompress_chunk" "s2_wait_for_finish" "s2_commit" "s1_show_chunk_state"
+permutation "s1_show_chunk_state" "s2_begin" "s2_insert_existing_do_nothing" "s1_recompress_chunk" "s2_wait_for_finish" "s2_commit" "s1_show_chunk_state"
+permutation "s1_recompress_chunk" "s1_show_chunk_state" "s1_insert_for_recompression" "s1_show_chunk_state" "s2_begin" "s2_insert_existing_do_nothing" "s1_recompress_chunk" "s2_wait_for_finish" "s2_commit" "s1_show_chunk_state"
+## recompression can block inserts if its able to get the ExclusiveLock to update
+## chunk status, it should be quick to release it
+permutation "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_upsert" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_upsert_existing" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count"
+## if recompression cannot update the status, there is no blocking
+permutation "s1_show_chunk_state" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_upsert" "s2_wait_for_finish" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count" "s3_release_exclusive_lock"
+permutation "s1_show_chunk_state" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_upsert_existing" "s2_wait_for_finish" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count" "s3_release_exclusive_lock"
+permutation "s1_show_chunk_state" "s2_begin" "s2_upsert" "s1_recompress_chunk" "s2_wait_for_finish" "s2_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_show_chunk_state" "s2_begin" "s2_upsert_existing" "s1_recompress_chunk" "s2_wait_for_finish" "s2_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_recompress_chunk" "s1_insert_for_recompression" "s1_show_chunk_state" "s2_begin" "s2_upsert_existing" "s1_recompress_chunk" "s2_wait_for_finish" "s2_commit" "s1_show_chunk_state" "s2_show_updated_count"
+# test that we don't update chunk status to fully compressed if there were concurrent inserts to uncompressed chunk
+permutation "s1_show_chunk_state" "s3_begin" "s1_begin" "s3_delete_uncompressed" "s1_recompress_chunk" "s2_insert_do_nothing" "s3_rollback" "s1_commit" "s1_show_chunk_state"
+
+## test delete and recompression
+## recompression can block deletes if its able to get the ExclusiveLock to update
+## chunk status, it should be quick to release it
+permutation "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_delete_compressed" "s1_commit" "s1_show_chunk_state"
+permutation "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_delete_uncompressed" "s1_commit" "s1_show_chunk_state"
+permutation "s1_recompress_chunk" "s1_insert_for_recompression" "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_delete_recompressed" "s1_commit" "s1_show_chunk_state"
+## if recompression cannot update the status, there is no blocking
+permutation "s1_show_chunk_state" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_delete_compressed" "s2_wait_for_finish" "s1_commit" "s1_show_chunk_state" "s3_release_exclusive_lock"
+## unless they block each other on tuple level
+permutation "s1_show_chunk_state" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_delete_uncompressed" "s1_commit" "s1_show_chunk_state" "s3_release_exclusive_lock"
+permutation "s1_recompress_chunk" "s3_block_exclusive_lock" "s1_insert_for_recompression" "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_delete_recompressed" "s1_commit" "s1_show_chunk_state" "s3_release_exclusive_lock"
+permutation "s1_show_chunk_state" "s2_begin" "s2_delete_uncompressed" "s1_recompress_chunk" "s2_commit" "s1_show_chunk_state"
+permutation "s1_show_chunk_state" "s2_begin" "s2_delete_compressed" "s1_recompress_chunk" "s2_commit" "s1_show_chunk_state"
+permutation "s1_recompress_chunk" "s1_insert_for_recompression" "s1_show_chunk_state" "s2_begin" "s2_delete_recompressed" "s1_recompress_chunk" "s2_commit" "s1_show_chunk_state"
+
+##test update and recompression
+## recompression can block deletes if its able to get the ExclusiveLock to update
+## chunk status, it should be quick to release it
+permutation "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_update_compressed"  "s1_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_show_chunk_state" "s1_begin" "s1_recompress_chunk" "s2_update_uncompressed" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_recompress_chunk" "s1_insert_for_recompression" "s1_begin" "s1_recompress_chunk" "s2_update_recompressed" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count"
+## if recompression cannot update the status, there is no blocking
+permutation "s1_show_chunk_state" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_update_compressed" "s2_wait_for_finish" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count" "s3_release_exclusive_lock"
+## unless they block each other on tuple level
+permutation "s1_show_chunk_state" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_update_uncompressed" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count" "s3_release_exclusive_lock"
+permutation "s1_recompress_chunk" "s1_insert_for_recompression" "s3_block_exclusive_lock" "s1_begin" "s1_recompress_chunk" "s2_update_recompressed" "s1_commit" "s1_show_chunk_state" "s2_show_updated_count" "s3_release_exclusive_lock"
+permutation "s1_show_chunk_state" "s2_begin" "s2_update_uncompressed" "s1_recompress_chunk" "s2_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_show_chunk_state" "s2_begin" "s2_update_compressed" "s1_recompress_chunk" "s2_commit" "s1_show_chunk_state" "s2_show_updated_count"
+permutation "s1_recompress_chunk" "s1_insert_for_recompression" "s1_show_chunk_state" "s2_begin" "s2_update_recompressed" "s1_recompress_chunk" "s2_commit" "s1_show_chunk_state" "s2_show_updated_count"
+
+## test multiple recompressions running at same time
+## blocking each other since they acquire ShareUpdateExclusive locks on the chunk
+permutation "s1_show_chunk_state" "s1_begin" "s3_begin" "s1_recompress_chunk" "s3_recompress_chunk"  "s1_commit" "s3_commit" "s1_show_chunk_state" "s2_show_updated_count"

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -132,9 +132,9 @@ query_generates_wal(
 	"recompress chunk",
 	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
 	qq(message: transactional: 1 prefix: ::timescaledb-compression-start, sz: 0 content:
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 18:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_internal.compress_hyper_2_3_chunk: INSERT: _ts_meta_count[integer]:1 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 18:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-06-30 18:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJhOK/kAAAComE4r+QAAAAAAQAAAAEAAAAAAAAADgAFRMJxX8gA' value[_timescaledb_internal.compressed_data]:'AwA/8AAAAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAEAAAAAAAAAAoAAAABCgAAAAAAAAP/'
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
 message: transactional: 1 prefix: ::timescaledb-compression-end, sz: 0 content:)
 );
 
@@ -164,11 +164,11 @@ query_generates_wal(
 	"compress chunk after update",
 	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
 	qq(message: transactional: 1 prefix: ::timescaledb-compression-start, sz: 0 content:
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 18:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 19:00:00-07' device_id[bigint]:1 value[double precision]:22
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:22
 table _timescaledb_internal.compress_hyper_2_3_chunk: INSERT: _ts_meta_count[integer]:3 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-06-30 19:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJiD0OIAAAAAADWk6QAAAAAAwAAAAMAAAAAAAAB7gAFRMDEOIAAAAVEvxcRN/8AAAAAAAAAAA==' value[_timescaledb_internal.compressed_data]:'AwBANgAAAAAAAAAAAAMAAAABAAAAAAAAAAEAAAAAAAAABwAAAAMAAAABAAAAAAAAAAEAAAAAAAAABwAAAAESAAAAAAAAEEEAAAADAAAAAQAAAAAAAAAEAAAAAAAADu4AAAABKgAAA/4/+OAb'
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
 message: transactional: 1 prefix: ::timescaledb-compression-end, sz: 0 content:)
 );
 


### PR DESCRIPTION
Recompression used to take heavy Exclusive lock on chunk while it recompressed data. This blocked a lot of concurrent operations like inserts, deletes, and updates. By reducing the locking requirement to ShareUpdateExclusive, we enable more concurrent operations on the chunk and hypertable while relying on tuple locking. Recompression can still end up taking an Exclusive lock at the end in order to change the chunk status but it does this conditionally, meaning it won't take it unless it can do it immediately.

Disable-check: force-changelog-file