### PR TITLE
Fix cleanup of compression settings with drop cascade

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -752,6 +752,7 @@ ts_hypertable_drop(Hypertable *hypertable, DropBehavior behavior)
 		};
 
 		/* Drop the postgres table */
+		ts_compression_settings_delete(hypertable->main_table_relid);
 		performDeletion(&hypertable_addr, behavior, 0);
 	}
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1413,6 +1413,7 @@ process_drop_table_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 		.objectId = chunk_relid,
 	};
 
+	ts_compression_settings_delete(chunk_relid);
 	performDeletion(&objaddr, stmt->behavior, 0);
 }
 

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -374,3 +374,54 @@ SELECT * FROM metrics WHERE d1 = 'foo';
 ------+----+----+-------
 (0 rows)
 
+SELECT * FROM settings;
+                 relid                  |                 compress_relid                  | segmentby |      orderby       | orderby_desc | orderby_nullsfirst 
+----------------------------------------+-------------------------------------------------+-----------+--------------------+--------------+--------------------
+ metrics                                |                                                 | {d1,d2}   | {time}             | {t}          | {t}
+ metrics2                               |                                                 |           | {d1,d2,value,time} | {t,f,t,f}    | {f,t,t,t}
+ _timescaledb_internal._hyper_3_6_chunk | _timescaledb_internal.compress_hyper_4_11_chunk |           | {time}             | {t}          | {t}
+ _timescaledb_internal._hyper_3_8_chunk | _timescaledb_internal.compress_hyper_4_12_chunk |           | {time}             | {t}          | {t}
+(4 rows)
+
+-- Check that TRUNCATE <hypertable> also cleans up compression
+-- settings for chunks that are dropped when truncating.
+TRUNCATE metrics;
+SELECT * FROM settings;
+  relid   | compress_relid | segmentby |      orderby       | orderby_desc | orderby_nullsfirst 
+----------+----------------+-----------+--------------------+--------------+--------------------
+ metrics  |                | {d1,d2}   | {time}             | {t}          | {t}
+ metrics2 |                |           | {d1,d2,value,time} | {t,f,t,f}    | {f,t,t,t}
+(2 rows)
+
+SELECT * FROM chunk_settings;
+ hypertable | chunk | segmentby | orderby 
+------------+-------+-----------+---------
+(0 rows)
+
+-- Recreate chunks
+INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_13_chunk
+ _timescaledb_internal._hyper_3_14_chunk
+(2 rows)
+
+SELECT * FROM settings;
+                  relid                  |                 compress_relid                  | segmentby |      orderby       | orderby_desc | orderby_nullsfirst 
+-----------------------------------------+-------------------------------------------------+-----------+--------------------+--------------+--------------------
+ metrics                                 |                                                 | {d1,d2}   | {time}             | {t}          | {t}
+ metrics2                                |                                                 |           | {d1,d2,value,time} | {t,f,t,f}    | {f,t,t,t}
+ _timescaledb_internal._hyper_3_13_chunk | _timescaledb_internal.compress_hyper_4_15_chunk | {d1,d2}   | {time}             | {t}          | {t}
+ _timescaledb_internal._hyper_3_14_chunk | _timescaledb_internal.compress_hyper_4_16_chunk | {d1,d2}   | {time}             | {t}          | {t}
+(4 rows)
+
+-- DROP TABLE with CASCADE uses a different code path for dropping
+-- hypertable so needs to be tested separately.
+DROP TABLE metrics CASCADE;
+SELECT * FROM settings;
+  relid   | compress_relid | segmentby |      orderby       | orderby_desc | orderby_nullsfirst 
+----------+----------------+-----------+--------------------+--------------+--------------------
+ metrics2 |                |           | {d1,d2,value,time} | {t,f,t,f}    | {f,t,t,t}
+(1 row)
+

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -120,3 +120,22 @@ SELECT * FROM chunk_settings;
 
 SELECT * FROM metrics WHERE d1 = 'foo';
 
+SELECT * FROM settings;
+
+
+-- Check that TRUNCATE <hypertable> also cleans up compression
+-- settings for chunks that are dropped when truncating.
+TRUNCATE metrics;
+SELECT * FROM settings;
+SELECT * FROM chunk_settings;
+
+-- Recreate chunks
+INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+
+SELECT * FROM settings;
+
+-- DROP TABLE with CASCADE uses a different code path for dropping
+-- hypertable so needs to be tested separately.
+DROP TABLE metrics CASCADE;
+SELECT * FROM settings;


### PR DESCRIPTION
When a table was dropped with the "cascade" option, compression settings weren't properly cleaned up as a result of refactoring in commit adf7c39. It seems dropping with the "cascade" option invokes a different path for dropping the hypertable and children chunks, and there was no test for it. A test has now been added.

Disable-check: force-changelog-file