### PR TITLE
Try even lazier decompression

### DIFF
--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -15,19 +15,21 @@ typedef struct ArrowArray ArrowArray;
 /* How to obtain the decompressed datum for individual row. */
 typedef enum
 {
-	DT_ArrowTextDict = -4,
+	DT_ArrowTextDict = -5,
 
-	DT_ArrowText = -3,
+	DT_ArrowText = -4,
 
 	/*
 	 * The decompressed value is already in the decompressed slot. This is used
 	 * for segmentby and compressed columns with default value in batch.
 	 */
-	DT_Scalar = -2,
+	DT_Scalar = -3,
 
-	DT_Iterator = -1,
+	DT_Iterator = -2,
 
-	DT_Invalid = 0,
+	DT_Pending = -1,
+
+	DT_NoData = 0,
 
 	/*
 	 * Any positive number is also valid for the decompression type. It means
@@ -48,6 +50,7 @@ typedef struct CompressedColumnValues
 	/*
 	 * The flattened source buffers for getting the decompressed datum.
 	 * Depending on decompression type, they are as follows:
+	 * invalid:         compressed data (this is used for lazier decompression).
 	 * iterator:        iterator
 	 * arrow fixed:     validity, value
 	 * arrow text:      validity, uint32* offsets, void* bodies
@@ -125,6 +128,7 @@ extern void compressed_batch_save_first_tuple(DecompressContext *dcontext,
 											  DecompressBatchState *batch_state,
 											  TupleTableSlot *first_tuple_slot);
 
+extern void compressed_batch_decompress_column(CompressedColumnValues *column_values);
 /*
  * Initialize the batch memory context and bulk decompression context.
  *

--- a/tsl/src/nodes/vector_agg/grouping_policy_batch.c
+++ b/tsl/src/nodes/vector_agg/grouping_policy_batch.c
@@ -134,7 +134,8 @@ compute_single_aggregate(GroupingPolicyBatch *policy, TupleTableSlot *vector_slo
 		const CompressedColumnValues *values =
 			vector_slot_get_compressed_column_values(vector_slot, attnum);
 
-		Assert(values->decompression_type != DT_Invalid);
+		Assert(values->decompression_type != DT_NoData);
+		Assert(values->decompression_type != DT_Pending);
 		Assert(values->decompression_type != DT_Iterator);
 
 		if (values->arrow != NULL)

--- a/tsl/src/nodes/vector_agg/grouping_policy_hash.c
+++ b/tsl/src/nodes/vector_agg/grouping_policy_hash.c
@@ -141,7 +141,7 @@ compute_single_aggregate(GroupingPolicyHash *policy, TupleTableSlot *vector_slot
 		const CompressedColumnValues *values =
 			vector_slot_get_compressed_column_values(vector_slot, attnum);
 
-		Assert(values->decompression_type != DT_Invalid);
+		Assert(values->decompression_type != DT_NoData);
 		Assert(values->decompression_type != DT_Iterator);
 
 		if (values->arrow != NULL)

--- a/tsl/src/nodes/vector_agg/vector_slot.h
+++ b/tsl/src/nodes/vector_agg/vector_slot.h
@@ -92,7 +92,11 @@ vector_slot_get_compressed_column_values(TupleTableSlot *slot, const AttrNumber 
 		return values;
 	}
 
-	const DecompressBatchState *batch_state = (const DecompressBatchState *) slot;
-	const CompressedColumnValues *values = &batch_state->compressed_columns[offset];
+	DecompressBatchState *batch_state = (DecompressBatchState *) slot;
+	CompressedColumnValues *values = &batch_state->compressed_columns[offset];
+	if (values->decompression_type == DT_Pending)
+	{
+		compressed_batch_decompress_column(values);
+	}
 	return values;
 }


### PR DESCRIPTION
Decompress in vectorized aggregation code when the column is required. This improves cache locality.