### PR TITLE
Avoid recompression for DESC order during rollup

### DIFF
--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -380,14 +380,6 @@ check_is_chunk_order_violated_by_merge(CompressChunkCxt *cxt, const Dimension *t
 	if (index != 1)
 		return true;
 
-	/*
-	 * Sort order must not be DESC for merge. We don't need to check
-	 * NULLS FIRST/LAST here because partitioning columns have NOT NULL
-	 * constraint.
-	 */
-	if (ts_array_get_element_bool(ht_settings->fd.orderby_desc, index))
-		return true;
-
 	return false;
 }
 

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -107,6 +107,34 @@ INSERT INTO test2
 SELECT t, i, gen_rand_minstd()
 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
 CROSS JOIN generate_series(1, 5, 1) i;
+-- Setting compression with time DESC to confirm we are don't have to recompress due to DESC order
+-- This is made possible by removal of sequence numbers
+\set VERBOSITY default
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time" DESC', timescaledb.compress_chunk_time_interval='10 hours');
+\set VERBOSITY terse
+-- Verify we are not generating unordered chunks
+BEGIN;
+  SELECT count(compress_chunk(chunk,  true)) FROM show_chunks('test2') chunk;
+ count 
+-------
+    24
+(1 row)
+
+  SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
+    FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
+    JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test2' LIMIT 1 \gset
+  -- We want to sure we are not fully recompressing them which will make
+  -- the chunk contain multiple batches per segment group
+  SELECT count(*)
+  FROM :CHUNK
+  WHERE i = 1;
+ count 
+-------
+    10
+(1 row)
+
+ROLLBACK;
 -- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
 \set VERBOSITY default
 ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
@@ -300,10 +328,10 @@ SELECT
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
 (4 rows)
 
 SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
@@ -318,14 +346,14 @@ LIMIT 1 \gset
 DROP INDEX :INDEXNAME;
 -- Merging works without indexes on compressed chunks
 SELECT compress_chunk(i, true) FROM show_chunks('test5') i LIMIT 5;
-NOTICE:  chunk "_hyper_9_187_chunk" is already compressed
+NOTICE:  chunk "_hyper_9_190_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
- _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
+ _timescaledb_internal._hyper_9_190_chunk
 (5 rows)
 
 SELECT 'test5' AS "HYPERTABLE_NAME" \gset
@@ -334,7 +362,7 @@ SELECT 'test5' AS "HYPERTABLE_NAME" \gset
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
-psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_187_chunk" is already compressed
+psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_190_chunk" is already compressed
  count_compressed 
 ------------------
                17
@@ -374,30 +402,30 @@ ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i',
 SELECT compress_chunk(i) FROM show_chunks('test6') i;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_212_chunk
