### PR TITLE
Update source build docs

### DIFF
--- a/docs/BuildSource.md
+++ b/docs/BuildSource.md
@@ -9,8 +9,8 @@ See the Releases tab for the latest release.
 
 **Prerequisites**:
 
-- A standard PostgreSQL 14, 15 or 16 installation with development
-environment (header files) (e.g., `postgresql-server-dev-16` package
+- A standard PostgreSQL 14, 15, 16, or 17 installation with development
+environment (header files) (e.g., `postgresql-server-dev-17` package
 for Linux, Postgres.app for MacOS)
 - C compiler (e.g., gcc or clang)
 - [CMake](https://cmake.org/) version 3.15 or greater
@@ -42,7 +42,7 @@ See the Releases tab for the latest release.
 
 **Prerequisites**:
 
-- A standard [PostgreSQL 14, 15 or 16 64-bit installation](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
+- A standard [PostgreSQL 14, 15, 16, or 17 64-bit installation](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
 - OpenSSL for Windows
 - Microsoft Visual Studio 2017 with CMake and Git components
 - OR Visual Studio 2015/2016 with [CMake](https://cmake.org/) version 3.15 or greater and Git


### PR DESCRIPTION
Minor fix but raising this PR because I noticed that the `docs/BuildSource.md` file mistakenly says that timescaledb cannot be built against postgres 17. Looking at the git blame for `CMakelists.txt` it seems that postgres 17 build functionality was officially supported as of commit `abd637beaa`

Disable-check: force-changelog-file