### PR TITLE
Incremental CAgg Refresh Policy

### DIFF
--- a/.unreleased/pr_7790
+++ b/.unreleased/pr_7790
@@ -1,0 +1,1 @@
+Implements: #7790 Add configurable Incremental CAgg Refresh Policy

--- a/sql/policy_api.sql
+++ b/sql/policy_api.sql
@@ -81,12 +81,16 @@ CREATE OR REPLACE PROCEDURE @extschema@.remove_columnstore_policy(
 
 /* continuous aggregates policy */
 CREATE OR REPLACE FUNCTION @extschema@.add_continuous_aggregate_policy(
-    continuous_aggregate REGCLASS, start_offset "any",
-    end_offset "any", schedule_interval INTERVAL,
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
     if_not_exists BOOL = false,
     initial_start TIMESTAMPTZ = NULL,
     timezone TEXT = NULL,
-    include_tiered_data BOOL = NULL
+    include_tiered_data BOOL = NULL,
+    buckets_per_batch INTEGER = NULL,
+    max_batches_per_execution INTEGER = NULL
 )
 RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_policy_refresh_cagg_add'

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -66,3 +66,32 @@ CREATE INDEX compression_settings_compress_relid_idx ON _timescaledb_catalog.com
 DROP TABLE _timescaledb_catalog.tempsettings CASCADE;
 GRANT SELECT ON _timescaledb_catalog.compression_settings TO PUBLIC;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_settings', '');
+
+
+-- New add_continuous_aggregate_policy API for incremental refresh policy
+DROP FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL,
+    initial_start TIMESTAMPTZ,
+    timezone TEXT,
+    include_tiered_data BOOL
+);
+
+CREATE FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL = false,
+    initial_start TIMESTAMPTZ = NULL,
+    timezone TEXT = NULL,
+	include_tiered_data BOOL = NULL,
+    buckets_per_batch INTEGER = NULL,
+    max_batches_per_execution INTEGER = NULL
+)
+RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
+LANGUAGE C VOLATILE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -39,3 +39,31 @@ FROM
 DROP TABLE _timescaledb_catalog.tempsettings CASCADE;
 GRANT SELECT ON _timescaledb_catalog.compression_settings TO PUBLIC;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_settings', '');
+
+-- Revert add_continuous_aggregate_policy API for incremental refresh policy
+DROP FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL,
+    initial_start TIMESTAMPTZ,
+    timezone TEXT,
+	include_tiered_data BOOL,
+    buckets_per_batch INTEGER,
+    max_batches_per_execution INTEGER
+);
+
+CREATE FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL = false,
+    initial_start TIMESTAMPTZ = NULL,
+    timezone TEXT = NULL,
+	include_tiered_data BOOL = NULL
+)
+RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
+LANGUAGE C VOLATILE;

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -971,3 +971,17 @@ pg_cmp_u32(uint32 a, uint32 b)
 }
 
 #endif
+
+#if PG16_LT
+/*
+ * Similarly, wrappers around labs()/llabs() matching our int64.
+ *
+ * Introduced on PG16:
+ * https://github.com/postgres/postgres/commit/357cfefb09115292cfb98d504199e6df8201c957
+ */
+#ifdef HAVE_LONG_INT_64
+#define i64abs(i) labs(i)
+#else
+#define i64abs(i) llabs(i)
+#endif
+#endif

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -1216,6 +1216,36 @@ ts_dimension_slice_nth_latest_slice(int32 dimension_id, int n)
 	return ret;
 }
 
+DimensionSlice *
+ts_dimension_slice_nth_earliest_slice(int32 dimension_id, int n)
+{
+	ScanKeyData scankey[1];
+	int num_tuples;
+	DimensionSlice *ret = NULL;
+
+	ScanKeyInit(&scankey[0],
+				Anum_dimension_slice_dimension_id_range_start_range_end_idx_dimension_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(dimension_id));
+
+	num_tuples = dimension_slice_scan_limit_direction_internal(
+		DIMENSION_SLICE_DIMENSION_ID_RANGE_START_RANGE_END_IDX,
+		scankey,
+		1,
+		dimension_slice_nth_tuple_found,
+		(void *) &ret,
+		n,
+		ForwardScanDirection,
+		AccessShareLock,
+		NULL,
+		CurrentMemoryContext);
+	if (num_tuples < n)
+		return NULL;
+
+	return ret;
+}
+
 int32
 ts_dimension_slice_oldest_valid_chunk_for_reorder(int32 job_id, int32 dimension_id,
 												  StrategyNumber start_strategy, int64 start_value,

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -88,6 +88,7 @@ extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSli
 extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 
 extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_nth_latest_slice(int32 dimension_id, int n);
+extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_nth_earliest_slice(int32 dimension_id, int n);
 extern TSDLLEXPORT int32 ts_dimension_slice_oldest_valid_chunk_for_reorder(
 	int32 job_id, int32 dimension_id, StrategyNumber start_strategy, int64 start_value,
 	StrategyNumber end_strategy, int64 end_value);

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1680,3 +1680,47 @@ ts_continuous_agg_fixed_bucket_width(const ContinuousAggsBucketFunction *bucket_
 		return bucket_function->bucket_integer_width;
 	}
 }
