### PR TITLE
Fix flaky ordered append regression tests

### DIFF
--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -13,6 +13,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -13,6 +13,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/expected/ordered_append-16.out
+++ b/tsl/test/shared/expected/ordered_append-16.out
@@ -13,6 +13,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/expected/ordered_append-17.out
+++ b/tsl/test/shared/expected/ordered_append-17.out
@@ -13,6 +13,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -18,6 +18,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -30,6 +31,7 @@ set max_parallel_workers_per_gather to 0;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -79,6 +81,7 @@ QUERY PLAN
                            ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (10 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -116,6 +119,7 @@ QUERY PLAN
          ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (6 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -261,7 +265,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (19 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -296,7 +299,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -335,7 +337,6 @@ QUERY PLAN
 (24 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -740,6 +741,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -813,6 +815,7 @@ QUERY PLAN
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (22 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -862,6 +865,7 @@ QUERY PLAN
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (18 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1081,7 +1085,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (22 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -1140,7 +1143,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -1197,7 +1199,6 @@ QUERY PLAN
 (42 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -1626,6 +1627,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -1695,6 +1697,7 @@ QUERY PLAN
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -1745,6 +1748,7 @@ QUERY PLAN
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (16 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1950,7 +1954,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -2004,7 +2007,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -2056,7 +2058,6 @@ QUERY PLAN
 (37 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -2531,6 +2532,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -2664,6 +2666,7 @@ QUERY PLAN
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (52 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -2746,6 +2749,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (48 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -3214,7 +3218,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -3330,7 +3333,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -3420,7 +3422,6 @@ QUERY PLAN
 (75 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -18,6 +18,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -30,6 +31,7 @@ set max_parallel_workers_per_gather to 0;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -80,6 +82,7 @@ QUERY PLAN
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (11 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -117,6 +120,7 @@ QUERY PLAN
          ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (6 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -266,7 +270,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (19 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -302,7 +305,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -341,7 +343,6 @@ QUERY PLAN
 (24 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -746,6 +747,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -820,6 +822,7 @@ QUERY PLAN
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (23 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -869,6 +872,7 @@ QUERY PLAN
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (18 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1092,7 +1096,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (22 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -1152,7 +1155,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -1209,7 +1211,6 @@ QUERY PLAN
 (42 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -1638,6 +1639,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -1708,6 +1710,7 @@ QUERY PLAN
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -1758,6 +1761,7 @@ QUERY PLAN
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (16 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1967,7 +1971,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -2022,7 +2025,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -2074,7 +2076,6 @@ QUERY PLAN
 (37 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -2549,6 +2550,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -2683,6 +2685,7 @@ QUERY PLAN
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (53 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -2765,6 +2768,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (48 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -3237,7 +3241,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -3354,7 +3357,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -3444,7 +3446,6 @@ QUERY PLAN
 (75 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -18,6 +18,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -30,6 +31,7 @@ set max_parallel_workers_per_gather to 0;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -80,6 +82,7 @@ QUERY PLAN
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (11 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -117,6 +120,7 @@ QUERY PLAN
          ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (6 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -266,7 +270,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (19 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -302,7 +305,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -341,7 +343,6 @@ QUERY PLAN
 (24 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -746,6 +747,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -820,6 +822,7 @@ QUERY PLAN
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (23 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -869,6 +872,7 @@ QUERY PLAN
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (18 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1092,7 +1096,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (22 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -1152,7 +1155,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -1209,7 +1211,6 @@ QUERY PLAN
 (42 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -1638,6 +1639,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -1708,6 +1710,7 @@ QUERY PLAN
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -1758,6 +1761,7 @@ QUERY PLAN
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (16 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1967,7 +1971,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -2022,7 +2025,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -2074,7 +2076,6 @@ QUERY PLAN
 (37 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -2549,6 +2550,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -2683,6 +2685,7 @@ QUERY PLAN
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (53 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -2765,6 +2768,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (48 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -3237,7 +3241,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -3354,7 +3357,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -3444,7 +3446,6 @@ QUERY PLAN
 (75 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column

--- a/tsl/test/shared/expected/ordered_append_join-17.out
+++ b/tsl/test/shared/expected/ordered_append_join-17.out
@@ -18,6 +18,7 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -30,6 +31,7 @@ set max_parallel_workers_per_gather to 0;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -80,6 +82,7 @@ QUERY PLAN
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (11 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -117,6 +120,7 @@ QUERY PLAN
          ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
 (6 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -266,7 +270,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (19 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -302,7 +305,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -338,7 +340,6 @@ QUERY PLAN
 (21 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -743,6 +744,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -817,6 +819,7 @@ QUERY PLAN
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (23 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -866,6 +869,7 @@ QUERY PLAN
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
 (18 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1089,7 +1093,6 @@ QUERY PLAN
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (22 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -1149,7 +1152,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -1197,7 +1199,6 @@ QUERY PLAN
 (33 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -1626,6 +1627,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -1696,6 +1698,7 @@ QUERY PLAN
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -1746,6 +1749,7 @@ QUERY PLAN
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (16 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -1955,7 +1959,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -2010,7 +2013,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -2059,7 +2061,6 @@ QUERY PLAN
 (34 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column
@@ -2534,6 +2535,7 @@ RESET enable_seqscan;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
+SET enable_nestloop TO on;
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -2668,6 +2670,7 @@ QUERY PLAN
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (53 rows)
 
+SET enable_nestloop TO off;
 -- test plan with best index is chosen
 -- this should use device_id, time index
 :PREFIX
@@ -2750,6 +2753,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (48 rows)
 
+SET enable_nestloop TO on;
 -- test LATERAL with correlated query
 -- only last chunk should be executed
 :PREFIX
@@ -3222,7 +3226,6 @@ QUERY PLAN
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
 (31 rows)
 
-RESET enable_nestloop;
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -3339,7 +3342,6 @@ QUERY PLAN
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 :PREFIX
 SELECT o1.time,
@@ -3420,7 +3422,6 @@ QUERY PLAN
 (66 rows)
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 SET enable_seqscan TO false;
 -- test JOIN on time column

--- a/tsl/test/shared/sql/include/ordered_append_join.sql
+++ b/tsl/test/shared/sql/include/ordered_append_join.sql
@@ -11,6 +11,8 @@
 
 SET timescaledb.enable_decompression_sorted_merge = 0;
 
+SET enable_nestloop TO on;
+
 -- test LATERAL with ordered append in the outer query
 :PREFIX
 SELECT time,
@@ -37,6 +39,7 @@ FROM (
     ORDER BY time DESC
     LIMIT 2) l;
 
+SET enable_nestloop TO off;
 
 -- test plan with best index is chosen
 -- this should use device_id, time index
@@ -55,6 +58,8 @@ SELECT time
 FROM :TEST_TABLE
 ORDER BY time DESC
 LIMIT 1;
+
+SET enable_nestloop TO on;
 
 -- test LATERAL with correlated query
 -- only last chunk should be executed
@@ -129,8 +134,6 @@ WHERE o1.time < '2000-02-01'
   AND o2.device_id = 2
 ORDER BY o1.time;
 
-RESET enable_nestloop;
-
 -- test JOIN
 -- last chunk of o2 should not be executed
 :PREFIX
@@ -148,7 +151,6 @@ LIMIT 10;
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
 SET enable_hashjoin = FALSE;
-SET enable_nestloop = FALSE;
 SET enable_hashagg = FALSE;
 
 :PREFIX
@@ -162,7 +164,6 @@ WHERE o1.device_id = 1
 ORDER BY time;
 
 RESET enable_hashjoin;
-RESET enable_nestloop;
 RESET enable_hashagg;
 
 SET enable_seqscan TO false;

--- a/tsl/test/shared/sql/ordered_append.sql.in
+++ b/tsl/test/shared/sql/ordered_append.sql.in
@@ -15,8 +15,9 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 
 set work_mem to '64MB';
-
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
+
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 \set TEST_TABLE 'metrics_space'
@@ -57,3 +58,5 @@ SET client_min_messages TO error;
 
 -- diff compressed and uncompressed results
 :DIFF_CMD
+
+reset enable_nestloop;

--- a/tsl/test/shared/sql/ordered_append_join.sql.in
+++ b/tsl/test/shared/sql/ordered_append_join.sql.in
@@ -22,8 +22,9 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 
 set work_mem to '64MB';
-
 set max_parallel_workers_per_gather to 0;
+set enable_nestloop to off;
+
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
 \set TEST_TABLE 'metrics_space'
@@ -85,3 +86,4 @@ GROUP BY 1 ORDER BY 1;
 DROP TABLE i4418_1;
 DROP TABLE i4418_2;
 
+reset enable_nestloop;


### PR DESCRIPTION
Disabling nested loops to make output tests deterministic.

https://github.com/timescale/timescaledb/actions/runs/13556017463/job/37890546418#step:12:42 https://github.com/timescale/timescaledb/actions/runs/13556017463/job/37890546624#step:12:42

Disable-check: force-changelog-file
