### PR TITLE
Explicitly reset is_valid_query in continuous_agg_validate_query

### DIFF
--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -135,6 +135,10 @@ continuous_agg_validate_query(PG_FUNCTION_ARGS)
 			}
 			else
 			{
+				/* Explicitly reset is_valid_query to false to ensure the compiler
+				 * does not optimize away the variable.
+				 */
+				is_valid_query = false;
 				pstate->p_sourcetext = sql;
 				query = transformTopLevelStmt(pstate, rawstmt);
 				free_parsestate(pstate);


### PR DESCRIPTION
cagg_utils failed on AArch64 RHEL9
```
 SELECT * FROM cagg_validate_query($$ SELECT 1 $$);
  is_valid | error_level | error_code |           error_message            | error_detail |            error_hint            
 ----------+-------------+------------+------------------------------------+--------------+----------------------------------
- f        | ERROR       | 0A000      | invalid continuous aggregate query |              | FROM clause missing in the query
+ t        | ERROR       | 0A000      | invalid continuous aggregate query |              | FROM clause missing in the query
 (1 row)
```
On AArch64, the compiler optimized away the is_valid_query variable, leading to incorrect output. Marking is_valid_query as volatile eliminated the issue, confirming that the root cause is compiler optimization.

To prevent this incorrect optimization, this PR explicitly resets is_valid_query to false in the PG_CATCH block, ensuring correct behavior.

Disable-check: force-changelog-file