+
+/*
+ * Get the width of a bucket
+ */
+int64
+ts_continuous_agg_bucket_width(const ContinuousAggsBucketFunction *bucket_function)
+{
+	int64 bucket_width;
+
+	if (bucket_function->bucket_fixed_interval == false)
+	{
+		/*
+		 * There are several cases of variable-sized buckets:
+		 * 1. Monthly buckets
+		 * 2. Buckets with timezones
+		 * 3. Cases 1 and 2 at the same time
+		 *
+		 * For months we simply take 30 days like on interval_to_int64 and
+		 * multiply this number by the number of months in the bucket. This
+		 * reduces the task to days/hours/minutes scenario.
+		 *
+		 * Days/hours/minutes case is handled the same way as for fixed-sized
+		 * buckets. The refresh window at least two buckets in size is adequate
+		 * for such corner cases as DST.
+		 */
+
+		/* bucket_function should always be specified for variable-sized buckets */
+		Assert(bucket_function != NULL);
+		/* ... and bucket_function->bucket_time_width too */
+		Assert(bucket_function->bucket_time_width != NULL);
+
+		/* Make a temporary copy of bucket_width */
+		Interval interval = *bucket_function->bucket_time_width;
+		interval.day += 30 * interval.month;
+		interval.month = 0;
+		bucket_width = ts_interval_value_to_internal(IntervalPGetDatum(&interval), INTERVALOID);
+	}
+	else
+	{
+		bucket_width = ts_continuous_agg_fixed_bucket_width(bucket_function);
+	}
+
+	return bucket_width;
+}

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -215,3 +215,5 @@ extern TSDLLEXPORT Query *ts_continuous_agg_get_query(ContinuousAgg *cagg);
 
 extern TSDLLEXPORT int64
 ts_continuous_agg_fixed_bucket_width(const ContinuousAggsBucketFunction *bucket_function);
+extern TSDLLEXPORT int64
+ts_continuous_agg_bucket_width(const ContinuousAggsBucketFunction *bucket_function);

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -146,6 +146,28 @@ policy_refresh_cagg_get_include_tiered_data(const Jsonb *config, bool *isnull)
 	return res;
 }
 
+int32
+policy_refresh_cagg_get_buckets_per_batch(const Jsonb *config)
+{
+	bool found;
+	int32 res = ts_jsonb_get_int32_field(config, POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH, &found);
+
+	return res;
+}
+
+int32
+policy_refresh_cagg_get_max_batches_per_execution(const Jsonb *config)
+{
+	bool found;
+	int32 res =
+		ts_jsonb_get_int32_field(config, POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION, &found);
+
+	if (!found)
+		res = 10; /* default value */
+
+	return res;
+}
+
 /* returns false if a policy could not be found */
 bool
 policy_refresh_cagg_exists(int32 materialization_id)
@@ -445,39 +467,7 @@ validate_window_size(const ContinuousAgg *cagg, const CaggPolicyConfig *config)
 	else
 		end_offset = interval_to_int64(config->offset_end.value, config->offset_end.type);
 
-	if (cagg->bucket_function->bucket_fixed_interval == false)
-	{
-		/*
-		 * There are several cases of variable-sized buckets:
-		 * 1. Monthly buckets
-		 * 2. Buckets with timezones
-		 * 3. Cases 1 and 2 at the same time
-		 *
-		 * For months we simply take 30 days like on interval_to_int64 and
-		 * multiply this number by the number of months in the bucket. This
-		 * reduces the task to days/hours/minutes scenario.
-		 *
-		 * Days/hours/minutes case is handled the same way as for fixed-sized
-		 * buckets. The refresh window at least two buckets in size is adequate
-		 * for such corner cases as DST.
-		 */
-
-		/* bucket_function should always be specified for variable-sized buckets */
-		Assert(cagg->bucket_function != NULL);
-		/* ... and bucket_function->bucket_time_width too */
-		Assert(cagg->bucket_function->bucket_time_width != NULL);
-
-		/* Make a temporary copy of bucket_width */
-		Interval interval = *cagg->bucket_function->bucket_time_width;
-		interval.day += 30 * interval.month;
-		interval.month = 0;
-		bucket_width = ts_interval_value_to_internal(IntervalPGetDatum(&interval), INTERVALOID);
-	}
-	else
-	{
-		bucket_width = ts_continuous_agg_fixed_bucket_width(cagg->bucket_function);
-	}
-
+	bucket_width = ts_continuous_agg_bucket_width(cagg->bucket_function);
 	Assert(bucket_width > 0);
 
 	if (ts_time_saturating_add(end_offset, bucket_width * 2, INT8OID) > start_offset)
@@ -530,7 +520,8 @@ policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type, NullableDa
 								 Oid end_offset_type, NullableDatum end_offset,
 								 Interval refresh_interval, bool if_not_exists, bool fixed_schedule,
 								 TimestampTz initial_start, const char *timezone,
