### PR TITLE
Remove costing index scan of hypertable parent

### DIFF
--- a/.unreleased/pr_7768
+++ b/.unreleased/pr_7768
@@ -1,0 +1,1 @@
+Fixes: #7768 Remove costing index scan of hypertable parent

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1375,6 +1375,19 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 #endif
 			TS_FALLTHROUGH;
 		default:
+			/*
+			 * Set the indexlist for a hypertable parent to NIL since we
+			 * should not try to do any index scans on hypertable parents,
+			 * similar to how it works for partitioned tables.
+			 *
+			 * This can happen when building a merge join path and computing
+			 * cost for it. See get_actual_variable_range().
+			 *
+			 * This has to be after the hypertable is expanded, since the
+			 * indexlist is used during hypertable expansion.
+			 */
+			if (reltype == TS_REL_HYPERTABLE)
+				rel->indexlist = NIL;
 			apply_optimizations(root, reltype, rel, rte, ht);
 			break;
 	}


### PR DESCRIPTION
When computing cost for a merge join path, an index scan will be done on the relation to find the actual variable range using `get_actual_variable_range()`, which will include an index scan of the hypertable parent.

In addition to being unneccessary, it can also cause problems in situations where the hypertable parent contains data as a result of a bug.

There is a check that an index scan is not done for a partitioned table, so we do the same here by setting the indexlist to NIL after hypertable expansion. The index list is needed while expanding the hypertables to construct correct index scans for chunks of a hypertable.