### PR TITLE
Remove now() from test

### DIFF
--- a/tsl/test/expected/cagg_refresh_policy_incremental.out
+++ b/tsl/test/expected/cagg_refresh_policy_incremental.out
@@ -527,8 +527,8 @@ SELECT
     t, d, 10
 FROM
     generate_series(
-        NOW() - INTERVAL '30 days',
-        NOW(),
+        '2025-03-11 00:00:00+00'::timestamptz - INTERVAL '30 days',
+        '2025-03-11 00:00:00+00'::timestamptz,
         '1 hour'::interval) AS t,
     generate_series(1,5) AS d;
 SELECT ts_bgw_params_reset_time(0, true);
@@ -549,16 +549,16 @@ SELECT * FROM sorted_bgw_log;
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       2 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Wed Mar 05 16:00:00 2025 PST, Mon Mar 10 17:00:00 2025 PDT ] (batch 2 of 4)
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Thu Mar 06 16:00:00 2025 PST, Tue Mar 11 17:00:00 2025 PDT ] (batch 2 of 4)
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Fri Feb 28 16:00:00 2025 PST, Wed Mar 05 16:00:00 2025 PST ] (batch 3 of 4)
+      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Mar 01 16:00:00 2025 PST, Thu Mar 06 16:00:00 2025 PST ] (batch 3 of 4)
       4 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       5 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-      6 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Feb 23 16:00:00 2025 PST, Fri Feb 28 16:00:00 2025 PST ] (batch 4 of 4)
+      6 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Mon Feb 24 16:00:00 2025 PST, Sat Mar 01 16:00:00 2025 PST ] (batch 4 of 4)
       7 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       8 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-      0 |         0 | Refresh Continuous Aggregate Policy [1002] | continuous aggregate refresh (individual invalidation) on "conditions_by_day_manual_refresh" in window [ Sun Feb 23 16:00:00 2025 PST, Mon Mar 10 17:00:00 2025 PDT ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1002] | continuous aggregate refresh (individual invalidation) on "conditions_by_day_manual_refresh" in window [ Mon Feb 24 16:00:00 2025 PST, Tue Mar 11 17:00:00 2025 PDT ]
       1 |         0 | Refresh Continuous Aggregate Policy [1002] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1002] | inserted 75 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (15 rows)

--- a/tsl/test/sql/cagg_refresh_policy_incremental.sql
+++ b/tsl/test/sql/cagg_refresh_policy_incremental.sql
@@ -309,8 +309,8 @@ SELECT
     t, d, 10
 FROM
     generate_series(
-        NOW() - INTERVAL '30 days',
-        NOW(),
+        '2025-03-11 00:00:00+00'::timestamptz - INTERVAL '30 days',
+        '2025-03-11 00:00:00+00'::timestamptz,
         '1 hour'::interval) AS t,
     generate_series(1,5) AS d;
 


### PR DESCRIPTION
The continuous aggregate incremental refresh test accidentally used the now() function which makes it fail. Replace it with fixed dates.

Disable-check: force-changelog-file
Disable-check: approval-count