-								 NullableDatum include_tiered_data)
+								 NullableDatum include_tiered_data, NullableDatum buckets_per_batch,
+								 NullableDatum max_batches_per_execution)
 {
 	NameData application_name;
 	NameData proc_name, proc_schema, check_name, check_schema, owner;
@@ -627,6 +618,7 @@ policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type, NullableDa
 	ts_jsonb_add_int32(parse_state,
 					   POL_REFRESH_CONF_KEY_MAT_HYPERTABLE_ID,
 					   cagg->data.mat_hypertable_id);
+
 	if (!policyconf.offset_start.isnull)
 		json_add_dim_interval_value(parse_state,
 									POL_REFRESH_CONF_KEY_START_OFFSET,
@@ -634,6 +626,7 @@ policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type, NullableDa
 									policyconf.offset_start.value);
 	else
 		ts_jsonb_add_null(parse_state, POL_REFRESH_CONF_KEY_START_OFFSET);
+
 	if (!policyconf.offset_end.isnull)
 		json_add_dim_interval_value(parse_state,
 									POL_REFRESH_CONF_KEY_END_OFFSET,
@@ -641,10 +634,22 @@ policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type, NullableDa
 									policyconf.offset_end.value);
 	else
 		ts_jsonb_add_null(parse_state, POL_REFRESH_CONF_KEY_END_OFFSET);
+
 	if (!include_tiered_data.isnull)
 		ts_jsonb_add_bool(parse_state,
 						  POL_REFRESH_CONF_KEY_INCLUDE_TIERED_DATA,
 						  include_tiered_data.value);
+
+	if (!buckets_per_batch.isnull)
+		ts_jsonb_add_int32(parse_state,
+						   POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH,
+						   buckets_per_batch.value);
+
+	if (!max_batches_per_execution.isnull)
+		ts_jsonb_add_int32(parse_state,
+						   POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION,
+						   max_batches_per_execution.value);
+
 	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
 	Jsonb *config = JsonbValueToJsonb(result);
 
@@ -676,6 +681,8 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 	bool if_not_exists;
 	NullableDatum start_offset, end_offset;
 	NullableDatum include_tiered_data;
+	NullableDatum buckets_per_batch;
+	NullableDatum max_batches_per_execution;
 
 	ts_feature_flag_check(FEATURE_POLICY);
 
@@ -700,6 +707,10 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 	char *valid_timezone = NULL;
 	include_tiered_data.value = PG_GETARG_DATUM(7);
 	include_tiered_data.isnull = PG_ARGISNULL(7);
+	buckets_per_batch.value = PG_GETARG_DATUM(8);
+	buckets_per_batch.isnull = PG_ARGISNULL(8);
+	max_batches_per_execution.value = PG_GETARG_DATUM(9);
+	max_batches_per_execution.isnull = PG_ARGISNULL(9);
 
 	Datum retval;
 	/* if users pass in -infinity for initial_start, then use the current_timestamp instead */
@@ -723,7 +734,9 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 											  fixed_schedule,
 											  initial_start,
 											  valid_timezone,
-											  include_tiered_data);
+											  include_tiered_data,
+											  buckets_per_batch,
+											  max_batches_per_execution);
 	if (!TIMESTAMP_NOT_FINITE(initial_start))
 	{
 		int32 job_id = DatumGetInt32(retval);

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -21,14 +21,15 @@ int64 policy_refresh_cagg_get_refresh_start(const ContinuousAgg *cagg, const Dim
 int64 policy_refresh_cagg_get_refresh_end(const Dimension *dim, const Jsonb *config,
 										  bool *end_isnull);
 bool policy_refresh_cagg_get_include_tiered_data(const Jsonb *config, bool *isnull);
+int32 policy_refresh_cagg_get_buckets_per_batch(const Jsonb *config);
+int32 policy_refresh_cagg_get_max_batches_per_execution(const Jsonb *config);
 bool policy_refresh_cagg_refresh_start_lt(int32 materialization_id, Oid cmp_type,
 										  Datum cmp_interval);
 bool policy_refresh_cagg_exists(int32 materialization_id);
 
-Datum policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type,
-									   NullableDatum start_offset, Oid end_offset_type,
-									   NullableDatum end_offset, Interval refresh_interval,
-									   bool if_not_exists, bool fixed_schedule,
-									   TimestampTz initial_start, const char *timezone,
-									   NullableDatum include_tiered_data);
+Datum policy_refresh_cagg_add_internal(
+	Oid cagg_oid, Oid start_offset_type, NullableDatum start_offset, Oid end_offset_type,
+	NullableDatum end_offset, Interval refresh_interval, bool if_not_exists, bool fixed_schedule,
+	TimestampTz initial_start, const char *timezone, NullableDatum include_tiered_data,
+	NullableDatum buckets_per_batch, NullableDatum max_batches_per_execution);
 Datum policy_refresh_cagg_remove_internal(Oid cagg_oid, bool if_exists);

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -37,7 +37,9 @@ typedef struct PolicyContinuousAggData
 	InternalTimeRange refresh_window;
 	ContinuousAgg *cagg;
 	bool include_tiered_data;
-	bool start_is_null, end_is_null, include_tiered_data_isnull;
+	bool include_tiered_data_isnull;
+	int32 buckets_per_batch;
+	int32 max_batches_per_execution;
 } PolicyContinuousAggData;
 
 typedef struct PolicyCompressionData

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -207,6 +207,8 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 	if (all_policies.refresh && all_policies.refresh->create_policy)
 	{
 		NullableDatum include_tiered_data = { .isnull = true };
+		NullableDatum nbuckets_per_refresh = { .isnull = true };
+		NullableDatum max_batches_per_execution = { .isnull = true };
 
 		if (all_policies.is_alter_policy)
 			policy_refresh_cagg_remove_internal(all_policies.rel_oid, if_exists);
@@ -220,7 +222,9 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 														  false,
 														  DT_NOBEGIN,
 														  NULL,
-														  include_tiered_data);
+														  include_tiered_data,
+														  nbuckets_per_refresh,
+														  max_batches_per_execution);
 	}
 	if (all_policies.compress && all_policies.compress->create_policy)
 	{

--- a/tsl/src/bgw_policy/policies_v2.h
+++ b/tsl/src/bgw_policy/policies_v2.h
@@ -20,6 +20,8 @@
 #define POL_REFRESH_CONF_KEY_START_OFFSET "start_offset"
 #define POL_REFRESH_CONF_KEY_END_OFFSET "end_offset"
 #define POL_REFRESH_CONF_KEY_INCLUDE_TIERED_DATA "include_tiered_data"
+#define POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH "buckets_per_batch"
+#define POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION "max_batches_per_execution"
 
 #define POLICY_COMPRESSION_PROC_NAME "policy_compression"
 #define POLICY_COMPRESSION_CHECK_NAME "policy_compression_check"

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -80,7 +80,15 @@ typedef enum CaggRefreshCallContext
 	CAGG_REFRESH_CREATION,
 	CAGG_REFRESH_WINDOW,
 	CAGG_REFRESH_POLICY,
+	CAGG_REFRESH_POLICY_BATCHED
 } CaggRefreshCallContext;
