### PR TITLE
Add a new dummy compression called NULL

### DIFF
--- a/.unreleased/pr_7798
+++ b/.unreleased/pr_7798
@@ -1,0 +1,1 @@
+Fixes: #7714 Fixes a wrong result when compressed NULL values were confused with default values. This happened in very special circumstances with alter table added a new column with a default value, an update and compression in a very particular order.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -4,8 +4,9 @@ CREATE FUNCTION _timescaledb_functions.compressed_data_has_nulls(_timescaledb_in
     AS '@MODULE_PATHNAME@', 'ts_update_placeholder';
 
 INSERT INTO _timescaledb_catalog.compression_algorithm( id, version, name, description) values
-( 5, 1, 'COMPRESSION_ALGORITHM_BOOL', 'bool');
-
+( 5, 1, 'COMPRESSION_ALGORITHM_BOOL', 'bool'),
+( 6, 1, 'COMPRESSION_ALGORITHM_NULL', 'null')
+;
 
 -------------------------------
 -- Update compression settings

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,6 +1,7 @@
 DROP FUNCTION IF EXISTS _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data);
 
 DELETE FROM _timescaledb_catalog.compression_algorithm WHERE id = 5 AND version = 1 AND name = 'COMPRESSION_ALGORITHM_BOOL';
+DELETE FROM _timescaledb_catalog.compression_algorithm WHERE id = 6 AND version = 1 AND name = 'COMPRESSION_ALGORITHM_NULL';
 
 -- Update compression settings
 CREATE TABLE _timescaledb_catalog.tempsettings (LIKE _timescaledb_catalog.compression_settings);

--- a/src/guc.c
+++ b/src/guc.c
@@ -154,6 +154,9 @@ bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = false;
 
+/* Only settable in debug mode for testing */
+TSDLLEXPORT bool ts_guc_enable_null_compression = true;
+
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
 TSDLLEXPORT bool ts_guc_enable_columnarscan = true;
@@ -760,6 +763,19 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+#ifdef TS_DEBUG
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_null_compression"),
+							 "Debug only flag to enable NULL compression",
+							 "Enable null compression",
+							 &ts_guc_enable_null_compression,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+#endif
 
 	/*
 	 * Define the limit on number of invalidation-based refreshes we allow per

--- a/src/guc.h
+++ b/src/guc.h
@@ -71,6 +71,9 @@ extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
 
+/* Only settable in debug mode for testing */
+extern TSDLLEXPORT bool ts_guc_enable_null_compression;
+
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel
 {

--- a/tsl/src/compression/algorithms/CMakeLists.txt
+++ b/tsl/src/compression/algorithms/CMakeLists.txt
@@ -4,5 +4,6 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/deltadelta.c
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary.c
     ${CMAKE_CURRENT_SOURCE_DIR}/gorilla.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/bool_compress.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/bool_compress.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/null.c)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/compression/algorithms/null.c
+++ b/tsl/src/compression/algorithms/null.c
@@ -1,0 +1,57 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include "null.h"
+#include "fmgr.h"
+
+typedef struct NullCompressed
+{
+	CompressedDataHeaderFields;
+} NullCompressed;
+
+extern DecompressionIterator *
+null_decompression_iterator_from_datum_forward(Datum bool_compressed, Oid element_type)
+{
+	elog(ERROR, "null decompression iterator not implemented");
+	return NULL;
+}
+
+extern DecompressionIterator *
+null_decompression_iterator_from_datum_reverse(Datum bool_compressed, Oid element_type)
+{
+	elog(ERROR, "null decompression iterator not implemented");
+	return NULL;
+}
+
+extern void
+null_compressed_send(CompressedDataHeader *header, StringInfo buffer)
+{
+	elog(ERROR, "null compression doesn't implement send");
+}
+
+extern Datum
+null_compressed_recv(StringInfo buffer)
+{
+	elog(ERROR, "null compression doesn't implement recv");
+	PG_RETURN_VOID();
+}
+
+extern Compressor *
+null_compressor_for_type(Oid element_type)
+{
+	elog(ERROR, "null compressor not implemented");
+	return NULL;
+}
+
+extern void *
+null_compressor_get_dummy_block(void)
+{
+	NullCompressed *compressed = palloc(sizeof(NullCompressed));
+	Size compressed_size = sizeof(NullCompressed);
+	compressed->compression_algorithm = COMPRESSION_ALGORITHM_NULL;
+	SET_VARSIZE(&compressed->vl_len_, compressed_size);
+	return compressed;
+}

--- a/tsl/src/compression/algorithms/null.h
+++ b/tsl/src/compression/algorithms/null.h
@@ -1,0 +1,48 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+/*
+ * The NULL compression algorithm is a no-op compression algorithm that is only
+ * used to signal that all values in a compressed block are NULLs. The compression
+ * interface functions are only defined to comply with the framework, but they
+ * are not implemented and return an ERROR. Calling these function is a software
+ * bug.
+ */
+
+#include <postgres.h>
+#include <fmgr.h>
+#include <lib/stringinfo.h>
+
+#include "compression/compression.h"
+
+/*
+ * Compressor framework functions and definitions for the null algorithm.
+ */
+
+extern DecompressionIterator *null_decompression_iterator_from_datum_forward(Datum bool_compressed,
+																			 Oid element_type);
+
+extern DecompressionIterator *null_decompression_iterator_from_datum_reverse(Datum bool_compressed,
+																			 Oid element_type);
+
+extern void null_compressed_send(CompressedDataHeader *header, StringInfo buffer);
+
+extern Datum null_compressed_recv(StringInfo buffer);
+
+extern Compressor *null_compressor_for_type(Oid element_type);
+
+extern void *null_compressor_get_dummy_block(void);
+
+#define NULL_COMPRESS_ALGORITHM_DEFINITION                                                         \
+	{                                                                                              \
+		.iterator_init_forward = null_decompression_iterator_from_datum_forward,                   \
+		.iterator_init_reverse = null_decompression_iterator_from_datum_reverse,                   \
+		.decompress_all = NULL, .compressed_data_send = null_compressed_send,                      \
+		.compressed_data_recv = null_compressed_recv,                                              \
+		.compressor_for_type = null_compressor_for_type,                                           \
+		.compressed_data_storage = TOAST_STORAGE_EXTERNAL,                                         \
+	}

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -194,6 +194,7 @@ typedef enum CompressionAlgorithm
 	COMPRESSION_ALGORITHM_GORILLA,
 	COMPRESSION_ALGORITHM_DELTADELTA,
 	COMPRESSION_ALGORITHM_BOOL,
+	COMPRESSION_ALGORITHM_NULL,
 
 	/* When adding an algorithm also add a static assert statement below */
 	/* end of real values */
@@ -317,13 +318,14 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 	StaticAssertStmt(COMPRESSION_ALGORITHM_GORILLA == 3, "algorithm index has changed");
 	StaticAssertStmt(COMPRESSION_ALGORITHM_DELTADELTA == 4, "algorithm index has changed");
 	StaticAssertStmt(COMPRESSION_ALGORITHM_BOOL == 5, "algorithm index has changed");
+	StaticAssertStmt(COMPRESSION_ALGORITHM_NULL == 6, "algorithm index has changed");
 
 	/*
 	 * This should change when adding a new algorithm after adding the new
 	 * algorithm to the assert list above. This statement prevents adding a
 	 * new algorithm without updating the asserts above
 	 */
-	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS == 6,
+	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS == 7,
 					 "number of algorithms have changed, the asserts should be updated");
 }
 