- _timescaledb_internal._hyper_11_212_chunk
- _timescaledb_internal._hyper_11_214_chunk
- _timescaledb_internal._hyper_11_214_chunk
- _timescaledb_internal._hyper_11_216_chunk
- _timescaledb_internal._hyper_11_216_chunk
- _timescaledb_internal._hyper_11_218_chunk
- _timescaledb_internal._hyper_11_218_chunk
- _timescaledb_internal._hyper_11_220_chunk
- _timescaledb_internal._hyper_11_220_chunk
- _timescaledb_internal._hyper_11_222_chunk
- _timescaledb_internal._hyper_11_222_chunk
- _timescaledb_internal._hyper_11_224_chunk
- _timescaledb_internal._hyper_11_224_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_228_chunk
- _timescaledb_internal._hyper_11_228_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_232_chunk
- _timescaledb_internal._hyper_11_232_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_219_chunk
+ _timescaledb_internal._hyper_11_219_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_223_chunk
+ _timescaledb_internal._hyper_11_223_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_227_chunk
+ _timescaledb_internal._hyper_11_227_chunk
+ _timescaledb_internal._hyper_11_229_chunk
+ _timescaledb_internal._hyper_11_229_chunk
+ _timescaledb_internal._hyper_11_231_chunk
+ _timescaledb_internal._hyper_11_231_chunk
+ _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_237_chunk
+ _timescaledb_internal._hyper_11_237_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -414,56 +442,56 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Altering compress chunk time interval will cause us to create 6 chunks from the additional 24 chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='4 hours');
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_212_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_214_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_216_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_218_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_220_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_222_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_224_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_228_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_232_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_215_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_219_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_223_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_227_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_229_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_231_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_233_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_235_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_237_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_212_chunk
- _timescaledb_internal._hyper_11_214_chunk
- _timescaledb_internal._hyper_11_216_chunk
- _timescaledb_internal._hyper_11_218_chunk
- _timescaledb_internal._hyper_11_220_chunk
- _timescaledb_internal._hyper_11_222_chunk
- _timescaledb_internal._hyper_11_224_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_228_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_232_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_250_chunk
- _timescaledb_internal._hyper_11_250_chunk
- _timescaledb_internal._hyper_11_250_chunk
- _timescaledb_internal._hyper_11_250_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_258_chunk
- _timescaledb_internal._hyper_11_258_chunk
- _timescaledb_internal._hyper_11_258_chunk
- _timescaledb_internal._hyper_11_258_chunk
- _timescaledb_internal._hyper_11_262_chunk
- _timescaledb_internal._hyper_11_262_chunk
- _timescaledb_internal._hyper_11_262_chunk
- _timescaledb_internal._hyper_11_262_chunk
- _timescaledb_internal._hyper_11_266_chunk
- _timescaledb_internal._hyper_11_266_chunk
- _timescaledb_internal._hyper_11_266_chunk
- _timescaledb_internal._hyper_11_266_chunk
- _timescaledb_internal._hyper_11_270_chunk
- _timescaledb_internal._hyper_11_270_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_219_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_223_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_227_chunk
+ _timescaledb_internal._hyper_11_229_chunk
+ _timescaledb_internal._hyper_11_231_chunk
+ _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_237_chunk
+ _timescaledb_internal._hyper_11_237_chunk
+ _timescaledb_internal._hyper_11_237_chunk
+ _timescaledb_internal._hyper_11_253_chunk
+ _timescaledb_internal._hyper_11_253_chunk
+ _timescaledb_internal._hyper_11_253_chunk
+ _timescaledb_internal._hyper_11_253_chunk
+ _timescaledb_internal._hyper_11_257_chunk
+ _timescaledb_internal._hyper_11_257_chunk
+ _timescaledb_internal._hyper_11_257_chunk
+ _timescaledb_internal._hyper_11_257_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_269_chunk
+ _timescaledb_internal._hyper_11_269_chunk
+ _timescaledb_internal._hyper_11_269_chunk
+ _timescaledb_internal._hyper_11_269_chunk
+ _timescaledb_internal._hyper_11_273_chunk
+ _timescaledb_internal._hyper_11_273_chunk
 (36 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -482,47 +510,47 @@ CROSS JOIN generate_series(1, 5, 1) i;
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='30 minutes');
 WARNING:  compress chunk interval is not a multiple of chunk interval, you should use a factor of chunk interval to merge as much as possible
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_212_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_214_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_216_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_218_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_220_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_222_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_224_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_228_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_232_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_250_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_258_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_262_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_266_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_270_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_215_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_219_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_223_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_227_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_229_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_231_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_233_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_235_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_237_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_253_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_257_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_261_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_265_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_269_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_273_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_212_chunk
- _timescaledb_internal._hyper_11_214_chunk
- _timescaledb_internal._hyper_11_216_chunk
- _timescaledb_internal._hyper_11_218_chunk
- _timescaledb_internal._hyper_11_220_chunk
- _timescaledb_internal._hyper_11_222_chunk
- _timescaledb_internal._hyper_11_224_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_228_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_232_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_250_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_258_chunk
- _timescaledb_internal._hyper_11_262_chunk
- _timescaledb_internal._hyper_11_266_chunk
- _timescaledb_internal._hyper_11_270_chunk
- _timescaledb_internal._hyper_11_278_chunk
- _timescaledb_internal._hyper_11_279_chunk
- _timescaledb_internal._hyper_11_280_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_219_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_223_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_227_chunk
+ _timescaledb_internal._hyper_11_229_chunk
+ _timescaledb_internal._hyper_11_231_chunk
+ _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_237_chunk
+ _timescaledb_internal._hyper_11_253_chunk
+ _timescaledb_internal._hyper_11_257_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_269_chunk
+ _timescaledb_internal._hyper_11_273_chunk
+ _timescaledb_internal._hyper_11_281_chunk
+ _timescaledb_internal._hyper_11_282_chunk
+ _timescaledb_internal._hyper_11_283_chunk
 (21 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -540,53 +568,53 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Setting compressed chunk to anything less than chunk interval should disable merging chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval=0);
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_212_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_214_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_216_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_218_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_220_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_222_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_224_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_228_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_232_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_250_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_258_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_262_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_266_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_270_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_278_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_279_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_280_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_215_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_219_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_223_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_227_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_229_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_231_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_233_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_235_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_237_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_253_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_257_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_261_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_265_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_269_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_273_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_281_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_282_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_283_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_212_chunk
- _timescaledb_internal._hyper_11_214_chunk
- _timescaledb_internal._hyper_11_216_chunk
- _timescaledb_internal._hyper_11_218_chunk
- _timescaledb_internal._hyper_11_220_chunk
- _timescaledb_internal._hyper_11_222_chunk
- _timescaledb_internal._hyper_11_224_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_228_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_232_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_250_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_258_chunk
- _timescaledb_internal._hyper_11_262_chunk
- _timescaledb_internal._hyper_11_266_chunk
- _timescaledb_internal._hyper_11_270_chunk
- _timescaledb_internal._hyper_11_278_chunk
- _timescaledb_internal._hyper_11_279_chunk
- _timescaledb_internal._hyper_11_280_chunk
- _timescaledb_internal._hyper_11_284_chunk
- _timescaledb_internal._hyper_11_285_chunk
- _timescaledb_internal._hyper_11_286_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_219_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_223_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_227_chunk
+ _timescaledb_internal._hyper_11_229_chunk
+ _timescaledb_internal._hyper_11_231_chunk
+ _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_237_chunk
+ _timescaledb_internal._hyper_11_253_chunk
+ _timescaledb_internal._hyper_11_257_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_269_chunk
+ _timescaledb_internal._hyper_11_273_chunk
+ _timescaledb_internal._hyper_11_281_chunk
+ _timescaledb_internal._hyper_11_282_chunk
+ _timescaledb_internal._hyper_11_283_chunk
+ _timescaledb_internal._hyper_11_287_chunk
+ _timescaledb_internal._hyper_11_288_chunk
+ _timescaledb_internal._hyper_11_289_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -664,10 +692,10 @@ INSERT INTO test8 (time, series_id, value) SELECT t, s, 1 FROM generate_series(N
 SELECT compress_chunk(c, true) FROM show_chunks('test8') c LIMIT 4;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_15_338_chunk
- _timescaledb_internal._hyper_15_338_chunk
- _timescaledb_internal._hyper_15_338_chunk
- _timescaledb_internal._hyper_15_338_chunk
+ _timescaledb_internal._hyper_15_341_chunk
+ _timescaledb_internal._hyper_15_341_chunk
+ _timescaledb_internal._hyper_15_341_chunk
+ _timescaledb_internal._hyper_15_341_chunk
 (4 rows)
 
 SET enable_indexscan TO OFF;
@@ -696,7 +724,7 @@ INSERT INTO test9 (time, series_id, value) SELECT '2020-01-01 00:00:00'::TIMESTA
 SELECT compress_chunk(show_chunks('test9'), true);
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_347_chunk
 (1 row)
 
 INSERT INTO test9 (time, series_id, value) SELECT '2020-01-01 01:00:00'::TIMESTAMPTZ, 1, 1;
@@ -709,11 +737,11 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
 (2 rows)
 
 SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_347_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_344_chunk
- _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_347_chunk
+ _timescaledb_internal._hyper_17_347_chunk
 (2 rows)
 
 -- should be 1 chunk because of rollup
@@ -735,11 +763,11 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = '');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_347_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_344_chunk
  _timescaledb_internal._hyper_17_347_chunk
