### PR TITLE
Do DELETE instead of TRUNCATE when locks aren't acquired

### DIFF
--- a/.unreleased/pr_7785
+++ b/.unreleased/pr_7785
@@ -1,0 +1,1 @@
+Implements: #7785 Do DELETE instead of TRUNCATE when locks aren't acquired

--- a/src/guc.c
+++ b/src/guc.c
@@ -117,6 +117,12 @@ static const struct config_enum_entry hypercore_copy_to_options[] = {
 	{ NULL, 0, false }
 };
 
+static const struct config_enum_entry compress_truncate_behaviour_options[] = {
+	{ "truncate_only", COMPRESS_TRUNCATE_ONLY, false},
+	{"truncate_or_delete", COMPRESS_TRUNCATE_OR_DELETE, false},
+	{"truncate_disabled", COMPRESS_TRUNCATE_DISABLED, false},
+};
+
 bool ts_guc_enable_deprecation_warnings = true;
 bool ts_guc_enable_optimizations = true;
 bool ts_guc_restoring = false;
@@ -156,6 +162,7 @@ TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = false;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
+TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
 
 /* Only settable in debug mode for testing */
 TSDLLEXPORT bool ts_guc_enable_null_compression = true;
@@ -1010,6 +1017,19 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+	DefineCustomEnumVariable(MAKE_EXTOPTION("compress_truncate_behaviour"),
+							 "Define behaviour of truncate after compression",
+							 "Define behaviour of truncate after compression",
+							 (int*)&ts_guc_compress_truncate_behaviour,
+							 COMPRESS_TRUNCATE_ONLY,
+							 compress_truncate_behaviour_options,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
 
 #ifdef USE_TELEMETRY
 	DefineCustomEnumVariable(MAKE_EXTOPTION("telemetry_level"),

--- a/src/guc.c
+++ b/src/guc.c
@@ -118,9 +118,9 @@ static const struct config_enum_entry hypercore_copy_to_options[] = {
 };
 
 static const struct config_enum_entry compress_truncate_behaviour_options[] = {
-	{ "truncate_only", COMPRESS_TRUNCATE_ONLY, false},
-	{"truncate_or_delete", COMPRESS_TRUNCATE_OR_DELETE, false},
-	{"truncate_disabled", COMPRESS_TRUNCATE_DISABLED, false},
+	{ "truncate_only", COMPRESS_TRUNCATE_ONLY, false },
+	{ "truncate_or_delete", COMPRESS_TRUNCATE_OR_DELETE, false },
+	{ "truncate_disabled", COMPRESS_TRUNCATE_DISABLED, false },
 };
 
 bool ts_guc_enable_deprecation_warnings = true;
@@ -1020,8 +1020,11 @@ _guc_init(void)
 
 	DefineCustomEnumVariable(MAKE_EXTOPTION("compress_truncate_behaviour"),
 							 "Define behaviour of truncate after compression",
-							 "Define behaviour of truncate after compression",
-							 (int*)&ts_guc_compress_truncate_behaviour,
+							 "Defines how truncate behaves at the end of compression. "
+							 "'truncate_only' forces truncation. 'truncate_disabled' deletes rows "
+							 "instead of truncate. 'truncate_or_delete' allows falling back to "
+							 "deletion.",
+							 (int *) &ts_guc_compress_truncate_behaviour,
 							 COMPRESS_TRUNCATE_ONLY,
 							 compress_truncate_behaviour_options,
 							 PGC_USERSET,
@@ -1029,7 +1032,6 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
-
 
 #ifdef USE_TELEMETRY
 	DefineCustomEnumVariable(MAKE_EXTOPTION("telemetry_level"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -80,6 +80,14 @@ extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;
 
+typedef enum CompressTruncateBehaviour
+{
+	COMPRESS_TRUNCATE_ONLY,
+	COMPRESS_TRUNCATE_OR_DELETE,
+	COMPRESS_TRUNCATE_DISABLED,
+} CompressTruncateBehaviour;
+extern TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour;
+
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel
 {

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2883,6 +2883,7 @@ ALTER TABLE hyper_delete SET (timescaledb.compress, timescaledb.compress_segment
 NOTICE:  default order by for hypertable "hyper_delete" is set to ""time" DESC"
 SET timescaledb.enable_delete_after_compression TO true;
 SELECT FROM compress_chunk(:'CHUNK');
+NOTICE:  timescaledb.enable_delete_after_compression is deprecated and will be removed in a future version. Please use timescaledb.compress_truncate_behaviour instead.
 --
 (1 row)
 

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -16,7 +16,7 @@ lock_chunktable
 
 step IB: BEGIN;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step C1: 
   BEGIN;
@@ -74,7 +74,7 @@ lock_chunktable
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step C1: 
   BEGIN;
@@ -132,7 +132,7 @@ lock_chunktable
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step C1: 
   BEGIN;
@@ -190,7 +190,7 @@ lock_chunktable
 
 step IB: BEGIN;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step C1: 
   BEGIN;
@@ -254,7 +254,7 @@ lock_chunktable
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step C1: 
   BEGIN;
@@ -318,7 +318,7 @@ lock_chunktable
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step C1: 
   BEGIN;
@@ -392,7 +392,7 @@ step C1:
  <waiting ...>
 step IB: BEGIN;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step C1: <... completed>
@@ -459,7 +459,7 @@ step C1:
  <waiting ...>
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step C1: <... completed>
@@ -526,7 +526,7 @@ step C1:
  <waiting ...>
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step C1: <... completed>
@@ -593,7 +593,7 @@ step C1:
  <waiting ...>
 step IB: BEGIN;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step C1: <... completed>
@@ -660,7 +660,7 @@ step C1:
  <waiting ...>
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step C1: <... completed>
@@ -727,7 +727,7 @@ step C1:
  <waiting ...>
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step C1: <... completed>
@@ -797,7 +797,7 @@ chunk_status
 
 step IB: BEGIN;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -857,7 +857,7 @@ chunk_status
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -917,7 +917,7 @@ chunk_status
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -977,7 +977,7 @@ chunk_status
 
 step IB: BEGIN;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1043,7 +1043,7 @@ chunk_status
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1103,7 +1103,7 @@ chunk_status
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1163,7 +1163,7 @@ chunk_status
 
 step IB: BEGIN;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1229,7 +1229,7 @@ chunk_status
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1289,7 +1289,7 @@ chunk_status
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1349,7 +1349,7 @@ chunk_status
 
 step IB: BEGIN;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1415,7 +1415,7 @@ chunk_status
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1475,7 +1475,7 @@ chunk_status
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunkTuple: ROLLBACK;
@@ -1521,7 +1521,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1559,7 +1559,7 @@ step RC:
  <waiting ...>
 step IB: BEGIN;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
@@ -1610,7 +1610,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1648,7 +1648,7 @@ step RC:
  <waiting ...>
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
@@ -1699,7 +1699,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1737,7 +1737,7 @@ step RC:
  <waiting ...>
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
@@ -1788,7 +1788,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1826,7 +1826,7 @@ step RC:
  <waiting ...>
 step IB: BEGIN;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
@@ -1877,7 +1877,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1915,7 +1915,7 @@ step RC:
  <waiting ...>
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
@@ -1972,7 +1972,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2010,7 +2010,7 @@ step RC:
  <waiting ...>
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
@@ -2067,7 +2067,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2153,7 +2153,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2245,7 +2245,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2269,7 +2269,7 @@ lock_chunktable
 
 step IB: BEGIN;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step RC: 
   DO $$
@@ -2334,7 +2334,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2358,7 +2358,7 @@ lock_chunktable
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step RC: 
   DO $$
@@ -2423,7 +2423,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2447,7 +2447,7 @@ lock_chunktable
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
  <waiting ...>
 step RC: 
   DO $$
@@ -2512,7 +2512,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2536,7 +2536,7 @@ lock_chunktable
 
 step IB: BEGIN;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step RC: 
   DO $$
@@ -2607,7 +2607,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2631,7 +2631,7 @@ lock_chunktable
 
 step IBRR: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step RC: 
   DO $$
@@ -2702,7 +2702,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2726,7 +2726,7 @@ lock_chunktable
 
 step IBS: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 step Iu1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
  <waiting ...>
 step RC: 
   DO $$
@@ -2797,7 +2797,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2883,7 +2883,7 @@ t
 
 step CAc: COMMIT;
 step I1: 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');

--- a/tsl/test/isolation/expected/compression_freeze.out
+++ b/tsl/test/isolation/expected/compression_freeze.out
@@ -226,7 +226,7 @@ Uncompressed      |    2
 (1 row)
 
 step s1_compress_delete: 
-   SET timescaledb.enable_delete_after_compression TO on;
+   SET timescaledb.compress_truncate_behaviour TO truncate_disabled;
    SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
  <waiting ...>
 step s2_select_count_and_stats: 
@@ -259,6 +259,70 @@ debug_waitpoint_release
 (1 row)
 
 step s1_compress_delete: <... completed>
+count
+-----
+    2
+(1 row)
+
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Compressed        |    2
+(1 row)
+
+
+starting permutation: s2_lock_compression_after_truncate_or_delete s2_select_count_and_stats s1_compress_truncate_or_delete s2_unlock_compression_after_truncate_or_delete s2_select_count_and_stats
+step s2_lock_compression_after_truncate_or_delete: 
+    SELECT debug_waitpoint_enable('compression_done_after_truncate_or_delete_uncompressed');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
+
+step s1_compress_truncate_or_delete: 
+   SET timescaledb.compress_truncate_behaviour TO truncate_or_delete;
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+ <waiting ...>
+step s2_unlock_compression_after_truncate_or_delete: 
+    SELECT locktype, mode, granted, objid FROM pg_locks WHERE granted AND relation::regclass::text LIKE '%hyper%chunk' ORDER BY relation, locktype, mode, granted;
+    SELECT debug_waitpoint_release('compression_done_after_truncate_or_delete_uncompressed');
+
+locktype|mode               |granted|objid
+--------+-------------------+-------+-----
+relation|AccessExclusiveLock|t      |     
+relation|ExclusiveLock      |t      |     
+relation|ShareLock          |t      |     
+(3 rows)
+
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_compress_truncate_or_delete: <... completed>
 count
 -----
     2

--- a/tsl/test/isolation/specs/compression_conflicts_iso.spec
+++ b/tsl/test/isolation/specs/compression_conflicts_iso.spec
@@ -31,11 +31,11 @@ session "I"
 step "IB" { BEGIN; }
 step "IBRR" { BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; }
 step "IBS" { BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; }
-step "I1"   { 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING; 
+step "I1"   {
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 100) ON CONFLICT DO NOTHING;
 }
-step "Iu1"   { 
-    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98; 
+step "Iu1"   {
+    INSERT INTO ts_device_table VALUES (1, 1, 100, 98) ON CONFLICT(time, device) DO UPDATE SET value = 98;
 }
 step "Ic"   { COMMIT; }
 
@@ -182,13 +182,13 @@ permutation "CA1" "CAc" "I1" "SChunkStat" "LockChunk1" "IBS"  "Iu1" "RC"  "Unloc
 permutation "CA1" "CAc" "I1" "SChunkStat" "LockChunk1" "IN1"  "RC" "UnlockChunk" "INc" "SH" "SA" "SChunkStat"
 permutation "CA1" "CAc" "I1" "SChunkStat" "LockChunk1" "INu1" "RC" "UnlockChunk" "INc" "SH" "SA" "SChunkStat" "SU"
 
-# Decompressing a chunk should not stop any reads 
+# Decompressing a chunk should not stop any reads
 # until the end when we drop the compressed chunk
 # which happens after updates to the chunk catalog tuple
 permutation "CA1" "CAc" "LockChunkTuple" "DA1" "SA" "SF" "UnlockChunkTuple" "DAc"
 
 # Compressing a chunk should not stop any reads
-# until it comes to truncating the uncompressed chunk
-# which happens at the end of the operations along with
-# catalog updates.
+# Truncating the uncompressed chunk (which happens at the end
+# of the operations along with catalog updates) does not block
+# It falls back to deleting the tuples row-by-row if lock upgrade does not go through
 permutation "SB" "SA" "CA1" "SA" "SF" "SR" "CAc"

--- a/tsl/test/isolation/specs/compression_freeze.spec
+++ b/tsl/test/isolation/specs/compression_freeze.spec
@@ -111,4 +111,7 @@ permutation "s2_lock_compression_after_truncate" "s2_select_count_and_stats" "s1
 permutation "s2_lock_compression_after_delete" "s2_select_count_and_stats" "s1_compress_delete" "s2_select_count_and_stats" "s2_unlock_compression_after_delete" "s2_select_count_and_stats"
 
 # Check after TRUNCATE OR DELETE
+# Ideally, we want s2 to be a transaction, so that we can test the spin-lock that is triggered here.
+# However, spin locks don't play well with isolation tests, so that is tesed in a TAP test instead `tsl/test/t/004_truncate_or_delete_spin_lock_test.pl`
+
 permutation "s2_lock_compression_after_truncate_or_delete" "s2_select_count_and_stats" "s1_compress_truncate_or_delete" "s2_unlock_compression_after_truncate_or_delete" "s2_select_count_and_stats"

--- a/tsl/test/isolation/specs/compression_freeze.spec
+++ b/tsl/test/isolation/specs/compression_freeze.spec
@@ -3,7 +3,7 @@
 # LICENSE-TIMESCALE for a copy of the license.
 
 ###
-# This test verifies if the compressed and uncompressed data are seen in parallel. Since 
+# This test verifies if the compressed and uncompressed data are seen in parallel. Since
 # we freeze the compressed data immediately, it becomes visible to all transactions
 # that are running concurrently. However, parallel transactions should not be able to
 # see the compressed hypertable in the catalog and query the data two times.
@@ -45,7 +45,12 @@ step "s1_compress" {
 }
 
 step "s1_compress_delete" {
-   SET timescaledb.enable_delete_after_compression TO on;
+   SET timescaledb.compress_truncate_behaviour TO truncate_disabled;
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+}
+
+step "s1_compress_truncate_or_delete" {
+   SET timescaledb.compress_truncate_behaviour TO truncate_or_delete;
    SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
 }
 
@@ -71,6 +76,10 @@ step "s2_lock_compression_after_delete" {
     SELECT debug_waitpoint_enable('compression_done_after_delete_uncompressed');
 }
 
+step "s2_lock_compression_after_truncate_or_delete" {
+    SELECT debug_waitpoint_enable('compression_done_after_truncate_or_delete_uncompressed');
+}
+
 step "s2_unlock_compression" {
     SELECT locktype, mode, granted, objid FROM pg_locks WHERE not granted AND (locktype = 'advisory' or relation::regclass::text LIKE '%chunk') ORDER BY relation, locktype, mode, granted;
     SELECT debug_waitpoint_release('compression_done_before_truncate_uncompressed');
@@ -86,6 +95,11 @@ step "s2_unlock_compression_after_delete" {
     SELECT debug_waitpoint_release('compression_done_after_delete_uncompressed');
 }
 
+step "s2_unlock_compression_after_truncate_or_delete" {
+    SELECT locktype, mode, granted, objid FROM pg_locks WHERE granted AND relation::regclass::text LIKE '%hyper%chunk' ORDER BY relation, locktype, mode, granted;
+    SELECT debug_waitpoint_release('compression_done_after_truncate_or_delete_uncompressed');
+}
+
 permutation "s1_select_count" "s2_select_count_and_stats"
 permutation "s1_select_count" "s1_compress" "s1_select_count" "s2_select_count_and_stats"
 permutation "s2_lock_compression" "s2_select_count_and_stats" "s1_compress" "s2_select_count_and_stats" "s2_unlock_compression" "s2_select_count_and_stats"
@@ -95,3 +109,6 @@ permutation "s2_lock_compression_after_truncate" "s2_select_count_and_stats" "s1
 
 # Check after DELETE
 permutation "s2_lock_compression_after_delete" "s2_select_count_and_stats" "s1_compress_delete" "s2_select_count_and_stats" "s2_unlock_compression_after_delete" "s2_select_count_and_stats"
+
+# Check after TRUNCATE OR DELETE
+permutation "s2_lock_compression_after_truncate_or_delete" "s2_select_count_and_stats" "s1_compress_truncate_or_delete" "s2_unlock_compression_after_truncate_or_delete" "s2_select_count_and_stats"

--- a/tsl/test/t/004_truncate_or_delete_spin_lock.pl
+++ b/tsl/test/t/004_truncate_or_delete_spin_lock.pl
@@ -1,0 +1,187 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# This TAP test verifies the spin lock behaviour when the `timescaledb.compress_truncate_behaviour` GUC is set to `truncate_or_delete`
+# The order of operations tested are the same as the `compression_freeze` isolation test for this GUC behaviour, except session 2 starts a transaction rather than using debug_waitpoints
+# This ensures that we can actually test the spin lock
+
+use strict;
+use warnings;
+use TimescaleNode;
+use Data::Dumper;
+use Test::More;
+
+# Test setup
+
+# Create node with timescaledb
+my $node = TimescaleNode->create('node');
+
+# Create table
+my $result = $node->safe_psql(
+	'postgres', q{
+  CREATE TABLE sensor_data (
+	time timestamptz not null,
+	sensor_id integer not null,
+	cpu double precision null,
+	temperature double precision null);
+	}
+);
+is($result, '', 'create table');
+
+# Create hypertable
+$result = $node->safe_psql(
+	'postgres', q{
+   SELECT FROM create_hypertable('sensor_data','time', chunk_time_interval => INTERVAL '1 month');
+	}
+);
+is($result, '', 'create hypertable');
+
+# Insert data
+$result = $node->safe_psql(
+	'postgres', q{
+   INSERT INTO sensor_data
+   SELECT
+   time + (INTERVAL '1 minute' * random()) AS time,
+   sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01', '2022-01-14', INTERVAL '1 hour') AS g1(time),
+   generate_series(1, 50, 1) AS g2(sensor_id)
+   ORDER BY time;
+	}
+);
+is($result, '', 'insert data');
+
+# Define count query
+my $count_query = "SELECT count(*) FROM sensor_data;";
+
+# Define compression query
+my $compress_query =
+  "SELECT count(*) FROM (SELECT compress_chunk(show_chunks('sensor_data')));";
+
+# Count inserted rows
+my $num_rows = $node->safe_psql('postgres', $count_query);
+
+is($num_rows, 15650, 'validate inserted rows');
+
+# Enable compression
+$result = $node->safe_psql(
+	'postgres', q{
+   ALTER TABLE sensor_data SET (timescaledb.compress, timescaledb.compress_segmentby = 'sensor_id');
+	}
+);
+is($result, '', 'enable compression');
+
+# Get number of chunks
+my $n_chunks = $node->safe_psql(
+	'postgres', q{
+SELECT count(*) FROM show_chunks('sensor_data');
+});
+
+# Create psql sessions
+my $s1 = $node->background_psql('postgres');
+my $s2 = $node->background_psql('postgres');
+
+# SET session 1 behaviour to `truncate_or_delete`
+$result = $s1->query_safe(
+	"SET timescaledb.compress_truncate_behaviour TO truncate_or_delete;");
+isnt($result, '', "session 1: set truncate_or_delete");
+
+# Run tests
+
+# TEST 1:
+# Session 1 tries to truncate at the end of compression, but is blocked by session 2
+# After the spin lock timeout is exceeded it falls back to delete instead
+
+# Begin txns in both sessions
+$result = $s1->query_safe("BEGIN");
+isnt($result, '', "session 1: begin");
+
+$result = $s2->query_safe("BEGIN");
+isnt($result, '', "session 2: begin");
+
+# The aggregation query takes an AccessShareLock on the chunk, preventing truncate
+$result = $s2->query_safe($count_query);
+is($result, $num_rows, "session 2: validate row count");
+
+# Compress the chunk
+# This tries and fails to acquire an AccessExclusiveLock on the table
+# so after the spin-lock timeout it falls back to doing a delete
+$result = $s1->query_safe($compress_query);
+is($result, 1, "session 1: compress chunk");
+
+$result = $s1->query_safe(
+	"SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;"
+);
+
+my $expected = "Compressed|1";
+is($result, $expected, "verify chunks are compressed");
+
+$result = $node->safe_psql('postgres', $count_query);
+is($result, $num_rows, "session 2: validate row count again");
+
+$result = $s2->query_safe("COMMIT");
+isnt($result, '', "session 2: commit");
+
+# No AccessExclusiveLock on the uncompressed chunk
+$result = $s1->query_safe(
+	"SELECT relation::regclass::text FROM pg_locks WHERE granted AND relation::regclass::text LIKE '%hyper%chunk' AND locktype = 'relation' AND mode = 'AccessExclusiveLock' ORDER BY relation, locktype;"
+);
+$expected = "_timescaledb_internal.compress_hyper_2_2_chunk";
+is($result, $expected, "verify AccessExclusiveLock was not taken");
+
+
+$result = $s1->query_safe("ROLLBACK");
+isnt($result, '', "session 1: rollback");
+
+##########################################################################
+
+# TEST 2:
+# Session 1 is blocked by session 2 but session 2 commits before the spin-lock timeout is exceeded so session 1 truncates
+
+# Begin txns in both sessions
+$result = $s1->query_safe("BEGIN");
+isnt($result, '', "session 1: begin");
+
+$result = $s2->query_safe("BEGIN");
+isnt($result, '', "session 2: begin");
+
+$result = $s2->query_safe($count_query);
+is($result, $num_rows, "session 2: validate row count");
+
+# We have to use 'query_until('', ...)' so that the test immediately fires the next query
+# Otherwise s1 times out and performs a delete
+$s1->query_until('', $compress_query);
+
+# Session 2 immediately commits, releasing the AccessShareLock on the table
+$result = $s2->query_safe("COMMIT");
+isnt($result, '', "session 2: commit");
+
+# The result from the previous query_until() is returned with the next query
+# so perform a dummy query on s1 to discard the result
+# There might be a better way of doing this...
+$s1->query_safe("SELECT 1");
+
+$result = $s1->query_safe(
+	"SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;"
+);
+is($result, 'Compressed|1', "verify chunks are compressed");
+
+# AccessExclusiveLock taken on the uncompressed chunk
+$result = $s1->query_safe(
+	"SELECT relation::regclass::text FROM pg_locks WHERE granted AND relation::regclass::text LIKE '%hyper%chunk' AND locktype = 'relation' AND mode = 'AccessExclusiveLock' ORDER BY relation, locktype;"
+);
+
+$expected = "_timescaledb_internal._hyper_1_1_chunk
+_timescaledb_internal.compress_hyper_2_3_chunk";
+is($result, $expected, "verify AccessExclusiveLock was taken");
+
+$result = $s1->query_safe("ROLLBACK");
+isnt($result, '', "session 1: rollback");
+
+$s1->quit();
+$s2->quit();
+
+done_testing();

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -2,6 +2,14 @@ set(PROVE_TEST_FILES 001_job_crash_log.pl 002_logrepl_decomp_marker.pl)
 
 set(PROVE_DEBUG_TEST_FILES 003_mvcc_cagg.pl)
 
+# The API for PostgreSQL::Cluster::BackgroundPsql was changed in PG16. We only
+# use the new version of the API, so run TAP tests that use it only on later
+# versions.
+
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
+  list(APPEND PROVE_TEST_FILES 004_truncate_or_delete_spin_lock.pl)
+endif()
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND PROVE_TEST_FILES ${PROVE_DEBUG_TEST_FILES})
 endif(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
After compression, the uncompressed part of the chunk is truncated. This requires upgrading the `ExclusiveLock` to an
`AccessExclusiveLock` and hence is sometimes blocked by other other operations, including reads, on the chunk. This leads to longer compress times or potential deadlocks.

Instead of this, we fall back to deleting the tuples in the chunk row-by-row when the upgraded lock isn't immediately acquired.