### PR TITLE
Remove useless function from regression tests

### DIFF
--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -916,6 +916,9 @@ cagg_get_bucket_function_datum(int32 mat_hypertable_id, FunctionCallInfo fcinfo)
 /*
  * This function returns the `time_bucket` function Oid in the user view definition
  * of a given materialization hupertable.
+ *
+ * NOTE: this function is deprecated and should be removed in the future, use
+ * `cagg_get_bucket_function_info` instead.
  */
 Datum
 continuous_agg_get_bucket_function(PG_FUNCTION_ARGS)

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -259,11 +259,6 @@ SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 year', bucket) AS buc
 --
 -- Test bucket Oid recovery
 --
-\c :TEST_DBNAME :ROLE_SUPERUSER
-CREATE OR REPLACE FUNCTION cagg_get_bucket_function(
-    mat_hypertable_id INTEGER
-) RETURNS regprocedure AS :MODULE_PATHNAME, 'ts_continuous_agg_get_bucket_function' LANGUAGE C STRICT VOLATILE;
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SET timezone TO PST8PDT;
 CREATE TABLE timestamp_ht (
   time timestamp NOT NULL,
@@ -352,12 +347,12 @@ CREATE MATERIALIZED VIEW integer_ht_cagg_offset
      GROUP BY bucket, a;
 NOTICE:  continuous aggregate "integer_ht_cagg_offset" is already up-to-date
 -- Get the bucket Oids
-SELECT user_view_name, cagg_get_bucket_function(mat_hypertable_id)
-FROM _timescaledb_catalog.continuous_agg
+SELECT user_view_name, bf.bucket_func
+FROM _timescaledb_catalog.continuous_agg, LATERAL _timescaledb_functions.cagg_get_bucket_function_info(mat_hypertable_id) AS bf
 WHERE user_view_name IN
   ('temperature_4h', 'temperature_tz_4h', 'temperature_tz_4h_ts', 'temperature_tz_4h_ts_origin', 'temperature_tz_4h_ts_offset', 'integer_ht_cagg', 'integer_ht_cagg_offset')
 ORDER BY user_view_name;
-       user_view_name        |                               cagg_get_bucket_function                                
+       user_view_name        |                                      bucket_func                                      
 -----------------------------+---------------------------------------------------------------------------------------
  integer_ht_cagg             | time_bucket(integer,integer)
  integer_ht_cagg_offset      | time_bucket(integer,integer,integer)
@@ -435,4 +430,3 @@ ORDER BY user_view_name;
  temperature_tz_4h_3 | time_bucket(interval,timestamp with time zone)
 (1 row)
 
-DROP FUNCTION IF EXISTS cagg_get_bucket_function(INTEGER);


### PR DESCRIPTION
The temporary function `cagg_get_bucket_function` was created to be used in the update script for 2.14.2 to 2.15.0 and for some regression tests, but in 2.16.0 (#7042) we added a new persistent function `cagg_get_bucket_function_info` as a replacement so used it instead.

Leftover from #7042 refactoring PR.

Disable-check: force-changelog-file