--- a/tsl/src/hypercore/arrow_array.c
+++ b/tsl/src/hypercore/arrow_array.c
@@ -364,6 +364,14 @@ arrow_from_compressed(Datum compressed, Oid typid, MemoryContext dest_mcxt, Memo
 	 */
 	MemoryContext oldcxt = MemoryContextSwitchTo(tmp_mcxt);
 	const CompressedDataHeader *header = (CompressedDataHeader *) PG_DETOAST_DATUM(compressed);
+	if (header->compression_algorithm == COMPRESSION_ALGORITHM_NULL)
+	{
+		/*
+		 * The NULL compression algorithm represents all NULL values.
+		 */
+		MemoryContextSwitchTo(oldcxt);
+		return NULL;
+	}
 	DecompressAllFunction decompress_all =
 		arrow_get_decompress_all(header->compression_algorithm, typid);
 

--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -2889,8 +2889,12 @@ hypercore_index_build_callback(Relation index, ItemPointer tid, Datum *values, b
 
 				/* The number of elements in the arrow array should be the
 				 * same as the number of rows in the segment (count
-				 * column). */
-				Assert(num_rows == icstate->arrow_columns[i]->length);
+				 * column), except when we use the NULL compression method
+				 * to signify all values are NULLs. In this case the
+				 * arrow_column value is NULL.
+				 */
+				Assert(icstate->arrow_columns[i] == NULL ||
+					   num_rows == icstate->arrow_columns[i]->length);
 			}
 			else
 			{

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -2653,8 +2653,10 @@ SELECT compress_chunk(show_chunks('test_notnull'));
  _timescaledb_internal._hyper_46_237_chunk
 (1 row)
 
--- broken atm due to bug in default handling in compression
+\set ON_ERROR_STOP 0
 ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+ERROR:  column "c2" of relation "_hyper_46_237_chunk" contains null values
+\set ON_ERROR_STOP 1
 -- test alias in parameter name
 CREATE TABLE alias(time timestamptz NOT NULL);
 SELECT create_hypertable('alias','time');

--- a/tsl/test/expected/compression_nulls_and_defaults.out
+++ b/tsl/test/expected/compression_nulls_and_defaults.out
@@ -1,0 +1,728 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- test case #1: altering a compressed hypertable by adding a new column
+-- with a default value
+--
+-- The point of this test is to verify the behaviour of the default value if
+-- the hypertable is compressed before the new column is added.
+-- It adds rows before and after the column is added to make sure that the
+-- default value is returned correctly in both cases. This is to make sure
+-- that changing the code related to the default value does not break the
+-- behaviour of the default values.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+NOTICE:  table "t" does not exist, skipping
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+NOTICE:  default order by for hypertable "t" is set to ""
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+alter table t add column a double precision default 7.1;
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+(1 row)
+
+select compress_chunk(show_chunks('t'));
+NOTICE:  chunk "_hyper_1_1_chunk" is already compressed
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+(1 row)
+
+insert into t (ts,c1) values (7,7);
+select compress_chunk(show_chunks('t'));
+NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+  7 |  7 | 7.1
+(2 rows)
+
+set timescaledb.enable_segmentwise_recompression to on;
+-- test case #2: altering an uncompressed hypertable by adding a new column
+-- with a default value
+--
+-- This is another test case to check that the correct behaviour is preserved
+-- after changing the code related to the default value.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (3,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t" is set to ""
+alter table t add column a double precision default 7.1;
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+(1 row)
+
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 |  6 |  
+(1 row)
+
+insert into t (ts,c1) values (7,7);
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 |  6 |  
+  7 |  7 |  
+(2 rows)
+
+-- test case #3: altering an uncompressed hypertable by adding a new column
+-- with a default value
+--
+-- This is one more testcase for establishing the correct behaviour of the
+-- default value after changing the code related to the default value.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (5,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+NOTICE:  default order by for hypertable "t" is set to ""
+alter table t add column a double precision default 7.1;
+insert into t (ts,c1) values (4,4);
+insert into t (ts,c1) values (5,5);
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_6_chunk
+(1 row)
+
+update t set a = null;
+select * from t;
+ ts | c1 | a 
+----+----+---
+  4 |  4 |  
+  5 |  5 |  
+  6 |  6 |  
+(3 rows)
+
+select compress_chunk(show_chunks('t'));
+NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_5_6_chunk"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_6_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  4 |  4 |  
+  5 |  5 |  
+  6 |  6 |  
+(3 rows)
+
+set timescaledb.enable_segmentwise_recompression to on;
+-- test case #4: altering a compressed hypertable by adding a new column
+-- with a default value
+--
+-- This is one more testcase for establishing the correct behaviour of the
+-- default value after changing the code.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (7,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t" is set to ""
+alter table t add column a double precision default 7.1;
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_9_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+(1 row)
+
+update t set a = null;
+insert into t (ts,c1) values (7,7);
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_9_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 |  6 |  
+  7 |  7 |  
+(2 rows)
+
+-- test case #5: altering an uncompressed hypertable by adding a new column
+-- with a default value
+--
+-- This is the first testcase to reproduce the problem found by Sven.
+-- Before the fix, the default value was not returned correctly after
+-- compressing the hypertable.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t (ts int);
+select create_hypertable('t', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (9,public,t,t)
+(1 row)
+
+alter table t set(timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+NOTICE:  default order by for hypertable "t" is set to ""
+insert into t (ts) values (1);
+alter table t add column c1 double precision default 42.99;
+update t set c1 = null;
+select * from t;
+ ts | c1 
+----+----
+  1 |   
+(1 row)
+
+select compress_chunk(show_chunks('t'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_11_chunk
+(1 row)
+
+select * from t;
+ ts | c1 
+----+----
+  1 |   
+(1 row)
+
+set timescaledb.enable_segmentwise_recompression to on;
+-- test case #6: altering a compressed hypertable by adding a new column
+-- with a default value
+--
+-- This is the second testcase to reproduce the problem, by Alex.
+-- Before the fix, the default value was not returned correctly after
+-- compressing the hypertable the second time.
+--
+drop table if exists t;
+create table t(ts int);
+select create_hypertable('t', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (11,public,t,t)
+(1 row)
+
+insert into t values (1);
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t" is set to ""
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_13_chunk
+(1 row)
+
+alter table t add column a double precision default 7.987;
+insert into t values (2, null);
+select * from t;
+ ts |   a   
+----+-------
+  1 | 7.987
+  2 |      
+(2 rows)
+
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_13_chunk
+(1 row)
+
+select * from t;
+ ts |   a   
+----+-------
+  1 | 7.987
+  2 |      
+(2 rows)
+
+-- test case #7: a variation of #1 where
+-- the default value is changed after the column is added
+--
+-- This is a variation of the first test case where the default value is
+-- changed after the column is added. This is to make sure that changing the
+-- default value does not break the behaviour of the default values.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (13,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+NOTICE:  default order by for hypertable "t" is set to ""
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_13_15_chunk
+(1 row)
+
+alter table t add column a double precision default 7.1;
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+(1 row)
+
+select compress_chunk(show_chunks('t'));
+NOTICE:  chunk "_hyper_13_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_13_15_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+(1 row)
+
+alter table t alter column a set default 7.2;
+insert into t (ts,c1) values (7,7);
+select compress_chunk(show_chunks('t'));
+NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_13_15_chunk"
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_13_15_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+  7 |  7 | 7.2
+(2 rows)
+
+set timescaledb.enable_segmentwise_recompression to on;
+-- test case #8: a variation of #5 and #7 where
+-- I change the default value multiple times
+--
+-- This is a variation of the previous test cases with changing the default
+-- values. Before the fix the first default value was returned for all rows
+-- even if it was changed twice afterwards and the value was set to null.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (15,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t" is set to ""
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_15_18_chunk
+(1 row)
+
+alter table t add column a double precision default 7.1;
+alter table t alter column a set default 8.2;
+insert into t (ts,c1) values (7,7);
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+  7 |  7 | 8.2
+(2 rows)
+
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_15_18_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+  7 |  7 | 8.2
+(2 rows)
+
+alter table t alter column a set default 9.3;
+insert into t (ts,c1) values (8,8);
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+  7 |  7 | 8.2
+  8 |  8 | 9.3
+(3 rows)
+
+update t set a = null;
+select * from t;
+ ts | c1 | a 
+----+----+---
+  8 |  8 |  
+  6 |  6 |  
+  7 |  7 |  
+(3 rows)
+
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_15_18_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 |  6 |  
+  7 |  7 |  
+  8 |  8 |  
+(3 rows)
+
+-- test case #9: a variation of the previous ones with the twist
+-- of updating another column which triggers decompression and
+-- risk of re-applying the default value for the other column.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (17,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t" is set to ""
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_17_20_chunk
+(1 row)
+
+alter table t add column a double precision default 7.1;
+select compress_chunk(show_chunks('t'));
+NOTICE:  chunk "_hyper_17_20_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_17_20_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  6 |  6 | 7.1
+(1 row)
+
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_17_20_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 |  6 |  
+(1 row)
+
+update t set c1 = 99, a = null;
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 | 99 |  
+(1 row)
+
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_17_20_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 | 99 |  
+(1 row)
+
+update t set c1 = 98;
+select * from t;
+ ts | c1 | a 
+----+----+---
+  6 | 98 |  
+(1 row)
+
+-- test case #10: adding a few columns to a compressed hypertable
+-- and then updating them to null and dropping them
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (19,public,t,t)
+(1 row)
+
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t" is set to ""
+insert into t (ts,c1) values (1,1);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+alter table t add column a double precision default 3.3;
+insert into t (ts,c1) values (2,2);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  
+----+----+-----
+  1 |  1 | 3.3
+  2 |  2 | 3.3
+(2 rows)
+
+alter table t add column b double precision default 4.4;
+insert into t (ts,c1) values (3,3);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  |  b  
+----+----+-----+-----
+  1 |  1 | 3.3 | 4.4
+  2 |  2 | 3.3 | 4.4
+  3 |  3 | 3.3 | 4.4
+(3 rows)
+
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | a |  b  
+----+----+---+-----
+  1 |  1 |   | 4.4
+  2 |  2 |   | 4.4
+  3 |  3 |   | 4.4
+(3 rows)
+
+alter table t add column c double precision;
+insert into t (ts,c1) values (4,4);
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  |  b  | c 
+----+----+-----+-----+---
+  1 |  1 |     | 4.4 |  
+  2 |  2 |     | 4.4 |  
+  3 |  3 |     | 4.4 |  
+  4 |  4 | 3.3 | 4.4 |  
+(4 rows)
+
+update t set b = null;
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 |  a  | b | c 
+----+----+-----+---+---
+  1 |  1 |     |   |  
+  2 |  2 |     |   |  
+  3 |  3 |     |   |  
+  4 |  4 | 3.3 |   |  
+(4 rows)
+
+alter table t drop column a;
+update t set b = null;
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | b | c 
+----+----+---+---
+  1 |  1 |   |  
+  2 |  2 |   |  
+  3 |  3 |   |  
+  4 |  4 |   |  
+(4 rows)
+
+alter table t drop column b;
+update t set c = null;
+select compress_chunk(show_chunks('t'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_22_chunk
+(1 row)
+
+select * from t;
+ ts | c1 | c 
+----+----+---
+  1 |  1 |  
+  2 |  2 |  
+  3 |  3 |  
+  4 |  4 |  
+(4 rows)
+
+-- this is to make codecove happy so we exercise some
+-- code paths that are hard to do through the unit tests
+drop table if exists codecov;
+NOTICE:  table "codecov" does not exist, skipping
+create table codecov(ts int, c1 int);
+select create_hypertable('codecov','ts');
+NOTICE:  adding not-null constraint to column "ts"
+   create_hypertable   
+-----------------------
+ (21,public,codecov,t)
+(1 row)
+
+alter table codecov set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "codecov" is set to ""
+insert into codecov (ts,c1) values (1,NULL);
+select compress_chunk(show_chunks('codecov'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_21_24_chunk
+(1 row)
+
+DO $$
+DECLARE
+	comp_regclass REGCLASS;
+	rec RECORD;
+BEGIN
+	FOR comp_regclass IN
+		SELECT
+			format('%I.%I', comp.schema_name, comp.table_name)::regclass as comp_regclass
+		FROM
+			_timescaledb_catalog.chunk uncomp,
+			_timescaledb_catalog.chunk comp,
+			(SELECT show_chunks('codecov') as c) as x
+		WHERE
+			uncomp.dropped IS FALSE AND uncomp.compressed_chunk_id IS NOT NULL AND
+			comp.id = uncomp.compressed_chunk_id AND
+			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
+	LOOP
+		-- codecov to record coverage of 'tsl_compressed_data_info'
+		FOR rec IN
+			EXECUTE format('SELECT c1, _timescaledb_functions.compressed_data_info(c1) FROM %s', comp_regclass)
+		LOOP
+			RAISE NOTICE 'Compressed info results: %', rec;
+		END LOOP;
+
+		-- codecov to record coverage of 'tsl_compressed_data_has_nulls'
+		FOR rec IN
+			EXECUTE format('SELECT c1, _timescaledb_functions.compressed_data_has_nulls(c1) FROM %s', comp_regclass)
+		LOOP
+			RAISE NOTICE 'Has nulls results: %', rec;
+		END LOOP;
+
+	END LOOP;
+END;
+$$;
+NOTICE:  Compressed info results: (Bg==,"(NULL,t)")
+NOTICE:  Has nulls results: (Bg==,t)

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -50,9 +50,9 @@ INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
 SELECT compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name_1
 from compressed_chunk_info_view where hypertable_name = 'mytab_oneseg' \gset
 SELECT ctid, * FROM :compressed_chunk_name_1;
- ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 | b 
--------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+---
- (0,1) |              2 | 2 | 2 | Sun Jan 01 11:56:10.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/qlnY///////Z2mAAAAAAgAAAAIAAAAAAAAA7gAFKG/+g/vGAAUob/+1KMU= | 
+ ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 |  b   
+-------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+------
+ (0,1) |              2 | 2 | 2 | Sun Jan 01 11:56:10.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/qlnY///////Z2mAAAAAAgAAAAIAAAAAAAAA7gAFKG/+g/vGAAUob/+1KMU= | Bg==
 (1 row)
 
 -- after compressing the chunk
@@ -79,10 +79,10 @@ INFO:  Using index "compress_hyper_2_2_chunk_a_c__ts_meta_min_1__ts_meta_max_1_i
 
 -- check the ctid of the rows in the recompressed chunk to verify that we've written new data
 SELECT ctid, * FROM :compressed_chunk_name_1;
- ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 | b 
--------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+---
- (0,1) |              2 | 2 | 2 | Sun Jan 01 11:56:10.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/qlnY///////Z2mAAAAAAgAAAAIAAAAAAAAA7gAFKG/+g/vGAAUob/+1KMU= | 
- (0,2) |              1 | 2 | 2 | Sun Jan 01 09:56:20.048355 2023 PST | Sun Jan 01 09:56:20.048355 2023 PST | BAAAApQ2Uhq14wAClDZSGrXjAAAAAQAAAAEAAAAAAAAADgAFKGykNWvG             | 
+ ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 |  b   
+-------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+------
+ (0,1) |              2 | 2 | 2 | Sun Jan 01 11:56:10.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/qlnY///////Z2mAAAAAAgAAAAIAAAAAAAAA7gAFKG/+g/vGAAUob/+1KMU= | Bg==
+ (0,2) |              1 | 2 | 2 | Sun Jan 01 09:56:20.048355 2023 PST | Sun Jan 01 09:56:20.048355 2023 PST | BAAAApQ2Uhq14wAClDZSGrXjAAAAAQAAAAEAAAAAAAAADgAFKGykNWvG             | Bg==
 (2 rows)
 
 -- after recompressing chunk
@@ -144,10 +144,10 @@ select * from :chunk_to_compress_2 ORDER BY a, c, time DESC;
 SELECT compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name_2
 from compressed_chunk_info_view where hypertable_name = 'mytab_twoseg' \gset
 select ctid, * from :compressed_chunk_name_2;
- ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 | b 
--------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+---
- (0,1) |              1 | 2 | 2 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/0H94wAClDf/Qf3jAAAAAQAAAAEAAAAAAAAADgAFKG/+g/vG             | 
- (0,2) |              2 | 3 | 3 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:57:20.048355 2023 PST | BAAAApQ3/0H94//////8bHkAAAAAAgAAAAIAAAAAAAAA7gAFKHAFqwnGAAUocAzSF8U= | 
+ ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 |  b   
+-------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+------
+ (0,1) |              1 | 2 | 2 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/0H94wAClDf/Qf3jAAAAAQAAAAEAAAAAAAAADgAFKG/+g/vG             | Bg==
+ (0,2) |              2 | 3 | 3 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:57:20.048355 2023 PST | BAAAApQ3/0H94//////8bHkAAAAAAgAAAAIAAAAAAAAA7gAFKHAFqwnGAAUocAzSF8U= | Bg==
 (2 rows)
 
 select _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress_2');
@@ -159,11 +159,11 @@ INFO:  Using index "compress_hyper_4_4_chunk_a_c__ts_meta_min_1__ts_meta_max_1_i
 
 -- verify that metadata count looks good
 select ctid, * from :compressed_chunk_name_2;
- ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 | b 
--------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+---
- (0,1) |              1 | 2 | 2 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/0H94wAClDf/Qf3jAAAAAQAAAAEAAAAAAAAADgAFKG/+g/vG             | 
- (0,2) |              2 | 3 | 3 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:57:20.048355 2023 PST | BAAAApQ3/0H94//////8bHkAAAAAAgAAAAIAAAAAAAAA7gAFKHAFqwnGAAUocAzSF8U= | 
- (0,3) |              1 | 2 | 2 | Sun Jan 01 09:56:20.048355 2023 PST | Sun Jan 01 09:56:20.048355 2023 PST | BAAAApQ2Uhq14wAClDZSGrXjAAAAAQAAAAEAAAAAAAAADgAFKGykNWvG             | 
+ ctid  | _ts_meta_count | a | c |           _ts_meta_min_1            |           _ts_meta_max_1            |                                 time                                 |  b   
+-------+----------------+---+---+-------------------------------------+-------------------------------------+----------------------------------------------------------------------+------
+ (0,1) |              1 | 2 | 2 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:56:20.048355 2023 PST | BAAAApQ3/0H94wAClDf/Qf3jAAAAAQAAAAEAAAAAAAAADgAFKG/+g/vG             | Bg==
+ (0,2) |              2 | 3 | 3 | Sun Jan 01 11:56:20.048355 2023 PST | Sun Jan 01 11:57:20.048355 2023 PST | BAAAApQ3/0H94//////8bHkAAAAAAgAAAAIAAAAAAAAA7gAFKHAFqwnGAAUocAzSF8U= | Bg==
+ (0,3) |              1 | 2 | 2 | Sun Jan 01 09:56:20.048355 2023 PST | Sun Jan 01 09:56:20.048355 2023 PST | BAAAApQ2Uhq14wAClDZSGrXjAAAAAQAAAAEAAAAAAAAADgAFKGykNWvG             | Bg==
 (3 rows)
 
 -- verify that initial data is returned as expected
@@ -209,17 +209,17 @@ and compressed_chunk_name is not null limit 1 \gset
 insert into mytab2 values ('2023-01-01 00:00:02+00'::timestamptz, 0, NULL, 0); -- goes into the uncompressed chunk
 select show_chunks('mytab2') as chunk_to_compress_2 \gset
 select ctid, * from :compressed_chunk_name_2;
- ctid  | _ts_meta_count | a | c |        _ts_meta_min_1        |        _ts_meta_max_1        |                                       time                                       | b 
--------+----------------+---+---+------------------------------+------------------------------+----------------------------------------------------------------------------------+---
- (0,1) |           1000 | 0 | 0 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA== | 
- (0,2) |           1000 | 0 | 0 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA== | 
- (0,3) |            881 | 0 | 0 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA== | 
- (0,4) |           1000 | 1 | 1 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA== | 
- (0,5) |           1000 | 1 | 1 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA== | 
- (0,6) |            881 | 1 | 1 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA== | 
- (0,7) |           1000 | 2 | 2 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA== | 
- (0,8) |           1000 | 2 | 2 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA== | 
- (0,9) |            881 | 2 | 2 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA== | 
+ ctid  | _ts_meta_count | a | c |        _ts_meta_min_1        |        _ts_meta_max_1        |                                       time                                       |  b   
+-------+----------------+---+---+------------------------------+------------------------------+----------------------------------------------------------------------------------+------
+ (0,1) |           1000 | 0 | 0 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA== | Bg==
+ (0,2) |           1000 | 0 | 0 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA== | Bg==
+ (0,3) |            881 | 0 | 0 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA== | Bg==
+ (0,4) |           1000 | 1 | 1 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA== | Bg==
+ (0,5) |           1000 | 1 | 1 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA== | Bg==
+ (0,6) |            881 | 1 | 1 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA== | Bg==
+ (0,7) |           1000 | 2 | 2 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA== | Bg==
+ (0,8) |           1000 | 2 | 2 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA== | Bg==
+ (0,9) |            881 | 2 | 2 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA== | Bg==
 (9 rows)
 
 -- after compression
@@ -238,17 +238,17 @@ INFO:  Using index "compress_hyper_6_6_chunk_a_c__ts_meta_min_1__ts_meta_max_1_i
 (1 row)
 
 select ctid, * from :compressed_chunk_name_2;
-  ctid  | _ts_meta_count | a | c |        _ts_meta_min_1        |        _ts_meta_max_1        |                                           time                                           | b 
---------+----------------+---+---+------------------------------+------------------------------+------------------------------------------------------------------------------------------+---
- (0,1)  |           1000 | 0 | 0 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA==         | 
- (0,2)  |           1000 | 0 | 0 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA==         | 
- (0,4)  |           1000 | 1 | 1 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA==         | 
- (0,5)  |           1000 | 1 | 1 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA==         | 
- (0,6)  |            881 | 1 | 1 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA==         | 
- (0,7)  |           1000 | 2 | 2 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA==         | 
- (0,8)  |           1000 | 2 | 2 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA==         | 
- (0,9)  |            881 | 2 | 2 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA==         | 
- (0,10) |            882 | 0 | 0 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP//////4XuAAAADcgAAAAQAAAAAAADf7gAFKFrcytAAAAUoWuBeVv8AADbgAAAAAAMZdQAAPQkA | 
+  ctid  | _ts_meta_count | a | c |        _ts_meta_min_1        |        _ts_meta_max_1        |                                           time                                           |  b   
+--------+----------------+---+---+------------------------------+------------------------------+------------------------------------------------------------------------------------------+------
+ (0,1)  |           1000 | 0 | 0 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA==         | Bg==
+ (0,2)  |           1000 | 0 | 0 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA==         | Bg==
+ (0,4)  |           1000 | 1 | 1 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA==         | Bg==
+ (0,5)  |           1000 | 1 | 1 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA==         | Bg==
+ (0,6)  |            881 | 1 | 1 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA==         | Bg==
+ (0,7)  |           1000 | 2 | 2 | Sun Jan 01 07:40:30 2023 PST | Sun Jan 01 16:00:00 2023 PST | BAAAApQ0bFLXgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKHbNWYAAAAUodtDtBv8AAD5gAAAAAA==         | Bg==
+ (0,8)  |           1000 | 2 | 2 | Sat Dec 31 23:20:30 2022 PST | Sun Jan 01 07:40:00 2023 PST | BAAAApQtcC8rgP/////+NjyAAAAD6AAAAAMAAAAAAAAP7gAFKGjVEigAAAUoaNilrv8AAD5gAAAAAA==         | Bg==
+ (0,9)  |            881 | 2 | 2 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP/////+NjyAAAADcQAAAAMAAAAAAAAP7gAFKFrcytAAAAUoWuBeVv8AADbwAAAAAA==         | Bg==
+ (0,10) |            882 | 0 | 0 | Sat Dec 31 16:00:00 2022 PST | Sat Dec 31 23:20:00 2022 PST | BAAAApQnSNVgAP//////4XuAAAADcgAAAAQAAAAAAADf7gAFKFrcytAAAAUoWuBeVv8AADbgAAAAAAMZdQAAPQkA | Bg==
 (9 rows)
 
 -- stats are no longer updated during segmentwise recompression

--- a/tsl/test/expected/vector_agg_filter.out
+++ b/tsl/test/expected/vector_agg_filter.out
@@ -60,6 +60,55 @@ select t, s, cint2, cint4,
     end as ss
 from source where s != 1
 ;
+-- print a few reference values before compression
+select count(ss) from aggfilter;
+ count  
+--------
+ 179981
+(1 row)
+
+select count(ss) filter (where cint2 < 0) from aggfilter;
+ count 
+-------
+ 90014
+(1 row)
+
+select count(ss) filter (where cint4 > 0) from aggfilter;
+ count 
+-------
+ 90142
+(1 row)
+
+select count(ss) filter (where s != 5) from aggfilter;
+ count  
+--------
+ 159981
+(1 row)
+
+select s, count(ss) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+ s | count 
+---+-------
+ 2 |     0
+(1 row)
+
+select s, count(ss) filter (where cint2 < 0) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+ s | count 
+---+-------
+ 2 |     0
+(1 row)
+
+select s, count(ss) filter (where ss > 1000) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+ s | count 
+---+-------
+ 2 |     0
+(1 row)
+
+select s, count(ss) filter (where cint4 > 0) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+ s | count 
+---+-------
+ 2 |     0
+(1 row)
+
 select count(compress_chunk(x)) from show_chunks('aggfilter') x;
  count 
 -------
@@ -851,13 +900,13 @@ select s, min(s) filter (where s != 5) from aggfilter group by s order by min(s)
 select count(ss) from aggfilter;
  count  
 --------
- 199981
+ 179981
 (1 row)
 
 select count(ss) filter (where cint2 < 0) from aggfilter;
- count  
---------
- 100127
+ count 
+-------
+ 90014
 (1 row)
 
 select count(ss) filter (where ss > 1000) from aggfilter;
@@ -867,24 +916,24 @@ select count(ss) filter (where ss > 1000) from aggfilter;
 (1 row)
 
 select count(ss) filter (where cint4 > 0) from aggfilter;
- count  
---------
- 100027
+ count 
+-------
+ 90142
 (1 row)
 
 select count(ss) filter (where s != 5) from aggfilter;
  count  
 --------
- 179981
+ 159981
 (1 row)
 
 select s, count(ss) from aggfilter group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  3 | 19981
  0 | 20000
  1 | 20000
- 2 | 20000
  4 | 20000
  5 | 20000
  6 | 20000
@@ -896,10 +945,10 @@ select s, count(ss) from aggfilter group by s order by count(ss), s limit 10;
 select s, count(ss) filter (where cint2 < 0) from aggfilter group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  3 | 10076
  0 |  9968
  1 |  9885
- 2 | 10113
  4 | 10074
  5 |  9871
  6 | 10089
@@ -911,10 +960,10 @@ select s, count(ss) filter (where cint2 < 0) from aggfilter group by s order by 
 select s, count(ss) filter (where ss > 1000) from aggfilter group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  3 |     0
  0 |     0
  1 |     0
- 2 |     0
  4 |     0
  5 |     0
  6 |     0
@@ -926,10 +975,10 @@ select s, count(ss) filter (where ss > 1000) from aggfilter group by s order by 
 select s, count(ss) filter (where cint4 > 0) from aggfilter group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  3 | 10052
  0 | 10002
  1 | 10046
- 2 |  9885
  4 |  9995
  5 | 10106
  6 |  9977
@@ -941,10 +990,10 @@ select s, count(ss) filter (where cint4 > 0) from aggfilter group by s order by 
 select s, count(ss) filter (where s != 5) from aggfilter group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  3 | 19981
  0 | 20000
  1 | 20000
- 2 | 20000
  4 | 20000
  5 |     0
  6 | 20000
@@ -995,7 +1044,7 @@ select s, min(ss) from aggfilter group by s order by min(ss), s limit 10;
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where cint2 < 0) from aggfilter group by s order by min(ss), s limit 10;
@@ -1010,7 +1059,7 @@ select s, min(ss) filter (where cint2 < 0) from aggfilter group by s order by mi
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where ss > 1000) from aggfilter group by s order by min(ss), s limit 10;
@@ -1040,7 +1089,7 @@ select s, min(ss) filter (where cint4 > 0) from aggfilter group by s order by mi
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where s != 5) from aggfilter group by s order by min(ss), s limit 10;
@@ -1055,7 +1104,7 @@ select s, min(ss) filter (where s != 5) from aggfilter group by s order by min(s
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select count(*) from aggfilter where cint2 > 0;
@@ -1796,7 +1845,7 @@ select s, min(s) filter (where s != 5) from aggfilter where cint2 > 0 group by s
 select count(ss) from aggfilter where cint2 > 0;
  count 
 -------
- 99657
+ 89789
 (1 row)
 
 select count(ss) filter (where cint2 < 0) from aggfilter where cint2 > 0;
@@ -1814,19 +1863,19 @@ select count(ss) filter (where ss > 1000) from aggfilter where cint2 > 0;
 select count(ss) filter (where cint4 > 0) from aggfilter where cint2 > 0;
  count 
 -------
- 49813
+ 44890
 (1 row)
 
 select count(ss) filter (where s != 5) from aggfilter where cint2 > 0;
  count 
 -------
- 89547
+ 79679
 (1 row)
 
 select s, count(ss) from aggfilter where cint2 > 0 group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
- 2 |  9868
+ 2 |     0
  3 |  9886
  6 |  9890
  8 |  9898
@@ -1871,7 +1920,7 @@ select s, count(ss) filter (where ss > 1000) from aggfilter where cint2 > 0 grou
 select s, count(ss) filter (where cint4 > 0) from aggfilter where cint2 > 0 group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
- 2 |  4923
+ 2 |     0
  3 |  4968
  6 |  4911
  8 |  4929
@@ -1886,7 +1935,7 @@ select s, count(ss) filter (where cint4 > 0) from aggfilter where cint2 > 0 grou
 select s, count(ss) filter (where s != 5) from aggfilter where cint2 > 0 group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
- 2 |  9868
+ 2 |     0
  3 |  9886
  6 |  9890
  8 |  9898
@@ -1940,7 +1989,7 @@ select s, min(ss) from aggfilter where cint2 > 0 group by s order by min(ss), s 
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where cint2 < 0) from aggfilter where cint2 > 0 group by s order by min(ss), s limit 10;
@@ -1985,7 +2034,7 @@ select s, min(ss) filter (where cint4 > 0) from aggfilter where cint2 > 0 group 
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where s != 5) from aggfilter where cint2 > 0 group by s order by min(ss), s limit 10;
@@ -2000,7 +2049,7 @@ select s, min(ss) filter (where s != 5) from aggfilter where cint2 > 0 group by 
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select count(*) from aggfilter where cint2 is null;
@@ -2741,7 +2790,7 @@ select s, min(s) filter (where s != 5) from aggfilter where cint2 is null group 
 select count(ss) from aggfilter where cint2 is null;
  count 
 -------
-   190
+   171
 (1 row)
 
 select count(ss) filter (where cint2 < 0) from aggfilter where cint2 is null;
@@ -2759,21 +2808,21 @@ select count(ss) filter (where ss > 1000) from aggfilter where cint2 is null;
 select count(ss) filter (where cint4 > 0) from aggfilter where cint2 is null;
  count 
 -------
-    92
+    83
 (1 row)
 
 select count(ss) filter (where s != 5) from aggfilter where cint2 is null;
  count 
 -------
-   171
+   152
 (1 row)
 
 select s, count(ss) from aggfilter where cint2 is null group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  0 |    19
  1 |    19
- 2 |    19
  3 |    19
  4 |    19
  5 |    19
@@ -2786,9 +2835,9 @@ select s, count(ss) from aggfilter where cint2 is null group by s order by count
 select s, count(ss) filter (where cint2 < 0) from aggfilter where cint2 is null group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  0 |     0
  1 |     0
- 2 |     0
  3 |     0
  4 |     0
  5 |     0
@@ -2801,9 +2850,9 @@ select s, count(ss) filter (where cint2 < 0) from aggfilter where cint2 is null 
 select s, count(ss) filter (where ss > 1000) from aggfilter where cint2 is null group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  0 |     0
  1 |     0
- 2 |     0
  3 |     0
  4 |     0
  5 |     0
@@ -2816,9 +2865,9 @@ select s, count(ss) filter (where ss > 1000) from aggfilter where cint2 is null 
 select s, count(ss) filter (where cint4 > 0) from aggfilter where cint2 is null group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  0 |     9
  1 |    12
- 2 |     9
  3 |    11
  4 |     5
  5 |    11
@@ -2831,9 +2880,9 @@ select s, count(ss) filter (where cint4 > 0) from aggfilter where cint2 is null 
 select s, count(ss) filter (where s != 5) from aggfilter where cint2 is null group by s order by count(ss), s limit 10;
  s | count 
 ---+-------
+ 2 |     0
  0 |    19
  1 |    19
- 2 |    19
  3 |    19
  4 |    19
  5 |     0
@@ -2885,7 +2934,7 @@ select s, min(ss) from aggfilter where cint2 is null group by s order by min(ss)
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where cint2 < 0) from aggfilter where cint2 is null group by s order by min(ss), s limit 10;
@@ -2930,7 +2979,7 @@ select s, min(ss) filter (where cint4 > 0) from aggfilter where cint2 is null gr
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select s, min(ss) filter (where s != 5) from aggfilter where cint2 is null group by s order by min(ss), s limit 10;
@@ -2945,7 +2994,7 @@ select s, min(ss) filter (where s != 5) from aggfilter where cint2 is null group
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 reset timescaledb.debug_require_vector_agg;
@@ -2976,7 +3025,6 @@ order by 2, 3;
  ss | count | count 
 ----+-------+-------
   5 |     0 |  9871
-    |    19 |    12
   4 | 19981 | 10064
   3 | 19981 | 10076
   9 | 20000 |  9961
@@ -2984,7 +3032,8 @@ order by 2, 3;
   7 | 20000 | 10008
   8 | 20000 | 10082
   6 | 20000 | 10089
- 11 | 40019 | 20008
+ 11 | 20019 |  9895
+    | 20019 | 10125
 (10 rows)
 
 reset timescaledb.debug_require_vector_agg;

--- a/tsl/test/expected/vector_agg_functions.out
+++ b/tsl/test/expected/vector_agg_functions.out
@@ -71,6 +71,60 @@ select *, ss::text as x from (
     from source where s != 1
 ) t
 ;
+-- print some reference results before compression
+select ss, count(*) from aggfns group by ss having (ss=11 or ss is null) order by count(*), ss limit 10;
+ ss | count 
+----+-------
+ 11 | 20019
+    | 20019
+(2 rows)
+
+select ss, min(cdate) from aggfns group by ss having (ss is null) order by min(cdate), ss limit 10;
+ ss |    min     
+----+------------
+    | 10-05-2075
+(1 row)
+
+select ss, avg(cfloat4) from aggfns group by ss having (ss is null) order by avg(cfloat4), ss limit 10;
+ ss |   avg    
+----+----------
+    | Infinity
+(1 row)
+
+select ss, max(cfloat4) from aggfns group by ss having (ss=11 or ss is null) order by max(cfloat4), ss limit 10;
+ ss |   max    
+----+----------
+    | Infinity
+ 11 |      NaN
+(2 rows)
+
+select ss, min(cfloat4) from aggfns group by ss having (ss=11 or ss is null) order by min(cfloat4), ss limit 10;
+ ss |   min    
+----+----------
+    | -49.9991
+ 11 | -49.9974
+(2 rows)
+
+select ss, stddev(cfloat4) from aggfns group by ss having (ss is null) order by stddev(cfloat4), ss limit 10;
+ ss | stddev 
+----+--------
+    |    NaN
+(1 row)
+
+select ss, avg(cfloat8) from aggfns group by ss having (ss is null or ss=11) order by avg(cfloat8), ss limit 10;
+ ss |        avg        
+----+-------------------
+    | 0.203097089119745
+ 11 |  12.9913492471038
+(2 rows)
+
+select ss, max(cfloat8) from aggfns group by ss having (ss is null or ss=11) order by max(cfloat8), ss limit 10;
+ ss |       max        
+----+------------------
+ 11 | 42.8941954858601
+    | 49.9975695507601
+(2 rows)
+
 select count(compress_chunk(x)) from show_chunks('aggfns') x;
  count 
 -------
@@ -201,7 +255,6 @@ select s, count(*) from aggfns group by s order by count(*), s limit 10;
 select ss, count(*) from aggfns group by ss order by count(*), ss limit 10;
  ss | count 
 ----+-------
-    |    19
   3 | 19981
   4 | 19981
   0 | 20000
@@ -210,7 +263,8 @@ select ss, count(*) from aggfns group by ss order by count(*), ss limit 10;
   7 | 20000
   8 | 20000
   9 | 20000
- 11 | 40019
+ 11 | 20019
+    | 20019
 (10 rows)
 
 select max(cdate) from aggfns;
@@ -275,8 +329,8 @@ select ss, min(cdate) from aggfns group by ss order by min(cdate), ss limit 10;
 ----+------------
   0 | 01-01-2021
  11 | 05-19-2048
+    | 10-05-2075
   3 | 02-21-2103
-    | 02-21-2103
   4 | 07-09-2130
   5 | 11-24-2157
   6 | 04-11-2185
@@ -310,7 +364,6 @@ select ss, avg(cfloat4) from aggfns group by ss order by avg(cfloat4), ss limit 
  ss |         avg          
 ----+----------------------
   3 |            -Infinity
-    |    -1.39583652270468
   9 |   -0.292700759558938
   4 |   -0.169252917487522
   6 | -0.00610964622725733
@@ -318,6 +371,7 @@ select ss, avg(cfloat4) from aggfns group by ss order by avg(cfloat4), ss limit 
   0 |   0.0862269837114494
   7 |     0.19168354413514
   8 |    0.456703752867272
+    |             Infinity
  11 |                  NaN
 (10 rows)
 
@@ -343,18 +397,18 @@ select s, max(cfloat4) from aggfns group by s order by max(cfloat4), s limit 10;
 (10 rows)
 
 select ss, max(cfloat4) from aggfns group by ss order by max(cfloat4), ss limit 10;
- ss |   max   
-----+---------
-    | 47.2047
-  9 | 49.9899
-  4 | 49.9946
-  6 | 49.9956
-  7 | 49.9969
-  3 | 49.9979
-  5 | 49.9992
-  0 | 49.9995
-  8 | 49.9997
- 11 |     NaN
+ ss |   max    
+----+----------
+  9 |  49.9899
+  4 |  49.9946
+  6 |  49.9956
+  7 |  49.9969
+  3 |  49.9979
+  5 |  49.9992
+  0 |  49.9995
+  8 |  49.9997
+    | Infinity
+ 11 |      NaN
 (10 rows)
 
 select min(cfloat4) from aggfns;
@@ -384,13 +438,13 @@ select ss, min(cfloat4) from aggfns group by ss order by min(cfloat4), ss limit 
   3 | -Infinity
   4 |  -49.9999
   6 |  -49.9995
- 11 |  -49.9991
+    |  -49.9991
   7 |  -49.9984
+ 11 |  -49.9974
   8 |  -49.9969
   0 |  -49.9949
   5 |  -49.9942
   9 |  -49.9911
-    |  -45.4083
 (10 rows)
 
 select stddev(cfloat4) from aggfns;
@@ -424,9 +478,9 @@ select ss, stddev(cfloat4) from aggfns group by ss order by stddev(cfloat4), ss 
   6 | 28.9190577543738
   8 | 29.0040125904064
   5 | 29.0213532270614
-    | 30.6324072248673
   3 |              NaN
  11 |              NaN
+    |              NaN
 (10 rows)
 
 select sum(cfloat4) from aggfns;
@@ -457,11 +511,11 @@ select ss, sum(cfloat4) from aggfns group by ss order by sum(cfloat4), ss limit 
   9 |  -5854.02
   4 |  -3381.84
   6 |  -122.193
-    |  -26.5209
   5 |   215.643
   0 |   1724.54
   7 |   3833.67
   8 |   9134.08
+    |  Infinity
  11 |       NaN
 (10 rows)
 
@@ -497,8 +551,8 @@ select ss, avg(cfloat8) from aggfns group by ss order by avg(cfloat8), ss limit 
   7 | -0.063637967283139
   5 | 0.0438265096326359
   6 |  0.169599099685438
-    |   5.42090986487701
- 11 |   6.59778165165114
+    |  0.203097089119745
+ 11 |   12.9913492471038
 (10 rows)
 
 select max(cfloat8) from aggfns;
@@ -525,14 +579,14 @@ select s, max(cfloat8) from aggfns group by s order by max(cfloat8), s limit 10;
 select ss, max(cfloat8) from aggfns group by ss order by max(cfloat8), ss limit 10;
  ss |       max        
 ----+------------------
-    | 46.3985309237614
+ 11 | 42.8941954858601
   5 | 49.9874341068789
   3 | 49.9890822684392
   6 | 49.9939429108053
   8 | 49.9963666079566
   0 | 49.9965498689562
   7 | 49.9973275698721
- 11 | 49.9975695507601
+    | 49.9975695507601
   4 | 49.9978997278959
   9 | 49.9995574122295
 (10 rows)
@@ -562,7 +616,7 @@ select ss, min(cfloat8) from aggfns group by ss order by min(cfloat8), ss limit 
  ss |        min        
 ----+-------------------
   0 | -49.9994775978848
- 11 | -49.9985320260748
+    | -49.9985320260748
   4 | -49.9983572866768
   3 | -49.9977725092322
   6 | -49.9967515002936
@@ -570,7 +624,7 @@ select ss, min(cfloat8) from aggfns group by ss order by min(cfloat8), ss limit 
   5 | -49.9921301845461
   7 |   -49.99003498815
   8 | -49.9897602945566
-    | -38.5084833716974
+ 11 | -46.2087355088443
 (10 rows)
 
 select stddev(cfloat8) from aggfns;
@@ -595,18 +649,18 @@ select s, stddev(cfloat8) from aggfns group by s order by stddev(cfloat8), s lim
 (10 rows)
 
 select ss, stddev(cfloat8) from aggfns group by ss order by stddev(cfloat8), ss limit 10;
- ss |      stddev      
-----+------------------
- 11 | 21.3262797346004
-    |  22.894065438835
-  9 | 28.7642081921344
-  4 | 28.7760615445521
-  5 | 28.7843925303698
-  6 | 28.8543767497508
-  3 |  28.926156595386
-  8 |   28.96331707256
-  0 | 28.9653425568561
-  7 | 28.9656492103736
+ ss |      stddev       
+----+-------------------
+ 11 | 0.998497915010093
+    |  28.7561000172161
+  9 |  28.7642081921344
+  4 |  28.7760615445521
+  5 |  28.7843925303698
+  6 |  28.8543767497508
+  3 |   28.926156595386
+  8 |    28.96331707256
+  0 |  28.9653425568561
+  7 |  28.9656492103736
 (10 rows)
 
 select sum(cfloat8) from aggfns;
@@ -639,10 +693,10 @@ select ss, sum(cfloat8) from aggfns group by ss order by sum(cfloat8), ss limit 
   3 | -3066.93256727885
   9 | -2296.84818079695
   7 | -1272.75934566278
-    |  102.997287432663
   5 |  876.530192652717
   6 |  3391.98199370876
- 11 |  264036.623917427
+    |  4065.80062708817
+ 11 |  260073.820577771
 (10 rows)
 
 select avg(cint2) from aggfns;
@@ -667,18 +721,18 @@ select s, avg(cint2) from aggfns group by s order by avg(cint2), s limit 10;
 (10 rows)
 
 select ss, avg(cint2) from aggfns group by ss order by avg(cint2), ss limit 10;
- ss |          avg           
-----+------------------------
-    | -1368.1578947368421053
-  8 |  -129.4959711726139833
-  3 |   -94.5546037471195271
-  6 |   -61.0756218407487113
-  7 |   -55.8695260497472599
- 11 |   -33.7550336409794652
-  4 |   -27.5652740206392145
-  9 |   -21.7994594865121866
-  0 |    17.5951654071367799
-  5 |   110.0305290025524248
+ ss |          avg          
+----+-----------------------
+    | -159.4671500000000000
+  8 | -129.4959711726139833
+  3 |  -94.5546037471195271
+  6 |  -61.0756218407487113
+  7 |  -55.8695260497472599
+  4 |  -27.5652740206392145
+  9 |  -21.7994594865121866
+  0 |   17.5951654071367799
+ 11 |   90.6894000000000000
+  5 |  110.0305290025524248
 (10 rows)
 
 select count(cint2) from aggfns;
@@ -705,7 +759,6 @@ select s, count(cint2) from aggfns group by s order by count(cint2), s limit 10;
 select ss, count(cint2) from aggfns group by ss order by count(cint2), ss limit 10;
  ss | count 
 ----+-------
-    |    19
   3 | 19962
   4 | 19962
   0 | 19981
@@ -714,7 +767,8 @@ select ss, count(cint2) from aggfns group by ss order by count(cint2), ss limit 
   7 | 19981
   8 | 19981
   9 | 19981
- 11 | 39981
+ 11 | 20000
+    | 20000
 (10 rows)
 
 select max(cint2) from aggfns;
@@ -741,10 +795,10 @@ select s, max(cint2) from aggfns group by s order by max(cint2), s limit 10;
 select ss, max(cint2) from aggfns group by ss order by max(cint2), ss limit 10;
  ss |  max  
 ----+-------
-    | 16362
   3 | 16380
   5 | 16381
   7 | 16381
+    | 16381
   8 | 16382
   0 | 16383
   4 | 16383
@@ -783,10 +837,10 @@ select ss, min(cint2) from aggfns group by ss order by min(cint2), ss limit 10;
   6 | -16383
   7 | -16382
   8 | -16382
- 11 | -16382
+    | -16382
   3 | -16381
+ 11 | -16378
   9 | -16375
-    | -16100
 (10 rows)
 
 select stddev(cint2) from aggfns;
@@ -813,8 +867,8 @@ select s, stddev(cint2) from aggfns group by s order by stddev(cint2), s limit 1
 select ss, stddev(cint2) from aggfns group by ss order by stddev(cint2), ss limit 10;
  ss |      stddev       
 ----+-------------------
-    | 8413.549166956554
   9 | 9450.322790943425
+    | 9457.685918593809
   7 | 9462.161209850735
   6 | 9467.569674984571
   5 | 9467.776835158782
@@ -822,7 +876,7 @@ select ss, stddev(cint2) from aggfns group by ss order by stddev(cint2), ss limi
   8 | 9477.586839536066
   4 | 9483.611454519949
   0 | 9484.907423282680
- 11 | 9494.206429493352
+ 11 | 9528.120007675789
 (10 rows)
 
 select sum(cint2) from aggfns;
@@ -849,15 +903,15 @@ select s, sum(cint2) from aggfns group by s order by sum(cint2), s limit 10;
 select ss, sum(cint2) from aggfns group by ss order by sum(cint2), ss limit 10;
  ss |   sum    
 ----+----------
+    | -3189343
   8 | -2587459
   3 | -1887499
- 11 | -1349560
   6 | -1220352
   7 | -1116329
   4 |  -550258
   9 |  -435575
-    |   -25995
   0 |   351569
+ 11 |  1813788
   5 |  2198520
 (10 rows)
 
@@ -886,15 +940,15 @@ select ss, avg(cint4) from aggfns group by ss order by avg(cint4), ss limit 10;
  ss |          avg          
 ----+-----------------------
   9 | -102.4283000000000000
+    |  -99.2131475098656277
   6 |  -53.1566500000000000
   7 |  -42.6121500000000000
   8 |  -29.2615500000000000
- 11 |  -16.4247732327144606
   4 |    9.6930584054852110
   0 |   27.7536500000000000
   3 |   68.3874180471447875
+ 11 |   68.4650082421699386
   5 |  103.1069000000000000
-    | 2197.6842105263157895
 (10 rows)
 
 select max(cint4) from aggfns;
@@ -921,10 +975,10 @@ select s, max(cint4) from aggfns group by s order by max(cint4), s limit 10;
 select ss, max(cint4) from aggfns group by ss order by max(cint4), ss limit 10;
  ss |  max  
 ----+-------
-    | 14812
   3 | 16379
   5 | 16379
   7 | 16379
+    | 16381
   0 | 16383
   4 | 16383
   6 | 16383
@@ -959,14 +1013,14 @@ select ss, min(cint4) from aggfns group by ss order by min(cint4), ss limit 10;
 ----+--------
   0 | -16383
   7 | -16383
- 11 | -16383
+    | -16383
   3 | -16382
   4 | -16382
   6 | -16382
   8 | -16382
   9 | -16382
+ 11 | -16382
   5 | -16380
-    | -15907
 (10 rows)
 
 select stddev(cint4) from aggfns;
@@ -993,13 +1047,13 @@ select s, stddev(cint4) from aggfns group by s order by stddev(cint4), s limit 1
 select ss, stddev(cint4) from aggfns group by ss order by stddev(cint4), ss limit 10;
  ss |      stddev       
 ----+-------------------
-    | 9361.317298404296
   0 | 9406.815855797801
   6 | 9410.397911988306
   9 | 9426.452583637956
+    | 9440.633682496139
   4 | 9442.480718256247
   8 | 9450.281544631633
- 11 | 9450.690059613938
+ 11 | 9460.158622933231
   3 | 9474.873657491443
   7 | 9485.765898279180
   5 | 9504.684751625578
@@ -1030,14 +1084,14 @@ select ss, sum(cint4) from aggfns group by ss order by sum(cint4), ss limit 10;
  ss |   sum    
 ----+----------
   9 | -2048566
+    | -1986148
   6 | -1063133
   7 |  -852243
- 11 |  -657303
   8 |  -585231
-    |    41756
   4 |   193677
   0 |   555073
   3 |  1366449
+ 11 |  1370601
   5 |  2062138
 (10 rows)
 
@@ -1063,18 +1117,18 @@ select s, avg(cint8) from aggfns group by s order by avg(cint8), s limit 10;
 (10 rows)
 
 select ss, avg(cint8) from aggfns group by ss order by avg(cint8), ss limit 10;
- ss |          avg          
-----+-----------------------
-  8 | -118.4870000000000000
-  5 |  -81.6955500000000000
-  4 |  -17.0811771182623492
- 11 |  -15.1685449411529523
-  7 |   -2.3563500000000000
-  6 |   11.9056500000000000
-  0 |   15.3018000000000000
-  3 |   37.6662329212752115
-  9 |   61.7467500000000000
-    | 2467.2631578947368421
+ ss |           avg           
+----+-------------------------
+  8 |   -118.4870000000000000
+  5 |    -81.6955500000000000
+ 11 |    -27.8558869074379340
+  4 |    -17.0811771182623492
+  7 |     -2.3563500000000000
+    | -0.12513112543084070133
+  6 |     11.9056500000000000
+  0 |     15.3018000000000000
+  3 |     37.6662329212752115
+  9 |     61.7467500000000000
 (10 rows)
 
 select max(cint8) from aggfns;
@@ -1101,7 +1155,7 @@ select s, max(cint8) from aggfns group by s order by max(cint8), s limit 10;
 select ss, max(cint8) from aggfns group by ss order by max(cint8), ss limit 10;
  ss |  max  
 ----+-------
-    | 13750
+    | 16379
   6 | 16380
   7 | 16380
   8 | 16380
@@ -1145,8 +1199,8 @@ select ss, min(cint8) from aggfns group by ss order by min(cint8), ss limit 10;
   5 | -16382
   4 | -16381
   9 | -16380
+    | -16379
   3 | -16378
-    | -14174
 (10 rows)
 
 select sum(cint8) from aggfns;
@@ -1175,10 +1229,10 @@ select ss, sum(cint8) from aggfns group by ss order by sum(cint8), ss limit 10;
 ----+----------
   8 | -2369740
   5 | -1633911
- 11 |  -607030
+ 11 |  -557647
   4 |  -341299
   7 |   -47127
-    |    46878
+    |    -2505
   6 |   238113
   0 |   306036
   3 |   752609
@@ -1247,8 +1301,8 @@ select ss, min(cts) from aggfns group by ss order by min(cts), ss limit 10;
 ----+--------------------------
   0 | Fri Jan 01 01:01:01 2021
  11 | Fri Jan 01 03:47:41 2021
+    | Fri Jan 01 06:34:21 2021
   3 | Fri Jan 01 09:21:01 2021
-    | Fri Jan 01 09:21:01 2021
   4 | Fri Jan 01 12:07:41 2021
   5 | Fri Jan 01 14:54:21 2021
   6 | Fri Jan 01 17:41:01 2021
@@ -1319,8 +1373,8 @@ select ss, min(ctstz) from aggfns group by ss order by min(ctstz), ss limit 10;
 ----+------------------------------
   0 | Fri Jan 01 01:01:01 2021 PST
  11 | Fri Jan 01 03:47:41 2021 PST
+    | Fri Jan 01 06:34:21 2021 PST
   3 | Fri Jan 01 09:21:01 2021 PST
-    | Fri Jan 01 09:21:01 2021 PST
   4 | Fri Jan 01 12:07:41 2021 PST
   5 | Fri Jan 01 14:54:21 2021 PST
   6 | Fri Jan 01 17:41:01 2021 PST
@@ -1354,9 +1408,9 @@ select ss, avg(s) from aggfns group by ss order by avg(s), ss limit 10;
  ss |            avg             
 ----+----------------------------
   0 | 0.000000000000000000000000
- 11 |         1.5011869362053025
+ 11 |     1.00284729506968380039
+    |         2.0009490983565613
   3 |         3.0000000000000000
-    |         3.0000000000000000
   4 |         4.0000000000000000
   5 |         5.0000000000000000
   6 |         6.0000000000000000
@@ -1389,7 +1443,6 @@ select s, count(s) from aggfns group by s order by count(s), s limit 10;
 select ss, count(s) from aggfns group by ss order by count(s), ss limit 10;
  ss | count 
 ----+-------
-    |    19
   3 | 19981
   4 | 19981
   0 | 20000
@@ -1398,7 +1451,8 @@ select ss, count(s) from aggfns group by ss order by count(s), ss limit 10;
   7 | 20000
   8 | 20000
   9 | 20000
- 11 | 40019
+ 11 | 20019
+    | 20019
 (10 rows)
 
 select max(s) from aggfns;
@@ -1463,8 +1517,8 @@ select ss, min(s) from aggfns group by ss order by min(s), ss limit 10;
 ----+-----
   0 |   0
  11 |   1
+    |   2
   3 |   3
-    |   3
   4 |   4
   5 |   5
   6 |   6
@@ -1505,8 +1559,8 @@ select ss, stddev(s) from aggfns group by ss order by stddev(s), ss limit 10;
   7 |                      0
   8 |                      0
   9 |                      0
-    |                      0
- 11 | 0.50284545977155885187
+    | 0.03079358595744834506
+ 11 | 0.09238075787234503528
 (10 rows)
 
 select sum(s) from aggfns;
@@ -1534,9 +1588,9 @@ select ss, sum(s) from aggfns group by ss order by sum(s), ss limit 10;
  ss |  sum   
 ----+--------
   0 |      0
-    |     57
+ 11 |  20076
+    |  40057
   3 |  59943
- 11 |  60076
   4 |  79924
   5 | 100000
   6 | 120000
@@ -1548,7 +1602,7 @@ select ss, sum(s) from aggfns group by ss order by sum(s), ss limit 10;
 select avg(ss) from aggfns;
         avg         
 --------------------
- 6.4009880938689175
+ 5.8899328262427701
 (1 row)
 
 select s, avg(ss) from aggfns group by s order by avg(ss), s limit 10;
@@ -1563,7 +1617,7 @@ select s, avg(ss) from aggfns group by s order by avg(ss), s limit 10;
  8 |         8.0000000000000000
  9 |         9.0000000000000000
  1 |        11.0000000000000000
- 2 |        11.0000000000000000
+ 2 |                           
 (10 rows)
 
 select ss, avg(ss) from aggfns group by ss order by avg(ss), ss limit 10;
@@ -1598,8 +1652,8 @@ select s, max(ss) from aggfns group by s order by max(ss), s limit 10;
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
  4 |  11
+ 2 |    
 (10 rows)
 
 select ss, max(ss) from aggfns group by ss order by max(ss), ss limit 10;
@@ -1635,7 +1689,7 @@ select s, min(ss) from aggfns group by s order by min(ss), s limit 10;
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select ss, min(ss) from aggfns group by ss order by min(ss), ss limit 10;
@@ -1656,7 +1710,7 @@ select ss, min(ss) from aggfns group by ss order by min(ss), ss limit 10;
 select stddev(ss) from aggfns;
        stddev       
 --------------------
- 3.3528328280068652
+ 3.1431098825513430
 (1 row)
 
 select s, stddev(ss) from aggfns group by s order by stddev(ss), s limit 10;
@@ -1664,7 +1718,6 @@ select s, stddev(ss) from aggfns group by s order by stddev(ss), s limit 10;
 ---+------------------------
  0 |                      0
  1 |                      0
- 2 |                      0
  3 |                      0
  5 |                      0
  6 |                      0
@@ -1672,6 +1725,7 @@ select s, stddev(ss) from aggfns group by s order by stddev(ss), s limit 10;
  8 |                      0
  9 |                      0
  4 | 0.21565737387148452722
+ 2 |                       
 (10 rows)
 
 select ss, stddev(ss) from aggfns group by ss order by stddev(ss), ss limit 10;
@@ -1692,7 +1746,7 @@ select ss, stddev(ss) from aggfns group by ss order by stddev(ss), ss limit 10;
 select sum(ss) from aggfns;
    sum   
 ---------
- 1280076
+ 1060076
 (1 row)
 
 select s, sum(ss) from aggfns group by s order by sum(ss), s limit 10;
@@ -1707,7 +1761,7 @@ select s, sum(ss) from aggfns group by s order by sum(ss), s limit 10;
  8 | 160000
  9 | 180000
  1 | 220000
- 2 | 220000
+ 2 |       
 (10 rows)
 
 select ss, sum(ss) from aggfns group by ss order by sum(ss), ss limit 10;
@@ -1721,7 +1775,7 @@ select ss, sum(ss) from aggfns group by ss order by sum(ss), ss limit 10;
   7 | 140000
   8 | 160000
   9 | 180000
- 11 | 440209
+ 11 | 220209
     |       
 (10 rows)
 
@@ -1787,8 +1841,8 @@ select ss, min(t) from aggfns group by ss order by min(t), ss limit 10;
 ----+-------
   0 |     1
  11 | 10001
+    | 20001
   3 | 30001
-    | 30537
   4 | 40001
   5 | 50001
   6 | 60001
@@ -1821,7 +1875,6 @@ select s, count(*) from aggfns where cfloat8 > 0 group by s order by count(*), s
 select ss, count(*) from aggfns where cfloat8 > 0 group by ss order by count(*), ss limit 10;
  ss | count 
 ----+-------
-    |    13
   4 |  9872
   0 |  9881
   9 |  9945
@@ -1829,8 +1882,9 @@ select ss, count(*) from aggfns where cfloat8 > 0 group by ss order by count(*),
   8 |  9950
   5 |  9972
   7 | 10021
+    | 10087
   6 | 10097
- 11 | 30084
+ 11 | 20010
 (10 rows)
 
 select max(cdate) from aggfns where cfloat8 > 0;
@@ -1895,8 +1949,8 @@ select ss, min(cdate) from aggfns where cfloat8 > 0 group by ss order by min(cda
 ----+------------
   0 | 01-01-2021
  11 | 05-19-2048
+    | 10-05-2075
   3 | 02-21-2103
-    | 02-21-2103
   4 | 07-09-2130
   5 | 11-24-2157
   6 | 04-11-2185
@@ -1932,12 +1986,12 @@ select ss, avg(cfloat4) from aggfns where cfloat8 > 0 group by ss order by avg(c
   3 |          -Infinity
   4 | -0.458554823065329
   0 | -0.334856044433109
+    | -0.216905626765383
   9 | -0.208302219537011
   6 |  0.199537611181853
   7 |  0.313851696029514
   5 |  0.374879026647364
   8 |  0.606801085094336
-    |   1.47322510755979
  11 |                NaN
 (10 rows)
 
@@ -1965,10 +2019,10 @@ select s, max(cfloat4) from aggfns where cfloat8 > 0 group by s order by max(cfl
 select ss, max(cfloat4) from aggfns where cfloat8 > 0 group by ss order by max(cfloat4), ss limit 10;
  ss |   max   
 ----+---------
-    | 47.2047
   9 | 49.9744
   3 | 49.9744
   0 | 49.9863
+    |  49.988
   8 | 49.9923
   4 | 49.9928
   6 | 49.9956
@@ -2006,11 +2060,11 @@ select ss, min(cfloat4) from aggfns where cfloat8 > 0 group by ss order by min(c
  11 |  -49.9974
   8 |  -49.9969
   7 |  -49.9969
+    |  -49.9928
   0 |  -49.9915
   9 |  -49.9911
   5 |  -49.9892
   6 |  -49.9891
-    |  -41.6131
 (10 rows)
 
 select stddev(cfloat4) from aggfns where cfloat8 > 0;
@@ -2041,10 +2095,10 @@ select ss, stddev(cfloat4) from aggfns where cfloat8 > 0 group by ss order by st
   0 | 28.7315562731003
   9 | 28.7729261590403
   4 | 28.8497176060195
+    | 28.8503326655456
   5 | 28.9107809470208
   6 | 28.9388387251543
   8 | 29.1042713834566
-    |  29.539145536489
   3 |              NaN
  11 |              NaN
 (10 rows)
@@ -2076,8 +2130,8 @@ select ss, sum(cfloat4) from aggfns where cfloat8 > 0 group by ss order by sum(c
   3 | -Infinity
   4 |  -4526.85
   0 |  -3308.71
+    |  -2187.93
   9 |  -2071.57
-    |   19.1519
   6 |   2014.73
   7 |   3145.11
   5 |   3738.29
@@ -2109,8 +2163,8 @@ select s, avg(cfloat8) from aggfns where cfloat8 > 0 group by s order by avg(cfl
 select ss, avg(cfloat8) from aggfns where cfloat8 > 0 group by ss order by avg(cfloat8), ss limit 10;
  ss |       avg        
 ----+------------------
-    | 16.6705740293345
- 11 | 16.9860875451313
+ 11 | 13.0086523265127
+    | 24.8758840206794
   6 | 24.9229571834467
   9 |  24.933601739557
   8 | 24.9404756362227
@@ -2145,14 +2199,14 @@ select s, max(cfloat8) from aggfns where cfloat8 > 0 group by s order by max(cfl
 select ss, max(cfloat8) from aggfns where cfloat8 > 0 group by ss order by max(cfloat8), ss limit 10;
  ss |       max        
 ----+------------------
-    | 46.3985309237614
+ 11 | 42.8941954858601
   5 | 49.9874341068789
   3 | 49.9890822684392
   6 | 49.9939429108053
   8 | 49.9963666079566
   0 | 49.9965498689562
   7 | 49.9973275698721
- 11 | 49.9975695507601
+    | 49.9975695507601
   4 | 49.9978997278959
   9 | 49.9995574122295
 (10 rows)
@@ -2185,12 +2239,12 @@ select ss, min(cfloat8) from aggfns where cfloat8 > 0 group by ss order by min(c
   7 | 0.000956561416387558
   6 |  0.00179046764969826
   0 |  0.00247885473072529
- 11 |  0.00441970769315958
+    |  0.00441970769315958
   3 |  0.00545482616871595
   5 |  0.00628724228590727
   9 |   0.0187294092029333
   8 |   0.0195798231288791
-    |    0.312147964723408
+ 11 |    0.362602039240301
 (10 rows)
 
 select stddev(cfloat8) from aggfns where cfloat8 > 0;
@@ -2215,18 +2269,18 @@ select s, stddev(cfloat8) from aggfns where cfloat8 > 0 group by s order by stdd
 (10 rows)
 
 select ss, stddev(cfloat8) from aggfns where cfloat8 > 0 group by ss order by stddev(cfloat8), ss limit 10;
- ss |      stddev      
-----+------------------
- 11 | 10.0892977778207
-  9 | 14.3145979997847
-  3 | 14.3656116060957
-  4 | 14.4158826742614
-  6 | 14.4175557556357
-  5 | 14.4400766885504
-  0 | 14.4509605112521
-  7 | 14.4643374353136
-  8 |  14.507225286092
-    | 15.8897779049656
+ ss |      stddev       
+----+-------------------
+ 11 | 0.484009165262532
+  9 |  14.3145979997847
+  3 |  14.3656116060957
+  4 |  14.4158826742614
+  6 |  14.4175557556357
+  5 |  14.4400766885504
+  0 |  14.4509605112521
+  7 |  14.4643374353136
+    |  14.4848342833185
+  8 |   14.507225286092
 (10 rows)
 
 select sum(cfloat8) from aggfns where cfloat8 > 0;
@@ -2253,7 +2307,6 @@ select s, sum(cfloat8) from aggfns where cfloat8 > 0 group by s order by sum(cfl
 select ss, sum(cfloat8) from aggfns where cfloat8 > 0 group by ss order by sum(cfloat8), ss limit 10;
  ss |       sum        
 ----+------------------
-    | 216.717462381348
   4 | 246523.092672974
   0 | 247792.285921541
   9 | 247964.669299894
@@ -2261,8 +2314,9 @@ select ss, sum(cfloat8) from aggfns where cfloat8 > 0 group by ss order by sum(c
   3 | 249100.415408076
   5 | 249441.510896711
   7 |  250489.97692517
+    | 250923.042116594
   6 | 251647.098681261
- 11 | 511009.457707731
+ 11 | 260303.133053519
 (10 rows)
 
 select avg(cint2) from aggfns where cfloat8 > 0;
@@ -2287,18 +2341,18 @@ select s, avg(cint2) from aggfns where cfloat8 > 0 group by s order by avg(cint2
 (10 rows)
 
 select ss, avg(cint2) from aggfns where cfloat8 > 0 group by ss order by avg(cint2), ss limit 10;
- ss |          avg           
-----+------------------------
-    | -2431.3076923076923077
-  9 |  -192.8237544036235531
-  3 |  -156.9368272809576501
-  7 |  -142.7671027664036752
-  4 |  -119.1966149792236749
-  6 |   -98.2421689135606661
-  8 |    -1.6297525648762824
- 11 |     7.3528100356037667
-  0 |    28.7771364925070879
-  5 |   153.6364822808954924
+ ss |          avg          
+----+-----------------------
+  9 | -192.8237544036235531
+    | -159.8433746898263027
+  3 | -156.9368272809576501
+  7 | -142.7671027664036752
+  4 | -119.1966149792236749
+  6 |  -98.2421689135606661
+  8 |   -1.6297525648762824
+  0 |   28.7771364925070879
+ 11 |   90.0299634835676054
+  5 |  153.6364822808954924
 (10 rows)
 
 select count(cint2) from aggfns where cfloat8 > 0;
@@ -2325,7 +2379,6 @@ select s, count(cint2) from aggfns where cfloat8 > 0 group by s order by count(c
 select ss, count(cint2) from aggfns where cfloat8 > 0 group by ss order by count(cint2), ss limit 10;
  ss | count 
 ----+-------
-    |    13
   4 |  9867
   0 |  9876
   9 |  9935
@@ -2333,8 +2386,9 @@ select ss, count(cint2) from aggfns where cfloat8 > 0 group by ss order by count
   8 |  9942
   5 |  9961
   7 | 10013
+    | 10075
   6 | 10088
- 11 | 30053
+ 11 | 19991
 (10 rows)
 
 select max(cint2) from aggfns where cfloat8 > 0;
@@ -2361,7 +2415,7 @@ select s, max(cint2) from aggfns where cfloat8 > 0 group by s order by max(cint2
 select ss, max(cint2) from aggfns where cfloat8 > 0 group by ss order by max(cint2), ss limit 10;
  ss |  max  
 ----+-------
-    |  7971
+    | 16379
   3 | 16380
   8 | 16380
   5 | 16381
@@ -2405,8 +2459,8 @@ select ss, min(cint2) from aggfns where cfloat8 > 0 group by ss order by min(cin
   7 | -16380
   3 | -16378
  11 | -16378
+    | -16377
   9 | -16375
-    | -16100
 (10 rows)
 
 select stddev(cint2) from aggfns where cfloat8 > 0;
@@ -2433,7 +2487,7 @@ select s, stddev(cint2) from aggfns where cfloat8 > 0 group by s order by stddev
 select ss, stddev(cint2) from aggfns where cfloat8 > 0 group by ss order by stddev(cint2), ss limit 10;
  ss |      stddev       
 ----+-------------------
-    | 7759.524506314969
+    | 9405.087937792723
   5 | 9422.095841513016
   6 | 9433.502305093184
   9 | 9441.945023643920
@@ -2441,8 +2495,8 @@ select ss, stddev(cint2) from aggfns where cfloat8 > 0 group by ss order by stdd
   7 | 9460.956887483220
   3 | 9463.490872675688
   8 | 9466.374225763893
- 11 | 9488.645998388904
   0 | 9519.824544774386
+ 11 | 9528.643287409910
 (10 rows)
 
 select sum(cint2) from aggfns where cfloat8 > 0;
@@ -2470,15 +2524,15 @@ select ss, sum(cint2) from aggfns where cfloat8 > 0 group by ss order by sum(cin
  ss |   sum    
 ----+----------
   9 | -1915704
+    | -1610422
   3 | -1560109
   7 | -1429527
   4 | -1176113
   6 |  -991067
-    |   -31607
   8 |   -16203
- 11 |   220974
   0 |   284203
   5 |  1530373
+ 11 |  1799789
 (10 rows)
 
 select avg(cint4) from aggfns where cfloat8 > 0;
@@ -2506,15 +2560,15 @@ select ss, avg(cint4) from aggfns where cfloat8 > 0 group by ss order by avg(cin
  ss |          avg          
 ----+-----------------------
   9 | -227.0452488687782805
+    | -151.3793992267274710
   6 |  -94.7697335842329405
   4 |  -40.9285858995137763
   7 |   -7.9618800518910288
- 11 |   -4.2226765057838053
   8 |   30.7776884422110553
   5 |   70.0002005615724027
+ 11 |   70.5258370814592704
   0 |   78.5152312518975812
   3 |  169.6967839195979899
-    |  868.6923076923076923
 (10 rows)
 
 select max(cint4) from aggfns where cfloat8 > 0;
@@ -2541,13 +2595,13 @@ select s, max(cint4) from aggfns where cfloat8 > 0 group by s order by max(cint4
 select ss, max(cint4) from aggfns where cfloat8 > 0 group by ss order by max(cint4), ss limit 10;
  ss |  max  
 ----+-------
-    | 14812
   3 | 16379
   5 | 16379
   7 | 16379
   0 | 16380
   6 | 16380
   9 | 16381
+    | 16381
   4 | 16382
   8 | 16382
  11 | 16383
@@ -2578,15 +2632,15 @@ select ss, min(cint4) from aggfns where cfloat8 > 0 group by ss order by min(cin
  ss |  min   
 ----+--------
   7 | -16383
- 11 | -16383
+    | -16383
   0 | -16382
   9 | -16382
+ 11 | -16382
   5 | -16380
   3 | -16379
   4 | -16378
   6 | -16378
   8 | -16377
-    | -15907
 (10 rows)
 
 select stddev(cint4) from aggfns where cfloat8 > 0;
@@ -2613,12 +2667,12 @@ select s, stddev(cint4) from aggfns where cfloat8 > 0 group by s order by stddev
 select ss, stddev(cint4) from aggfns where cfloat8 > 0 group by ss order by stddev(cint4), ss limit 10;
  ss |      stddev       
 ----+-------------------
-    | 8985.945186647640
   0 | 9368.404782340758
   6 | 9385.470128440942
   8 | 9411.536015886790
   4 | 9416.391322858156
- 11 | 9460.260597896060
+    | 9459.354319355396
+ 11 | 9459.593914000701
   9 | 9474.284943213442
   5 | 9475.929892556881
   7 | 9500.872262505529
@@ -2650,14 +2704,14 @@ select ss, sum(cint4) from aggfns where cfloat8 > 0 group by ss order by sum(cin
  ss |   sum    
 ----+----------
   9 | -2257965
+    | -1526964
   6 |  -956890
   4 |  -404047
- 11 |  -127035
   7 |   -79786
-    |    11293
   8 |   306238
   5 |   698042
   0 |   775809
+ 11 |  1411222
   3 |  1688483
 (10 rows)
 
@@ -2689,12 +2743,12 @@ select ss, avg(cint8) from aggfns where cfloat8 > 0 group by ss order by avg(cin
   5 |   -78.9197753710389089
   4 |   -61.5197528363047002
   6 |   -32.8705556105773992
+ 11 |   -25.3466266866566717
   7 | 1.15707015267937331604
- 11 |    33.0028919026725170
   0 |    42.9815808116587390
   9 |    44.5682252388134741
   3 |   106.1022110552763819
-    |  2876.8461538461538462
+    |   152.4183602656885100
 (10 rows)
 
 select max(cint8) from aggfns where cfloat8 > 0;
@@ -2721,7 +2775,7 @@ select s, max(cint8) from aggfns where cfloat8 > 0 group by s order by max(cint8
 select ss, max(cint8) from aggfns where cfloat8 > 0 group by ss order by max(cint8), ss limit 10;
  ss |  max  
 ----+-------
-    | 13750
+    | 16373
   7 | 16378
   6 | 16379
   0 | 16380
@@ -2765,8 +2819,8 @@ select ss, min(cint8) from aggfns where cfloat8 > 0 group by ss order by min(cin
   6 | -16381
   9 | -16380
   0 | -16379
+    | -16379
   3 | -16378
-    | -11918
 (10 rows)
 
 select sum(cint8) from aggfns where cfloat8 > 0;
@@ -2796,13 +2850,13 @@ select ss, sum(cint8) from aggfns where cfloat8 > 0 group by ss order by sum(cin
   8 | -1656179
   5 |  -786988
   4 |  -607323
+ 11 |  -507186
   6 |  -331894
   7 |    11595
-    |    37399
   0 |   424701
   9 |   443231
- 11 |   992859
   3 |  1055717
+    |  1537444
 (10 rows)
 
 select max(cts) from aggfns where cfloat8 > 0;
@@ -2867,8 +2921,8 @@ select ss, min(cts) from aggfns where cfloat8 > 0 group by ss order by min(cts),
 ----+--------------------------
   0 | Fri Jan 01 01:01:01 2021
  11 | Fri Jan 01 03:47:41 2021
+    | Fri Jan 01 06:34:21 2021
   3 | Fri Jan 01 09:21:01 2021
-    | Fri Jan 01 09:21:01 2021
   4 | Fri Jan 01 12:07:41 2021
   5 | Fri Jan 01 14:54:21 2021
   6 | Fri Jan 01 17:41:01 2021
@@ -2939,8 +2993,8 @@ select ss, min(ctstz) from aggfns where cfloat8 > 0 group by ss order by min(cts
 ----+------------------------------
   0 | Fri Jan 01 01:01:01 2021 PST
  11 | Fri Jan 01 03:47:41 2021 PST
+    | Fri Jan 01 06:34:21 2021 PST
   3 | Fri Jan 01 09:21:01 2021 PST
-    | Fri Jan 01 09:21:01 2021 PST
   4 | Fri Jan 01 12:07:41 2021 PST
   5 | Fri Jan 01 14:54:21 2021 PST
   6 | Fri Jan 01 17:41:01 2021 PST
@@ -2974,9 +3028,9 @@ select ss, avg(s) from aggfns where cfloat8 > 0 group by ss order by avg(s), ss 
  ss |          avg           
 ----+------------------------
   0 | 0.00000000000000000000
- 11 |     1.3358595931392102
+ 11 | 1.00149925037481259370
+    |     2.0012887875483295
   3 |     3.0000000000000000
-    |     3.0000000000000000
   4 |     4.0000000000000000
   5 |     5.0000000000000000
   6 |     6.0000000000000000
@@ -3009,7 +3063,6 @@ select s, count(s) from aggfns where cfloat8 > 0 group by s order by count(s), s
 select ss, count(s) from aggfns where cfloat8 > 0 group by ss order by count(s), ss limit 10;
  ss | count 
 ----+-------
-    |    13
   4 |  9872
   0 |  9881
   9 |  9945
@@ -3017,8 +3070,9 @@ select ss, count(s) from aggfns where cfloat8 > 0 group by ss order by count(s),
   8 |  9950
   5 |  9972
   7 | 10021
+    | 10087
   6 | 10097
- 11 | 30084
+ 11 | 20010
 (10 rows)
 
 select max(s) from aggfns where cfloat8 > 0;
@@ -3083,8 +3137,8 @@ select ss, min(s) from aggfns where cfloat8 > 0 group by ss order by min(s), ss 
 ----+-----
   0 |   0
  11 |   1
+    |   2
   3 |   3
-    |   3
   4 |   4
   5 |   5
   6 |   6
@@ -3125,8 +3179,8 @@ select ss, stddev(s) from aggfns where cfloat8 > 0 group by ss order by stddev(s
   7 |                      0
   8 |                      0
   9 |                      0
-    |                      0
- 11 | 0.47440470436008342899
+    | 0.03587832479578534559
+ 11 | 0.06705019050544684015
 (10 rows)
 
 select sum(s) from aggfns where cfloat8 > 0;
@@ -3154,10 +3208,10 @@ select ss, sum(s) from aggfns where cfloat8 > 0 group by ss order by sum(s), ss 
  ss |  sum  
 ----+-------
   0 |     0
-    |    39
+ 11 | 20040
+    | 20187
   3 | 29850
   4 | 39488
- 11 | 40188
   5 | 49860
   6 | 60582
   7 | 70147
@@ -3168,7 +3222,7 @@ select ss, sum(s) from aggfns where cfloat8 > 0 group by ss order by sum(s), ss 
 select avg(ss) from aggfns where cfloat8 > 0;
         avg         
 --------------------
- 6.8319425718762526
+ 6.4107805572829946
 (1 row)
 
 select s, avg(ss) from aggfns where cfloat8 > 0 group by s order by avg(ss), s limit 10;
@@ -3183,7 +3237,7 @@ select s, avg(ss) from aggfns where cfloat8 > 0 group by s order by avg(ss), s l
  8 |     8.0000000000000000
  9 |     9.0000000000000000
  1 |    11.0000000000000000
- 2 |    11.0000000000000000
+ 2 |                       
 (10 rows)
 
 select ss, avg(ss) from aggfns where cfloat8 > 0 group by ss order by avg(ss), ss limit 10;
@@ -3218,8 +3272,8 @@ select s, max(ss) from aggfns where cfloat8 > 0 group by s order by max(ss), s l
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
  4 |  11
+ 2 |    
 (10 rows)
 
 select ss, max(ss) from aggfns where cfloat8 > 0 group by ss order by max(ss), ss limit 10;
@@ -3255,7 +3309,7 @@ select s, min(ss) from aggfns where cfloat8 > 0 group by s order by min(ss), s l
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select ss, min(ss) from aggfns where cfloat8 > 0 group by ss order by min(ss), ss limit 10;
@@ -3276,7 +3330,7 @@ select ss, min(ss) from aggfns where cfloat8 > 0 group by ss order by min(ss), s
 select stddev(ss) from aggfns where cfloat8 > 0;
        stddev       
 --------------------
- 3.4547844482354617
+ 3.3479473483697611
 (1 row)
 
 select s, stddev(ss) from aggfns where cfloat8 > 0 group by s order by stddev(ss), s limit 10;
@@ -3284,7 +3338,6 @@ select s, stddev(ss) from aggfns where cfloat8 > 0 group by s order by stddev(ss
 ---+------------------------
  0 |                      0
  1 |                      0
- 2 |                      0
  3 |                      0
  5 |                      0
  6 |                      0
@@ -3292,6 +3345,7 @@ select s, stddev(ss) from aggfns where cfloat8 > 0 group by s order by stddev(ss
  8 |                      0
  9 |                      0
  4 | 0.22257569540261848080
+ 2 |                       
 (10 rows)
 
 select ss, stddev(ss) from aggfns where cfloat8 > 0 group by ss order by stddev(ss), ss limit 10;
@@ -3312,7 +3366,7 @@ select ss, stddev(ss) from aggfns where cfloat8 > 0 group by ss order by stddev(
 select sum(ss) from aggfns where cfloat8 > 0;
   sum   
 --------
- 749956
+ 639142
 (1 row)
 
 select s, sum(ss) from aggfns where cfloat8 > 0 group by s order by sum(ss), s limit 10;
@@ -3326,8 +3380,8 @@ select s, sum(ss) from aggfns where cfloat8 > 0 group by s order by sum(ss), s l
  7 |  70147
  8 |  79600
  9 |  89505
- 2 | 110814
  1 | 220000
+ 2 |       
 (10 rows)
 
 select ss, sum(ss) from aggfns where cfloat8 > 0 group by ss order by sum(ss), ss limit 10;
@@ -3341,7 +3395,7 @@ select ss, sum(ss) from aggfns where cfloat8 > 0 group by ss order by sum(ss), s
   7 |  70147
   8 |  79600
   9 |  89505
- 11 | 330924
+ 11 | 220110
     |       
 (10 rows)
 
@@ -3407,8 +3461,8 @@ select ss, min(t) from aggfns where cfloat8 > 0 group by ss order by min(t), ss 
 ----+-------
   0 |     1
  11 | 10001
+    | 20001
   3 | 30001
-    | 30537
   4 | 40003
   5 | 50001
   6 | 60002
@@ -3440,9 +3494,9 @@ select s, count(*) from aggfns where cfloat8 <= 0 group by s order by count(*), 
 select ss, count(*) from aggfns where cfloat8 <= 0 group by ss order by count(*), ss limit 10;
  ss | count 
 ----+-------
-    |     6
+ 11 |     9
   6 |  9903
- 11 |  9935
+    |  9932
   7 |  9979
   5 | 10028
   3 | 10031
@@ -3511,10 +3565,10 @@ select ss, min(cdate) from aggfns where cfloat8 <= 0 group by ss order by min(cd
  ss |    min     
 ----+------------
   0 | 01-01-2021
- 11 | 10-05-2075
+    | 10-05-2075
   3 | 02-21-2103
-    | 02-21-2103
   4 | 07-09-2130
+ 11 | 07-09-2130
   5 | 11-24-2157
   6 | 04-11-2185
   7 | 08-28-2212
@@ -3545,7 +3599,7 @@ select s, avg(cfloat4) from aggfns where cfloat8 <= 0 group by s order by avg(cf
 select ss, avg(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by avg(cfloat4), ss limit 10;
  ss |        avg         
 ----+--------------------
-    |  -7.61213672161102
+ 11 |  -14.5702234903971
   9 | -0.376175993822296
   5 | -0.351281471733702
   3 | -0.323676224863234
@@ -3554,7 +3608,7 @@ select ss, avg(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by avg(
   4 |  0.113266462457489
   8 |  0.308099926433512
   0 |  0.497406092427368
- 11 |           Infinity
+    |           Infinity
 (10 rows)
 
 select max(cfloat4) from aggfns where cfloat8 <= 0;
@@ -3580,7 +3634,7 @@ select s, max(cfloat4) from aggfns where cfloat8 <= 0 group by s order by max(cf
 select ss, max(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by max(cfloat4), ss limit 10;
  ss |   max    
 ----+----------
-    |  43.8334
+ 11 |  33.4543
   5 |  49.9753
   9 |  49.9899
   7 |   49.992
@@ -3589,7 +3643,7 @@ select ss, max(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by max(
   3 |  49.9979
   0 |  49.9995
   8 |  49.9997
- 11 | Infinity
+    | Infinity
 (10 rows)
 
 select min(cfloat4) from aggfns where cfloat8 <= 0;
@@ -3617,14 +3671,14 @@ select ss, min(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by min(
 ----+----------
   4 | -49.9999
   6 | -49.9995
- 11 | -49.9991
+    | -49.9991
   7 | -49.9984
   0 | -49.9949
   5 | -49.9942
   9 | -49.9874
   8 | -49.9853
   3 |  -49.974
-    | -45.4083
+ 11 | -49.5659
 (10 rows)
 
 select stddev(cfloat4) from aggfns where cfloat8 <= 0;
@@ -3658,8 +3712,8 @@ select ss, stddev(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by s
   8 | 28.9050890855561
   9 | 28.9126192916064
   5 | 29.1278202173095
-    | 34.8729157239149
- 11 |              NaN
+ 11 | 32.8656208490092
+    |              NaN
 (10 rows)
 
 select sum(cfloat4) from aggfns where cfloat8 <= 0;
@@ -3689,12 +3743,12 @@ select ss, sum(cfloat4) from aggfns where cfloat8 <= 0 group by ss order by sum(
   5 | -3522.65
   3 |  -3246.8
   6 | -2136.92
-    | -45.6728
+ 11 | -131.132
   7 |  688.563
   4 |  1145.01
   8 |   3096.4
   0 |  5033.25
- 11 | Infinity
+    | Infinity
 (10 rows)
 
 select avg(cfloat8) from aggfns where cfloat8 <= 0;
@@ -3720,16 +3774,16 @@ select s, avg(cfloat8) from aggfns where cfloat8 <= 0 group by s order by avg(cf
 select ss, avg(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by avg(cfloat8), ss limit 10;
  ss |        avg        
 ----+-------------------
+ 11 | -25.4791639719365
   7 |  -25.229255062715
   8 | -25.2270239386592
   3 | -25.1388045035744
   0 | -25.0944548448943
   6 | -25.0686778438405
   9 | -24.8892608135943
- 11 |  -24.858866008083
+    | -24.8547363561725
   4 | -24.8295616508204
   5 | -24.7870942066272
-    | -18.9533624914475
 (10 rows)
 
 select max(cfloat8) from aggfns where cfloat8 <= 0;
@@ -3755,7 +3809,7 @@ select s, max(cfloat8) from aggfns where cfloat8 <= 0 group by s order by max(cf
 select ss, max(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by max(cfloat8), ss limit 10;
  ss |         max          
 ----+----------------------
-    |    -5.18986904062331
+ 11 |     -6.9206316024065
   0 | -0.00547224190086126
   9 | -0.00466627534478903
   4 |  -0.0041270861402154
@@ -3764,7 +3818,7 @@ select ss, max(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by max(
   3 | -0.00268903095275164
   5 | -0.00228420831263065
   8 | -0.00182925723493099
- 11 | -0.00172397121787071
+    | -0.00172397121787071
 (10 rows)
 
 select min(cfloat8) from aggfns where cfloat8 <= 0;
@@ -3791,7 +3845,7 @@ select ss, min(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by min(
  ss |        min        
 ----+-------------------
   0 | -49.9994775978848
- 11 | -49.9985320260748
+    | -49.9985320260748
   4 | -49.9983572866768
   3 | -49.9977725092322
   6 | -49.9967515002936
@@ -3799,7 +3853,7 @@ select ss, min(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by min(
   5 | -49.9921301845461
   7 |   -49.99003498815
   8 | -49.9897602945566
-    | -38.5084833716974
+ 11 | -46.2087355088443
 (10 rows)
 
 select stddev(cfloat8) from aggfns where cfloat8 <= 0;
@@ -3826,7 +3880,7 @@ select ss, stddev(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by s
  ss |      stddev      
 ----+------------------
   7 | 14.4030112329563
- 11 | 14.4033336871388
+    | 14.4036067581472
   6 | 14.4144870413512
   3 | 14.4335904065982
   4 | 14.4339025361113
@@ -3834,7 +3888,7 @@ select ss, stddev(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by s
   9 |  14.445355480345
   8 | 14.4532419971748
   0 | 14.5136612753879
-    | 15.4584765893444
+ 11 | 15.5912132906587
 (10 rows)
 
 select sum(cfloat8) from aggfns where cfloat8 <= 0;
@@ -3868,8 +3922,8 @@ select ss, sum(cfloat8) from aggfns where cfloat8 <= 0 group by ss order by sum(
   9 | -250261.517480691
   5 | -248564.980704058
   6 | -248255.116687552
- 11 | -246972.833790304
-    | -113.720174948685
+    | -246857.241489505
+ 11 | -229.312475747429
 (10 rows)
 
 select avg(cint2) from aggfns where cfloat8 <= 0;
@@ -3896,7 +3950,7 @@ select ss, avg(cint2) from aggfns where cfloat8 <= 0 group by ss order by avg(ci
  ss |          avg          
 ----+-----------------------
   8 | -256.1267058471959359
- 11 | -158.1923851732473811
+    | -159.0852392947103275
   3 |  -32.6703921764294981
   6 |  -23.1764884261599110
   0 |    6.6666006927263731
@@ -3904,7 +3958,7 @@ select ss, avg(cint2) from aggfns where cfloat8 <= 0 group by ss order by avg(ci
   4 |   61.9965329370975731
   5 |   66.6813373253493014
   9 |  147.3351582719490344
-    |  935.3333333333333333
+ 11 | 1555.4444444444444444
 (10 rows)
 
 select count(cint2) from aggfns where cfloat8 <= 0;
@@ -3930,9 +3984,9 @@ select s, count(cint2) from aggfns where cfloat8 <= 0 group by s order by count(
 select ss, count(cint2) from aggfns where cfloat8 <= 0 group by ss order by count(cint2), ss limit 10;
  ss | count 
 ----+-------
-    |     6
+ 11 |     9
   6 |  9893
- 11 |  9928
+    |  9925
   7 |  9968
   5 | 10020
   3 | 10021
@@ -3965,13 +4019,13 @@ select s, max(cint2) from aggfns where cfloat8 <= 0 group by s order by max(cint
 select ss, max(cint2) from aggfns where cfloat8 <= 0 group by ss order by max(cint2), ss limit 10;
  ss |  max  
 ----+-------
-    | 16362
+ 11 | 16032
   7 | 16376
   9 | 16376
   3 | 16378
   0 | 16381
   5 | 16381
- 11 | 16381
+    | 16381
   8 | 16382
   4 | 16383
   6 | 16383
@@ -4005,11 +4059,11 @@ select ss, min(cint2) from aggfns where cfloat8 <= 0 group by ss order by min(ci
   6 | -16383
   7 | -16382
   8 | -16382
- 11 | -16382
+    | -16382
   3 | -16381
   4 | -16379
   9 | -16374
-    |  -7696
+ 11 |  -9975
 (10 rows)
 
 select stddev(cint2) from aggfns where cfloat8 <= 0;
@@ -4033,18 +4087,18 @@ select s, stddev(cint2) from aggfns where cfloat8 <= 0 group by s order by stdde
 (9 rows)
 
 select ss, stddev(cint2) from aggfns where cfloat8 <= 0 group by ss order by stddev(cint2), ss limit 10;
- ss |       stddev       
-----+--------------------
-  0 |  9451.115288155243
-  9 |  9456.028731464701
-  7 |  9463.041992703462
-  3 |  9485.440311868001
-  8 |  9487.451140540082
-  6 |  9502.509922580216
- 11 |  9510.413974851870
-  5 |  9513.243501566793
-  4 |  9518.051043653511
-    | 10051.146773710285
+ ss |      stddev       
+----+-------------------
+ 11 | 8648.748017937497
+  0 | 9451.115288155243
+  9 | 9456.028731464701
+  7 | 9463.041992703462
+  3 | 9485.440311868001
+  8 | 9487.451140540082
+  6 | 9502.509922580216
+    | 9511.255220707033
+  5 | 9513.243501566793
+  4 | 9518.051043653511
 (10 rows)
 
 select sum(cint2) from aggfns where cfloat8 <= 0;
@@ -4071,10 +4125,10 @@ select ss, sum(cint2) from aggfns where cfloat8 <= 0 group by ss order by sum(ci
  ss |   sum    
 ----+----------
   8 | -2571256
- 11 | -1570534
+    | -1578921
   3 |  -327390
   6 |  -229285
-    |     5612
+ 11 |    13999
   0 |    67366
   7 |   313198
   4 |   625855
@@ -4103,18 +4157,18 @@ select s, avg(cint4) from aggfns where cfloat8 <= 0 group by s order by avg(cint
 (9 rows)
 
 select ss, avg(cint4) from aggfns where cfloat8 <= 0 group by ss order by avg(cint4), ss limit 10;
- ss |          avg          
-----+-----------------------
-  8 |  -88.7033830845771144
-  7 |  -77.4082573404148712
- 11 |  -53.3737292400603926
-  3 |  -32.1038779782673711
-  0 |  -21.8140132424152584
-  6 |  -10.7283651418761991
-  9 |   20.8253605171556440
-  4 |   59.1279058264912454
-  5 |  136.0287195851615477
-    | 5077.1666666666666667
+ ss |          avg           
+----+------------------------
+ 11 | -4513.4444444444444444
+  8 |   -88.7033830845771144
+  7 |   -77.4082573404148712
+    |   -46.2327829238824003
+  3 |   -32.1038779782673711
+  0 |   -21.8140132424152584
+  6 |   -10.7283651418761991
+  9 |    20.8253605171556440
+  4 |    59.1279058264912454
+  5 |   136.0287195851615477
 (10 rows)
 
 select max(cint4) from aggfns where cfloat8 <= 0;
@@ -4140,11 +4194,11 @@ select s, max(cint4) from aggfns where cfloat8 <= 0 group by s order by max(cint
 select ss, max(cint4) from aggfns where cfloat8 <= 0 group by ss order by max(cint4), ss limit 10;
  ss |  max  
 ----+-------
-    | 13078
+ 11 | 12631
   5 | 16364
   7 | 16378
   3 | 16379
- 11 | 16381
+    | 16381
   0 | 16383
   4 | 16383
   6 | 16383
@@ -4182,9 +4236,9 @@ select ss, min(cint4) from aggfns where cfloat8 <= 0 group by ss order by min(ci
   8 | -16382
   9 | -16381
   7 | -16379
- 11 | -16377
+    | -16377
   5 | -16374
-    |  -8992
+ 11 | -14100
 (10 rows)
 
 select stddev(cint4) from aggfns where cfloat8 <= 0;
@@ -4211,7 +4265,7 @@ select ss, stddev(cint4) from aggfns where cfloat8 <= 0 group by ss order by std
  ss |      stddev       
 ----+-------------------
   9 | 9377.745829196558
- 11 | 9422.029173765748
+    | 9421.763392134212
   6 | 9436.031206307503
   3 | 9439.178404000439
   0 | 9444.372352979574
@@ -4219,7 +4273,7 @@ select ss, stddev(cint4) from aggfns where cfloat8 <= 0 group by ss order by std
   7 | 9470.920199125109
   8 | 9488.579674823607
   5 | 9533.551517829360
-    |    10351.23962464
+ 11 |    10187.00521634
 (10 rows)
 
 select sum(cint4) from aggfns where cfloat8 <= 0;
@@ -4247,11 +4301,11 @@ select ss, sum(cint4) from aggfns where cfloat8 <= 0 group by ss order by sum(ci
 ----+---------
   8 | -891469
   7 | -772457
- 11 | -530268
+    | -459184
   3 | -322034
   0 | -220736
   6 | -106243
-    |   30463
+ 11 |  -40621
   9 |  209399
   4 |  597724
   5 | 1364096
@@ -4278,18 +4332,18 @@ select s, avg(cint8) from aggfns where cfloat8 <= 0 group by s order by avg(cint
 (9 rows)
 
 select ss, avg(cint8) from aggfns where cfloat8 <= 0 group by ss order by avg(cint8), ss limit 10;
- ss |          avg          
-----+-----------------------
- 11 | -161.0356316054353296
-  5 |  -84.4558236936577583
-  8 |  -71.0010945273631841
-  3 |  -30.2171269065895723
-  0 |  -11.7269493032908390
-  7 |   -5.8845575708988877
-  4 |   26.3155603917301415
-  6 |   57.5590225184287590
-  9 |   78.7373446046742914
-    | 1579.8333333333333333
+ ss |          avg           
+----+------------------------
+ 11 | -5606.7777777777777778
+    |  -155.0492347966169956
+  5 |   -84.4558236936577583
+  8 |   -71.0010945273631841
+  3 |   -30.2171269065895723
+  0 |   -11.7269493032908390
+  7 |    -5.8845575708988877
+  4 |    26.3155603917301415
+  6 |    57.5590225184287590
+  9 |    78.7373446046742914
 (10 rows)
 
 select max(cint8) from aggfns where cfloat8 <= 0;
@@ -4315,9 +4369,9 @@ select s, max(cint8) from aggfns where cfloat8 <= 0 group by s order by max(cint
 select ss, max(cint8) from aggfns where cfloat8 <= 0 group by ss order by max(cint8), ss limit 10;
  ss |  max  
 ----+-------
-    | 12678
+ 11 | 11372
   8 | 16379
- 11 | 16379
+    | 16379
   6 | 16380
   7 | 16380
   5 | 16381
@@ -4357,9 +4411,9 @@ select ss, min(cint8) from aggfns where cfloat8 <= 0 group by ss order by min(ci
   4 | -16381
   7 | -16381
   3 | -16375
- 11 | -16375
+    | -16375
   9 | -16372
-    | -14174
+ 11 | -14502
 (10 rows)
 
 select sum(cint8) from aggfns where cfloat8 <= 0;
@@ -4385,13 +4439,13 @@ select s, sum(cint8) from aggfns where cfloat8 <= 0 group by s order by sum(cint
 select ss, sum(cint8) from aggfns where cfloat8 <= 0 group by ss order by sum(cint8), ss limit 10;
  ss |   sum    
 ----+----------
- 11 | -1599889
+    | -1539949
   5 |  -846923
   8 |  -713561
   3 |  -303108
   0 |  -118665
   7 |   -58722
-    |     9479
+ 11 |   -50461
   4 |   266024
   6 |   570007
   9 |   791704
@@ -4456,10 +4510,10 @@ select ss, min(cts) from aggfns where cfloat8 <= 0 group by ss order by min(cts)
  ss |           min            
 ----+--------------------------
   0 | Fri Jan 01 01:01:01 2021
- 11 | Fri Jan 01 06:34:21 2021
+    | Fri Jan 01 06:34:21 2021
   3 | Fri Jan 01 09:21:01 2021
-    | Fri Jan 01 09:21:01 2021
   4 | Fri Jan 01 12:07:41 2021
+ 11 | Fri Jan 01 12:07:41 2021
   5 | Fri Jan 01 14:54:21 2021
   6 | Fri Jan 01 17:41:01 2021
   7 | Fri Jan 01 20:27:41 2021
@@ -4526,10 +4580,10 @@ select ss, min(ctstz) from aggfns where cfloat8 <= 0 group by ss order by min(ct
  ss |             min              
 ----+------------------------------
   0 | Fri Jan 01 01:01:01 2021 PST
- 11 | Fri Jan 01 06:34:21 2021 PST
+    | Fri Jan 01 06:34:21 2021 PST
   3 | Fri Jan 01 09:21:01 2021 PST
-    | Fri Jan 01 09:21:01 2021 PST
   4 | Fri Jan 01 12:07:41 2021 PST
+ 11 | Fri Jan 01 12:07:41 2021 PST
   5 | Fri Jan 01 14:54:21 2021 PST
   6 | Fri Jan 01 17:41:01 2021 PST
   7 | Fri Jan 01 20:27:41 2021 PST
@@ -4561,10 +4615,10 @@ select ss, avg(s) from aggfns where cfloat8 <= 0 group by ss order by avg(s), ss
  ss |            avg             
 ----+----------------------------
   0 | 0.000000000000000000000000
- 11 |         2.0018117765475591
+    |         2.0006041079339509
   3 |         3.0000000000000000
-    |         3.0000000000000000
   4 |         4.0000000000000000
+ 11 |         4.0000000000000000
   5 |         5.0000000000000000
   6 |         6.0000000000000000
   7 |         7.0000000000000000
@@ -4595,9 +4649,9 @@ select s, count(s) from aggfns where cfloat8 <= 0 group by s order by count(s), 
 select ss, count(s) from aggfns where cfloat8 <= 0 group by ss order by count(s), ss limit 10;
  ss | count 
 ----+-------
-    |     6
+ 11 |     9
   6 |  9903
- 11 |  9935
+    |  9932
   7 |  9979
   5 | 10028
   3 | 10031
@@ -4666,10 +4720,10 @@ select ss, min(s) from aggfns where cfloat8 <= 0 group by ss order by min(s), ss
  ss | min 
 ----+-----
   0 |   0
- 11 |   2
+    |   2
   3 |   3
-    |   3
   4 |   4
+ 11 |   4
   5 |   5
   6 |   6
   7 |   7
@@ -4708,8 +4762,8 @@ select ss, stddev(s) from aggfns where cfloat8 <= 0 group by ss order by stddev(
   7 |                      0
   8 |                      0
   9 |                      0
-    |                      0
- 11 | 0.06017171256636552646
+ 11 |                      0
+    | 0.02457241911841021973
 (10 rows)
 
 select sum(s) from aggfns where cfloat8 <= 0;
@@ -4736,8 +4790,8 @@ select ss, sum(s) from aggfns where cfloat8 <= 0 group by ss order by sum(s), ss
  ss |  sum  
 ----+-------
   0 |     0
-    |    18
- 11 | 19888
+ 11 |    36
+    | 19870
   3 | 30093
   4 | 40436
   5 | 50140
@@ -4750,7 +4804,7 @@ select ss, sum(s) from aggfns where cfloat8 <= 0 group by ss order by sum(s), ss
 select avg(ss) from aggfns where cfloat8 <= 0;
         avg         
 --------------------
- 5.8765755079870079
+ 5.2431274366926996
 (1 row)
 
 select s, avg(ss) from aggfns where cfloat8 <= 0 group by s order by avg(ss), s limit 10;
@@ -4764,7 +4818,7 @@ select s, avg(ss) from aggfns where cfloat8 <= 0 group by s order by avg(ss), s 
  7 |         7.0000000000000000
  8 |         8.0000000000000000
  9 |         9.0000000000000000
- 2 |        11.0000000000000000
+ 2 |                           
 (9 rows)
 
 select ss, avg(ss) from aggfns where cfloat8 <= 0 group by ss order by avg(ss), ss limit 10;
@@ -4798,8 +4852,8 @@ select s, max(ss) from aggfns where cfloat8 <= 0 group by s order by max(ss), s 
  7 |   7
  8 |   8
  9 |   9
- 2 |  11
  4 |  11
+ 2 |    
 (9 rows)
 
 select ss, max(ss) from aggfns where cfloat8 <= 0 group by ss order by max(ss), ss limit 10;
@@ -4834,7 +4888,7 @@ select s, min(ss) from aggfns where cfloat8 <= 0 group by s order by min(ss), s 
  7 |   7
  8 |   8
  9 |   9
- 2 |  11
+ 2 |    
 (9 rows)
 
 select ss, min(ss) from aggfns where cfloat8 <= 0 group by ss order by min(ss), ss limit 10;
@@ -4855,14 +4909,13 @@ select ss, min(ss) from aggfns where cfloat8 <= 0 group by ss order by min(ss), 
 select stddev(ss) from aggfns where cfloat8 <= 0;
        stddev       
 --------------------
- 3.1457968709791645
+ 2.7336515224169933
 (1 row)
 
 select s, stddev(ss) from aggfns where cfloat8 <= 0 group by s order by stddev(ss), s limit 10;
  s |         stddev         
 ---+------------------------
  0 |                      0
- 2 |                      0
  3 |                      0
  5 |                      0
  6 |                      0
@@ -4870,6 +4923,7 @@ select s, stddev(ss) from aggfns where cfloat8 <= 0 group by s order by stddev(s
  8 |                      0
  9 |                      0
  4 | 0.20868929911309143893
+ 2 |                       
 (9 rows)
 
 select ss, stddev(ss) from aggfns where cfloat8 <= 0 group by ss order by stddev(ss), ss limit 10;
@@ -4890,36 +4944,36 @@ select ss, stddev(ss) from aggfns where cfloat8 <= 0 group by ss order by stddev
 select sum(ss) from aggfns where cfloat8 <= 0;
   sum   
 --------
- 530120
+ 420934
 (1 row)
 
 select s, sum(ss) from aggfns where cfloat8 <= 0 group by s order by sum(ss), s limit 10;
- s |  sum   
----+--------
- 0 |      0
- 3 |  30093
- 4 |  40535
- 5 |  50140
- 6 |  59418
- 7 |  69853
- 8 |  80400
- 9 |  90495
- 2 | 109186
+ s |  sum  
+---+-------
+ 0 |     0
+ 3 | 30093
+ 4 | 40535
+ 5 | 50140
+ 6 | 59418
+ 7 | 69853
+ 8 | 80400
+ 9 | 90495
+ 2 |      
 (9 rows)
 
 select ss, sum(ss) from aggfns where cfloat8 <= 0 group by ss order by sum(ss), ss limit 10;
- ss |  sum   
-----+--------
-  0 |      0
-  3 |  30093
-  4 |  40436
-  5 |  50140
-  6 |  59418
-  7 |  69853
-  8 |  80400
-  9 |  90495
- 11 | 109285
-    |       
+ ss |  sum  
+----+-------
+  0 |     0
+ 11 |    99
+  3 | 30093
+  4 | 40436
+  5 | 50140
+  6 | 59418
+  7 | 69853
+  8 | 80400
+  9 | 90495
+    |      
 (10 rows)
 
 select max(t) from aggfns where cfloat8 <= 0;
@@ -4981,10 +5035,10 @@ select ss, min(t) from aggfns where cfloat8 <= 0 group by ss order by min(t), ss
  ss |  min  
 ----+-------
   0 |     8
- 11 | 20003
+    | 20003
   3 | 30002
-    | 33696
   4 | 40001
+ 11 | 41223
   5 | 50004
   6 | 60001
   7 | 70002
@@ -5016,7 +5070,6 @@ select s, count(*) from aggfns where cfloat8 < 1000 group by s order by count(*)
 select ss, count(*) from aggfns where cfloat8 < 1000 group by ss order by count(*), ss limit 10;
  ss | count 
 ----+-------
-    |    19
   3 | 19981
   4 | 19981
   0 | 20000
@@ -5025,7 +5078,8 @@ select ss, count(*) from aggfns where cfloat8 < 1000 group by ss order by count(
   7 | 20000
   8 | 20000
   9 | 20000
- 11 | 40019
+ 11 | 20019
+    | 20019
 (10 rows)
 
 select max(cdate) from aggfns where cfloat8 < 1000;
@@ -5090,8 +5144,8 @@ select ss, min(cdate) from aggfns where cfloat8 < 1000 group by ss order by min(
 ----+------------
   0 | 01-01-2021
  11 | 05-19-2048
+    | 10-05-2075
   3 | 02-21-2103
-    | 02-21-2103
   4 | 07-09-2130
   5 | 11-24-2157
   6 | 04-11-2185
@@ -5125,7 +5179,6 @@ select ss, avg(cfloat4) from aggfns where cfloat8 < 1000 group by ss order by av
  ss |         avg          
 ----+----------------------
   3 |            -Infinity
-    |    -1.39583652270468
   9 |   -0.292700759558938
   4 |   -0.169252917487522
   6 | -0.00610964622725733
@@ -5133,6 +5186,7 @@ select ss, avg(cfloat4) from aggfns where cfloat8 < 1000 group by ss order by av
   0 |   0.0862269837114494
   7 |     0.19168354413514
   8 |    0.456703752867272
+    |             Infinity
  11 |                  NaN
 (10 rows)
 
@@ -5158,18 +5212,18 @@ select s, max(cfloat4) from aggfns where cfloat8 < 1000 group by s order by max(
 (10 rows)
 
 select ss, max(cfloat4) from aggfns where cfloat8 < 1000 group by ss order by max(cfloat4), ss limit 10;
- ss |   max   
-----+---------
-    | 47.2047
-  9 | 49.9899
-  4 | 49.9946
-  6 | 49.9956
-  7 | 49.9969
-  3 | 49.9979
-  5 | 49.9992
-  0 | 49.9995
-  8 | 49.9997
- 11 |     NaN
+ ss |   max    
+----+----------
+  9 |  49.9899
+  4 |  49.9946
+  6 |  49.9956
+  7 |  49.9969
+  3 |  49.9979
+  5 |  49.9992
+  0 |  49.9995
+  8 |  49.9997
+    | Infinity
+ 11 |      NaN
 (10 rows)
 
 select min(cfloat4) from aggfns where cfloat8 < 1000;
@@ -5199,13 +5253,13 @@ select ss, min(cfloat4) from aggfns where cfloat8 < 1000 group by ss order by mi
   3 | -Infinity
   4 |  -49.9999
   6 |  -49.9995
- 11 |  -49.9991
+    |  -49.9991
   7 |  -49.9984
+ 11 |  -49.9974
   8 |  -49.9969
   0 |  -49.9949
   5 |  -49.9942
   9 |  -49.9911
-    |  -45.4083
 (10 rows)
 
 select stddev(cfloat4) from aggfns where cfloat8 < 1000;
@@ -5239,9 +5293,9 @@ select ss, stddev(cfloat4) from aggfns where cfloat8 < 1000 group by ss order by
   6 | 28.9190577543738
   8 | 29.0040125904064
   5 | 29.0213532270614
-    | 30.6324072248673
   3 |              NaN
  11 |              NaN
+    |              NaN
 (10 rows)
 
 select sum(cfloat4) from aggfns where cfloat8 < 1000;
@@ -5272,11 +5326,11 @@ select ss, sum(cfloat4) from aggfns where cfloat8 < 1000 group by ss order by su
   9 |  -5854.02
   4 |  -3381.84
   6 |  -122.193
-    |  -26.5209
   5 |   215.643
   0 |   1724.54
   7 |   3833.67
   8 |   9134.08
+    |  Infinity
  11 |       NaN
 (10 rows)
 
@@ -5312,8 +5366,8 @@ select ss, avg(cfloat8) from aggfns where cfloat8 < 1000 group by ss order by av
   7 | -0.063637967283139
   5 | 0.0438265096326359
   6 |  0.169599099685438
-    |   5.42090986487701
- 11 |   6.59778165165114
+    |  0.203097089119745
+ 11 |   12.9913492471038
 (10 rows)
 
 select max(cfloat8) from aggfns where cfloat8 < 1000;
@@ -5340,14 +5394,14 @@ select s, max(cfloat8) from aggfns where cfloat8 < 1000 group by s order by max(
 select ss, max(cfloat8) from aggfns where cfloat8 < 1000 group by ss order by max(cfloat8), ss limit 10;
  ss |       max        
 ----+------------------
-    | 46.3985309237614
+ 11 | 42.8941954858601
   5 | 49.9874341068789
   3 | 49.9890822684392
   6 | 49.9939429108053
   8 | 49.9963666079566
   0 | 49.9965498689562
   7 | 49.9973275698721
- 11 | 49.9975695507601
+    | 49.9975695507601
   4 | 49.9978997278959
   9 | 49.9995574122295
 (10 rows)
@@ -5377,7 +5431,7 @@ select ss, min(cfloat8) from aggfns where cfloat8 < 1000 group by ss order by mi
  ss |        min        
 ----+-------------------
   0 | -49.9994775978848
- 11 | -49.9985320260748
+    | -49.9985320260748
   4 | -49.9983572866768
   3 | -49.9977725092322
   6 | -49.9967515002936
@@ -5385,7 +5439,7 @@ select ss, min(cfloat8) from aggfns where cfloat8 < 1000 group by ss order by mi
   5 | -49.9921301845461
   7 |   -49.99003498815
   8 | -49.9897602945566
-    | -38.5084833716974
+ 11 | -46.2087355088443
 (10 rows)
 
 select stddev(cfloat8) from aggfns where cfloat8 < 1000;
@@ -5410,18 +5464,18 @@ select s, stddev(cfloat8) from aggfns where cfloat8 < 1000 group by s order by s
 (10 rows)
 
 select ss, stddev(cfloat8) from aggfns where cfloat8 < 1000 group by ss order by stddev(cfloat8), ss limit 10;
- ss |      stddev      
-----+------------------
- 11 | 21.3262797346004
-    |  22.894065438835
-  9 | 28.7642081921344
-  4 | 28.7760615445521
-  5 | 28.7843925303698
-  6 | 28.8543767497508
-  3 |  28.926156595386
-  8 |   28.96331707256
-  0 | 28.9653425568561
-  7 | 28.9656492103736
+ ss |      stddev       
+----+-------------------
+ 11 | 0.998497915010093
+    |  28.7561000172161
+  9 |  28.7642081921344
+  4 |  28.7760615445521
+  5 |  28.7843925303698
+  6 |  28.8543767497508
+  3 |   28.926156595386
+  8 |    28.96331707256
+  0 |  28.9653425568561
+  7 |  28.9656492103736
 (10 rows)
 
 select sum(cfloat8) from aggfns where cfloat8 < 1000;
@@ -5454,10 +5508,10 @@ select ss, sum(cfloat8) from aggfns where cfloat8 < 1000 group by ss order by su
   3 | -3066.93256727885
   9 | -2296.84818079695
   7 | -1272.75934566278
-    |  102.997287432663
   5 |  876.530192652717
   6 |  3391.98199370876
- 11 |  264036.623917427
+    |  4065.80062708817
+ 11 |  260073.820577771
 (10 rows)
 
 select avg(cint2) from aggfns where cfloat8 < 1000;
@@ -5482,18 +5536,18 @@ select s, avg(cint2) from aggfns where cfloat8 < 1000 group by s order by avg(ci
 (10 rows)
 
 select ss, avg(cint2) from aggfns where cfloat8 < 1000 group by ss order by avg(cint2), ss limit 10;
- ss |          avg           
-----+------------------------
-    | -1368.1578947368421053
-  8 |  -129.4959711726139833
-  3 |   -94.5546037471195271
-  6 |   -61.0756218407487113
-  7 |   -55.8695260497472599
- 11 |   -33.7550336409794652
-  4 |   -27.5652740206392145
-  9 |   -21.7994594865121866
-  0 |    17.5951654071367799
-  5 |   110.0305290025524248
+ ss |          avg          
+----+-----------------------
+    | -159.4671500000000000
+  8 | -129.4959711726139833
+  3 |  -94.5546037471195271
+  6 |  -61.0756218407487113
+  7 |  -55.8695260497472599
+  4 |  -27.5652740206392145
+  9 |  -21.7994594865121866
+  0 |   17.5951654071367799
+ 11 |   90.6894000000000000
+  5 |  110.0305290025524248
 (10 rows)
 
 select count(cint2) from aggfns where cfloat8 < 1000;
@@ -5520,7 +5574,6 @@ select s, count(cint2) from aggfns where cfloat8 < 1000 group by s order by coun
 select ss, count(cint2) from aggfns where cfloat8 < 1000 group by ss order by count(cint2), ss limit 10;
  ss | count 
 ----+-------
-    |    19
   3 | 19962
   4 | 19962
   0 | 19981
@@ -5529,7 +5582,8 @@ select ss, count(cint2) from aggfns where cfloat8 < 1000 group by ss order by co
   7 | 19981
   8 | 19981
   9 | 19981
- 11 | 39981
+ 11 | 20000
+    | 20000
 (10 rows)
 
 select max(cint2) from aggfns where cfloat8 < 1000;
@@ -5556,10 +5610,10 @@ select s, max(cint2) from aggfns where cfloat8 < 1000 group by s order by max(ci
 select ss, max(cint2) from aggfns where cfloat8 < 1000 group by ss order by max(cint2), ss limit 10;
  ss |  max  
 ----+-------
-    | 16362
   3 | 16380
   5 | 16381
   7 | 16381
+    | 16381
   8 | 16382
   0 | 16383
   4 | 16383
@@ -5598,10 +5652,10 @@ select ss, min(cint2) from aggfns where cfloat8 < 1000 group by ss order by min(
   6 | -16383
   7 | -16382
   8 | -16382
- 11 | -16382
+    | -16382
   3 | -16381
+ 11 | -16378
   9 | -16375
-    | -16100
 (10 rows)
 
 select stddev(cint2) from aggfns where cfloat8 < 1000;
@@ -5628,8 +5682,8 @@ select s, stddev(cint2) from aggfns where cfloat8 < 1000 group by s order by std
 select ss, stddev(cint2) from aggfns where cfloat8 < 1000 group by ss order by stddev(cint2), ss limit 10;
  ss |      stddev       
 ----+-------------------
-    | 8413.549166956554
   9 | 9450.322790943425
+    | 9457.685918593809
   7 | 9462.161209850735
   6 | 9467.569674984571
   5 | 9467.776835158782
@@ -5637,7 +5691,7 @@ select ss, stddev(cint2) from aggfns where cfloat8 < 1000 group by ss order by s
   8 | 9477.586839536066
   4 | 9483.611454519949
   0 | 9484.907423282680
- 11 | 9494.206429493352
+ 11 | 9528.120007675789
 (10 rows)
 
 select sum(cint2) from aggfns where cfloat8 < 1000;
@@ -5664,15 +5718,15 @@ select s, sum(cint2) from aggfns where cfloat8 < 1000 group by s order by sum(ci
 select ss, sum(cint2) from aggfns where cfloat8 < 1000 group by ss order by sum(cint2), ss limit 10;
  ss |   sum    
 ----+----------
+    | -3189343
   8 | -2587459
   3 | -1887499
- 11 | -1349560
   6 | -1220352
   7 | -1116329
   4 |  -550258
   9 |  -435575
-    |   -25995
   0 |   351569
+ 11 |  1813788
   5 |  2198520
 (10 rows)
 
@@ -5701,15 +5755,15 @@ select ss, avg(cint4) from aggfns where cfloat8 < 1000 group by ss order by avg(
  ss |          avg          
 ----+-----------------------
   9 | -102.4283000000000000
+    |  -99.2131475098656277
   6 |  -53.1566500000000000
   7 |  -42.6121500000000000
   8 |  -29.2615500000000000
- 11 |  -16.4247732327144606
   4 |    9.6930584054852110
   0 |   27.7536500000000000
   3 |   68.3874180471447875
+ 11 |   68.4650082421699386
   5 |  103.1069000000000000
-    | 2197.6842105263157895
 (10 rows)
 
 select max(cint4) from aggfns where cfloat8 < 1000;
@@ -5736,10 +5790,10 @@ select s, max(cint4) from aggfns where cfloat8 < 1000 group by s order by max(ci
 select ss, max(cint4) from aggfns where cfloat8 < 1000 group by ss order by max(cint4), ss limit 10;
  ss |  max  
 ----+-------
-    | 14812
   3 | 16379
   5 | 16379
   7 | 16379
+    | 16381
   0 | 16383
   4 | 16383
   6 | 16383
@@ -5774,14 +5828,14 @@ select ss, min(cint4) from aggfns where cfloat8 < 1000 group by ss order by min(
 ----+--------
   0 | -16383
   7 | -16383
- 11 | -16383
+    | -16383
   3 | -16382
   4 | -16382
   6 | -16382
   8 | -16382
   9 | -16382
+ 11 | -16382
   5 | -16380
-    | -15907
 (10 rows)
 
 select stddev(cint4) from aggfns where cfloat8 < 1000;
@@ -5808,13 +5862,13 @@ select s, stddev(cint4) from aggfns where cfloat8 < 1000 group by s order by std
 select ss, stddev(cint4) from aggfns where cfloat8 < 1000 group by ss order by stddev(cint4), ss limit 10;
  ss |      stddev       
 ----+-------------------
-    | 9361.317298404296
   0 | 9406.815855797801
   6 | 9410.397911988306
   9 | 9426.452583637956
+    | 9440.633682496139
   4 | 9442.480718256247
   8 | 9450.281544631633
- 11 | 9450.690059613938
+ 11 | 9460.158622933231
   3 | 9474.873657491443
   7 | 9485.765898279180
   5 | 9504.684751625578
@@ -5845,14 +5899,14 @@ select ss, sum(cint4) from aggfns where cfloat8 < 1000 group by ss order by sum(
  ss |   sum    
 ----+----------
   9 | -2048566
+    | -1986148
   6 | -1063133
   7 |  -852243
- 11 |  -657303
   8 |  -585231
-    |    41756
   4 |   193677
   0 |   555073
   3 |  1366449
+ 11 |  1370601
   5 |  2062138
 (10 rows)
 
@@ -5878,18 +5932,18 @@ select s, avg(cint8) from aggfns where cfloat8 < 1000 group by s order by avg(ci
 (10 rows)
 
 select ss, avg(cint8) from aggfns where cfloat8 < 1000 group by ss order by avg(cint8), ss limit 10;
- ss |          avg          
-----+-----------------------
-  8 | -118.4870000000000000
-  5 |  -81.6955500000000000
-  4 |  -17.0811771182623492
- 11 |  -15.1685449411529523
-  7 |   -2.3563500000000000
-  6 |   11.9056500000000000
-  0 |   15.3018000000000000
-  3 |   37.6662329212752115
-  9 |   61.7467500000000000
-    | 2467.2631578947368421
+ ss |           avg           
+----+-------------------------
+  8 |   -118.4870000000000000
+  5 |    -81.6955500000000000
+ 11 |    -27.8558869074379340
+  4 |    -17.0811771182623492
+  7 |     -2.3563500000000000
+    | -0.12513112543084070133
+  6 |     11.9056500000000000
+  0 |     15.3018000000000000
+  3 |     37.6662329212752115
+  9 |     61.7467500000000000
 (10 rows)
 
 select max(cint8) from aggfns where cfloat8 < 1000;
@@ -5916,7 +5970,7 @@ select s, max(cint8) from aggfns where cfloat8 < 1000 group by s order by max(ci
 select ss, max(cint8) from aggfns where cfloat8 < 1000 group by ss order by max(cint8), ss limit 10;
  ss |  max  
 ----+-------
-    | 13750
+    | 16379
   6 | 16380
   7 | 16380
   8 | 16380
@@ -5960,8 +6014,8 @@ select ss, min(cint8) from aggfns where cfloat8 < 1000 group by ss order by min(
   5 | -16382
   4 | -16381
   9 | -16380
+    | -16379
   3 | -16378
-    | -14174
 (10 rows)
 
 select sum(cint8) from aggfns where cfloat8 < 1000;
@@ -5990,10 +6044,10 @@ select ss, sum(cint8) from aggfns where cfloat8 < 1000 group by ss order by sum(
 ----+----------
   8 | -2369740
   5 | -1633911
- 11 |  -607030
+ 11 |  -557647
   4 |  -341299
   7 |   -47127
-    |    46878
+    |    -2505
   6 |   238113
   0 |   306036
   3 |   752609
@@ -6062,8 +6116,8 @@ select ss, min(cts) from aggfns where cfloat8 < 1000 group by ss order by min(ct
 ----+--------------------------
   0 | Fri Jan 01 01:01:01 2021
  11 | Fri Jan 01 03:47:41 2021
+    | Fri Jan 01 06:34:21 2021
   3 | Fri Jan 01 09:21:01 2021
-    | Fri Jan 01 09:21:01 2021
   4 | Fri Jan 01 12:07:41 2021
   5 | Fri Jan 01 14:54:21 2021
   6 | Fri Jan 01 17:41:01 2021
@@ -6134,8 +6188,8 @@ select ss, min(ctstz) from aggfns where cfloat8 < 1000 group by ss order by min(
 ----+------------------------------
   0 | Fri Jan 01 01:01:01 2021 PST
  11 | Fri Jan 01 03:47:41 2021 PST
+    | Fri Jan 01 06:34:21 2021 PST
   3 | Fri Jan 01 09:21:01 2021 PST
-    | Fri Jan 01 09:21:01 2021 PST
   4 | Fri Jan 01 12:07:41 2021 PST
   5 | Fri Jan 01 14:54:21 2021 PST
   6 | Fri Jan 01 17:41:01 2021 PST
@@ -6169,9 +6223,9 @@ select ss, avg(s) from aggfns where cfloat8 < 1000 group by ss order by avg(s), 
  ss |            avg             
 ----+----------------------------
   0 | 0.000000000000000000000000
- 11 |         1.5011869362053025
+ 11 |     1.00284729506968380039
+    |         2.0009490983565613
   3 |         3.0000000000000000
-    |         3.0000000000000000
   4 |         4.0000000000000000
   5 |         5.0000000000000000
   6 |         6.0000000000000000
@@ -6204,7 +6258,6 @@ select s, count(s) from aggfns where cfloat8 < 1000 group by s order by count(s)
 select ss, count(s) from aggfns where cfloat8 < 1000 group by ss order by count(s), ss limit 10;
  ss | count 
 ----+-------
-    |    19
   3 | 19981
   4 | 19981
   0 | 20000
@@ -6213,7 +6266,8 @@ select ss, count(s) from aggfns where cfloat8 < 1000 group by ss order by count(
   7 | 20000
   8 | 20000
   9 | 20000
- 11 | 40019
+ 11 | 20019
+    | 20019
 (10 rows)
 
 select max(s) from aggfns where cfloat8 < 1000;
@@ -6278,8 +6332,8 @@ select ss, min(s) from aggfns where cfloat8 < 1000 group by ss order by min(s), 
 ----+-----
   0 |   0
  11 |   1
+    |   2
   3 |   3
-    |   3
   4 |   4
   5 |   5
   6 |   6
@@ -6320,8 +6374,8 @@ select ss, stddev(s) from aggfns where cfloat8 < 1000 group by ss order by stdde
   7 |                      0
   8 |                      0
   9 |                      0
-    |                      0
- 11 | 0.50284545977155885187
+    | 0.03079358595744834506
+ 11 | 0.09238075787234503528
 (10 rows)
 
 select sum(s) from aggfns where cfloat8 < 1000;
@@ -6349,9 +6403,9 @@ select ss, sum(s) from aggfns where cfloat8 < 1000 group by ss order by sum(s), 
  ss |  sum   
 ----+--------
   0 |      0
-    |     57
+ 11 |  20076
+    |  40057
   3 |  59943
- 11 |  60076
   4 |  79924
   5 | 100000
   6 | 120000
@@ -6363,7 +6417,7 @@ select ss, sum(s) from aggfns where cfloat8 < 1000 group by ss order by sum(s), 
 select avg(ss) from aggfns where cfloat8 < 1000;
         avg         
 --------------------
- 6.4009880938689175
+ 5.8899328262427701
 (1 row)
 
 select s, avg(ss) from aggfns where cfloat8 < 1000 group by s order by avg(ss), s limit 10;
@@ -6378,7 +6432,7 @@ select s, avg(ss) from aggfns where cfloat8 < 1000 group by s order by avg(ss), 
  8 |         8.0000000000000000
  9 |         9.0000000000000000
  1 |        11.0000000000000000
- 2 |        11.0000000000000000
+ 2 |                           
 (10 rows)
 
 select ss, avg(ss) from aggfns where cfloat8 < 1000 group by ss order by avg(ss), ss limit 10;
@@ -6413,8 +6467,8 @@ select s, max(ss) from aggfns where cfloat8 < 1000 group by s order by max(ss), 
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
  4 |  11
+ 2 |    
 (10 rows)
 
 select ss, max(ss) from aggfns where cfloat8 < 1000 group by ss order by max(ss), ss limit 10;
@@ -6450,7 +6504,7 @@ select s, min(ss) from aggfns where cfloat8 < 1000 group by s order by min(ss), 
  8 |   8
  9 |   9
  1 |  11
- 2 |  11
+ 2 |    
 (10 rows)
 
 select ss, min(ss) from aggfns where cfloat8 < 1000 group by ss order by min(ss), ss limit 10;
@@ -6471,7 +6525,7 @@ select ss, min(ss) from aggfns where cfloat8 < 1000 group by ss order by min(ss)
 select stddev(ss) from aggfns where cfloat8 < 1000;
        stddev       
 --------------------
- 3.3528328280068652
+ 3.1431098825513430
 (1 row)
 
 select s, stddev(ss) from aggfns where cfloat8 < 1000 group by s order by stddev(ss), s limit 10;
@@ -6479,7 +6533,6 @@ select s, stddev(ss) from aggfns where cfloat8 < 1000 group by s order by stddev
 ---+------------------------
  0 |                      0
  1 |                      0
- 2 |                      0
  3 |                      0
  5 |                      0
  6 |                      0
@@ -6487,6 +6540,7 @@ select s, stddev(ss) from aggfns where cfloat8 < 1000 group by s order by stddev
  8 |                      0
  9 |                      0
  4 | 0.21565737387148452722
+ 2 |                       
 (10 rows)
 
 select ss, stddev(ss) from aggfns where cfloat8 < 1000 group by ss order by stddev(ss), ss limit 10;
@@ -6507,7 +6561,7 @@ select ss, stddev(ss) from aggfns where cfloat8 < 1000 group by ss order by stdd
 select sum(ss) from aggfns where cfloat8 < 1000;
    sum   
 ---------
- 1280076
+ 1060076
 (1 row)
 
 select s, sum(ss) from aggfns where cfloat8 < 1000 group by s order by sum(ss), s limit 10;
@@ -6522,7 +6576,7 @@ select s, sum(ss) from aggfns where cfloat8 < 1000 group by s order by sum(ss), 
  8 | 160000
  9 | 180000
  1 | 220000
- 2 | 220000
+ 2 |       
 (10 rows)
 
 select ss, sum(ss) from aggfns where cfloat8 < 1000 group by ss order by sum(ss), ss limit 10;
@@ -6536,7 +6590,7 @@ select ss, sum(ss) from aggfns where cfloat8 < 1000 group by ss order by sum(ss)
   7 | 140000
   8 | 160000
   9 | 180000
- 11 | 440209
+ 11 | 220209
     |       
 (10 rows)
 
@@ -6602,8 +6656,8 @@ select ss, min(t) from aggfns where cfloat8 < 1000 group by ss order by min(t), 
 ----+-------
   0 |     1
  11 | 10001
+    | 20001
   3 | 30001
-    | 30537
   4 | 40001
   5 | 50001
   6 | 60001
@@ -7365,7 +7419,8 @@ select ss, avg(cint2) from aggfns where cint2 is null group by ss order by avg(c
   8 |    
   9 |    
  11 |    
-(9 rows)
+    |    
+(10 rows)
 
 select count(cint2) from aggfns where cint2 is null;
  count 
@@ -7400,7 +7455,8 @@ select ss, count(cint2) from aggfns where cint2 is null group by ss order by cou
   8 |     0
   9 |     0
  11 |     0
-(9 rows)
+    |     0
+(10 rows)
 
 select max(cint2) from aggfns where cint2 is null;
  max 
@@ -7435,7 +7491,8 @@ select ss, max(cint2) from aggfns where cint2 is null group by ss order by max(c
   8 |    
   9 |    
  11 |    
-(9 rows)
+    |    
+(10 rows)
 
 select min(cint2) from aggfns where cint2 is null;
  min 
@@ -7470,7 +7527,8 @@ select ss, min(cint2) from aggfns where cint2 is null group by ss order by min(c
   8 |    
   9 |    
  11 |    
-(9 rows)
+    |    
+(10 rows)
 
 select stddev(cint2) from aggfns where cint2 is null;
  stddev 
@@ -7505,7 +7563,8 @@ select ss, stddev(cint2) from aggfns where cint2 is null group by ss order by st
   8 |       
   9 |       
  11 |       
-(9 rows)
+    |       
+(10 rows)
 
 select sum(cint2) from aggfns where cint2 is null;
  sum 
@@ -7540,7 +7599,8 @@ select ss, sum(cint2) from aggfns where cint2 is null group by ss order by sum(c
   8 |    
   9 |    
  11 |    
-(9 rows)
+    |    
+(10 rows)
 
 -- Test multiple aggregate functions as well.
 select count(*), count(cint2), min(cfloat4), cint2 from aggfns group by cint2

--- a/tsl/test/expected/vector_agg_text.out
+++ b/tsl/test/expected/vector_agg_text.out
@@ -56,6 +56,87 @@ select *, ss::text as x from (
     from source where s != 1
 ) t
 ;
+-- print a few reference values before compression
+select x, count(*) from agggroup group by x having (x='11' or x is null) order by count(*), x limit 10;
+ x  | count 
+----+-------
+ 11 | 20019
+    | 20019
+(2 rows)
+
+select x, count(cint2) from agggroup group by x having (x='11' or x is null) order by count(cint2), x limit 10;
+ x  | count 
+----+-------
+ 11 | 20000
+    | 20000
+(2 rows)
+
+select x, min(cint2) from agggroup group by x having (x='11' or x is null) order by min(cint2), x limit 10;
+ x  |  min   
+----+--------
+    | -16382
+ 11 | -16378
+(2 rows)
+
+select x, count(*) from agggroup where cint2 > 0 group by x having (x='11' or x is null) order by count(*), x limit 10;
+ x  | count 
+----+-------
+    |  9877
+ 11 | 10105
+(2 rows)
+
+select x, count(cint2) from agggroup where cint2 > 0 group by x having (x='11' or x is null) order by count(cint2), x limit 10;
+ x  | count 
+----+-------
+    |  9877
+ 11 | 10105
+(2 rows)
+
+select x, min(cint2) from agggroup where cint2 > 0 group by x order by min(cint2), x limit 10;
+ x  | min 
+----+-----
+ 11 |   1
+ 3  |   1
+ 5  |   1
+ 7  |   1
+ 8  |   1
+    |   1
+ 9  |   2
+ 6  |   3
+ 0  |   4
+ 4  |   4
+(10 rows)
+
+select x, count(*) from agggroup where cint2 is null group by x having (x='11') order by count(*), x limit 10;
+ x  | count 
+----+-------
+ 11 |    19
+(1 row)
+
+select x, count(cint2) from agggroup where cint2 is null group by x having (x is null) order by count(cint2), x limit 10;
+ x | count 
+---+-------
+   |     0
+(1 row)
+
+select x, count(*) from agggroup where cint2 is null and x is null group by x order by count(*), x limit 10;
+ x | count 
+---+-------
+   |    19
+(1 row)
+
+select x, count(cint2) from agggroup where cint2 is null and x is null group by x order by count(cint2), x limit 10;
+ x | count 
+---+-------
+   |     0
+(1 row)
+
+select x, min(cint2) from agggroup where cint2 is null and x is null group by x order by min(cint2), x limit 10;
+ x | min 
+---+-----
+   |    
+(1 row)
+
 select count(compress_chunk(x)) from show_chunks('agggroup') x;
  count 
 -------
@@ -125,7 +206,6 @@ order by explain, condition.n, variable, function, grouping.n
 select x, count(*) from agggroup group by x order by count(*), x limit 10;
  x  | count 
 ----+-------
-    |    19
  3  | 19981
  4  | 19981
  0  | 20000
@@ -134,13 +214,13 @@ select x, count(*) from agggroup group by x order by count(*), x limit 10;
  7  | 20000
  8  | 20000
  9  | 20000
- 11 | 40019
+ 11 | 20019
+    | 20019
 (10 rows)
 
 select x, count(cint2) from agggroup group by x order by count(cint2), x limit 10;
  x  | count 
 ----+-------
-    |    19
  3  | 19962
  4  | 19962
  0  | 19981
@@ -149,7 +229,8 @@ select x, count(cint2) from agggroup group by x order by count(cint2), x limit 1
  7  | 19981
  8  | 19981
  9  | 19981
- 11 | 39981
+ 11 | 20000
+    | 20000
 (10 rows)
 
 select x, min(cint2) from agggroup group by x order by min(cint2), x limit 10;
@@ -159,18 +240,18 @@ select x, min(cint2) from agggroup group by x order by min(cint2), x limit 10;
  4  | -16383
  5  | -16383
  6  | -16383
- 11 | -16382
  7  | -16382
  8  | -16382
+    | -16382
  3  | -16381
+ 11 | -16378
  9  | -16375
-    | -16295
 (10 rows)
 
 select x, count(*) from agggroup where cint2 > 0 group by x order by count(*), x limit 10;
  x  | count 
 ----+-------
-    |     9
+    |  9877
  3  |  9884
  6  |  9890
  4  |  9897
@@ -178,14 +259,14 @@ select x, count(*) from agggroup where cint2 > 0 group by x order by count(*), x
  7  |  9973
  0  | 10012
  9  | 10018
+ 11 | 10105
  5  | 10110
- 11 | 19973
 (10 rows)
 
 select x, count(cint2) from agggroup where cint2 > 0 group by x order by count(cint2), x limit 10;
  x  | count 
 ----+-------
-    |     9
+    |  9877
  3  |  9884
  6  |  9890
  4  |  9897
@@ -193,29 +274,30 @@ select x, count(cint2) from agggroup where cint2 > 0 group by x order by count(c
  7  |  9973
  0  | 10012
  9  | 10018
+ 11 | 10105
  5  | 10110
- 11 | 19973
 (10 rows)
 
 select x, min(cint2) from agggroup where cint2 > 0 group by x order by min(cint2), x limit 10;
- x  | min  
-----+------
- 11 |    1
- 3  |    1
- 5  |    1
- 7  |    1
- 8  |    1
- 9  |    2
- 6  |    3
- 0  |    4
- 4  |    4
-    | 4895
+ x  | min 
+----+-----
+ 11 |   1
+ 3  |   1
+ 5  |   1
+ 7  |   1
+ 8  |   1
+    |   1
+ 9  |   2
+ 6  |   3
+ 0  |   4
+ 4  |   4
 (10 rows)
 
 select x, count(*) from agggroup where cint2 is null group by x order by count(*), x limit 10;
  x  | count 
 ----+-------
  0  |    19
+ 11 |    19
  3  |    19
  4  |    19
  5  |    19
@@ -223,8 +305,8 @@ select x, count(*) from agggroup where cint2 is null group by x order by count(*
  7  |    19
  8  |    19
  9  |    19
- 11 |    38
-(9 rows)
+    |    19
+(10 rows)
 
 select x, count(cint2) from agggroup where cint2 is null group by x order by count(cint2), x limit 10;
  x  | count 
@@ -238,7 +320,8 @@ select x, count(cint2) from agggroup where cint2 is null group by x order by cou
  7  |     0
  8  |     0
  9  |     0
-(9 rows)
+    |     0
+(10 rows)
 
 select x, min(cint2) from agggroup where cint2 is null group by x order by min(cint2), x limit 10;
  x  | min 
@@ -252,22 +335,26 @@ select x, min(cint2) from agggroup where cint2 is null group by x order by min(c
  7  |    
  8  |    
  9  |    
-(9 rows)
+    |    
+(10 rows)
 
 select x, count(*) from agggroup where cint2 is null and x is null group by x order by count(*), x limit 10;
  x | count 
 ---+-------
-(0 rows)
+   |    19
+(1 row)
 
 select x, count(cint2) from agggroup where cint2 is null and x is null group by x order by count(cint2), x limit 10;
  x | count 
 ---+-------
-(0 rows)
+   |     0
+(1 row)
 
 select x, min(cint2) from agggroup where cint2 is null and x is null group by x order by min(cint2), x limit 10;
  x | min 
 ---+-----
-(0 rows)
+   |    
+(1 row)
 
 -- Test grouping by long strings
 select count(*) from long group by a order by 1 limit 10;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_FILES
     compression_fks.sql
     compression_insert.sql
     compression_indexcreate.sql
+    compression_nulls_and_defaults.sql
     compression_policy.sql
     compression_qualpushdown.sql
     compression_sequence_num_removal.sql

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -1150,8 +1150,10 @@ UPDATE test_notnull SET c2 = NULL;
 ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(show_chunks('test_notnull'));
--- broken atm due to bug in default handling in compression
+
+\set ON_ERROR_STOP 0
 ALTER TABLE test_notnull ALTER COLUMN c2 SET NOT NULL;
+\set ON_ERROR_STOP 1
 
 -- test alias in parameter name
 CREATE TABLE alias(time timestamptz NOT NULL);

--- a/tsl/test/sql/compression_nulls_and_defaults.sql
+++ b/tsl/test/sql/compression_nulls_and_defaults.sql
@@ -1,0 +1,302 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- test case #1: altering a compressed hypertable by adding a new column
+-- with a default value
+--
+-- The point of this test is to verify the behaviour of the default value if
+-- the hypertable is compressed before the new column is added.
+-- It adds rows before and after the column is added to make sure that the
+-- default value is returned correctly in both cases. This is to make sure
+-- that changing the code related to the default value does not break the
+-- behaviour of the default values.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+alter table t add column a double precision default 7.1;
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+insert into t (ts,c1) values (7,7);
+select compress_chunk(show_chunks('t'));
+select * from t;
+set timescaledb.enable_segmentwise_recompression to on;
+
+
+-- test case #2: altering an uncompressed hypertable by adding a new column
+-- with a default value
+--
+-- This is another test case to check that the correct behaviour is preserved
+-- after changing the code related to the default value.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+alter table t add column a double precision default 7.1;
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+insert into t (ts,c1) values (7,7);
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+
+-- test case #3: altering an uncompressed hypertable by adding a new column
+-- with a default value
+--
+-- This is one more testcase for establishing the correct behaviour of the
+-- default value after changing the code related to the default value.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+alter table t add column a double precision default 7.1;
+insert into t (ts,c1) values (4,4);
+insert into t (ts,c1) values (5,5);
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+update t set a = null;
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+set timescaledb.enable_segmentwise_recompression to on;
+
+
+-- test case #4: altering a compressed hypertable by adding a new column
+-- with a default value
+--
+-- This is one more testcase for establishing the correct behaviour of the
+-- default value after changing the code.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+alter table t add column a double precision default 7.1;
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+select * from t;
+update t set a = null;
+insert into t (ts,c1) values (7,7);
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+
+-- test case #5: altering an uncompressed hypertable by adding a new column
+-- with a default value
+--
+-- This is the first testcase to reproduce the problem found by Sven.
+-- Before the fix, the default value was not returned correctly after
+-- compressing the hypertable.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t (ts int);
+select create_hypertable('t', 'ts');
+alter table t set(timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+insert into t (ts) values (1);
+alter table t add column c1 double precision default 42.99;
+update t set c1 = null;
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+set timescaledb.enable_segmentwise_recompression to on;
+
+-- test case #6: altering a compressed hypertable by adding a new column
+-- with a default value
+--
+-- This is the second testcase to reproduce the problem, by Alex.
+-- Before the fix, the default value was not returned correctly after
+-- compressing the hypertable the second time.
+--
+drop table if exists t;
+create table t(ts int);
+select create_hypertable('t', 'ts');
+insert into t values (1);
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+select compress_chunk(show_chunks('t'));
+alter table t add column a double precision default 7.987;
+insert into t values (2, null);
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+
+-- test case #7: a variation of #1 where
+-- the default value is changed after the column is added
+--
+-- This is a variation of the first test case where the default value is
+-- changed after the column is added. This is to make sure that changing the
+-- default value does not break the behaviour of the default values.
+--
+set timescaledb.enable_segmentwise_recompression to off;
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_segmentby = 'ts');
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+alter table t add column a double precision default 7.1;
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+alter table t alter column a set default 7.2;
+insert into t (ts,c1) values (7,7);
+select compress_chunk(show_chunks('t'));
+select * from t;
+set timescaledb.enable_segmentwise_recompression to on;
+
+
+-- test case #8: a variation of #5 and #7 where
+-- I change the default value multiple times
+--
+-- This is a variation of the previous test cases with changing the default
+-- values. Before the fix the first default value was returned for all rows
+-- even if it was changed twice afterwards and the value was set to null.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+alter table t add column a double precision default 7.1;
+alter table t alter column a set default 8.2;
+insert into t (ts,c1) values (7,7);
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+alter table t alter column a set default 9.3;
+insert into t (ts,c1) values (8,8);
+select * from t;
+update t set a = null;
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+
+-- test case #9: a variation of the previous ones with the twist
+-- of updating another column which triggers decompression and
+-- risk of re-applying the default value for the other column.
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into t (ts,c1) values (6,6);
+select compress_chunk(show_chunks('t'));
+alter table t add column a double precision default 7.1;
+select compress_chunk(show_chunks('t'));
+select * from t;
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+update t set c1 = 99, a = null;
+select * from t;
+select compress_chunk(show_chunks('t'));
+select * from t;
+update t set c1 = 98;
+select * from t;
+
+
+-- test case #10: adding a few columns to a compressed hypertable
+-- and then updating them to null and dropping them
+--
+drop table if exists t;
+create table t(ts int, c1 int);
+select create_hypertable('t','ts');
+alter table t set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into t (ts,c1) values (1,1);
+select compress_chunk(show_chunks('t'));
+
+alter table t add column a double precision default 3.3;
+insert into t (ts,c1) values (2,2);
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+alter table t add column b double precision default 4.4;
+insert into t (ts,c1) values (3,3);
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+update t set a = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+alter table t add column c double precision;
+insert into t (ts,c1) values (4,4);
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+update t set b = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+alter table t drop column a;
+update t set b = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+alter table t drop column b;
+update t set c = null;
+select compress_chunk(show_chunks('t'));
+select * from t;
+
+-- this is to make codecove happy so we exercise some
+-- code paths that are hard to do through the unit tests
+drop table if exists codecov;
+create table codecov(ts int, c1 int);
+select create_hypertable('codecov','ts');
+alter table codecov set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into codecov (ts,c1) values (1,NULL);
+select compress_chunk(show_chunks('codecov'));
+
+DO $$
+DECLARE
+	comp_regclass REGCLASS;
+	rec RECORD;
+BEGIN
+	FOR comp_regclass IN
+		SELECT
+			format('%I.%I', comp.schema_name, comp.table_name)::regclass as comp_regclass
+		FROM
+			_timescaledb_catalog.chunk uncomp,
+			_timescaledb_catalog.chunk comp,
+			(SELECT show_chunks('codecov') as c) as x
+		WHERE
+			uncomp.dropped IS FALSE AND uncomp.compressed_chunk_id IS NOT NULL AND
+			comp.id = uncomp.compressed_chunk_id AND
+			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
+	LOOP
+		-- codecov to record coverage of 'tsl_compressed_data_info'
+		FOR rec IN
+			EXECUTE format('SELECT c1, _timescaledb_functions.compressed_data_info(c1) FROM %s', comp_regclass)
+		LOOP
+			RAISE NOTICE 'Compressed info results: %', rec;
+		END LOOP;
+
+		-- codecov to record coverage of 'tsl_compressed_data_has_nulls'
+		FOR rec IN
+			EXECUTE format('SELECT c1, _timescaledb_functions.compressed_data_has_nulls(c1) FROM %s', comp_regclass)
+		LOOP
+			RAISE NOTICE 'Has nulls results: %', rec;
+		END LOOP;
+
+	END LOOP;
+END;
+$$;

--- a/tsl/test/sql/vector_agg_filter.sql
+++ b/tsl/test/sql/vector_agg_filter.sql
@@ -60,6 +60,17 @@ select t, s, cint2, cint4,
     end as ss
 from source where s != 1
 ;
+
+-- print a few reference values before compression
+select count(ss) from aggfilter;
+select count(ss) filter (where cint2 < 0) from aggfilter;
+select count(ss) filter (where cint4 > 0) from aggfilter;
+select count(ss) filter (where s != 5) from aggfilter;
+select s, count(ss) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+select s, count(ss) filter (where cint2 < 0) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+select s, count(ss) filter (where ss > 1000) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+select s, count(ss) filter (where cint4 > 0) from aggfilter group by s having s=2 order by count(ss), s limit 10;
+
 select count(compress_chunk(x)) from show_chunks('aggfilter') x;
 vacuum freeze analyze aggfilter;
 

--- a/tsl/test/sql/vector_agg_functions.sql
+++ b/tsl/test/sql/vector_agg_functions.sql
@@ -70,6 +70,17 @@ select *, ss::text as x from (
     from source where s != 1
 ) t
 ;
+
+-- print some reference results before compression
+select ss, count(*) from aggfns group by ss having (ss=11 or ss is null) order by count(*), ss limit 10;
+select ss, min(cdate) from aggfns group by ss having (ss is null) order by min(cdate), ss limit 10;
+select ss, avg(cfloat4) from aggfns group by ss having (ss is null) order by avg(cfloat4), ss limit 10;
+select ss, max(cfloat4) from aggfns group by ss having (ss=11 or ss is null) order by max(cfloat4), ss limit 10;
+select ss, min(cfloat4) from aggfns group by ss having (ss=11 or ss is null) order by min(cfloat4), ss limit 10;
+select ss, stddev(cfloat4) from aggfns group by ss having (ss is null) order by stddev(cfloat4), ss limit 10;
+select ss, avg(cfloat8) from aggfns group by ss having (ss is null or ss=11) order by avg(cfloat8), ss limit 10;
+select ss, max(cfloat8) from aggfns group by ss having (ss is null or ss=11) order by max(cfloat8), ss limit 10;
+
 select count(compress_chunk(x)) from show_chunks('aggfns') x;
 vacuum freeze analyze aggfns;
 

--- a/tsl/test/sql/vector_agg_text.sql
+++ b/tsl/test/sql/vector_agg_text.sql
@@ -55,6 +55,20 @@ select *, ss::text as x from (
 ) t
 ;
 
+
+-- print a few reference values before compression
+select x, count(*) from agggroup group by x having (x='11' or x is null) order by count(*), x limit 10;
+select x, count(cint2) from agggroup group by x having (x='11' or x is null) order by count(cint2), x limit 10;
+select x, min(cint2) from agggroup group by x having (x='11' or x is null) order by min(cint2), x limit 10;
+select x, count(*) from agggroup where cint2 > 0 group by x having (x='11' or x is null) order by count(*), x limit 10;
+select x, count(cint2) from agggroup where cint2 > 0 group by x having (x='11' or x is null) order by count(cint2), x limit 10;
+select x, min(cint2) from agggroup where cint2 > 0 group by x order by min(cint2), x limit 10;
+select x, count(*) from agggroup where cint2 is null group by x having (x='11') order by count(*), x limit 10;
+select x, count(cint2) from agggroup where cint2 is null group by x having (x is null) order by count(cint2), x limit 10;
+select x, count(*) from agggroup where cint2 is null and x is null group by x order by count(*), x limit 10;
+select x, count(cint2) from agggroup where cint2 is null and x is null group by x order by count(cint2), x limit 10;
+select x, min(cint2) from agggroup where cint2 is null and x is null group by x order by min(cint2), x limit 10;
+
 select count(compress_chunk(x)) from show_chunks('agggroup') x;
 vacuum freeze analyze agggroup;
 


### PR DESCRIPTION
This fixes bug #7714 where adding a column with a default value (jargon: missing value) and a compressed batch with all nulls created an ambiguity. In the all null cases the compressed block was stored as a NULL value.

With this change, I introduce a new special compression type, the 'NULL' compression which is a single byte place holder for an 'all-null' compressed block. This allows us to distinguish between the missing value vs the all-null values.

Please note that the wrong results impacted existing tests so I updated the expected results, as well as I added reference queries before compression to prove the updated values were wrong before.

A new debug only GUC was added for testing a future upgrade script, which will arrive as a separate PR.

Fixes #7714 