### PR TITLE
Add warning for poor compression ratio

### DIFF
--- a/.unreleased/pr_7756
+++ b/.unreleased/pr_7756
@@ -1,0 +1,1 @@
+Implements: #7756 Add warning for poor compression ratio

--- a/src/guc.c
+++ b/src/guc.c
@@ -166,6 +166,7 @@ TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPR
 
 /* Only settable in debug mode for testing */
 TSDLLEXPORT bool ts_guc_enable_null_compression = true;
+TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings = true;
 
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
@@ -842,6 +843,16 @@ _guc_init(void)
 							 NULL);
 #endif
 
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compression_ratio_warnings"),
+							 "Enable warnings for poor compression ratio",
+							 "Enable warnings for poor compression ratio",
+							 &ts_guc_enable_compression_ratio_warnings,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 	/*
 	 * Define the limit on number of invalidation-based refreshes we allow per
 	 * refresh call. If this limit is exceeded, fall back to a single refresh that

--- a/src/guc.h
+++ b/src/guc.h
@@ -79,6 +79,7 @@ extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;
+extern TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings;
 
 typedef enum CompressTruncateBehaviour
 {

--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -25,3 +25,4 @@ extra_float_digits=0
 @TELEMETRY_DEFAULT_SETTING@
 
 timescaledb.license='apache'
+timescaledb.enable_compression_ratio_warnings=false

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -540,6 +540,26 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 		 */
 		ts_chunk_constraints_create(cxt.compress_ht, compress_ht_chunk);
 		ts_trigger_create_all_on_chunk(compress_ht_chunk);
+
+		/* Detect and emit warning if poor compression ratio is found */
+		float compression_ratio = ((float) before_size.total_size / after_size.total_size);
+		float POOR_COMPRESSION_THRESHOLD = 1.0;
+		ereport(ts_guc_enable_compression_ratio_warnings &&
+						compression_ratio < POOR_COMPRESSION_THRESHOLD ?
+					WARNING :
+					DEBUG1,
+				errcode(ERRCODE_WARNING),
+				errmsg("poor compression rate detected for chunk \"%s\"'",
+					   get_rel_name(chunk_relid)),
+				errdetail("Chunk \"%s\" has a poor compression ratio: %.2f. Size before "
+						  "compression: " INT64_FORMAT
+						  " bytes. Size after compression: " INT64_FORMAT " bytes",
+						  get_rel_name(chunk_relid),
+						  compression_ratio,
+						  before_size.total_size,
+						  after_size.total_size),
+				errhint("Changing compression settings for \"%s\" can improve compression rate",
+						get_rel_name(hypertable_relid)));
 	}
 	else
 	{

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2981,3 +2981,33 @@ SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_
 (9 rows)
 
 ROLLBACK;
+-- Test poor compression rate warning works as expected
+-- Turn GUC on
+SET timescaledb.enable_compression_ratio_warnings TO ON;
+-- Compressing a table with very few rows virtually guarantees a poor compression rate
+CREATE TABLE badly_compressed_ht (time timestamptz, device_id integer, a integer);
+SELECT create_hypertable('badly_compressed_ht', 'time');
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable         
+-----------------------------------
+ (57,public,badly_compressed_ht,t)
+(1 row)
+
+ALTER TABLE badly_compressed_ht set (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
+NOTICE:  default order by for hypertable "badly_compressed_ht" is set to ""time" DESC"
+INSERT INTO badly_compressed_ht VALUES
+('2025-04-25 00:00'::timestamp, 1, 1),
+('2025-04-25 01:00'::timestamp, 2, 2),
+('2025-04-25 02:00'::timestamp, 3, 3);
+\set VERBOSITY default
+SELECT compress_chunk(show_chunks('badly_compressed_ht'));
+WARNING:  poor compression rate detected for chunk "_hyper_57_116_chunk"'
+DETAIL:  Chunk "_hyper_57_116_chunk" has a poor compression ratio: 0.60. Size before compression: 24576 bytes. Size after compression: 40960 bytes
+HINT:  Changing compression settings for "badly_compressed_ht" can improve compression rate
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_57_116_chunk
+(1 row)
+
+\set VERBOSITY terse
+RESET timescaledb.enable_compression_ratio_warnings;

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -35,3 +35,4 @@ log_statement='all'
 # It is necessary to have at least 2 more workers than `max_worker_processes`
 # in order to test failures starting bgworkers.
 timescaledb.max_background_workers=26
+timescaledb.enable_compression_ratio_warnings=false

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1239,3 +1239,23 @@ where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'C
 
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
 ROLLBACK;
+
+-- Test poor compression rate warning works as expected
+
+-- Turn GUC on
+SET timescaledb.enable_compression_ratio_warnings TO ON;
+
+-- Compressing a table with very few rows virtually guarantees a poor compression rate
+CREATE TABLE badly_compressed_ht (time timestamptz, device_id integer, a integer);
+SELECT create_hypertable('badly_compressed_ht', 'time');
+ALTER TABLE badly_compressed_ht set (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
+INSERT INTO badly_compressed_ht VALUES
+('2025-04-25 00:00'::timestamp, 1, 1),
+('2025-04-25 01:00'::timestamp, 2, 2),
+('2025-04-25 02:00'::timestamp, 3, 3);
+
+\set VERBOSITY default
+SELECT compress_chunk(show_chunks('badly_compressed_ht'));
+\set VERBOSITY terse
+
+RESET timescaledb.enable_compression_ratio_warnings;


### PR DESCRIPTION
Adds functionality to emit a warning to the user when the compression
ratio is "bad".

Currently, "bad" is defined to be when size after compression is higher
than after compression.