+
+typedef struct CaggRefreshContext
+{
+	CaggRefreshCallContext callctx;
+	int32 processing_batch;
+	int32 number_of_batches;
+} CaggRefreshContext;
 
 #define IS_TIME_BUCKET_INFO_TIME_BASED(bucket_function)                                            \
 	(bucket_function->bucket_width_type == INTERVALOID)

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -940,12 +940,8 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 		refresh_window.start = cagg_get_time_min(cagg);
 		refresh_window.end = ts_time_get_noend_or_max(refresh_window.type);
 
-		continuous_agg_refresh_internal(cagg,
-										&refresh_window,
-										CAGG_REFRESH_CREATION,
-										true,
-										true,
-										false);
+		CaggRefreshContext context = { .callctx = CAGG_REFRESH_CREATION };
+		continuous_agg_refresh_internal(cagg, &refresh_window, context, true, true, false);
 	}
 
 	return DDL_DONE;

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -996,7 +996,7 @@ InvalidationStore *
 invalidation_process_cagg_log(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
 							  const CaggsInfo *all_caggs_info, const long max_materializations,
 							  bool *do_merged_refresh, InternalTimeRange *ret_merged_refresh_window,
-							  const CaggRefreshCallContext callctx, bool force)
+							  const CaggRefreshContext context, bool force)
 {
 	CaggInvalidationState state;
 	InvalidationStore *store = NULL;
@@ -1035,7 +1035,7 @@ invalidation_process_cagg_log(const ContinuousAgg *cagg, const InternalTimeRange
 													   store,
 													   state.bucket_function,
 													   &merged_refresh_window,
-													   callctx);
+													   context);
 		*do_merged_refresh = true;
 		*ret_merged_refresh_window = merged_refresh_window;
 		invalidation_store_free(store);

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -49,6 +49,6 @@ extern InvalidationStore *
 invalidation_process_cagg_log(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
 							  const CaggsInfo *all_caggs_info, const long max_materializations,
 							  bool *do_merged_refresh, InternalTimeRange *ret_merged_refresh_window,
-							  const CaggRefreshCallContext callctx, bool force);
+							  const CaggRefreshContext context, bool force);
 
 extern void invalidation_store_free(InvalidationStore *store);

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -4,12 +4,10 @@
  * LICENSE-TIMESCALE for a copy of the license.
  */
 #include <postgres.h>
+
 #include <executor/spi.h>
 #include <fmgr.h>
 #include <lib/stringinfo.h>
-#include <scan_iterator.h>
-#include <scanner.h>
-#include <time_utils.h>
 #include <utils/builtins.h>
 #include <utils/date.h>
 #include <utils/guc.h>
@@ -23,6 +21,9 @@
 #include "debug_assert.h"
 #include "guc.h"
 #include "materialize.h"
+#include "scan_iterator.h"
+#include "scanner.h"
+#include "time_utils.h"
 #include "ts_catalog/continuous_agg.h"
 #include "ts_catalog/continuous_aggs_watermark.h"
 

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -33,6 +33,8 @@ typedef struct InternalTimeRange
 	Oid type;
 	int64 start; /* inclusive */
 	int64 end;	 /* exclusive */
+	bool start_isnull;
+	bool end_isnull;
 } InternalTimeRange;
 
 void continuous_agg_update_materialization(Hypertable *mat_ht, const ContinuousAgg *cagg,

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <postgres.h>
-#include "continuous_aggs/materialize.h"
 #include <fmgr.h>
 
 #include "invalidation.h"
@@ -16,9 +15,12 @@ extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void continuous_agg_calculate_merged_refresh_window(
 	const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
 	const InvalidationStore *invalidations, const ContinuousAggsBucketFunction *bucket_function,
-	InternalTimeRange *merged_refresh_window, const CaggRefreshCallContext callctx);
+	InternalTimeRange *merged_refresh_window, const CaggRefreshContext context);
 extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
