### PR TITLE
Fix compression settings handling in Hypercore TAM

### DIFF
--- a/.unreleased/pr_7764
+++ b/.unreleased/pr_7764
@@ -1,0 +1,1 @@
+Fixes: #7764 Fix compression settings handling in Hypercore TAM

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -171,3 +171,13 @@ $$;
 -- Repair relations that have relacl entries for users that do not
 -- exist in pg_authid
 CALL _timescaledb_functions.repair_relation_acls();
+
+-- Cleanup orphaned compression settings
+WITH orphaned_settings AS (
+     SELECT cs.relid, cl.relname
+     FROM _timescaledb_catalog.compression_settings cs
+     LEFT JOIN pg_class cl ON (cs.relid = cl.oid)
+     WHERE cl.relname IS NULL
+)
+DELETE FROM _timescaledb_catalog.compression_settings AS cs
+USING orphaned_settings AS os WHERE cs.relid = os.relid;

--- a/tsl/src/hypercore/hypercore_handler.h
+++ b/tsl/src/hypercore/hypercore_handler.h
@@ -62,10 +62,7 @@ typedef struct ColumnCompressionSettings
  */
 typedef struct HypercoreInfo
 {
-	int32 hypertable_id;		  /* TimescaleDB ID of parent hypertable */
-	int32 relation_id;			  /* TimescaleDB ID of relation (chunk ID) */
-	int32 compressed_relation_id; /* TimescaleDB ID of compressed relation (chunk ID) */
-	Oid compressed_relid;		  /* Relid of compressed relation */
+	Oid compressed_relid; /* Relid of compressed relation */
 	int num_columns;
 	AttrNumber count_cattno; /* Attribute number of count column in
 							  * compressed rel */

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -482,6 +482,17 @@ from compressed_rel_size_stats;
               0
 (1 row)
 
+-- Compression settings should be removed except for parent
+-- hypertables
+select cs.relid, cl.relname
+from _timescaledb_catalog.compression_settings cs
+left join pg_class cl on (cs.relid = cl.oid);
+ relid | relname 
+-------+---------
+ test2 | test2
+ test3 | test3
+(2 rows)
+
 -- Create hypercores again and check that compression size stats are
 -- updated showing compressed data
 select compress_chunk(ch, hypercore_use_access_method => true)

--- a/tsl/test/sql/hypercore_create.sql
+++ b/tsl/test/sql/hypercore_create.sql
@@ -253,6 +253,12 @@ select decompress_chunk(rel)
 select count(*) as orphaned_stats
 from compressed_rel_size_stats;
 
+-- Compression settings should be removed except for parent
+-- hypertables
+select cs.relid, cl.relname
+from _timescaledb_catalog.compression_settings cs
+left join pg_class cl on (cs.relid = cl.oid);
+
 -- Create hypercores again and check that compression size stats are
 -- updated showing compressed data
 select compress_chunk(ch, hypercore_use_access_method => true)


### PR DESCRIPTION
Fix a bug which caused compression settings to remain after having converted a Hypercore TAM chunk back to another TAM (e.g., heap).

Remove any orphaned settings in the update script.