### PR TITLE
Handle DEFAULT table access name in ALTER TABLE

### DIFF
--- a/.unreleased/pr_7799
+++ b/.unreleased/pr_7799
@@ -1,0 +1,1 @@
+Fixes: #7799 Handle DEFAULT table access name in ALTER TABLE

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3834,7 +3834,7 @@ process_set_access_method(AlterTableCmd *cmd, ProcessUtilityArgs *args)
 	Oid relid = AlterTableLookupRelation(stmt, NoLock);
 	Cache *hcache;
 	Hypertable *ht = ts_hypertable_cache_get_cache_and_entry(relid, CACHE_FLAG_MISSING_OK, &hcache);
-	if (ht && (strcmp(cmd->name, TS_HYPERCORE_TAM_NAME) == 0))
+	if (ht && cmd->name && (strcmp(cmd->name, TS_HYPERCORE_TAM_NAME) == 0))
 	{
 		/* For hypertables, we automatically add command to set the
 		 * compression flag if we are setting the access method to be a

--- a/test/expected/tableam_alter_defaults.out
+++ b/test/expected/tableam_alter_defaults.out
@@ -1,0 +1,94 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test support for setting table access method on hypertables using
+-- ALTER TABLE for version 17 and later. This is in addition to the
+-- tests in tableam_alter.sql.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ACCESS METHOD testam TYPE TABLE HANDLER heap_tableam_handler;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+CREATE VIEW chunk_info AS
+SELECT hypertable_name AS hypertable,
+       chunk_name AS chunk,
+       amname
+  FROM timescaledb_information.chunks ch
+  JOIN pg_class cl ON (format('%I.%I', ch.chunk_schema, ch.chunk_name)::regclass = cl.oid)
+  JOIN pg_am am ON (am.oid = cl.relam);
+CREATE TABLE test_table (time timestamptz not null, device int, temp float);
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+  relname   | amname 
+------------+--------
+ test_table | heap
+(1 row)
+
+-- Check that setting default access method of a normal table works.
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+-- Check that changing the access method and then changing it back
+-- works.
+ALTER TABLE test_table SET ACCESS METHOD testam;
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+-- Check that setting default access method of a hypertable works.
+SELECT create_hypertable('test_table', by_range('time'));
+ create_hypertable 
+-------------------
+ (1,t)
+(1 row)
+
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+  relname   | amname 
+------------+--------
+ test_table | heap
+(1 row)
+
+-- Test setting the access method together with other options. This
+-- should not generate an error.
+ALTER TABLE test_table
+      SET ACCESS METHOD testam,
+      SET (autovacuum_vacuum_threshold = 100);
+-- Add some rows to generate a chunk. This should get the access
+-- method of the hypertable.
+INSERT INTO test_table
+SELECT ts, 10 * random(), 100 * random()
+FROM generate_series('2001-01-01'::timestamp, '2001-01-14', '1d'::interval) as x(ts);
+SELECT * FROM chunk_info WHERE hypertable = 'test_table';
+ hypertable |      chunk       | amname 
+------------+------------------+--------
+ test_table | _hyper_1_1_chunk | testam
+ test_table | _hyper_1_2_chunk | testam
+ test_table | _hyper_1_3_chunk | testam
+(3 rows)
+
+-- Setting it to the default method after we have set it to a test
+-- access method should work fine also on a hypertable.
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+  relname   | amname 
+------------+--------
+ test_table | testam
+(1 row)
+
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+  relname   | amname 
+------------+--------
+ test_table | heap
+(1 row)
+
+SELECT chunk FROM show_chunks('test_table') t(chunk) limit 1 \gset
+ALTER TABLE :chunk SET ACCESS METHOD DEFAULT;
+SELECT * FROM chunk_info WHERE hypertable = 'test_table';
+ hypertable |      chunk       | amname 
+------------+------------------+--------
+ test_table | _hyper_1_1_chunk | heap
+ test_table | _hyper_1_2_chunk | testam
+ test_table | _hyper_1_3_chunk | testam
+(3 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -122,6 +122,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
   list(APPEND TEST_TEMPLATES ts_merge.sql.in)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))
+  list(APPEND TEST_FILES tableam_alter_defaults.sql)
+endif()
+
 # pg_dump_unprivileged.sql was fixed by an upstream change to pg_dump in 14.11,
 # 15.6, and 16.2
 if(((${PG_VERSION_MAJOR} EQUAL "14") AND (${PG_VERSION_MINOR} GREATER_EQUAL "11"

--- a/test/sql/tableam_alter_defaults.sql
+++ b/test/sql/tableam_alter_defaults.sql
@@ -1,0 +1,74 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Test support for setting table access method on hypertables using
+-- ALTER TABLE for version 17 and later. This is in addition to the
+-- tests in tableam_alter.sql.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ACCESS METHOD testam TYPE TABLE HANDLER heap_tableam_handler;
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+CREATE VIEW chunk_info AS
+SELECT hypertable_name AS hypertable,
+       chunk_name AS chunk,
+       amname
+  FROM timescaledb_information.chunks ch
+  JOIN pg_class cl ON (format('%I.%I', ch.chunk_schema, ch.chunk_name)::regclass = cl.oid)
+  JOIN pg_am am ON (am.oid = cl.relam);
+
+CREATE TABLE test_table (time timestamptz not null, device int, temp float);
+
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+
+-- Check that setting default access method of a normal table works.
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+
+-- Check that changing the access method and then changing it back
+-- works.
+ALTER TABLE test_table SET ACCESS METHOD testam;
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+
+-- Check that setting default access method of a hypertable works.
+SELECT create_hypertable('test_table', by_range('time'));
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+
+-- Test setting the access method together with other options. This
+-- should not generate an error.
+ALTER TABLE test_table
+      SET ACCESS METHOD testam,
+      SET (autovacuum_vacuum_threshold = 100);
+
+-- Add some rows to generate a chunk. This should get the access
+-- method of the hypertable.
+INSERT INTO test_table
+SELECT ts, 10 * random(), 100 * random()
+FROM generate_series('2001-01-01'::timestamp, '2001-01-14', '1d'::interval) as x(ts);
+
+SELECT * FROM chunk_info WHERE hypertable = 'test_table';
+
+-- Setting it to the default method after we have set it to a test
+-- access method should work fine also on a hypertable.
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+
+ALTER TABLE test_table SET ACCESS METHOD DEFAULT;
+
+SELECT cl.relname, amname
+  FROM pg_class cl JOIN pg_am am ON cl.relam = am.oid
+ WHERE cl.relname = 'test_table';
+
+SELECT chunk FROM show_chunks('test_table') t(chunk) limit 1 \gset
+
+ALTER TABLE :chunk SET ACCESS METHOD DEFAULT;
+
+SELECT * FROM chunk_info WHERE hypertable = 'test_table';

--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -3839,9 +3839,14 @@ hypercore_alter_access_method_begin(Oid relid, bool to_other_am)
 void
 hypercore_alter_access_method_finish(Oid relid, bool to_other_am)
 {
+	Chunk *chunk = ts_chunk_get_by_relid(relid, false);
+
+	/* If this is not a chunk, we just abort since there is nothing to do */
+	if (!chunk)
+		return;
+
 	if (to_other_am)
 	{
-		Chunk *chunk = ts_chunk_get_by_relid(relid, true);
 		Chunk *compress_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, false);
 
 		ts_compression_chunk_size_delete(chunk->fd.id);

--- a/tsl/src/process_utility.c
+++ b/tsl/src/process_utility.c
@@ -131,7 +131,8 @@ tsl_ddl_command_start(ProcessUtilityArgs *args)
 					case AT_SetAccessMethod:
 					{
 						Oid relid = AlterTableLookupRelation(stmt, NoLock);
-						bool to_hypercore = (strcmp(cmd->name, TS_HYPERCORE_TAM_NAME) == 0);
+						bool to_hypercore =
+							(cmd->name && strcmp(cmd->name, TS_HYPERCORE_TAM_NAME) == 0);
 						Relation rel = RelationIdGetRelation(relid);
 						bool is_hypercore = rel->rd_tableam == hypercore_routine();
 						RelationClose(rel);
@@ -278,7 +279,8 @@ tsl_ddl_command_end(EventTriggerData *command)
 					case AT_SetAccessMethod:
 					{
 						Oid relid = AlterTableLookupRelation(stmt, NoLock);
-						bool to_hypercore = (strcmp(cmd->name, TS_HYPERCORE_TAM_NAME) == 0);
+						bool to_hypercore =
+							(cmd->name && strcmp(cmd->name, TS_HYPERCORE_TAM_NAME) == 0);
 						hypercore_alter_access_method_finish(relid, !to_hypercore);
 						break;
 					}


### PR DESCRIPTION
If `ALTER TABLE ... SET ACCESS METHOD DEFAULT` is used, the name of the table access method is NULL in the `AlterTableCmd`, so add checks that the name is not null before using it.

Function `hypercore_alter_access_method_finish` expects a chunk, but could be called with a non-chunk, so checking that the relid is a chunk before calling it.