-											const CaggRefreshCallContext callctx,
+											const CaggRefreshContext context,
 											const bool start_isnull, const bool end_isnull,
 											bool force);
+extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,
+												 InternalTimeRange *original_refresh_window,
+												 int32 buckets_per_batch);

--- a/tsl/test/expected/cagg_refresh_policy_incremental.out
+++ b/tsl/test/expected/cagg_refresh_policy_incremental.out
@@ -1,0 +1,590 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_create() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time(set_time BIGINT = 0, wait BOOLEAN = false) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone = 'America/Sao_Paulo';
+CREATE TABLE public.bgw_log(
+    msg_no INT,
+    mock_time BIGINT,
+    application_name TEXT,
+    msg TEXT
+);
+CREATE VIEW sorted_bgw_log AS
+SELECT
+    msg_no,
+    mock_time,
+    application_name,
+    regexp_replace(regexp_replace(msg, '(Wait until|started at|execution time) [0-9]+(\.[0-9]+)?', '\1 (RANDOM)', 'g'), 'background worker "[^"]+"','connection') AS msg
+FROM
+    bgw_log
+ORDER BY
+    mock_time,
+    application_name COLLATE "C",
+    msg_no;
+CREATE TABLE public.bgw_dsm_handle_store(
+    handle BIGINT
+);
+INSERT INTO public.bgw_dsm_handle_store VALUES (0);
+SELECT ts_bgw_params_create();
+ ts_bgw_params_create 
+----------------------
+ 
+(1 row)
+
+CREATE TABLE conditions (
+    time         TIMESTAMP WITH TIME ZONE NOT NULL,
+    device_id    INTEGER,
+    temperature  NUMERIC
+);
+SELECT FROM create_hypertable('conditions', by_range('time'));
+--
+(1 row)
+
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        '2025-02-05 00:00:00-03',
+        '2025-03-05 00:00:00-03',
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+CREATE MATERIALIZED VIEW conditions_by_day
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+    time_bucket('1 day', time),
+    device_id,
+    count(*),
+    min(temperature),
+    max(temperature),
+    avg(temperature),
+    sum(temperature)
+FROM
+    conditions
+GROUP BY
+    1, 2
+WITH NO DATA;
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day',
+        start_offset => NULL,
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h',
+        buckets_per_batch => 10
+    ) AS job_id \gset
+SELECT
+    config
+FROM
+    timescaledb_information.jobs
+WHERE
+    job_id = :'job_id' \gset
+SELECT ts_bgw_params_reset_time(0, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time |              application_name              |                                                                                   msg                                                                                    
+--------+-----------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
+      2 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Fri Feb 28 16:00:00 2025 PST, Wed Mar 05 16:00:00 2025 PST ] (batch 1 of 4)
+      1 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 18 16:00:00 2025 PST, Fri Feb 28 16:00:00 2025 PST ] (batch 2 of 4)
+      4 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      6 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Feb 08 16:00:00 2025 PST, Tue Feb 18 16:00:00 2025 PST ] (batch 3 of 4)
+      7 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      8 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      9 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Nov 23 16:07:02 4714 LMT BC, Sat Feb 08 16:00:00 2025 PST ] (batch 4 of 4)
+     10 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+     11 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(15 rows)
+
+CREATE MATERIALIZED VIEW conditions_by_day_manual_refresh
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+    time_bucket('1 day', time),
+    device_id,
+    count(*),
+    min(temperature),
+    max(temperature),
+    avg(temperature),
+    sum(temperature)
+FROM
+    conditions
+GROUP BY
+    1, 2
+WITH NO DATA;
+CALL refresh_continuous_aggregate('conditions_by_day_manual_refresh', NULL, NULL);
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+   145
+(1 row)
+
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+ count 
+-------
+   145
+(1 row)
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+ has_diff 
+----------
+ f
+(1 row)
+
+TRUNCATE bgw_log, conditions_by_day;
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{max_batches_per_execution}', '2')
+    );
+                                                           config                                                            
+-----------------------------------------------------------------------------------------------------------------------------
+ {"end_offset": null, "start_offset": null, "buckets_per_batch": 10, "mat_hypertable_id": 2, "max_batches_per_execution": 2}
+(1 row)
+
+-- advance time by 1h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time  |              application_name              |                                                                                  msg                                                                                  
+--------+------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 | 3600000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 3600000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Fri Feb 28 16:00:00 2025 PST, Wed Mar 05 16:00:00 2025 PST ] (batch 1 of 4)
+      1 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 18 16:00:00 2025 PST, Fri Feb 28 16:00:00 2025 PST ] (batch 2 of 4)
+      4 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      6 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | reached maximum number of batches per execution (2), batches not processed (2)
+(9 rows)
+
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+    75
+(1 row)
+
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+ count 
+-------
+   145
+(1 row)
+
+-- Should have differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+ has_diff 
+----------
+ t
+(1 row)
+
+-- advance time by 2h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '2 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time  |              application_name              |                                                                                   msg                                                                                    
+--------+------------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 | 3600000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 3600000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Fri Feb 28 16:00:00 2025 PST, Wed Mar 05 16:00:00 2025 PST ] (batch 1 of 4)
+      1 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 18 16:00:00 2025 PST, Fri Feb 28 16:00:00 2025 PST ] (batch 2 of 4)
+      4 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      6 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | reached maximum number of batches per execution (2), batches not processed (2)
+      0 | 7200000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 7200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Feb 08 16:00:00 2025 PST, Tue Feb 18 16:00:00 2025 PST ] (batch 1 of 2)
+      1 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Nov 23 16:07:02 4714 LMT BC, Sat Feb 08 16:00:00 2025 PST ] (batch 2 of 2)
+      4 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(17 rows)
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+ has_diff 
+----------
+ f
+(1 row)
+
+-- Set max_batches_per_execution to 10
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{max_batches_per_execution}', '10')
+    );
+                                                            config                                                            
+------------------------------------------------------------------------------------------------------------------------------
+ {"end_offset": null, "start_offset": null, "buckets_per_batch": 10, "mat_hypertable_id": 2, "max_batches_per_execution": 10}
+(1 row)
+
+TRUNCATE bgw_log;
+-- Insert data into the past
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        '2020-02-05 00:00:00-03',
+        '2020-03-05 00:00:00-03',
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+-- advance time by 3h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '3 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+-- Should process all four batches in the past
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                                                  msg                                                                                  
+--------+-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 | 10800000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 10800000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Fri Feb 28 16:00:00 2020 PST, Thu Mar 05 16:00:00 2020 PST ] (batch 1 of 4)
+      1 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 30 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 18 16:00:00 2020 PST, Fri Feb 28 16:00:00 2020 PST ] (batch 2 of 4)
+      4 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      6 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Feb 08 16:00:00 2020 PST, Tue Feb 18 16:00:00 2020 PST ] (batch 3 of 4)
+      7 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      8 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      9 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 04 16:00:00 2020 PST, Sat Feb 08 16:00:00 2020 PST ] (batch 4 of 4)
+     10 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+     11 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(14 rows)
+
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+   295
+(1 row)
+
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+ count 
+-------
+   145
+(1 row)
+
+CALL refresh_continuous_aggregate('conditions_by_day_manual_refresh', NULL, NULL);
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+   295
+(1 row)
+
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+ count 
+-------
+   295
+(1 row)
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+ has_diff 
+----------
+ f
+(1 row)
+
+-- Check invalid configurations
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{max_batches_per_execution}', '-1')
+    );
+ERROR:  invalid max batches per execution
+DETAIL:  max_batches_per_execution: -1
+HINT:  The max batches per execution should be greater than or equal to zero.
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{buckets_per_batch}', '-1')
+    );
+ERROR:  invalid buckets per batch
+DETAIL:  buckets_per_batch: -1
+HINT:  The buckets per batch should be greater than or equal to zero.
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+-- Truncate all data from the original hypertable
+TRUNCATE bgw_log, conditions;
+-- advance time by 4h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '4 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+-- Should fallback to single batch processing because there's no data to be refreshed on the original hypertable
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                                            msg                                                                            
+--------+-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 | 14400000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 14400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 14400000000 | Refresh Continuous Aggregate Policy [1000] | no min slice range start for continuous aggregate "public.conditions_by_day", falling back to single batch processing
+      1 | 14400000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Nov 23 16:07:02 4714 LMT BC, Wed Mar 05 16:00:00 2025 PST ]
+      2 | 14400000000 | Refresh Continuous Aggregate Policy [1000] | deleted 295 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 14400000000 | Refresh Continuous Aggregate Policy [1000] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(6 rows)
+
+-- Should return zero rows
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+     0
+(1 row)
+
+-- 1 day of data
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        '2020-02-05 00:00:00-03',
+        '2020-02-06 00:00:00-03',
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+TRUNCATE bgw_log;
+-- advance time by 5h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '5 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+-- Should fallback to single batch processing because the refresh size is too small
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                                          msg                                                                           
+--------+-------------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 | 18000000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 18000000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 18000000000 | Refresh Continuous Aggregate Policy [1000] | only one batch produced for continuous aggregate "public.conditions_by_day", falling back to single batch processing
+      1 | 18000000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 04 16:00:00 2020 PST, Thu Feb 06 16:00:00 2020 PST ]
+      2 | 18000000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 18000000000 | Refresh Continuous Aggregate Policy [1000] | inserted 10 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(6 rows)
+
+-- Should return 10 rows because the bucket width is `1 day` and buckets per batch is `10`
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+    10
+(1 row)
+
+TRUNCATE conditions_by_day, conditions, bgw_log;
+-- Less than 1 day of data (smaller than the bucket width)
+INSERT INTO conditions
+VALUES ('2020-02-05 00:00:00-03', 1, 10);
+-- advance time by 6h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '6 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+-- Should fallback to single batch processing because the refresh size is too small
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                                            msg                                                                            
+--------+-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 | 21600000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 21600000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | refresh window size (7 days) is smaller than or equal to batch size (10 days), falling back to single batch processing
+      1 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Nov 23 16:07:02 4714 LMT BC, Wed Mar 05 16:00:00 2025 PST ]
+      2 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(6 rows)
+
+-- Should return 1 row
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+     1
+(1 row)
+
+SELECT delete_job(:job_id);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day',
+        start_offset => INTERVAL '15 days',
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h',
+        buckets_per_batch => 5
+    ) AS job_id \gset
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day_manual_refresh',
+        start_offset => INTERVAL '15 days',
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h'
+    ) AS job_id \gset
+TRUNCATE bgw_log, conditions_by_day, conditions_by_day_manual_refresh, conditions;
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        NOW() - INTERVAL '30 days',
+        NOW(),
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+SELECT ts_bgw_params_reset_time(0, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time |              application_name              |                                                                                  msg                                                                                  
+--------+-----------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
+      2 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Wed Mar 05 16:00:00 2025 PST, Mon Mar 10 17:00:00 2025 PDT ] (batch 2 of 4)
+      1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Fri Feb 28 16:00:00 2025 PST, Wed Mar 05 16:00:00 2025 PST ] (batch 3 of 4)
+      4 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      6 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Feb 23 16:00:00 2025 PST, Fri Feb 28 16:00:00 2025 PST ] (batch 4 of 4)
+      7 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      8 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      0 |         0 | Refresh Continuous Aggregate Policy [1002] | continuous aggregate refresh (individual invalidation) on "conditions_by_day_manual_refresh" in window [ Sun Feb 23 16:00:00 2025 PST, Mon Mar 10 17:00:00 2025 PDT ]
+      1 |         0 | Refresh Continuous Aggregate Policy [1002] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |         0 | Refresh Continuous Aggregate Policy [1002] | inserted 75 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+(15 rows)
+
+-- Both continuous aggregates should have the same data
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+    75
+(1 row)
+
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+ count 
+-------
+    75
+(1 row)
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+ has_diff 
+----------
+ f
+(1 row)
+

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -214,7 +214,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  ts_now_mock()
  add_columnstore_policy(regclass,"any",boolean,interval,timestamp with time zone,text,interval,boolean)
  add_compression_policy(regclass,"any",boolean,interval,timestamp with time zone,text,interval,boolean)
