### PR TITLE
Remove costs from hypercore_scans explain plan

### DIFF
--- a/tsl/test/expected/hypercore_scans.out
+++ b/tsl/test/expected/hypercore_scans.out
@@ -567,12 +567,12 @@ select count(*) from :chunk where location = 1::text;
 -- ColumnarScan declares itself as projection capable. This query
 -- would add a Result node on top if ColumnarScan couldn't project.
 set timescaledb.enable_columnarscan=true;
-explain
+explain (costs off)
 select time, device+device as device_x2 from :chunk limit 1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Limit  (cost=0.00..0.02 rows=1 width=12)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk  (cost=0.00..4.15 rows=204 width=12)
+                      QUERY PLAN                      
+------------------------------------------------------
+ Limit
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
 (2 rows)
 
 select time, device+device as device_x2 from :chunk limit 1;

--- a/tsl/test/sql/hypercore_scans.sql
+++ b/tsl/test/sql/hypercore_scans.sql
@@ -190,7 +190,7 @@ select count(*) from :chunk where location = 1::text;
 -- ColumnarScan declares itself as projection capable. This query
 -- would add a Result node on top if ColumnarScan couldn't project.
 set timescaledb.enable_columnarscan=true;
-explain
+explain (costs off)
 select time, device+device as device_x2 from :chunk limit 1;
 select time, device+device as device_x2 from :chunk limit 1;
 


### PR DESCRIPTION
Remove costs from explain plans to make tests less flaky.

Disable-check: force-changelog-file