+ _timescaledb_internal._hyper_17_350_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -754,11 +782,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time DESC');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_347_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_344_chunk
  _timescaledb_internal._hyper_17_347_chunk
+ _timescaledb_internal._hyper_17_350_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -773,11 +801,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time NULLS FIRST');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_347_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_344_chunk
  _timescaledb_internal._hyper_17_347_chunk
+ _timescaledb_internal._hyper_17_350_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -793,11 +821,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_347_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_344_chunk
- _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_347_chunk
+ _timescaledb_internal._hyper_17_347_chunk
 (2 rows)
 
   -- should be rolled up
@@ -832,9 +860,9 @@ SET timescaledb.enable_rowlevel_compression_locking to on;
 SELECT compress_chunk(show_chunks('test10'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_19_351_chunk
- _timescaledb_internal._hyper_19_351_chunk
- _timescaledb_internal._hyper_19_353_chunk
+ _timescaledb_internal._hyper_19_354_chunk
+ _timescaledb_internal._hyper_19_354_chunk
+ _timescaledb_internal._hyper_19_356_chunk
 (3 rows)
 
 RESET timescaledb.enable_rowlevel_compression_locking;


### PR DESCRIPTION
In the past, rolling up chunks while using primary dimension in DESC order would create unordered chunks which meant we had to do full recompress of the rolled up compressed chunk. With removal of sequence from compression schema, this no longer tracks thus we can remove this limitation.

Disable-check: force-changelog-file