- add_continuous_aggregate_policy(regclass,"any","any",interval,boolean,timestamp with time zone,text,boolean)
+ add_continuous_aggregate_policy(regclass,"any","any",interval,boolean,timestamp with time zone,text,boolean,integer,integer)
  add_dimension(regclass,_timescaledb_internal.dimension_info,boolean)
  add_dimension(regclass,name,integer,anyelement,regproc,boolean)
  add_job(regproc,interval,jsonb,timestamp with time zone,boolean,regproc,boolean,text)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -79,6 +79,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     bgw_scheduler_restart.sql
     bgw_reorder_drop_chunks.sql
     scheduler_fixed.sql
+    cagg_refresh_policy_incremental.sql
     compress_bgw_reorder_drop_chunks.sql
     chunk_api.sql
     chunk_merge.sql

--- a/tsl/test/sql/cagg_refresh_policy_incremental.sql
+++ b/tsl/test/sql/cagg_refresh_policy_incremental.sql
@@ -1,0 +1,331 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_create() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time(set_time BIGINT = 0, wait BOOLEAN = false) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone = 'America/Sao_Paulo';
+
+CREATE TABLE public.bgw_log(
+    msg_no INT,
+    mock_time BIGINT,
+    application_name TEXT,
+    msg TEXT
+);
+
+CREATE VIEW sorted_bgw_log AS
+SELECT
+    msg_no,
+    mock_time,
+    application_name,
+    regexp_replace(regexp_replace(msg, '(Wait until|started at|execution time) [0-9]+(\.[0-9]+)?', '\1 (RANDOM)', 'g'), 'background worker "[^"]+"','connection') AS msg
+FROM
+    bgw_log
+ORDER BY
+    mock_time,
+    application_name COLLATE "C",
+    msg_no;
+
+CREATE TABLE public.bgw_dsm_handle_store(
+    handle BIGINT
+);
+INSERT INTO public.bgw_dsm_handle_store VALUES (0);
+SELECT ts_bgw_params_create();
+
+CREATE TABLE conditions (
+    time         TIMESTAMP WITH TIME ZONE NOT NULL,
+    device_id    INTEGER,
+    temperature  NUMERIC
+);
+
+SELECT FROM create_hypertable('conditions', by_range('time'));
+
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        '2025-02-05 00:00:00-03',
+        '2025-03-05 00:00:00-03',
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+
+CREATE MATERIALIZED VIEW conditions_by_day
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+    time_bucket('1 day', time),
+    device_id,
+    count(*),
+    min(temperature),
+    max(temperature),
+    avg(temperature),
+    sum(temperature)
+FROM
+    conditions
+GROUP BY
+    1, 2
+WITH NO DATA;
+
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day',
+        start_offset => NULL,
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h',
+        buckets_per_batch => 10
+    ) AS job_id \gset
+
+SELECT
+    config
+FROM
+    timescaledb_information.jobs
+WHERE
+    job_id = :'job_id' \gset
+
+SELECT ts_bgw_params_reset_time(0, true);
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+CREATE MATERIALIZED VIEW conditions_by_day_manual_refresh
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+    time_bucket('1 day', time),
+    device_id,
+    count(*),
+    min(temperature),
+    max(temperature),
+    avg(temperature),
+    sum(temperature)
+FROM
+    conditions
+GROUP BY
+    1, 2
+WITH NO DATA;
+
+CALL refresh_continuous_aggregate('conditions_by_day_manual_refresh', NULL, NULL);
+
+SELECT count(*) FROM conditions_by_day;
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+
+TRUNCATE bgw_log, conditions_by_day;
+
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{max_batches_per_execution}', '2')
+    );
+
+-- advance time by 1h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1 hour')::bigint * 1000000, true);
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+SELECT count(*) FROM conditions_by_day;
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+
+-- Should have differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+
+-- advance time by 2h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '2 hour')::bigint * 1000000, true);
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+
+-- Set max_batches_per_execution to 10
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{max_batches_per_execution}', '10')
+    );
+
+TRUNCATE bgw_log;
+
+-- Insert data into the past
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        '2020-02-05 00:00:00-03',
+        '2020-03-05 00:00:00-03',
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+
+-- advance time by 3h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '3 hour')::bigint * 1000000, true);
+
+-- Should process all four batches in the past
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+SELECT count(*) FROM conditions_by_day;
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+
+CALL refresh_continuous_aggregate('conditions_by_day_manual_refresh', NULL, NULL);
+
+SELECT count(*) FROM conditions_by_day;
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+
+-- Check invalid configurations
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{max_batches_per_execution}', '-1')
+    );
+SELECT
+    config
+FROM
+    alter_job(
+        :'job_id',
+        config => jsonb_set(:'config', '{buckets_per_batch}', '-1')
+    );
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+
+-- Truncate all data from the original hypertable
+TRUNCATE bgw_log, conditions;
+
+-- advance time by 4h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '4 hour')::bigint * 1000000, true);
+
+-- Should fallback to single batch processing because there's no data to be refreshed on the original hypertable
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+-- Should return zero rows
+SELECT count(*) FROM conditions_by_day;
+
+-- 1 day of data
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        '2020-02-05 00:00:00-03',
+        '2020-02-06 00:00:00-03',
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+
+TRUNCATE bgw_log;
+
+-- advance time by 5h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '5 hour')::bigint * 1000000, true);
+
+-- Should fallback to single batch processing because the refresh size is too small
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+-- Should return 10 rows because the bucket width is `1 day` and buckets per batch is `10`
+SELECT count(*) FROM conditions_by_day;
+
+TRUNCATE conditions_by_day, conditions, bgw_log;
+
+-- Less than 1 day of data (smaller than the bucket width)
+INSERT INTO conditions
+VALUES ('2020-02-05 00:00:00-03', 1, 10);
+
+-- advance time by 6h so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '6 hour')::bigint * 1000000, true);
+
+-- Should fallback to single batch processing because the refresh size is too small
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+-- Should return 1 row
+SELECT count(*) FROM conditions_by_day;
+
+SELECT delete_job(:job_id);
+
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day',
+        start_offset => INTERVAL '15 days',
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h',
+        buckets_per_batch => 5
+    ) AS job_id \gset
+
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day_manual_refresh',
+        start_offset => INTERVAL '15 days',
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h'
+    ) AS job_id \gset
+
+
+TRUNCATE bgw_log, conditions_by_day, conditions_by_day_manual_refresh, conditions;
+
+INSERT INTO conditions
+SELECT
+    t, d, 10
+FROM
+    generate_series(
+        NOW() - INTERVAL '30 days',
+        NOW(),
+        '1 hour'::interval) AS t,
+    generate_series(1,5) AS d;
+
+SELECT ts_bgw_params_reset_time(0, true);
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+SELECT * FROM sorted_bgw_log;
+
+-- Both continuous aggregates should have the same data
+SELECT count(*) FROM conditions_by_day;
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;


