### PR TITLE
Fix ORDER BY on partially compressed chunks

### DIFF
--- a/.unreleased/pr_7816
+++ b/.unreleased/pr_7816
@@ -1,0 +1,1 @@
+Fixes: #7816 Fix ORDER BY for direct queries on partial chunks

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -1069,22 +1069,24 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, con
 
 					pathkeys = lappend(pathkeys, pathkey);
 				}
-				/*
-				 * Ideally, we would like for this to be a MergeAppend path.
-				 * However, accumulate_append_subpath will cut out MergeAppend
-				 * and directly add its children, so we have to combine the children
-				 * into a MergeAppend node later, at the chunk append level.
-				 */
-				chunk_path =
-					(Path *) create_append_path(root,
-												chunk_rel,
-												list_make2(chunk_path, uncompressed_path),
-												NIL /* partial paths */,
-												pathkeys,
-												req_outer,
-												0,
-												false,
-												chunk_path->rows + uncompressed_path->rows);
+				if (pathkeys)
+					chunk_path =
+						(Path *) create_merge_append_path(root,
+														  chunk_rel,
+														  list_make2(chunk_path, uncompressed_path),
+														  pathkeys,
+														  req_outer);
+				else
+					chunk_path =
+						(Path *) create_append_path(root,
+													chunk_rel,
+													list_make2(chunk_path, uncompressed_path),
+													NIL /* partial paths */,
+													pathkeys,
+													req_outer,
+													0,
+													false,
+													chunk_path->rows + uncompressed_path->rows);
 			}
 		}
 

--- a/tsl/test/expected/merge_append_partially_compressed-14.out
+++ b/tsl/test/expected/merge_append_partially_compressed-14.out
@@ -1481,5 +1481,51 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 (10 rows)
 
 reset enable_indexscan;
+-- test ordering on single chunk queries
+CREATE TABLE test4(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('test4','time',chunk_time_interval:='1 year'::interval);
+ table_name 
+------------
+ test4
+(1 row)
+
+ALTER TABLE test4 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+INSERT INTO test4 SELECT '2025-01-01', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test4') ch;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+set enable_hashagg TO false;
+SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | 
+ Thu Jan 02 00:00:00 2025 PST | d
+ Thu Jan 02 00:00:00 2025 PST | 
+(3 rows)
+
+EXPLAIN (costs off, analyze, timing off, summary off) SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Group (actual rows=3 loops=1)
+   Group Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_9_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_10_22_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_9_21_chunk (actual rows=1 loops=1)
+(13 rows)
+
 reset timescaledb.enable_decompression_sorted_merge;
 reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-15.out
+++ b/tsl/test/expected/merge_append_partially_compressed-15.out
@@ -1488,5 +1488,51 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 (10 rows)
 
 reset enable_indexscan;
+-- test ordering on single chunk queries
+CREATE TABLE test4(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('test4','time',chunk_time_interval:='1 year'::interval);
+ table_name 
+------------
+ test4
+(1 row)
+
+ALTER TABLE test4 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+INSERT INTO test4 SELECT '2025-01-01', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test4') ch;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+set enable_hashagg TO false;
+SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | 
+ Thu Jan 02 00:00:00 2025 PST | d
+ Thu Jan 02 00:00:00 2025 PST | 
+(3 rows)
+
+EXPLAIN (costs off, analyze, timing off, summary off) SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Group (actual rows=3 loops=1)
+   Group Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_9_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_10_22_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_9_21_chunk (actual rows=1 loops=1)
+(13 rows)
+
 reset timescaledb.enable_decompression_sorted_merge;
 reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-16.out
+++ b/tsl/test/expected/merge_append_partially_compressed-16.out
@@ -1488,5 +1488,51 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 (10 rows)
 
 reset enable_indexscan;
+-- test ordering on single chunk queries
+CREATE TABLE test4(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('test4','time',chunk_time_interval:='1 year'::interval);
+ table_name 
+------------
+ test4
+(1 row)
+
+ALTER TABLE test4 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+INSERT INTO test4 SELECT '2025-01-01', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test4') ch;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+set enable_hashagg TO false;
+SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | 
+ Thu Jan 02 00:00:00 2025 PST | d
+ Thu Jan 02 00:00:00 2025 PST | 
+(3 rows)
+
+EXPLAIN (costs off, analyze, timing off, summary off) SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Group (actual rows=3 loops=1)
+   Group Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_9_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_10_22_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_9_21_chunk (actual rows=1 loops=1)
+(13 rows)
+
 reset timescaledb.enable_decompression_sorted_merge;
 reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/merge_append_partially_compressed-17.out
+++ b/tsl/test/expected/merge_append_partially_compressed-17.out
@@ -1488,5 +1488,51 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 (10 rows)
 
 reset enable_indexscan;
+-- test ordering on single chunk queries
+CREATE TABLE test4(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('test4','time',chunk_time_interval:='1 year'::interval);
+ table_name 
+------------
+ test4
+(1 row)
+
+ALTER TABLE test4 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+INSERT INTO test4 SELECT '2025-01-01', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test4') ch;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+set enable_hashagg TO false;
+SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | 
+ Thu Jan 02 00:00:00 2025 PST | d
+ Thu Jan 02 00:00:00 2025 PST | 
+(3 rows)
+
+EXPLAIN (costs off, analyze, timing off, summary off) SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Group (actual rows=3 loops=1)
+   Group Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+         ->  Sort (actual rows=3 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_9_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_10_22_chunk (actual rows=2 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_9_21_chunk."time", _hyper_9_21_chunk.device
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_9_21_chunk (actual rows=1 loops=1)
+(13 rows)
+
 reset timescaledb.enable_decompression_sorted_merge;
 reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -136,9 +136,9 @@ select * from :chunk_to_compress_2 ORDER BY a, c, time DESC;
                 time                 | a | b | c 
 -------------------------------------+---+---+---
  Sun Jan 01 11:56:20.048355 2023 PST | 2 |   | 2
+ Sun Jan 01 09:56:20.048355 2023 PST | 2 |   | 2
  Sun Jan 01 11:57:20.048355 2023 PST | 3 |   | 3
  Sun Jan 01 11:56:20.048355 2023 PST | 3 |   | 3
- Sun Jan 01 09:56:20.048355 2023 PST | 2 |   | 2
 (4 rows)
 
 SELECT compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name_2

--- a/tsl/test/sql/merge_append_partially_compressed.sql.in
+++ b/tsl/test/sql/merge_append_partially_compressed.sql.in
@@ -264,6 +264,21 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, time LIMIT 10;
 
 reset enable_indexscan;
 
+-- test ordering on single chunk queries
+CREATE TABLE test4(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('test4','time',chunk_time_interval:='1 year'::interval);
+
+ALTER TABLE test4 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+
+INSERT INTO test4 SELECT '2025-01-01', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', NULL, 0.1;
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test4') ch;
+INSERT INTO test4 SELECT '2025-01-02', 'd', 0.1;
+
+set enable_hashagg TO false;
+SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
+EXPLAIN (costs off, analyze, timing off, summary off) SELECT time, device FROM _timescaledb_internal._hyper_9_21_chunk GROUP BY time, device;
 
 reset timescaledb.enable_decompression_sorted_merge;
 reset max_parallel_workers_per_gather;


### PR DESCRIPTION
When querying from a chunk directly that is partially compressed the ordering would be applied locally to compressed and uncompressed data and not globally to the complete resultset leading to incorrect ordering.

Fixes: #7084

Disable-check: approval-count