### PR DESCRIPTION
Nowadays a Continuous Aggregate refresh policy process everything only once independent of how large the refresh window is. For example if you have a hypertable with a huge amount of rows it can take a lot of time and requires a lot of resources in terms of CPU, Memory and I/O to refresh a CAgg, and all the aggregated data will be visible for the users only when the refresh policy complete it execution.

This PR add the capability of a CAgg refresh policy be executed incrementaly in "batches". Each "batch" is an individual transaction that will process a small fraction of the entire refresh window, and once the "batch" finishes the execution the data refreshed will already be visible for the users even before policy execution end.

To tweak and control the incremental refresh some new options was added to `add_continuous_aggregate_policy` API:
* `buckets_per_batch`: number of buckets to be refreshed by a "batch". To summarize this value is multiplied by the CAgg bucket width to determine the size of the batch range. Default value is `0` (zero) that means it will keep the current behavior of single batch execution. Values less than `0` (zero) are not allowed.
* `max_batches_per_execution`: maximum number of batches to be executed by a policy execution. This option is used to limit the number of batches processed by a single policy execution, so if some batches remain next time the policy run they will be processed. Default value is `10` (ten) that means that each job execution will process the maximum of ten batches. To make it unlimited then the value should be `0` (zero). Values less than `0` (zero) are not allowed.
