### PR TITLE
backport #7754 to 2.19.x

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -51,10 +51,19 @@ jobs:
         # vector_agg_text and vector_agg_groupagg use the UMASH hashing library
         # that we can't compile on i386.
         IGNORES: >-
-          append-* transparent_decompression-*
-          transparent_decompress_chunk-* pg_dump telemetry bgw_db_scheduler*
-          hypercore_vacuum vectorized_aggregation vector_agg_text
-          vector_agg_groupagg hypercore_parallel hypercore_vectoragg
+          append-*
+          bgw_db_scheduler*
+          hypercore_parallel
+          hypercore_vacuum
+          hypercore_vectoragg
+          pg_dump
+          telemetry
+          transparent_decompress_chunk-*
+          transparent_decompression-*
+          vector_agg_groupagg
+          vector_agg_grouping
+          vector_agg_text
+          vectorized_aggregation
         SKIPS: chunk_adaptive histogram_test-*
         EXTENSIONS: "postgres_fdw test_decoding pageinspect pgstattuple"
     strategy:

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -59,7 +59,15 @@ jobs:
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         ignores: ["bgw_launcher chunk_adaptive metadata telemetry"]
         tsl_ignores: ["compression_algos"]
-        tsl_skips: ["vector_agg_text vector_agg_groupagg bgw_db_scheduler bgw_db_scheduler_fixed"]
+        tsl_skips:
+          - >-
+            bgw_db_scheduler
+            bgw_db_scheduler_fixed
+            hypercore_vectoragg
+            vector_agg_groupagg
+            vector_agg_grouping
+            vector_agg_text
+            vectorized_aggregation
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         include:
           - pg: 14

--- a/.unreleased/hash-grouping-multiple
+++ b/.unreleased/hash-grouping-multiple
@@ -1,0 +1,1 @@
+Implements: #7754 Vectorized aggregation with grouping by several columns

--- a/tsl/src/nodes/vector_agg/grouping_policy.h
+++ b/tsl/src/nodes/vector_agg/grouping_policy.h
@@ -66,7 +66,8 @@ typedef enum
 	VAGT_HashSingleFixed2,
 	VAGT_HashSingleFixed4,
 	VAGT_HashSingleFixed8,
-	VAGT_HashSingleText
+	VAGT_HashSingleText,
+	VAGT_HashSerialized,
 } VectorAggGroupingType;
 
 extern GroupingPolicy *create_grouping_policy_batch(int num_agg_defs, VectorAggDef *agg_defs,

--- a/tsl/src/nodes/vector_agg/grouping_policy_hash.h
+++ b/tsl/src/nodes/vector_agg/grouping_policy_hash.h
@@ -79,11 +79,6 @@ typedef struct GroupingPolicyHash
 	HashingStrategy hashing;
 
 	/*
-	 * The last used index of an unique grouping key. Key index 0 is invalid.
-	 */
-	uint32 last_used_key_index;
-
-	/*
 	 * Temporary storage of unique indexes of keys corresponding to a given row
 	 * of the compressed batch that is currently being aggregated. We keep it in
 	 * the policy because it is potentially too big to keep on stack, and we

--- a/tsl/src/nodes/vector_agg/hashing/CMakeLists.txt
+++ b/tsl/src/nodes/vector_agg/hashing/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/hash_strategy_common.c)
 
 if(USE_UMASH)
-  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hash_strategy_single_text.c)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hash_strategy_single_text.c
+       ${CMAKE_CURRENT_SOURCE_DIR}/hash_strategy_serialized.c)
 endif()
 
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/nodes/vector_agg/hashing/batch_hashing_params.h
+++ b/tsl/src/nodes/vector_agg/hashing/batch_hashing_params.h
@@ -18,7 +18,11 @@ typedef struct BatchHashingParams
 	const uint64 *batch_filter;
 	CompressedColumnValues single_grouping_column;
 
-	GroupingPolicyHash *restrict policy;
+	int num_grouping_columns;
+	const CompressedColumnValues *grouping_column_values;
+
+	GroupingPolicyHash *policy;
+	HashingStrategy *restrict hashing;
 
 	uint32 *restrict result_key_indexes;
 } BatchHashingParams;
@@ -29,12 +33,18 @@ build_batch_hashing_params(GroupingPolicyHash *policy, TupleTableSlot *vector_sl
 	uint16 nrows;
 	BatchHashingParams params = {
 		.policy = policy,
+		.hashing = &policy->hashing,
 		.batch_filter = vector_slot_get_qual_result(vector_slot, &nrows),
+		.num_grouping_columns = policy->num_grouping_columns,
+		.grouping_column_values = policy->current_batch_grouping_column_values,
 		.result_key_indexes = policy->key_index_for_row,
 	};
 
-	Assert(policy->num_grouping_columns == 1);
-	params.single_grouping_column = policy->current_batch_grouping_column_values[0];
+	Assert(policy->num_grouping_columns > 0);
+	if (policy->num_grouping_columns == 1)
+	{
+		params.single_grouping_column = policy->current_batch_grouping_column_values[0];
+	}
 
 	return params;
 }

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_common.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_common.c
@@ -18,7 +18,7 @@ void
 hash_strategy_output_key_alloc(GroupingPolicyHash *policy, uint16 nrows)
 {
 	HashingStrategy *hashing = &policy->hashing;
-	const uint32 num_possible_keys = policy->last_used_key_index + 1 + nrows;
+	const uint32 num_possible_keys = hashing->last_used_key_index + 1 + nrows;
 
 	if (num_possible_keys > hashing->num_allocated_output_keys)
 	{

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_impl.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_impl.c
@@ -57,7 +57,17 @@ FUNCTION_NAME(hash_strategy_reset)(HashingStrategy *hashing)
 {
 	struct FUNCTION_NAME(hash) *table = (struct FUNCTION_NAME(hash) *) hashing->table;
 	FUNCTION_NAME(reset)(table);
+
+	hashing->last_used_key_index = 0;
+
 	hashing->null_key_index = 0;
+
+	/*
+	 * Have to reset this because it's in the key body context which is also
+	 * reset here.
+	 */
+	hashing->tmp_key_storage = NULL;
+	hashing->num_tmp_key_storage_bytes = 0;
 }
 
 static void
@@ -76,8 +86,7 @@ FUNCTION_NAME(hash_strategy_prepare_for_batch)(GroupingPolicyHash *policy,
 static pg_attribute_always_inline void
 FUNCTION_NAME(fill_offsets_impl)(BatchHashingParams params, int start_row, int end_row)
 {
-	GroupingPolicyHash *policy = params.policy;
-	HashingStrategy *hashing = &policy->hashing;
+	HashingStrategy *restrict hashing = params.hashing;
 
 	uint32 *restrict indexes = params.result_key_indexes;
 
@@ -90,7 +99,7 @@ FUNCTION_NAME(fill_offsets_impl)(BatchHashingParams params, int start_row, int e
 		if (!arrow_row_is_valid(params.batch_filter, row))
 		{
 			/* The row doesn't pass the filter. */
-			DEBUG_PRINT("%p: row %d doesn't pass batch filter\n", policy, row);
+			DEBUG_PRINT("%p: row %d doesn't pass batch filter\n", hashing, row);
 			continue;
 		}
 
@@ -109,10 +118,10 @@ FUNCTION_NAME(fill_offsets_impl)(BatchHashingParams params, int start_row, int e
 			/* The key is null. */
 			if (hashing->null_key_index == 0)
 			{
-				hashing->null_key_index = ++policy->last_used_key_index;
+				hashing->null_key_index = ++hashing->last_used_key_index;
 			}
 			indexes[row] = hashing->null_key_index;
-			DEBUG_PRINT("%p: row %d null key index %d\n", policy, row, hashing->null_key_index);
+			DEBUG_PRINT("%p: row %d null key index %d\n", hashing, row, hashing->null_key_index);
 			continue;
 		}
 
@@ -128,9 +137,9 @@ FUNCTION_NAME(fill_offsets_impl)(BatchHashingParams params, int start_row, int e
 			 */
 			indexes[row] = previous_key_index;
 #ifndef NDEBUG
-			policy->stat_consecutive_keys++;
+			params.policy->stat_consecutive_keys++;
 #endif
-			DEBUG_PRINT("%p: row %d consecutive key index %d\n", policy, row, previous_key_index);
+			DEBUG_PRINT("%p: row %d consecutive key index %d\n", hashing, row, previous_key_index);
 			continue;
 		}
 
@@ -144,14 +153,14 @@ FUNCTION_NAME(fill_offsets_impl)(BatchHashingParams params, int start_row, int e
 			/*
 			 * New key, have to store it persistently.
 			 */
-			const uint32 index = ++policy->last_used_key_index;
+			const uint32 index = ++hashing->last_used_key_index;
 			entry->key_index = index;
-			FUNCTION_NAME(key_hashing_store_new)(policy, index, output_key);
-			DEBUG_PRINT("%p: row %d new key index %d\n", policy, row, index);
+			FUNCTION_NAME(key_hashing_store_new)(hashing, index, output_key);
+			DEBUG_PRINT("%p: row %d new key index %d\n", hashing, row, index);
 		}
 		else
 		{
-			DEBUG_PRINT("%p: row %d old key index %d\n", policy, row, entry->key_index);
+			DEBUG_PRINT("%p: row %d old key index %d\n", hashing, row, entry->key_index);
 		}
 		indexes[row] = entry->key_index;
 

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_impl_single_fixed_key.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_impl_single_fixed_key.c
@@ -53,10 +53,10 @@ FUNCTION_NAME(key_hashing_get_key)(BatchHashingParams params, int row,
 }
 
 static pg_attribute_always_inline void
-FUNCTION_NAME(key_hashing_store_new)(GroupingPolicyHash *restrict policy, uint32 new_key_index,
+FUNCTION_NAME(key_hashing_store_new)(HashingStrategy *restrict hashing, uint32 new_key_index,
 									 OUTPUT_KEY_TYPE output_key)
 {
-	policy->hashing.output_keys[new_key_index] = OUTPUT_KEY_TO_DATUM(output_key);
+	hashing->output_keys[new_key_index] = OUTPUT_KEY_TO_DATUM(output_key);
 }
 
 static void

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_serialized.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_serialized.c
@@ -1,0 +1,449 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * Implementation of column hashing for multiple serialized columns.
+ */
+
+#include <postgres.h>
+
+#include <common/hashfn.h>
+
+#include "compression/arrow_c_data_interface.h"
+#include "nodes/decompress_chunk/compressed_batch.h"
+#include "nodes/vector_agg/exec.h"
+#include "nodes/vector_agg/grouping_policy_hash.h"
+#include "template_helper.h"
+
+#include "batch_hashing_params.h"
+
+#include "umash_fingerprint_key.h"
+
+#define EXPLAIN_NAME "serialized"
+#define KEY_VARIANT serialized
+#define OUTPUT_KEY_TYPE text *
+
+static void
+serialized_key_hashing_init(HashingStrategy *hashing)
+{
+	hashing->umash_params = umash_key_hashing_init();
+}
+
+static void
+serialized_key_hashing_prepare_for_batch(GroupingPolicyHash *policy, TupleTableSlot *vector_slot)
+{
+}
+
+static pg_attribute_always_inline bool
+byte_bitmap_row_is_valid(const uint8 *bitmap, size_t row_number)
+{
+	const size_t byte_index = row_number / 8;
+	const size_t bit_index = row_number % 8;
+	const uint8 mask = ((uint8) 1) << bit_index;
+	return bitmap[byte_index] & mask;
+}
+
+static pg_attribute_always_inline void
+byte_bitmap_set_row_validity(uint8 *bitmap, size_t row_number, bool value)
+{
+	const size_t byte_index = row_number / 8;
+	const size_t bit_index = row_number % 8;
+	const uint8 mask = ((uint8) 1) << bit_index;
+	const uint8 new_bit = ((uint8) value) << bit_index;
+
+	bitmap[byte_index] = (bitmap[byte_index] & ~mask) | new_bit;
+
+	Assert(byte_bitmap_row_is_valid(bitmap, row_number) == value);
+}
+
+static pg_attribute_always_inline void
+serialized_key_hashing_get_key(BatchHashingParams params, int row, void *restrict output_key_ptr,
+							   void *restrict hash_table_key_ptr, bool *restrict valid)
+{
+	HashingStrategy *hashing = params.hashing;
+
+	text **restrict output_key = (text **) output_key_ptr;
+	HASH_TABLE_KEY_TYPE *restrict hash_table_key = (HASH_TABLE_KEY_TYPE *) hash_table_key_ptr;
+
+	const int num_columns = params.num_grouping_columns;
+
+	const size_t bitmap_bytes = (num_columns + 7) / 8;
+
+	/*
+	 * Loop through the grouping columns to determine the length of the key. We
+	 * need that to allocate memory to store it.
+	 *
+	 * The key has the null bitmap at the beginning.
+	 */
+	size_t num_bytes = bitmap_bytes;
+	for (int column_index = 0; column_index < num_columns; column_index++)
+	{
+		const CompressedColumnValues *column_values = &params.grouping_column_values[column_index];
+
+		if (column_values->decompression_type == DT_Scalar)
+		{
+			if (!*column_values->output_isnull)
+			{
+				const GroupingColumn *def = &params.policy->grouping_columns[column_index];
+				if (def->by_value)
+				{
+					num_bytes += def->value_bytes;
+				}
+				else
+				{
+					/*
+					 * The default value always has a long varlena header, but
+					 * we are going to use short if it fits.
+					 */
+					const int32 value_bytes = VARSIZE_ANY_EXHDR(*column_values->output_value);
+					if (value_bytes + VARHDRSZ_SHORT <= VARATT_SHORT_MAX)
+					{
+						/* Short varlena, unaligned. */
+						const int total_bytes = value_bytes + VARHDRSZ_SHORT;
+						num_bytes += total_bytes;
+					}
+					else
+					{
+						/* Long varlena, requires alignment. */
+						const int total_bytes = value_bytes + VARHDRSZ;
+						num_bytes = TYPEALIGN(4, num_bytes) + total_bytes;
+					}
+				}
+			}
+
+			continue;
+		}
+
+		const bool is_valid = arrow_row_is_valid(column_values->buffers[0], row);
+		if (!is_valid)
+		{
+			continue;
+		}
+
+		if (column_values->decompression_type > 0)
+		{
+			num_bytes += column_values->decompression_type;
+		}
+		else
+		{
+			Assert(column_values->decompression_type == DT_ArrowText ||
+				   column_values->decompression_type == DT_ArrowTextDict);
+			Assert((column_values->decompression_type == DT_ArrowTextDict) ==
+				   (column_values->buffers[3] != NULL));
+
+			const uint32 data_row = (column_values->decompression_type == DT_ArrowTextDict) ?
+										((int16 *) column_values->buffers[3])[row] :
+										row;
+			const uint32 start = ((uint32 *) column_values->buffers[1])[data_row];
+			const int32 value_bytes = ((uint32 *) column_values->buffers[1])[data_row + 1] - start;
+
+			if (value_bytes + VARHDRSZ_SHORT <= VARATT_SHORT_MAX)
+			{
+				/* Short varlena, unaligned. */
+				const int total_bytes = value_bytes + VARHDRSZ_SHORT;
+				num_bytes += total_bytes;
+			}
+			else
+			{
+				/* Long varlena, requires alignment. */
+				const int total_bytes = value_bytes + VARHDRSZ;
+				num_bytes = TYPEALIGN(4, num_bytes) + total_bytes;
+			}
+		}
+	}
+
+	/*
+	 * The key has short or long varlena header. This is a little tricky, we
+	 * decide the header length after we have counted all the columns, but we
+	 * put it at the beginning. Technically it could change the length because
+	 * of the alignment. In practice, we only use alignment by 4 bytes for long
+	 * varlena strings, and if we have at least one long varlena string column,
+	 * the key is also going to use the long varlena header which is 4 bytes, so
+	 * the alignment is not affected. If we use the short varlena header for the
+	 * key, it necessarily means that there were no long varlena columns and
+	 * therefore no alignment is needed.
+	 */
+	const bool key_uses_short_header = num_bytes + VARHDRSZ_SHORT <= VARATT_SHORT_MAX;
+	num_bytes += key_uses_short_header ? VARHDRSZ_SHORT : VARHDRSZ;
+
+	/*
+	 * Use temporary storage for the new key, reallocate if it's too small.
+	 */
+	if (num_bytes > hashing->num_tmp_key_storage_bytes)
+	{
+		if (hashing->tmp_key_storage != NULL)
+		{
+			pfree(hashing->tmp_key_storage);
+		}
+		hashing->tmp_key_storage = MemoryContextAlloc(hashing->key_body_mctx, num_bytes);
+		hashing->num_tmp_key_storage_bytes = num_bytes;
+	}
+	uint8 *restrict serialized_key_storage = hashing->tmp_key_storage;
+
+	/*
+	 * Build the actual grouping key.
+	 */
+	uint32 offset = 0;
+	offset += key_uses_short_header ? VARHDRSZ_SHORT : VARHDRSZ;
+
+	/*
+	 * We must always save the validity bitmap, even when there are no
+	 * null words, so that the key is uniquely deserializable. Otherwise a key
+	 * with some nulls might collide with a key with no nulls.
+	 */
+	uint8 *restrict serialized_key_validity_bitmap = &serialized_key_storage[offset];
+	offset += bitmap_bytes;
+
+	/*
+	 * Loop through the grouping columns again and add their values to the
+	 * grouping key.
+	 */
+	for (int column_index = 0; column_index < num_columns; column_index++)
+	{
+		const CompressedColumnValues *column_values = &params.grouping_column_values[column_index];
+
+		if (column_values->decompression_type == DT_Scalar)
+		{
+			const bool is_valid = !*column_values->output_isnull;
+			byte_bitmap_set_row_validity(serialized_key_validity_bitmap, column_index, is_valid);
+			if (is_valid)
+			{
+				const GroupingColumn *def = &params.policy->grouping_columns[column_index];
+				if (def->by_value)
+				{
+					memcpy(&serialized_key_storage[offset],
+						   column_values->output_value,
+						   def->value_bytes);
+
+					offset += def->value_bytes;
+				}
+				else
+				{
+					/*
+					 * The default value always has a long varlena header, but
+					 * we are going to use short if it fits.
+					 */
+					const int32 value_bytes = VARSIZE_ANY_EXHDR(*column_values->output_value);
+					if (value_bytes + VARHDRSZ_SHORT <= VARATT_SHORT_MAX)
+					{
+						/* Short varlena, no alignment. */
+						const int32 total_bytes = value_bytes + VARHDRSZ_SHORT;
+						SET_VARSIZE_SHORT(&serialized_key_storage[offset], total_bytes);
+						offset += VARHDRSZ_SHORT;
+					}
+					else
+					{
+						/* Long varlena, requires alignment. Zero out the alignment bytes. */
+						memset(&serialized_key_storage[offset], 0, 4);
+						offset = TYPEALIGN(4, offset);
+						const int32 total_bytes = value_bytes + VARHDRSZ;
+						SET_VARSIZE(&serialized_key_storage[offset], total_bytes);
+						offset += VARHDRSZ;
+					}
+
+					memcpy(&serialized_key_storage[offset],
+						   VARDATA_ANY(*column_values->output_value),
+						   value_bytes);
+
+					offset += value_bytes;
+				}
+			}
+			continue;
+		}
+
+		const bool is_valid = arrow_row_is_valid(column_values->buffers[0], row);
+		byte_bitmap_set_row_validity(serialized_key_validity_bitmap, column_index, is_valid);
+
+		if (!is_valid)
+		{
+			continue;
+		}
+
+		if (column_values->decompression_type > 0)
+		{
+			Assert(offset <= UINT_MAX - column_values->decompression_type);
+
+			switch ((int) column_values->decompression_type)
+			{
+				case 2:
+					memcpy(&serialized_key_storage[offset],
+						   row + (int16 *) column_values->buffers[1],
+						   2);
+					break;
+				case 4:
+					memcpy(&serialized_key_storage[offset],
+						   row + (int32 *) column_values->buffers[1],
+						   4);
+					break;
+				case 8:
+					memcpy(&serialized_key_storage[offset],
+						   row + (int64 *) column_values->buffers[1],
+						   8);
+					break;
+				default:
+					pg_unreachable();
+					break;
+			}
+
+			offset += column_values->decompression_type;
+
+			continue;
+		}
+
+		Assert(column_values->decompression_type == DT_ArrowText ||
+			   column_values->decompression_type == DT_ArrowTextDict);
+
+		const uint32 data_row = column_values->decompression_type == DT_ArrowTextDict ?
+									((int16 *) column_values->buffers[3])[row] :
+									row;
+		const uint32 start = ((uint32 *) column_values->buffers[1])[data_row];
+		const int32 value_bytes = ((uint32 *) column_values->buffers[1])[data_row + 1] - start;
+
+		if (value_bytes + VARHDRSZ_SHORT <= VARATT_SHORT_MAX)
+		{
+			/* Short varlena, unaligned. */
+			const int32 total_bytes = value_bytes + VARHDRSZ_SHORT;
+			SET_VARSIZE_SHORT(&serialized_key_storage[offset], total_bytes);
+			offset += VARHDRSZ_SHORT;
+		}
+		else
+		{
+			/* Long varlena, requires alignment. Zero out the alignment bytes. */
+			memset(&serialized_key_storage[offset], 0, 4);
+			offset = TYPEALIGN(4, offset);
+			const int32 total_bytes = value_bytes + VARHDRSZ;
+			SET_VARSIZE(&serialized_key_storage[offset], total_bytes);
+			offset += VARHDRSZ;
+		}
+		memcpy(&serialized_key_storage[offset],
+			   &((uint8 *) column_values->buffers[2])[start],
+			   value_bytes);
+
+		offset += value_bytes;
+	}
+
+	Assert(offset == num_bytes);
+
+	if (key_uses_short_header)
+	{
+		SET_VARSIZE_SHORT(serialized_key_storage, offset);
+	}
+	else
+	{
+		SET_VARSIZE(serialized_key_storage, offset);
+	}
+
+	DEBUG_PRINT("key is %d bytes: ", offset);
+	for (size_t i = 0; i < offset; i++)
+	{
+		DEBUG_PRINT("%.2x.", serialized_key_storage[i]);
+	}
+	DEBUG_PRINT("\n");
+
+	*output_key = (text *) serialized_key_storage;
+
+	Assert(VARSIZE_ANY(*output_key) == num_bytes);
+
+	/*
+	 * The multi-column key is always considered non-null, and the null flags
+	 * for the individual columns are stored in a bitmap that is part of the
+	 * key.
+	 */
+	*valid = true;
+
+	const struct umash_fp fp = umash_fprint(params.hashing->umash_params,
+											/* seed = */ ~0ULL,
+											serialized_key_storage,
+											num_bytes);
+	*hash_table_key = umash_fingerprint_get_key(fp);
+}
+
+static pg_attribute_always_inline void
+serialized_key_hashing_store_new(HashingStrategy *restrict hashing, uint32 new_key_index,
+								 text *output_key)
+{
+	/*
+	 * We will store this key so we have to consume the temporary storage that
+	 * was used for it. The subsequent keys will need to allocate new memory.
+	 */
+	Assert(hashing->tmp_key_storage == (void *) output_key);
+	hashing->tmp_key_storage = NULL;
+	hashing->num_tmp_key_storage_bytes = 0;
+
+	hashing->output_keys[new_key_index] = PointerGetDatum(output_key);
+}
+
+static void
+serialized_emit_key(GroupingPolicyHash *policy, uint32 current_key, TupleTableSlot *aggregated_slot)
+{
+	const HashingStrategy *hashing = &policy->hashing;
+	const int num_key_columns = policy->num_grouping_columns;
+	const Datum serialized_key_datum = hashing->output_keys[current_key];
+	const uint8 *serialized_key = (const uint8 *) VARDATA_ANY(serialized_key_datum);
+	PG_USED_FOR_ASSERTS_ONLY const int key_data_bytes = VARSIZE_ANY_EXHDR(serialized_key_datum);
+	const uint8 *restrict ptr = serialized_key;
+
+	/*
+	 * We have the column validity bitmap at the beginning of the key.
+	 */
+	const int bitmap_bytes = (num_key_columns + 7) / 8;
+	Assert(bitmap_bytes <= key_data_bytes);
+	const uint8 *restrict key_validity_bitmap = serialized_key;
+	ptr += bitmap_bytes;
+
+	DEBUG_PRINT("emit key #%d, with header %ld without %d bytes: ",
+				current_key,
+				VARSIZE_ANY(serialized_key_datum),
+				key_data_bytes);
+	for (size_t i = 0; i < VARSIZE_ANY(serialized_key_datum); i++)
+	{
+		DEBUG_PRINT("%.2x.", ((const uint8 *) serialized_key_datum)[i]);
+	}
+	DEBUG_PRINT("\n");
+
+	for (int column_index = 0; column_index < num_key_columns; column_index++)
+	{
+		const GroupingColumn *col = &policy->grouping_columns[column_index];
+		const bool isnull = !byte_bitmap_row_is_valid(key_validity_bitmap, column_index);
+
+		aggregated_slot->tts_isnull[col->output_offset] = isnull;
+
+		if (isnull)
+		{
+			continue;
+		}
+
+		Datum *output = &aggregated_slot->tts_values[col->output_offset];
+		if (col->value_bytes > 0)
+		{
+			Assert(col->by_value);
+			Assert((size_t) col->value_bytes <= sizeof(Datum));
+			*output = 0;
+			memcpy(output, ptr, col->value_bytes);
+			ptr += col->value_bytes;
+		}
+		else
+		{
+			Assert(col->value_bytes == -1);
+			Assert(!col->by_value);
+			if (VARATT_IS_SHORT(ptr))
+			{
+				*output = PointerGetDatum(ptr);
+				ptr += VARSIZE_SHORT(ptr);
+			}
+			else
+			{
+				ptr = (const uint8 *) TYPEALIGN(4, ptr);
+				*output = PointerGetDatum(ptr);
+				ptr += VARSIZE(ptr);
+			}
+		}
+	}
+
+	Assert(ptr == serialized_key + key_data_bytes);
+}
+
+#include "hash_strategy_impl.c"

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_single_text.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_single_text.c
@@ -89,9 +89,9 @@ single_text_key_hashing_get_key(BatchHashingParams params, int row, void *restri
 	}
 
 	DEBUG_PRINT("%p consider key row %d key index %d is %d bytes: ",
-				params.policy,
+				hashing,
 				row,
-				params.policy->last_used_key_index + 1,
+				hashing->last_used_key_index + 1,
 				output_key->len);
 	for (size_t i = 0; i < output_key->len; i++)
 	{
@@ -107,14 +107,14 @@ single_text_key_hashing_get_key(BatchHashingParams params, int row, void *restri
 }
 
 static pg_attribute_always_inline void
-single_text_key_hashing_store_new(GroupingPolicyHash *restrict policy, uint32 new_key_index,
+single_text_key_hashing_store_new(HashingStrategy *restrict hashing, uint32 new_key_index,
 								  BytesView output_key)
 {
 	const int total_bytes = output_key.len + VARHDRSZ;
-	text *restrict stored = (text *) MemoryContextAlloc(policy->hashing.key_body_mctx, total_bytes);
+	text *restrict stored = (text *) MemoryContextAlloc(hashing->key_body_mctx, total_bytes);
 	SET_VARSIZE(stored, total_bytes);
 	memcpy(VARDATA(stored), output_key.data, output_key.len);
-	policy->hashing.output_keys[new_key_index] = PointerGetDatum(stored);
+	hashing->output_keys[new_key_index] = PointerGetDatum(stored);
 }
 
 /*

--- a/tsl/src/nodes/vector_agg/hashing/hashing_strategy.h
+++ b/tsl/src/nodes/vector_agg/hashing/hashing_strategy.h
@@ -50,6 +50,11 @@ typedef struct HashingStrategy
 	MemoryContext key_body_mctx;
 
 	/*
+	 * The last used index of an unique grouping key. Key index 0 is invalid.
+	 */
+	uint32 last_used_key_index;
+
+	/*
 	 * In single-column grouping, we store the null key outside of the hash
 	 * table, and its index is given by this value. Key index 0 is invalid.
 	 * This is done to avoid having an "is null" flag in the hash table entries,
@@ -63,6 +68,13 @@ typedef struct HashingStrategy
 	 */
 	struct umash_params *umash_params;
 #endif
+
+	/*
+	 * Temporary key storages. Some hashing strategies need to put the key in a
+	 * separate memory area, we don't want to alloc/free it on each row.
+	 */
+	uint8 *tmp_key_storage;
+	uint64 num_tmp_key_storage_bytes;
 } HashingStrategy;
 
 void hash_strategy_output_key_alloc(GroupingPolicyHash *policy, uint16 nrows);

--- a/tsl/src/nodes/vector_agg/plan.c
+++ b/tsl/src/nodes/vector_agg/plan.c
@@ -396,7 +396,14 @@ get_vectorized_grouping_type(const VectorQualInfo *vqinfo, Agg *agg, List *resol
 #endif
 	}
 
+#ifdef TS_USE_UMASH
+	/*
+	 * Use hashing of serialized keys when we have many grouping columns.
+	 */
+	return VAGT_HashSerialized;
+#else
 	return VAGT_Invalid;
+#endif
 }
 
 /*

--- a/tsl/test/expected/hypercore_vectoragg.out
+++ b/tsl/test/expected/hypercore_vectoragg.out
@@ -314,13 +314,11 @@ select location, count(*) from aggdata where location=1 group by location;
 --
 -- Test ordering/grouping on segmentby, orderby columns
 --
--- This grouping is currently NOT supported by VectorAgg
---
 set timescaledb.enable_vectorized_aggregation=true;
 explain (verbose, costs off)
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, (sum(_hyper_1_1_chunk.temp))
    ->  Sort
@@ -330,9 +328,9 @@ select time, device, sum(temp) from aggdata where device is not null group by ti
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, sum(_hyper_1_1_chunk.temp)
                Group Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device
                ->  Append
-                     ->  Partial HashAggregate
-                           Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, PARTIAL sum(_hyper_1_1_chunk.temp)
-                           Group Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device
+                     ->  Custom Scan (VectorAgg)
+                           Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, (PARTIAL sum(_hyper_1_1_chunk.temp))
+                           Grouping Policy: hashed with serialized key
                            ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                                  Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, _hyper_1_1_chunk.temp
                                  Filter: (_hyper_1_1_chunk.device IS NOT NULL)
@@ -344,7 +342,6 @@ select time, device, sum(temp) from aggdata where device is not null group by ti
                                  Filter: (_hyper_1_2_chunk.device IS NOT NULL)
 (21 rows)
 
-set timescaledb.debug_require_vector_agg to 'forbid';
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
              time             | device | sum 
 ------------------------------+--------+-----
@@ -355,11 +352,10 @@ select time, device, sum(temp) from aggdata where device is not null group by ti
 (4 rows)
 
 set timecaledb.enable_vectorized_aggregation=false;
-reset timescaledb.debug_require_vector_agg;
 explain (verbose, costs off)
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, (sum(_hyper_1_1_chunk.temp))
    ->  Sort
@@ -369,9 +365,9 @@ select time, device, sum(temp) from aggdata where device is not null group by ti
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, sum(_hyper_1_1_chunk.temp)
                Group Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device
                ->  Append
-                     ->  Partial HashAggregate
-                           Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, PARTIAL sum(_hyper_1_1_chunk.temp)
-                           Group Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device
+                     ->  Custom Scan (VectorAgg)
+                           Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, (PARTIAL sum(_hyper_1_1_chunk.temp))
+                           Grouping Policy: hashed with serialized key
                            ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                                  Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, _hyper_1_1_chunk.temp
                                  Filter: (_hyper_1_1_chunk.device IS NOT NULL)
@@ -395,8 +391,8 @@ select time, device, sum(temp) from aggdata where device is not null group by ti
 set timescaledb.enable_vectorized_aggregation=true;
 explain (verbose, costs off)
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, (sum(_hyper_1_1_chunk.temp) FILTER (WHERE (_hyper_1_1_chunk.device IS NOT NULL)))
    ->  Sort
@@ -406,9 +402,9 @@ select time, device, sum(temp) filter (where device is not null) from aggdata gr
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, sum(_hyper_1_1_chunk.temp) FILTER (WHERE (_hyper_1_1_chunk.device IS NOT NULL))
                Group Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device
                ->  Append
-                     ->  Partial HashAggregate
-                           Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, PARTIAL sum(_hyper_1_1_chunk.temp) FILTER (WHERE (_hyper_1_1_chunk.device IS NOT NULL))
-                           Group Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device
+                     ->  Custom Scan (VectorAgg)
+                           Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, (PARTIAL sum(_hyper_1_1_chunk.temp) FILTER (WHERE (_hyper_1_1_chunk.device IS NOT NULL)))
+                           Grouping Policy: hashed with serialized key
                            ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                                  Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device, _hyper_1_1_chunk.temp
                      ->  Partial HashAggregate
@@ -418,7 +414,6 @@ select time, device, sum(temp) filter (where device is not null) from aggdata gr
                                  Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device, _hyper_1_2_chunk.temp
 (19 rows)
 
-set timescaledb.debug_require_vector_agg to 'forbid';
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;
              time             | device | sum 
 ------------------------------+--------+-----
@@ -430,7 +425,6 @@ select time, device, sum(temp) filter (where device is not null) from aggdata gr
 (5 rows)
 
 set timescaledb.enable_vectorized_aggregation=false;
-reset timescaledb.debug_require_vector_agg;
 explain (verbose, costs off)
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;
                                                                                  QUERY PLAN                                                                                  

--- a/tsl/test/expected/vector_agg_grouping.out
+++ b/tsl/test/expected/vector_agg_grouping.out
@@ -1,0 +1,2096 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- helper function: float -> pseudorandom float [-0.5..0.5]
+CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
+    SELECT hashfloat8(x::float8) / pow(2, 32)
+$$ LANGUAGE SQL;
+-- To not confuse null with empty strings in the test reference
+\pset null $
+\set CHUNKS 2::int
+\set CHUNK_ROWS 100000::int
+\set GROUPING_CARDINALITY 10::int
+create table agggroup(t int, s int,
+    cint2 int2, cint4 int4, cint8 int8);
+select create_hypertable('agggroup', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
+NOTICE:  adding not-null constraint to column "s"
+   create_hypertable   
+-----------------------
+ (1,public,agggroup,t)
+(1 row)
+
+create view source as
+select s * 10000 + t as t,
+    s,
+    case when t % 1051 = 0 then null
+        else (mix(s + t * 1019) * 32767)::int2 end as cint2,
+    (mix(s + t * 1021) * 32767)::int4 as cint4,
+    (mix(s + t * 1031) * 32767)::int8 as cint8
+from
+    generate_series(1::int, :CHUNK_ROWS * :CHUNKS / :GROUPING_CARDINALITY) t,
+    generate_series(0::int, :GROUPING_CARDINALITY - 1::int) s(s)
+;
+insert into agggroup select * from source where s = 1;
+alter table agggroup set (timescaledb.compress, timescaledb.compress_orderby = 't',
+    timescaledb.compress_segmentby = 's');
+select count(compress_chunk(x)) from show_chunks('agggroup') x;
+ count 
+-------
+     1
+(1 row)
+
+alter table agggroup add column ss int default 11;
+alter table agggroup add column x text default '11';
+insert into agggroup
+select *, ss::text as x from (
+    select *,
+        case
+            -- null in entire batch
+            when s = 2 then null
+            -- null for some rows
+            when s = 3 and t % 1051 = 0 then null
+            -- for some rows same as default
+            when s = 4 and t % 1057 = 0 then 11
+            -- not null for entire batch
+            else s
+        end as ss
+    from source where s != 1
+) t
+;
+select count(compress_chunk(x)) from show_chunks('agggroup') x;
+ count 
+-------
+     2
+(1 row)
+
+vacuum freeze analyze agggroup;
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference. Note that there are minor discrepancies
+-- on float4 due to different numeric stability in our and PG implementations.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+select
+    format('%sselect %s%s(%s) from agggroup%s%s%s;',
+            explain,
+            grouping || ', ',
+            function, variable,
+            ' where ' || condition,
+            ' group by ' || grouping,
+            format(' order by %s(%s), ', function, variable) || grouping || ' limit 10',
+            function, variable)
+from
+    unnest(array[
+        'explain (costs off) ',
+        null]) explain,
+    unnest(array[
+        'cint2',
+        '*']) variable,
+    unnest(array[
+        'min',
+        'count']) function,
+    unnest(array[
+        null,
+        'cint2 > 0',
+        'cint2 is null',
+        'cint2 is null and x is null']) with ordinality as condition(condition, n),
+    unnest(array[
+        'cint4, cint2',
+        'cint4, cint8',
+        'cint2, cint4, cint8',
+        's, cint2',
+        's, ss',
+        's, x',
+        'ss, cint2, x',
+        'ss, s',
+        'ss, x, cint2',
+        't, s, ss, x, cint4, cint8, cint2',
+        'x']) with ordinality as grouping(grouping, n)
+where
+    true
+    and (explain is null /* or condition is null and grouping = 's' */)
+    and (variable != '*' or function = 'count')
+order by explain, condition.n, variable, function, grouping.n
+\gexec
+select cint4, cint2, count(*) from agggroup group by cint4, cint2 order by count(*), cint4, cint2 limit 10;
+ cint4  | cint2  | count 
+--------+--------+-------
+ -16383 |  -4883 |     1
+ -16383 |  -1995 |     1
+ -16383 |    607 |     1
+ -16382 | -12462 |     1
+ -16382 | -10682 |     1
+ -16382 | -10538 |     1
+ -16382 | -10164 |     1
+ -16382 |  -6061 |     1
+ -16382 |  -4558 |     1
+ -16382 |  -3173 |     1
+(10 rows)
+
+select cint4, cint8, count(*) from agggroup group by cint4, cint8 order by count(*), cint4, cint8 limit 10;
+ cint4  | cint8 | count 
+--------+-------+-------
+ -16383 |  4889 |     1
+ -16383 |  7417 |     1
+ -16383 |  8953 |     1
+ -16382 | -8851 |     1
+ -16382 | -8612 |     1
+ -16382 | -5254 |     1
+ -16382 | -4489 |     1
+ -16382 |  -470 |     1
+ -16382 |   411 |     1
+ -16382 |   899 |     1
+(10 rows)
+
+select cint2, cint4, cint8, count(*) from agggroup group by cint2, cint4, cint8 order by count(*), cint2, cint4, cint8 limit 10;
+ cint2  | cint4  | cint8  | count 
+--------+--------+--------+-------
+ -16383 | -16190 |  13646 |     1
+ -16383 | -13372 |  11094 |     1
+ -16383 | -10318 |   6326 |     1
+ -16383 |  -9008 |   4390 |     1
+ -16383 |  -3043 |  -1794 |     1
+ -16383 |   6729 |   6717 |     1
+ -16382 | -14012 |  -9888 |     1
+ -16382 |  -8606 | -10357 |     1
+ -16382 |  -3080 | -15609 |     1
+ -16382 |   2223 |   9035 |     1
+(10 rows)
+
+select s, cint2, count(*) from agggroup group by s, cint2 order by count(*), s, cint2 limit 10;
+ s | cint2  | count 
+---+--------+-------
+ 0 | -16377 |     1
+ 0 | -16376 |     1
+ 0 | -16375 |     1
+ 0 | -16373 |     1
+ 0 | -16372 |     1
+ 0 | -16371 |     1
+ 0 | -16370 |     1
+ 0 | -16369 |     1
+ 0 | -16368 |     1
+ 0 | -16367 |     1
+(10 rows)
+
+select s, ss, count(*) from agggroup group by s, ss order by count(*), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 3 |  $ |    19
+ 4 | 11 |    19
+ 3 |  3 | 19981
+ 4 |  4 | 19981
+ 0 |  0 | 20000
+ 1 | 11 | 20000
+ 2 |  $ | 20000
+ 5 |  5 | 20000
+ 6 |  6 | 20000
+ 7 |  7 | 20000
+(10 rows)
+
+select s, x, count(*) from agggroup group by s, x order by count(*), s, x limit 10;
+ s | x  | count 
+---+----+-------
+ 3 | $  |    19
+ 4 | 11 |    19
+ 3 | 3  | 19981
+ 4 | 4  | 19981
+ 0 | 0  | 20000
+ 1 | 11 | 20000
+ 2 | $  | 20000
+ 5 | 5  | 20000
+ 6 | 6  | 20000
+ 7 | 7  | 20000
+(10 rows)
+
+select ss, cint2, x, count(*) from agggroup group by ss, cint2, x order by count(*), ss, cint2, x limit 10;
+ ss | cint2  | x | count 
+----+--------+---+-------
+  0 | -16377 | 0 |     1
+  0 | -16376 | 0 |     1
+  0 | -16375 | 0 |     1
+  0 | -16373 | 0 |     1
+  0 | -16372 | 0 |     1
+  0 | -16371 | 0 |     1
+  0 | -16370 | 0 |     1
+  0 | -16369 | 0 |     1
+  0 | -16368 | 0 |     1
+  0 | -16367 | 0 |     1
+(10 rows)
+
+select ss, s, count(*) from agggroup group by ss, s order by count(*), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+ 11 | 4 |    19
+  $ | 3 |    19
+  3 | 3 | 19981
+  4 | 4 | 19981
+  0 | 0 | 20000
+  5 | 5 | 20000
+  6 | 6 | 20000
+  7 | 7 | 20000
+  8 | 8 | 20000
+  9 | 9 | 20000
+(10 rows)
+
+select ss, x, cint2, count(*) from agggroup group by ss, x, cint2 order by count(*), ss, x, cint2 limit 10;
+ ss | x | cint2  | count 
+----+---+--------+-------
+  0 | 0 | -16377 |     1
+  0 | 0 | -16376 |     1
+  0 | 0 | -16375 |     1
+  0 | 0 | -16373 |     1
+  0 | 0 | -16372 |     1
+  0 | 0 | -16371 |     1
+  0 | 0 | -16370 |     1
+  0 | 0 | -16369 |     1
+  0 | 0 | -16368 |     1
+  0 | 0 | -16367 |     1
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, count(*) from agggroup group by t, s, ss, x, cint4, cint8, cint2 order by count(*), t, s, ss, x, cint4, cint8, cint2 limit 10;
+ t  | s | ss | x | cint4  | cint8 | cint2  | count 
+----+---+----+---+--------+-------+--------+-------
+  1 | 0 |  0 | 0 | -15736 | 12910 |   3398 |     1
+  2 | 0 |  0 | 0 |   1096 | -6638 |  -5373 |     1
+  3 | 0 |  0 | 0 | -15920 | 13672 |  -7109 |     1
+  4 | 0 |  0 | 0 |  14299 | -8187 |  -4927 |     1
+  5 | 0 |  0 | 0 |   9267 |  6436 |   4859 |     1
+  6 | 0 |  0 | 0 |  -5203 |  9870 |  12177 |     1
+  7 | 0 |  0 | 0 |   6620 |  -781 |   5174 |     1
+  8 | 0 |  0 | 0 | -10427 |   876 | -12705 |     1
+  9 | 0 |  0 | 0 | -14954 | -1593 |   2257 |     1
+ 10 | 0 |  0 | 0 |  10047 | -7626 |   3923 |     1
+(10 rows)
+
+select x, count(*) from agggroup group by x order by count(*), x limit 10;
+ x  | count 
+----+-------
+ 3  | 19981
+ 4  | 19981
+ 0  | 20000
+ 5  | 20000
+ 6  | 20000
+ 7  | 20000
+ 8  | 20000
+ 9  | 20000
+ 11 | 20019
+ $  | 20019
+(10 rows)
+
+select cint4, cint2, count(cint2) from agggroup group by cint4, cint2 order by count(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -16291 |     $ |     0
+ -16091 |     $ |     0
+ -15799 |     $ |     0
+ -15724 |     $ |     0
+ -15328 |     $ |     0
+ -15279 |     $ |     0
+ -15063 |     $ |     0
+ -14998 |     $ |     0
+ -14949 |     $ |     0
+ -14848 |     $ |     0
+(10 rows)
+
+select cint4, cint8, count(cint2) from agggroup group by cint4, cint8 order by count(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  | count 
+--------+--------+-------
+ -16291 |    113 |     0
+ -16091 |  -4084 |     0
+ -15799 |  12603 |     0
+ -15724 |  15426 |     0
+ -15328 |  -6092 |     0
+ -15279 |  -3475 |     0
+ -15063 |   3990 |     0
+ -14998 |  14464 |     0
+ -14949 | -10395 |     0
+ -14848 |   3110 |     0
+(10 rows)
+
+select cint2, cint4, cint8, count(cint2) from agggroup group by cint2, cint4, cint8 order by count(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     $ | -16291 |    113 |     0
+     $ | -16091 |  -4084 |     0
+     $ | -15799 |  12603 |     0
+     $ | -15724 |  15426 |     0
+     $ | -15328 |  -6092 |     0
+     $ | -15279 |  -3475 |     0
+     $ | -15063 |   3990 |     0
+     $ | -14998 |  14464 |     0
+     $ | -14949 | -10395 |     0
+     $ | -14848 |   3110 |     0
+(10 rows)
+
+select s, cint2, count(cint2) from agggroup group by s, cint2 order by count(cint2), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 0 |     $ |     0
+ 1 |     $ |     0
+ 2 |     $ |     0
+ 3 |     $ |     0
+ 4 |     $ |     0
+ 5 |     $ |     0
+ 6 |     $ |     0
+ 7 |     $ |     0
+ 8 |     $ |     0
+ 9 |     $ |     0
+(10 rows)
+
+select s, ss, count(cint2) from agggroup group by s, ss order by count(cint2), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 3 |  $ |    19
+ 4 | 11 |    19
+ 3 |  3 | 19962
+ 4 |  4 | 19962
+ 0 |  0 | 19981
+ 1 | 11 | 19981
+ 2 |  $ | 19981
+ 5 |  5 | 19981
+ 6 |  6 | 19981
+ 7 |  7 | 19981
+(10 rows)
+
+select s, x, count(cint2) from agggroup group by s, x order by count(cint2), s, x limit 10;
+ s | x  | count 
+---+----+-------
+ 3 | $  |    19
+ 4 | 11 |    19
+ 3 | 3  | 19962
+ 4 | 4  | 19962
+ 0 | 0  | 19981
+ 1 | 11 | 19981
+ 2 | $  | 19981
+ 5 | 5  | 19981
+ 6 | 6  | 19981
+ 7 | 7  | 19981
+(10 rows)
+
+select ss, cint2, x, count(cint2) from agggroup group by ss, cint2, x order by count(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x  | count 
+----+-------+----+-------
+  0 |     $ | 0  |     0
+  3 |     $ | 3  |     0
+  4 |     $ | 4  |     0
+  5 |     $ | 5  |     0
+  6 |     $ | 6  |     0
+  7 |     $ | 7  |     0
+  8 |     $ | 8  |     0
+  9 |     $ | 9  |     0
+ 11 |     $ | 11 |     0
+  $ |     $ | $  |     0
+(10 rows)
+
+select ss, s, count(cint2) from agggroup group by ss, s order by count(cint2), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+ 11 | 4 |    19
+  $ | 3 |    19
+  3 | 3 | 19962
+  4 | 4 | 19962
+  0 | 0 | 19981
+  5 | 5 | 19981
+  6 | 6 | 19981
+  7 | 7 | 19981
+  8 | 8 | 19981
+  9 | 9 | 19981
+(10 rows)
+
+select ss, x, cint2, count(cint2) from agggroup group by ss, x, cint2 order by count(cint2), ss, x, cint2 limit 10;
+ ss | x  | cint2 | count 
+----+----+-------+-------
+  0 | 0  |     $ |     0
+  3 | 3  |     $ |     0
+  4 | 4  |     $ |     0
+  5 | 5  |     $ |     0
+  6 | 6  |     $ |     0
+  7 | 7  |     $ |     0
+  8 | 8  |     $ |     0
+  9 | 9  |     $ |     0
+ 11 | 11 |     $ |     0
+  $ | $  |     $ |     0
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, count(cint2) from agggroup group by t, s, ss, x, cint4, cint8, cint2 order by count(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | count 
+-------+---+----+---+--------+--------+-------+-------
+  1051 | 0 |  0 | 0 |  -8612 |  14327 |     $ |     0
+  2102 | 0 |  0 | 0 |  11069 |  16047 |     $ |     0
+  3153 | 0 |  0 | 0 |   6192 |  12700 |     $ |     0
+  4204 | 0 |  0 | 0 |   4165 | -10102 |     $ |     0
+  5255 | 0 |  0 | 0 |  16314 |  13418 |     $ |     0
+  6306 | 0 |  0 | 0 |    701 |  -3029 |     $ |     0
+  7357 | 0 |  0 | 0 |   1115 |   4913 |     $ |     0
+  8408 | 0 |  0 | 0 |  15553 |   1743 |     $ |     0
+  9459 | 0 |  0 | 0 | -14640 |  11933 |     $ |     0
+ 10510 | 0 |  0 | 0 | -14725 |   6531 |     $ |     0
+(10 rows)
+
+select x, count(cint2) from agggroup group by x order by count(cint2), x limit 10;
+ x  | count 
+----+-------
+ 3  | 19962
+ 4  | 19962
+ 0  | 19981
+ 5  | 19981
+ 6  | 19981
+ 7  | 19981
+ 8  | 19981
+ 9  | 19981
+ 11 | 20000
+ $  | 20000
+(10 rows)
+
+select cint4, cint2, min(cint2) from agggroup group by cint4, cint2 order by min(cint2), cint4, cint2 limit 10;
+ cint4  | cint2  |  min   
+--------+--------+--------
+ -16190 | -16383 | -16383
+ -13372 | -16383 | -16383
+ -10318 | -16383 | -16383
+  -9008 | -16383 | -16383
+  -3043 | -16383 | -16383
+   6729 | -16383 | -16383
+ -14012 | -16382 | -16382
+  -8606 | -16382 | -16382
+  -3080 | -16382 | -16382
+   2223 | -16382 | -16382
+(10 rows)
+
+select cint4, cint8, min(cint2) from agggroup group by cint4, cint8 order by min(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  |  min   
+--------+--------+--------
+ -16190 |  13646 | -16383
+ -13372 |  11094 | -16383
+ -10318 |   6326 | -16383
+  -9008 |   4390 | -16383
+  -3043 |  -1794 | -16383
+   6729 |   6717 | -16383
+ -14012 |  -9888 | -16382
+  -8606 | -10357 | -16382
+  -3080 | -15609 | -16382
+   2223 |   9035 | -16382
+(10 rows)
+
+select cint2, cint4, cint8, min(cint2) from agggroup group by cint2, cint4, cint8 order by min(cint2), cint2, cint4, cint8 limit 10;
+ cint2  | cint4  | cint8  |  min   
+--------+--------+--------+--------
+ -16383 | -16190 |  13646 | -16383
+ -16383 | -13372 |  11094 | -16383
+ -16383 | -10318 |   6326 | -16383
+ -16383 |  -9008 |   4390 | -16383
+ -16383 |  -3043 |  -1794 | -16383
+ -16383 |   6729 |   6717 | -16383
+ -16382 | -14012 |  -9888 | -16382
+ -16382 |  -8606 | -10357 | -16382
+ -16382 |  -3080 | -15609 | -16382
+ -16382 |   2223 |   9035 | -16382
+(10 rows)
+
+select s, cint2, min(cint2) from agggroup group by s, cint2 order by min(cint2), s, cint2 limit 10;
+ s | cint2  |  min   
+---+--------+--------
+ 0 | -16383 | -16383
+ 4 | -16383 | -16383
+ 5 | -16383 | -16383
+ 6 | -16383 | -16383
+ 2 | -16382 | -16382
+ 7 | -16382 | -16382
+ 8 | -16382 | -16382
+ 2 | -16381 | -16381
+ 3 | -16381 | -16381
+ 4 | -16381 | -16381
+(10 rows)
+
+select s, ss, min(cint2) from agggroup group by s, ss order by min(cint2), s, ss limit 10;
+ s | ss |  min   
+---+----+--------
+ 0 |  0 | -16383
+ 4 |  4 | -16383
+ 5 |  5 | -16383
+ 6 |  6 | -16383
+ 2 |  $ | -16382
+ 7 |  7 | -16382
+ 8 |  8 | -16382
+ 3 |  3 | -16381
+ 1 | 11 | -16378
+ 9 |  9 | -16375
+(10 rows)
+
+select s, x, min(cint2) from agggroup group by s, x order by min(cint2), s, x limit 10;
+ s | x  |  min   
+---+----+--------
+ 0 | 0  | -16383
+ 4 | 4  | -16383
+ 5 | 5  | -16383
+ 6 | 6  | -16383
+ 2 | $  | -16382
+ 7 | 7  | -16382
+ 8 | 8  | -16382
+ 3 | 3  | -16381
+ 1 | 11 | -16378
+ 9 | 9  | -16375
+(10 rows)
+
+select ss, cint2, x, min(cint2) from agggroup group by ss, cint2, x order by min(cint2), ss, cint2, x limit 10;
+ ss | cint2  | x |  min   
+----+--------+---+--------
+  0 | -16383 | 0 | -16383
+  4 | -16383 | 4 | -16383
+  5 | -16383 | 5 | -16383
+  6 | -16383 | 6 | -16383
+  7 | -16382 | 7 | -16382
+  8 | -16382 | 8 | -16382
+  $ | -16382 | $ | -16382
+  3 | -16381 | 3 | -16381
+  4 | -16381 | 4 | -16381
+  5 | -16381 | 5 | -16381
+(10 rows)
+
+select ss, s, min(cint2) from agggroup group by ss, s order by min(cint2), ss, s limit 10;
+ ss | s |  min   
+----+---+--------
+  0 | 0 | -16383
+  4 | 4 | -16383
+  5 | 5 | -16383
+  6 | 6 | -16383
+  7 | 7 | -16382
+  8 | 8 | -16382
+  $ | 2 | -16382
+  3 | 3 | -16381
+ 11 | 1 | -16378
+  9 | 9 | -16375
+(10 rows)
+
+select ss, x, cint2, min(cint2) from agggroup group by ss, x, cint2 order by min(cint2), ss, x, cint2 limit 10;
+ ss | x | cint2  |  min   
+----+---+--------+--------
+  0 | 0 | -16383 | -16383
+  4 | 4 | -16383 | -16383
+  5 | 5 | -16383 | -16383
+  6 | 6 | -16383 | -16383
+  7 | 7 | -16382 | -16382
+  8 | 8 | -16382 | -16382
+  $ | $ | -16382 | -16382
+  3 | 3 | -16381 | -16381
+  4 | 4 | -16381 | -16381
+  5 | 5 | -16381 | -16381
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, min(cint2) from agggroup group by t, s, ss, x, cint4, cint8, cint2 order by min(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2  |  min   
+-------+---+----+---+--------+--------+--------+--------
+  6194 | 0 |  0 | 0 | -13372 |  11094 | -16383 | -16383
+ 17044 | 0 |  0 | 0 | -10318 |   6326 | -16383 | -16383
+ 53843 | 4 |  4 | 4 |  -9008 |   4390 | -16383 | -16383
+ 60530 | 5 |  5 | 5 |   6729 |   6717 | -16383 | -16383
+ 73208 | 6 |  6 | 6 |  -3043 |  -1794 | -16383 | -16383
+ 74870 | 6 |  6 | 6 | -16190 |  13646 | -16383 | -16383
+ 22836 | 2 |  $ | $ |  -3080 | -15609 | -16382 | -16382
+ 29858 | 2 |  $ | $ | -14012 |  -9888 | -16382 | -16382
+ 31516 | 2 |  $ | $ |   6193 |    206 | -16382 | -16382
+ 76781 | 7 |  7 | 7 |   9938 |   6519 | -16382 | -16382
+(10 rows)
+
+select x, min(cint2) from agggroup group by x order by min(cint2), x limit 10;
+ x  |  min   
+----+--------
+ 0  | -16383
+ 4  | -16383
+ 5  | -16383
+ 6  | -16383
+ 7  | -16382
+ 8  | -16382
+ $  | -16382
+ 3  | -16381
+ 11 | -16378
+ 9  | -16375
+(10 rows)
+
+select cint4, cint2, count(*) from agggroup where cint2 > 0 group by cint4, cint2 order by count(*), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -16383 |   607 |     1
+ -16382 |    94 |     1
+ -16382 |   569 |     1
+ -16382 |  1891 |     1
+ -16382 |  4679 |     1
+ -16382 | 10118 |     1
+ -16382 | 14467 |     1
+ -16382 | 15369 |     1
+ -16380 |   448 |     1
+ -16379 |   390 |     1
+(10 rows)
+
+select cint4, cint8, count(*) from agggroup where cint2 > 0 group by cint4, cint8 order by count(*), cint4, cint8 limit 10;
+ cint4  | cint8 | count 
+--------+-------+-------
+ -16383 |  4889 |     1
+ -16382 | -8851 |     1
+ -16382 | -4489 |     1
+ -16382 |  -470 |     1
+ -16382 |   411 |     1
+ -16382 |  8377 |     1
+ -16382 |  8832 |     1
+ -16382 | 15709 |     1
+ -16380 |  1449 |     1
+ -16379 |  1234 |     1
+(10 rows)
+
+select cint2, cint4, cint8, count(*) from agggroup where cint2 > 0 group by cint2, cint4, cint8 order by count(*), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     1 | -12025 |  -2210 |     1
+     1 | -10344 | -13684 |     1
+     1 |  -4190 |  -2827 |     1
+     1 |  -1493 |  -1043 |     1
+     1 |   1863 |   7650 |     1
+     1 |   9242 |  -9798 |     1
+     1 |  11189 |  -5168 |     1
+     1 |  14078 |   9929 |     1
+     1 |  15656 |  12597 |     1
+     2 | -11410 |   6033 |     1
+(10 rows)
+
+select s, cint2, count(*) from agggroup where cint2 > 0 group by s, cint2 order by count(*), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 0 |     4 |     1
+ 0 |     7 |     1
+ 0 |     8 |     1
+ 0 |     9 |     1
+ 0 |    10 |     1
+ 0 |    11 |     1
+ 0 |    18 |     1
+ 0 |    24 |     1
+ 0 |    28 |     1
+ 0 |    31 |     1
+(10 rows)
+
+select s, ss, count(*) from agggroup where cint2 > 0 group by s, ss order by count(*), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 3 |  $ |     9
+ 4 | 11 |     9
+ 2 |  $ |  9868
+ 3 |  3 |  9884
+ 6 |  6 |  9890
+ 4 |  4 |  9897
+ 8 |  8 |  9898
+ 7 |  7 |  9973
+ 0 |  0 | 10012
+ 9 |  9 | 10018
+(10 rows)
+
+select s, x, count(*) from agggroup where cint2 > 0 group by s, x order by count(*), s, x limit 10;
+ s | x  | count 
+---+----+-------
+ 3 | $  |     9
+ 4 | 11 |     9
+ 2 | $  |  9868
+ 3 | 3  |  9884
+ 6 | 6  |  9890
+ 4 | 4  |  9897
+ 8 | 8  |  9898
+ 7 | 7  |  9973
+ 0 | 0  | 10012
+ 9 | 9  | 10018
+(10 rows)
+
+select ss, cint2, x, count(*) from agggroup where cint2 > 0 group by ss, cint2, x order by count(*), ss, cint2, x limit 10;
+ ss | cint2 | x | count 
+----+-------+---+-------
+  0 |     4 | 0 |     1
+  0 |     7 | 0 |     1
+  0 |     8 | 0 |     1
+  0 |     9 | 0 |     1
+  0 |    10 | 0 |     1
+  0 |    11 | 0 |     1
+  0 |    18 | 0 |     1
+  0 |    24 | 0 |     1
+  0 |    28 | 0 |     1
+  0 |    31 | 0 |     1
+(10 rows)
+
+select ss, s, count(*) from agggroup where cint2 > 0 group by ss, s order by count(*), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+ 11 | 4 |     9
+  $ | 3 |     9
+  $ | 2 |  9868
+  3 | 3 |  9884
+  6 | 6 |  9890
+  4 | 4 |  9897
+  8 | 8 |  9898
+  7 | 7 |  9973
+  0 | 0 | 10012
+  9 | 9 | 10018
+(10 rows)
+
+select ss, x, cint2, count(*) from agggroup where cint2 > 0 group by ss, x, cint2 order by count(*), ss, x, cint2 limit 10;
+ ss | x | cint2 | count 
+----+---+-------+-------
+  0 | 0 |     4 |     1
+  0 | 0 |     7 |     1
+  0 | 0 |     8 |     1
+  0 | 0 |     9 |     1
+  0 | 0 |    10 |     1
+  0 | 0 |    11 |     1
+  0 | 0 |    18 |     1
+  0 | 0 |    24 |     1
+  0 | 0 |    28 |     1
+  0 | 0 |    31 |     1
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, count(*) from agggroup where cint2 > 0 group by t, s, ss, x, cint4, cint8, cint2 order by count(*), t, s, ss, x, cint4, cint8, cint2 limit 10;
+ t  | s | ss | x | cint4  | cint8 | cint2 | count 
+----+---+----+---+--------+-------+-------+-------
+  1 | 0 |  0 | 0 | -15736 | 12910 |  3398 |     1
+  5 | 0 |  0 | 0 |   9267 |  6436 |  4859 |     1
+  6 | 0 |  0 | 0 |  -5203 |  9870 | 12177 |     1
+  7 | 0 |  0 | 0 |   6620 |  -781 |  5174 |     1
+  9 | 0 |  0 | 0 | -14954 | -1593 |  2257 |     1
+ 10 | 0 |  0 | 0 |  10047 | -7626 |  3923 |     1
+ 14 | 0 |  0 | 0 | -13766 |  -398 |  4669 |     1
+ 15 | 0 |  0 | 0 | -13009 | 14045 | 15101 |     1
+ 19 | 0 |  0 | 0 | -16257 |  4566 |  7684 |     1
+ 22 | 0 |  0 | 0 |  -6345 | -8658 | 11755 |     1
+(10 rows)
+
+select x, count(*) from agggroup where cint2 > 0 group by x order by count(*), x limit 10;
+ x  | count 
+----+-------
+ $  |  9877
+ 3  |  9884
+ 6  |  9890
+ 4  |  9897
+ 8  |  9898
+ 7  |  9973
+ 0  | 10012
+ 9  | 10018
+ 11 | 10105
+ 5  | 10110
+(10 rows)
+
+select cint4, cint2, count(cint2) from agggroup where cint2 > 0 group by cint4, cint2 order by count(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -16383 |   607 |     1
+ -16382 |    94 |     1
+ -16382 |   569 |     1
+ -16382 |  1891 |     1
+ -16382 |  4679 |     1
+ -16382 | 10118 |     1
+ -16382 | 14467 |     1
+ -16382 | 15369 |     1
+ -16380 |   448 |     1
+ -16379 |   390 |     1
+(10 rows)
+
+select cint4, cint8, count(cint2) from agggroup where cint2 > 0 group by cint4, cint8 order by count(cint2), cint4, cint8 limit 10;
+ cint4  | cint8 | count 
+--------+-------+-------
+ -16383 |  4889 |     1
+ -16382 | -8851 |     1
+ -16382 | -4489 |     1
+ -16382 |  -470 |     1
+ -16382 |   411 |     1
+ -16382 |  8377 |     1
+ -16382 |  8832 |     1
+ -16382 | 15709 |     1
+ -16380 |  1449 |     1
+ -16379 |  1234 |     1
+(10 rows)
+
+select cint2, cint4, cint8, count(cint2) from agggroup where cint2 > 0 group by cint2, cint4, cint8 order by count(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     1 | -12025 |  -2210 |     1
+     1 | -10344 | -13684 |     1
+     1 |  -4190 |  -2827 |     1
+     1 |  -1493 |  -1043 |     1
+     1 |   1863 |   7650 |     1
+     1 |   9242 |  -9798 |     1
+     1 |  11189 |  -5168 |     1
+     1 |  14078 |   9929 |     1
+     1 |  15656 |  12597 |     1
+     2 | -11410 |   6033 |     1
+(10 rows)
+
+select s, cint2, count(cint2) from agggroup where cint2 > 0 group by s, cint2 order by count(cint2), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 0 |     4 |     1
+ 0 |     7 |     1
+ 0 |     8 |     1
+ 0 |     9 |     1
+ 0 |    10 |     1
+ 0 |    11 |     1
+ 0 |    18 |     1
+ 0 |    24 |     1
+ 0 |    28 |     1
+ 0 |    31 |     1
+(10 rows)
+
+select s, ss, count(cint2) from agggroup where cint2 > 0 group by s, ss order by count(cint2), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 3 |  $ |     9
+ 4 | 11 |     9
+ 2 |  $ |  9868
+ 3 |  3 |  9884
+ 6 |  6 |  9890
+ 4 |  4 |  9897
+ 8 |  8 |  9898
+ 7 |  7 |  9973
+ 0 |  0 | 10012
+ 9 |  9 | 10018
+(10 rows)
+
+select s, x, count(cint2) from agggroup where cint2 > 0 group by s, x order by count(cint2), s, x limit 10;
+ s | x  | count 
+---+----+-------
+ 3 | $  |     9
+ 4 | 11 |     9
+ 2 | $  |  9868
+ 3 | 3  |  9884
+ 6 | 6  |  9890
+ 4 | 4  |  9897
+ 8 | 8  |  9898
+ 7 | 7  |  9973
+ 0 | 0  | 10012
+ 9 | 9  | 10018
+(10 rows)
+
+select ss, cint2, x, count(cint2) from agggroup where cint2 > 0 group by ss, cint2, x order by count(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x | count 
+----+-------+---+-------
+  0 |     4 | 0 |     1
+  0 |     7 | 0 |     1
+  0 |     8 | 0 |     1
+  0 |     9 | 0 |     1
+  0 |    10 | 0 |     1
+  0 |    11 | 0 |     1
+  0 |    18 | 0 |     1
+  0 |    24 | 0 |     1
+  0 |    28 | 0 |     1
+  0 |    31 | 0 |     1
+(10 rows)
+
+select ss, s, count(cint2) from agggroup where cint2 > 0 group by ss, s order by count(cint2), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+ 11 | 4 |     9
+  $ | 3 |     9
+  $ | 2 |  9868
+  3 | 3 |  9884
+  6 | 6 |  9890
+  4 | 4 |  9897
+  8 | 8 |  9898
+  7 | 7 |  9973
+  0 | 0 | 10012
+  9 | 9 | 10018
+(10 rows)
+
+select ss, x, cint2, count(cint2) from agggroup where cint2 > 0 group by ss, x, cint2 order by count(cint2), ss, x, cint2 limit 10;
+ ss | x | cint2 | count 
+----+---+-------+-------
+  0 | 0 |     4 |     1
+  0 | 0 |     7 |     1
+  0 | 0 |     8 |     1
+  0 | 0 |     9 |     1
+  0 | 0 |    10 |     1
+  0 | 0 |    11 |     1
+  0 | 0 |    18 |     1
+  0 | 0 |    24 |     1
+  0 | 0 |    28 |     1
+  0 | 0 |    31 |     1
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, count(cint2) from agggroup where cint2 > 0 group by t, s, ss, x, cint4, cint8, cint2 order by count(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+ t  | s | ss | x | cint4  | cint8 | cint2 | count 
+----+---+----+---+--------+-------+-------+-------
+  1 | 0 |  0 | 0 | -15736 | 12910 |  3398 |     1
+  5 | 0 |  0 | 0 |   9267 |  6436 |  4859 |     1
+  6 | 0 |  0 | 0 |  -5203 |  9870 | 12177 |     1
+  7 | 0 |  0 | 0 |   6620 |  -781 |  5174 |     1
+  9 | 0 |  0 | 0 | -14954 | -1593 |  2257 |     1
+ 10 | 0 |  0 | 0 |  10047 | -7626 |  3923 |     1
+ 14 | 0 |  0 | 0 | -13766 |  -398 |  4669 |     1
+ 15 | 0 |  0 | 0 | -13009 | 14045 | 15101 |     1
+ 19 | 0 |  0 | 0 | -16257 |  4566 |  7684 |     1
+ 22 | 0 |  0 | 0 |  -6345 | -8658 | 11755 |     1
+(10 rows)
+
+select x, count(cint2) from agggroup where cint2 > 0 group by x order by count(cint2), x limit 10;
+ x  | count 
+----+-------
+ $  |  9877
+ 3  |  9884
+ 6  |  9890
+ 4  |  9897
+ 8  |  9898
+ 7  |  9973
+ 0  | 10012
+ 9  | 10018
+ 11 | 10105
+ 5  | 10110
+(10 rows)
+
+select cint4, cint2, min(cint2) from agggroup where cint2 > 0 group by cint4, cint2 order by min(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | min 
+--------+-------+-----
+ -12025 |     1 |   1
+ -10344 |     1 |   1
+  -4190 |     1 |   1
+  -1493 |     1 |   1
+   1863 |     1 |   1
+   9242 |     1 |   1
+  11189 |     1 |   1
+  14078 |     1 |   1
+  15656 |     1 |   1
+ -11410 |     2 |   2
+(10 rows)
+
+select cint4, cint8, min(cint2) from agggroup where cint2 > 0 group by cint4, cint8 order by min(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  | min 
+--------+--------+-----
+ -12025 |  -2210 |   1
+ -10344 | -13684 |   1
+  -4190 |  -2827 |   1
+  -1493 |  -1043 |   1
+   1863 |   7650 |   1
+   9242 |  -9798 |   1
+  11189 |  -5168 |   1
+  14078 |   9929 |   1
+  15656 |  12597 |   1
+ -11410 |   6033 |   2
+(10 rows)
+
+select cint2, cint4, cint8, min(cint2) from agggroup where cint2 > 0 group by cint2, cint4, cint8 order by min(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | min 
+-------+--------+--------+-----
+     1 | -12025 |  -2210 |   1
+     1 | -10344 | -13684 |   1
+     1 |  -4190 |  -2827 |   1
+     1 |  -1493 |  -1043 |   1
+     1 |   1863 |   7650 |   1
+     1 |   9242 |  -9798 |   1
+     1 |  11189 |  -5168 |   1
+     1 |  14078 |   9929 |   1
+     1 |  15656 |  12597 |   1
+     2 | -11410 |   6033 |   2
+(10 rows)
+
+select s, cint2, min(cint2) from agggroup where cint2 > 0 group by s, cint2 order by min(cint2), s, cint2 limit 10;
+ s | cint2 | min 
+---+-------+-----
+ 1 |     1 |   1
+ 2 |     1 |   1
+ 3 |     1 |   1
+ 5 |     1 |   1
+ 7 |     1 |   1
+ 8 |     1 |   1
+ 1 |     2 |   2
+ 3 |     2 |   2
+ 7 |     2 |   2
+ 9 |     2 |   2
+(10 rows)
+
+select s, ss, min(cint2) from agggroup where cint2 > 0 group by s, ss order by min(cint2), s, ss limit 10;
+ s | ss | min 
+---+----+-----
+ 1 | 11 |   1
+ 2 |  $ |   1
+ 3 |  3 |   1
+ 5 |  5 |   1
+ 7 |  7 |   1
+ 8 |  8 |   1
+ 9 |  9 |   2
+ 6 |  6 |   3
+ 0 |  0 |   4
+ 4 |  4 |   4
+(10 rows)
+
+select s, x, min(cint2) from agggroup where cint2 > 0 group by s, x order by min(cint2), s, x limit 10;
+ s | x  | min 
+---+----+-----
+ 1 | 11 |   1
+ 2 | $  |   1
+ 3 | 3  |   1
+ 5 | 5  |   1
+ 7 | 7  |   1
+ 8 | 8  |   1
+ 9 | 9  |   2
+ 6 | 6  |   3
+ 0 | 0  |   4
+ 4 | 4  |   4
+(10 rows)
+
+select ss, cint2, x, min(cint2) from agggroup where cint2 > 0 group by ss, cint2, x order by min(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x  | min 
+----+-------+----+-----
+  3 |     1 | 3  |   1
+  5 |     1 | 5  |   1
+  7 |     1 | 7  |   1
+  8 |     1 | 8  |   1
+ 11 |     1 | 11 |   1
+  $ |     1 | $  |   1
+  3 |     2 | 3  |   2
+  7 |     2 | 7  |   2
+  9 |     2 | 9  |   2
+ 11 |     2 | 11 |   2
+(10 rows)
+
+select ss, s, min(cint2) from agggroup where cint2 > 0 group by ss, s order by min(cint2), ss, s limit 10;
+ ss | s | min 
+----+---+-----
+  3 | 3 |   1
+  5 | 5 |   1
+  7 | 7 |   1
+  8 | 8 |   1
+ 11 | 1 |   1
+  $ | 2 |   1
+  9 | 9 |   2
+  6 | 6 |   3
+  0 | 0 |   4
+  4 | 4 |   4
+(10 rows)
+
+select ss, x, cint2, min(cint2) from agggroup where cint2 > 0 group by ss, x, cint2 order by min(cint2), ss, x, cint2 limit 10;
+ ss | x  | cint2 | min 
+----+----+-------+-----
+  3 | 3  |     1 |   1
+  5 | 5  |     1 |   1
+  7 | 7  |     1 |   1
+  8 | 8  |     1 |   1
+ 11 | 11 |     1 |   1
+  $ | $  |     1 |   1
+  3 | 3  |     2 |   2
+  7 | 7  |     2 |   2
+  9 | 9  |     2 |   2
+ 11 | 11 |     2 |   2
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, min(cint2) from agggroup where cint2 > 0 group by t, s, ss, x, cint4, cint8, cint2 order by min(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x  | cint4  | cint8  | cint2 | min 
+-------+---+----+----+--------+--------+-------+-----
+ 11611 | 1 | 11 | 11 | -12025 |  -2210 |     1 |   1
+ 28649 | 2 |  $ | $  |  -1493 |  -1043 |     1 |   1
+ 28786 | 1 | 11 | 11 |  -4190 |  -2827 |     1 |   1
+ 41774 | 3 |  3 | 3  |   1863 |   7650 |     1 |   1
+ 41779 | 3 |  3 | 3  |  14078 |   9929 |     1 |   1
+ 51152 | 5 |  5 | 5  |   9242 |  -9798 |     1 |   1
+ 70932 | 7 |  7 | 7  | -10344 | -13684 |     1 |   1
+ 86957 | 7 |  7 | 7  |  15656 |  12597 |     1 |   1
+ 89689 | 8 |  8 | 8  |  11189 |  -5168 |     1 |   1
+ 22147 | 1 | 11 | 11 |  -9569 |   9760 |     2 |   2
+(10 rows)
+
+select x, min(cint2) from agggroup where cint2 > 0 group by x order by min(cint2), x limit 10;
+ x  | min 
+----+-----
+ 11 |   1
+ 3  |   1
+ 5  |   1
+ 7  |   1
+ 8  |   1
+ $  |   1
+ 9  |   2
+ 6  |   3
+ 0  |   4
+ 4  |   4
+(10 rows)
+
+select cint4, cint2, count(*) from agggroup where cint2 is null group by cint4, cint2 order by count(*), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -16291 |     $ |     1
+ -16091 |     $ |     1
+ -15799 |     $ |     1
+ -15724 |     $ |     1
+ -15328 |     $ |     1
+ -15279 |     $ |     1
+ -15063 |     $ |     1
+ -14998 |     $ |     1
+ -14949 |     $ |     1
+ -14848 |     $ |     1
+(10 rows)
+
+select cint4, cint8, count(*) from agggroup where cint2 is null group by cint4, cint8 order by count(*), cint4, cint8 limit 10;
+ cint4  | cint8  | count 
+--------+--------+-------
+ -16291 |    113 |     1
+ -16091 |  -4084 |     1
+ -15799 |  12603 |     1
+ -15724 |  15426 |     1
+ -15328 |  -6092 |     1
+ -15279 |  -3475 |     1
+ -15063 |   3990 |     1
+ -14998 |  14464 |     1
+ -14949 | -10395 |     1
+ -14848 |   3110 |     1
+(10 rows)
+
+select cint2, cint4, cint8, count(*) from agggroup where cint2 is null group by cint2, cint4, cint8 order by count(*), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     $ | -16291 |    113 |     1
+     $ | -16091 |  -4084 |     1
+     $ | -15799 |  12603 |     1
+     $ | -15724 |  15426 |     1
+     $ | -15328 |  -6092 |     1
+     $ | -15279 |  -3475 |     1
+     $ | -15063 |   3990 |     1
+     $ | -14998 |  14464 |     1
+     $ | -14949 | -10395 |     1
+     $ | -14848 |   3110 |     1
+(10 rows)
+
+select s, cint2, count(*) from agggroup where cint2 is null group by s, cint2 order by count(*), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 0 |     $ |    19
+ 1 |     $ |    19
+ 2 |     $ |    19
+ 3 |     $ |    19
+ 4 |     $ |    19
+ 5 |     $ |    19
+ 6 |     $ |    19
+ 7 |     $ |    19
+ 8 |     $ |    19
+ 9 |     $ |    19
+(10 rows)
+
+select s, ss, count(*) from agggroup where cint2 is null group by s, ss order by count(*), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 0 |  0 |    19
+ 1 | 11 |    19
+ 2 |  $ |    19
+ 3 |  3 |    19
+ 4 |  4 |    19
+ 5 |  5 |    19
+ 6 |  6 |    19
+ 7 |  7 |    19
+ 8 |  8 |    19
+ 9 |  9 |    19
+(10 rows)
+
+select s, x, count(*) from agggroup where cint2 is null group by s, x order by count(*), s, x limit 10;
+ s | x  | count 
+---+----+-------
+ 0 | 0  |    19
+ 1 | 11 |    19
+ 2 | $  |    19
+ 3 | 3  |    19
+ 4 | 4  |    19
+ 5 | 5  |    19
+ 6 | 6  |    19
+ 7 | 7  |    19
+ 8 | 8  |    19
+ 9 | 9  |    19
+(10 rows)
+
+select ss, cint2, x, count(*) from agggroup where cint2 is null group by ss, cint2, x order by count(*), ss, cint2, x limit 10;
+ ss | cint2 | x  | count 
+----+-------+----+-------
+  0 |     $ | 0  |    19
+  3 |     $ | 3  |    19
+  4 |     $ | 4  |    19
+  5 |     $ | 5  |    19
+  6 |     $ | 6  |    19
+  7 |     $ | 7  |    19
+  8 |     $ | 8  |    19
+  9 |     $ | 9  |    19
+ 11 |     $ | 11 |    19
+  $ |     $ | $  |    19
+(10 rows)
+
+select ss, s, count(*) from agggroup where cint2 is null group by ss, s order by count(*), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+  0 | 0 |    19
+  3 | 3 |    19
+  4 | 4 |    19
+  5 | 5 |    19
+  6 | 6 |    19
+  7 | 7 |    19
+  8 | 8 |    19
+  9 | 9 |    19
+ 11 | 1 |    19
+  $ | 2 |    19
+(10 rows)
+
+select ss, x, cint2, count(*) from agggroup where cint2 is null group by ss, x, cint2 order by count(*), ss, x, cint2 limit 10;
+ ss | x  | cint2 | count 
+----+----+-------+-------
+  0 | 0  |     $ |    19
+  3 | 3  |     $ |    19
+  4 | 4  |     $ |    19
+  5 | 5  |     $ |    19
+  6 | 6  |     $ |    19
+  7 | 7  |     $ |    19
+  8 | 8  |     $ |    19
+  9 | 9  |     $ |    19
+ 11 | 11 |     $ |    19
+  $ | $  |     $ |    19
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, count(*) from agggroup where cint2 is null group by t, s, ss, x, cint4, cint8, cint2 order by count(*), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | count 
+-------+---+----+---+--------+--------+-------+-------
+  1051 | 0 |  0 | 0 |  -8612 |  14327 |     $ |     1
+  2102 | 0 |  0 | 0 |  11069 |  16047 |     $ |     1
+  3153 | 0 |  0 | 0 |   6192 |  12700 |     $ |     1
+  4204 | 0 |  0 | 0 |   4165 | -10102 |     $ |     1
+  5255 | 0 |  0 | 0 |  16314 |  13418 |     $ |     1
+  6306 | 0 |  0 | 0 |    701 |  -3029 |     $ |     1
+  7357 | 0 |  0 | 0 |   1115 |   4913 |     $ |     1
+  8408 | 0 |  0 | 0 |  15553 |   1743 |     $ |     1
+  9459 | 0 |  0 | 0 | -14640 |  11933 |     $ |     1
+ 10510 | 0 |  0 | 0 | -14725 |   6531 |     $ |     1
+(10 rows)
+
+select x, count(*) from agggroup where cint2 is null group by x order by count(*), x limit 10;
+ x  | count 
+----+-------
+ 0  |    19
+ 11 |    19
+ 3  |    19
+ 4  |    19
+ 5  |    19
+ 6  |    19
+ 7  |    19
+ 8  |    19
+ 9  |    19
+ $  |    19
+(10 rows)
+
+select cint4, cint2, count(cint2) from agggroup where cint2 is null group by cint4, cint2 order by count(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -16291 |     $ |     0
+ -16091 |     $ |     0
+ -15799 |     $ |     0
+ -15724 |     $ |     0
+ -15328 |     $ |     0
+ -15279 |     $ |     0
+ -15063 |     $ |     0
+ -14998 |     $ |     0
+ -14949 |     $ |     0
+ -14848 |     $ |     0
+(10 rows)
+
+select cint4, cint8, count(cint2) from agggroup where cint2 is null group by cint4, cint8 order by count(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  | count 
+--------+--------+-------
+ -16291 |    113 |     0
+ -16091 |  -4084 |     0
+ -15799 |  12603 |     0
+ -15724 |  15426 |     0
+ -15328 |  -6092 |     0
+ -15279 |  -3475 |     0
+ -15063 |   3990 |     0
+ -14998 |  14464 |     0
+ -14949 | -10395 |     0
+ -14848 |   3110 |     0
+(10 rows)
+
+select cint2, cint4, cint8, count(cint2) from agggroup where cint2 is null group by cint2, cint4, cint8 order by count(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     $ | -16291 |    113 |     0
+     $ | -16091 |  -4084 |     0
+     $ | -15799 |  12603 |     0
+     $ | -15724 |  15426 |     0
+     $ | -15328 |  -6092 |     0
+     $ | -15279 |  -3475 |     0
+     $ | -15063 |   3990 |     0
+     $ | -14998 |  14464 |     0
+     $ | -14949 | -10395 |     0
+     $ | -14848 |   3110 |     0
+(10 rows)
+
+select s, cint2, count(cint2) from agggroup where cint2 is null group by s, cint2 order by count(cint2), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 0 |     $ |     0
+ 1 |     $ |     0
+ 2 |     $ |     0
+ 3 |     $ |     0
+ 4 |     $ |     0
+ 5 |     $ |     0
+ 6 |     $ |     0
+ 7 |     $ |     0
+ 8 |     $ |     0
+ 9 |     $ |     0
+(10 rows)
+
+select s, ss, count(cint2) from agggroup where cint2 is null group by s, ss order by count(cint2), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 0 |  0 |     0
+ 1 | 11 |     0
+ 2 |  $ |     0
+ 3 |  3 |     0
+ 4 |  4 |     0
+ 5 |  5 |     0
+ 6 |  6 |     0
+ 7 |  7 |     0
+ 8 |  8 |     0
+ 9 |  9 |     0
+(10 rows)
+
+select s, x, count(cint2) from agggroup where cint2 is null group by s, x order by count(cint2), s, x limit 10;
+ s | x  | count 
+---+----+-------
+ 0 | 0  |     0
+ 1 | 11 |     0
+ 2 | $  |     0
+ 3 | 3  |     0
+ 4 | 4  |     0
+ 5 | 5  |     0
+ 6 | 6  |     0
+ 7 | 7  |     0
+ 8 | 8  |     0
+ 9 | 9  |     0
+(10 rows)
+
+select ss, cint2, x, count(cint2) from agggroup where cint2 is null group by ss, cint2, x order by count(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x  | count 
+----+-------+----+-------
+  0 |     $ | 0  |     0
+  3 |     $ | 3  |     0
+  4 |     $ | 4  |     0
+  5 |     $ | 5  |     0
+  6 |     $ | 6  |     0
+  7 |     $ | 7  |     0
+  8 |     $ | 8  |     0
+  9 |     $ | 9  |     0
+ 11 |     $ | 11 |     0
+  $ |     $ | $  |     0
+(10 rows)
+
+select ss, s, count(cint2) from agggroup where cint2 is null group by ss, s order by count(cint2), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+  0 | 0 |     0
+  3 | 3 |     0
+  4 | 4 |     0
+  5 | 5 |     0
+  6 | 6 |     0
+  7 | 7 |     0
+  8 | 8 |     0
+  9 | 9 |     0
+ 11 | 1 |     0
+  $ | 2 |     0
+(10 rows)
+
+select ss, x, cint2, count(cint2) from agggroup where cint2 is null group by ss, x, cint2 order by count(cint2), ss, x, cint2 limit 10;
+ ss | x  | cint2 | count 
+----+----+-------+-------
+  0 | 0  |     $ |     0
+  3 | 3  |     $ |     0
+  4 | 4  |     $ |     0
+  5 | 5  |     $ |     0
+  6 | 6  |     $ |     0
+  7 | 7  |     $ |     0
+  8 | 8  |     $ |     0
+  9 | 9  |     $ |     0
+ 11 | 11 |     $ |     0
+  $ | $  |     $ |     0
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, count(cint2) from agggroup where cint2 is null group by t, s, ss, x, cint4, cint8, cint2 order by count(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | count 
+-------+---+----+---+--------+--------+-------+-------
+  1051 | 0 |  0 | 0 |  -8612 |  14327 |     $ |     0
+  2102 | 0 |  0 | 0 |  11069 |  16047 |     $ |     0
+  3153 | 0 |  0 | 0 |   6192 |  12700 |     $ |     0
+  4204 | 0 |  0 | 0 |   4165 | -10102 |     $ |     0
+  5255 | 0 |  0 | 0 |  16314 |  13418 |     $ |     0
+  6306 | 0 |  0 | 0 |    701 |  -3029 |     $ |     0
+  7357 | 0 |  0 | 0 |   1115 |   4913 |     $ |     0
+  8408 | 0 |  0 | 0 |  15553 |   1743 |     $ |     0
+  9459 | 0 |  0 | 0 | -14640 |  11933 |     $ |     0
+ 10510 | 0 |  0 | 0 | -14725 |   6531 |     $ |     0
+(10 rows)
+
+select x, count(cint2) from agggroup where cint2 is null group by x order by count(cint2), x limit 10;
+ x  | count 
+----+-------
+ 0  |     0
+ 11 |     0
+ 3  |     0
+ 4  |     0
+ 5  |     0
+ 6  |     0
+ 7  |     0
+ 8  |     0
+ 9  |     0
+ $  |     0
+(10 rows)
+
+select cint4, cint2, min(cint2) from agggroup where cint2 is null group by cint4, cint2 order by min(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | min 
+--------+-------+-----
+ -16291 |     $ |   $
+ -16091 |     $ |   $
+ -15799 |     $ |   $
+ -15724 |     $ |   $
+ -15328 |     $ |   $
+ -15279 |     $ |   $
+ -15063 |     $ |   $
+ -14998 |     $ |   $
+ -14949 |     $ |   $
+ -14848 |     $ |   $
+(10 rows)
+
+select cint4, cint8, min(cint2) from agggroup where cint2 is null group by cint4, cint8 order by min(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  | min 
+--------+--------+-----
+ -16291 |    113 |   $
+ -16091 |  -4084 |   $
+ -15799 |  12603 |   $
+ -15724 |  15426 |   $
+ -15328 |  -6092 |   $
+ -15279 |  -3475 |   $
+ -15063 |   3990 |   $
+ -14998 |  14464 |   $
+ -14949 | -10395 |   $
+ -14848 |   3110 |   $
+(10 rows)
+
+select cint2, cint4, cint8, min(cint2) from agggroup where cint2 is null group by cint2, cint4, cint8 order by min(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | min 
+-------+--------+--------+-----
+     $ | -16291 |    113 |   $
+     $ | -16091 |  -4084 |   $
+     $ | -15799 |  12603 |   $
+     $ | -15724 |  15426 |   $
+     $ | -15328 |  -6092 |   $
+     $ | -15279 |  -3475 |   $
+     $ | -15063 |   3990 |   $
+     $ | -14998 |  14464 |   $
+     $ | -14949 | -10395 |   $
+     $ | -14848 |   3110 |   $
+(10 rows)
+
+select s, cint2, min(cint2) from agggroup where cint2 is null group by s, cint2 order by min(cint2), s, cint2 limit 10;
+ s | cint2 | min 
+---+-------+-----
+ 0 |     $ |   $
+ 1 |     $ |   $
+ 2 |     $ |   $
+ 3 |     $ |   $
+ 4 |     $ |   $
+ 5 |     $ |   $
+ 6 |     $ |   $
+ 7 |     $ |   $
+ 8 |     $ |   $
+ 9 |     $ |   $
+(10 rows)
+
+select s, ss, min(cint2) from agggroup where cint2 is null group by s, ss order by min(cint2), s, ss limit 10;
+ s | ss | min 
+---+----+-----
+ 0 |  0 |   $
+ 1 | 11 |   $
+ 2 |  $ |   $
+ 3 |  3 |   $
+ 4 |  4 |   $
+ 5 |  5 |   $
+ 6 |  6 |   $
+ 7 |  7 |   $
+ 8 |  8 |   $
+ 9 |  9 |   $
+(10 rows)
+
+select s, x, min(cint2) from agggroup where cint2 is null group by s, x order by min(cint2), s, x limit 10;
+ s | x  | min 
+---+----+-----
+ 0 | 0  |   $
+ 1 | 11 |   $
+ 2 | $  |   $
+ 3 | 3  |   $
+ 4 | 4  |   $
+ 5 | 5  |   $
+ 6 | 6  |   $
+ 7 | 7  |   $
+ 8 | 8  |   $
+ 9 | 9  |   $
+(10 rows)
+
+select ss, cint2, x, min(cint2) from agggroup where cint2 is null group by ss, cint2, x order by min(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x  | min 
+----+-------+----+-----
+  0 |     $ | 0  |   $
+  3 |     $ | 3  |   $
+  4 |     $ | 4  |   $
+  5 |     $ | 5  |   $
+  6 |     $ | 6  |   $
+  7 |     $ | 7  |   $
+  8 |     $ | 8  |   $
+  9 |     $ | 9  |   $
+ 11 |     $ | 11 |   $
+  $ |     $ | $  |   $
+(10 rows)
+
+select ss, s, min(cint2) from agggroup where cint2 is null group by ss, s order by min(cint2), ss, s limit 10;
+ ss | s | min 
+----+---+-----
+  0 | 0 |   $
+  3 | 3 |   $
+  4 | 4 |   $
+  5 | 5 |   $
+  6 | 6 |   $
+  7 | 7 |   $
+  8 | 8 |   $
+  9 | 9 |   $
+ 11 | 1 |   $
+  $ | 2 |   $
+(10 rows)
+
+select ss, x, cint2, min(cint2) from agggroup where cint2 is null group by ss, x, cint2 order by min(cint2), ss, x, cint2 limit 10;
+ ss | x  | cint2 | min 
+----+----+-------+-----
+  0 | 0  |     $ |   $
+  3 | 3  |     $ |   $
+  4 | 4  |     $ |   $
+  5 | 5  |     $ |   $
+  6 | 6  |     $ |   $
+  7 | 7  |     $ |   $
+  8 | 8  |     $ |   $
+  9 | 9  |     $ |   $
+ 11 | 11 |     $ |   $
+  $ | $  |     $ |   $
+(10 rows)
+
+select t, s, ss, x, cint4, cint8, cint2, min(cint2) from agggroup where cint2 is null group by t, s, ss, x, cint4, cint8, cint2 order by min(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | min 
+-------+---+----+---+--------+--------+-------+-----
+  1051 | 0 |  0 | 0 |  -8612 |  14327 |     $ |   $
+  2102 | 0 |  0 | 0 |  11069 |  16047 |     $ |   $
+  3153 | 0 |  0 | 0 |   6192 |  12700 |     $ |   $
+  4204 | 0 |  0 | 0 |   4165 | -10102 |     $ |   $
+  5255 | 0 |  0 | 0 |  16314 |  13418 |     $ |   $
+  6306 | 0 |  0 | 0 |    701 |  -3029 |     $ |   $
+  7357 | 0 |  0 | 0 |   1115 |   4913 |     $ |   $
+  8408 | 0 |  0 | 0 |  15553 |   1743 |     $ |   $
+  9459 | 0 |  0 | 0 | -14640 |  11933 |     $ |   $
+ 10510 | 0 |  0 | 0 | -14725 |   6531 |     $ |   $
+(10 rows)
+
+select x, min(cint2) from agggroup where cint2 is null group by x order by min(cint2), x limit 10;
+ x  | min 
+----+-----
+ 0  |   $
+ 11 |   $
+ 3  |   $
+ 4  |   $
+ 5  |   $
+ 6  |   $
+ 7  |   $
+ 8  |   $
+ 9  |   $
+ $  |   $
+(10 rows)
+
+select cint4, cint2, count(*) from agggroup where cint2 is null and x is null group by cint4, cint2 order by count(*), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -15063 |     $ |     1
+ -14949 |     $ |     1
+ -14443 |     $ |     1
+ -11240 |     $ |     1
+  -8873 |     $ |     1
+  -7170 |     $ |     1
+  -4740 |     $ |     1
+  -1217 |     $ |     1
+   -166 |     $ |     1
+   -119 |     $ |     1
+(10 rows)
+
+select cint4, cint8, count(*) from agggroup where cint2 is null and x is null group by cint4, cint8 order by count(*), cint4, cint8 limit 10;
+ cint4  | cint8  | count 
+--------+--------+-------
+ -15063 |   3990 |     1
+ -14949 | -10395 |     1
+ -14443 | -12710 |     1
+ -11240 |  -8825 |     1
+  -8873 | -12094 |     1
+  -7170 |   7723 |     1
+  -4740 |   7720 |     1
+  -1217 |   6383 |     1
+   -166 | -10858 |     1
+   -119 |   -231 |     1
+(10 rows)
+
+select cint2, cint4, cint8, count(*) from agggroup where cint2 is null and x is null group by cint2, cint4, cint8 order by count(*), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     $ | -15063 |   3990 |     1
+     $ | -14949 | -10395 |     1
+     $ | -14443 | -12710 |     1
+     $ | -11240 |  -8825 |     1
+     $ |  -8873 | -12094 |     1
+     $ |  -7170 |   7723 |     1
+     $ |  -4740 |   7720 |     1
+     $ |  -1217 |   6383 |     1
+     $ |   -166 | -10858 |     1
+     $ |   -119 |   -231 |     1
+(10 rows)
+
+select s, cint2, count(*) from agggroup where cint2 is null and x is null group by s, cint2 order by count(*), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 2 |     $ |    19
+(1 row)
+
+select s, ss, count(*) from agggroup where cint2 is null and x is null group by s, ss order by count(*), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 2 |  $ |    19
+(1 row)
+
+select s, x, count(*) from agggroup where cint2 is null and x is null group by s, x order by count(*), s, x limit 10;
+ s | x | count 
+---+---+-------
+ 2 | $ |    19
+(1 row)
+
+select ss, cint2, x, count(*) from agggroup where cint2 is null and x is null group by ss, cint2, x order by count(*), ss, cint2, x limit 10;
+ ss | cint2 | x | count 
+----+-------+---+-------
+  $ |     $ | $ |    19
+(1 row)
+
+select ss, s, count(*) from agggroup where cint2 is null and x is null group by ss, s order by count(*), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+  $ | 2 |    19
+(1 row)
+
+select ss, x, cint2, count(*) from agggroup where cint2 is null and x is null group by ss, x, cint2 order by count(*), ss, x, cint2 limit 10;
+ ss | x | cint2 | count 
+----+---+-------+-------
+  $ | $ |     $ |    19
+(1 row)
+
+select t, s, ss, x, cint4, cint8, cint2, count(*) from agggroup where cint2 is null and x is null group by t, s, ss, x, cint4, cint8, cint2 order by count(*), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | count 
+-------+---+----+---+--------+--------+-------+-------
+ 21051 | 2 |  $ | $ |  14385 |   -587 |     $ |     1
+ 22102 | 2 |  $ | $ |  13826 |  -5912 |     $ |     1
+ 23153 | 2 |  $ | $ |  11182 |   4556 |     $ |     1
+ 24204 | 2 |  $ | $ | -15063 |   3990 |     $ |     1
+ 25255 | 2 |  $ | $ |   2876 |   5568 |     $ |     1
+ 26306 | 2 |  $ | $ |   -119 |   -231 |     $ |     1
+ 27357 | 2 |  $ | $ |   9448 |   -312 |     $ |     1
+ 28408 | 2 |  $ | $ |  -7170 |   7723 |     $ |     1
+ 29459 | 2 |  $ | $ | -14443 | -12710 |     $ |     1
+ 30510 | 2 |  $ | $ |  12536 |   8350 |     $ |     1
+(10 rows)
+
+select x, count(*) from agggroup where cint2 is null and x is null group by x order by count(*), x limit 10;
+ x | count 
+---+-------
+ $ |    19
+(1 row)
+
+select cint4, cint2, count(cint2) from agggroup where cint2 is null and x is null group by cint4, cint2 order by count(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | count 
+--------+-------+-------
+ -15063 |     $ |     0
+ -14949 |     $ |     0
+ -14443 |     $ |     0
+ -11240 |     $ |     0
+  -8873 |     $ |     0
+  -7170 |     $ |     0
+  -4740 |     $ |     0
+  -1217 |     $ |     0
+   -166 |     $ |     0
+   -119 |     $ |     0
+(10 rows)
+
+select cint4, cint8, count(cint2) from agggroup where cint2 is null and x is null group by cint4, cint8 order by count(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  | count 
+--------+--------+-------
+ -15063 |   3990 |     0
+ -14949 | -10395 |     0
+ -14443 | -12710 |     0
+ -11240 |  -8825 |     0
+  -8873 | -12094 |     0
+  -7170 |   7723 |     0
+  -4740 |   7720 |     0
+  -1217 |   6383 |     0
+   -166 | -10858 |     0
+   -119 |   -231 |     0
+(10 rows)
+
+select cint2, cint4, cint8, count(cint2) from agggroup where cint2 is null and x is null group by cint2, cint4, cint8 order by count(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | count 
+-------+--------+--------+-------
+     $ | -15063 |   3990 |     0
+     $ | -14949 | -10395 |     0
+     $ | -14443 | -12710 |     0
+     $ | -11240 |  -8825 |     0
+     $ |  -8873 | -12094 |     0
+     $ |  -7170 |   7723 |     0
+     $ |  -4740 |   7720 |     0
+     $ |  -1217 |   6383 |     0
+     $ |   -166 | -10858 |     0
+     $ |   -119 |   -231 |     0
+(10 rows)
+
+select s, cint2, count(cint2) from agggroup where cint2 is null and x is null group by s, cint2 order by count(cint2), s, cint2 limit 10;
+ s | cint2 | count 
+---+-------+-------
+ 2 |     $ |     0
+(1 row)
+
+select s, ss, count(cint2) from agggroup where cint2 is null and x is null group by s, ss order by count(cint2), s, ss limit 10;
+ s | ss | count 
+---+----+-------
+ 2 |  $ |     0
+(1 row)
+
+select s, x, count(cint2) from agggroup where cint2 is null and x is null group by s, x order by count(cint2), s, x limit 10;
+ s | x | count 
+---+---+-------
+ 2 | $ |     0
+(1 row)
+
+select ss, cint2, x, count(cint2) from agggroup where cint2 is null and x is null group by ss, cint2, x order by count(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x | count 
+----+-------+---+-------
+  $ |     $ | $ |     0
+(1 row)
+
+select ss, s, count(cint2) from agggroup where cint2 is null and x is null group by ss, s order by count(cint2), ss, s limit 10;
+ ss | s | count 
+----+---+-------
+  $ | 2 |     0
+(1 row)
+
+select ss, x, cint2, count(cint2) from agggroup where cint2 is null and x is null group by ss, x, cint2 order by count(cint2), ss, x, cint2 limit 10;
+ ss | x | cint2 | count 
+----+---+-------+-------
+  $ | $ |     $ |     0
+(1 row)
+
+select t, s, ss, x, cint4, cint8, cint2, count(cint2) from agggroup where cint2 is null and x is null group by t, s, ss, x, cint4, cint8, cint2 order by count(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | count 
+-------+---+----+---+--------+--------+-------+-------
+ 21051 | 2 |  $ | $ |  14385 |   -587 |     $ |     0
+ 22102 | 2 |  $ | $ |  13826 |  -5912 |     $ |     0
+ 23153 | 2 |  $ | $ |  11182 |   4556 |     $ |     0
+ 24204 | 2 |  $ | $ | -15063 |   3990 |     $ |     0
+ 25255 | 2 |  $ | $ |   2876 |   5568 |     $ |     0
+ 26306 | 2 |  $ | $ |   -119 |   -231 |     $ |     0
+ 27357 | 2 |  $ | $ |   9448 |   -312 |     $ |     0
+ 28408 | 2 |  $ | $ |  -7170 |   7723 |     $ |     0
+ 29459 | 2 |  $ | $ | -14443 | -12710 |     $ |     0
+ 30510 | 2 |  $ | $ |  12536 |   8350 |     $ |     0
+(10 rows)
+
+select x, count(cint2) from agggroup where cint2 is null and x is null group by x order by count(cint2), x limit 10;
+ x | count 
+---+-------
+ $ |     0
+(1 row)
+
+select cint4, cint2, min(cint2) from agggroup where cint2 is null and x is null group by cint4, cint2 order by min(cint2), cint4, cint2 limit 10;
+ cint4  | cint2 | min 
+--------+-------+-----
+ -15063 |     $ |   $
+ -14949 |     $ |   $
+ -14443 |     $ |   $
+ -11240 |     $ |   $
+  -8873 |     $ |   $
+  -7170 |     $ |   $
+  -4740 |     $ |   $
+  -1217 |     $ |   $
+   -166 |     $ |   $
+   -119 |     $ |   $
+(10 rows)
+
+select cint4, cint8, min(cint2) from agggroup where cint2 is null and x is null group by cint4, cint8 order by min(cint2), cint4, cint8 limit 10;
+ cint4  | cint8  | min 
+--------+--------+-----
+ -15063 |   3990 |   $
+ -14949 | -10395 |   $
+ -14443 | -12710 |   $
+ -11240 |  -8825 |   $
+  -8873 | -12094 |   $
+  -7170 |   7723 |   $
+  -4740 |   7720 |   $
+  -1217 |   6383 |   $
+   -166 | -10858 |   $
+   -119 |   -231 |   $
+(10 rows)
+
+select cint2, cint4, cint8, min(cint2) from agggroup where cint2 is null and x is null group by cint2, cint4, cint8 order by min(cint2), cint2, cint4, cint8 limit 10;
+ cint2 | cint4  | cint8  | min 
+-------+--------+--------+-----
+     $ | -15063 |   3990 |   $
+     $ | -14949 | -10395 |   $
+     $ | -14443 | -12710 |   $
+     $ | -11240 |  -8825 |   $
+     $ |  -8873 | -12094 |   $
+     $ |  -7170 |   7723 |   $
+     $ |  -4740 |   7720 |   $
+     $ |  -1217 |   6383 |   $
+     $ |   -166 | -10858 |   $
+     $ |   -119 |   -231 |   $
+(10 rows)
+
+select s, cint2, min(cint2) from agggroup where cint2 is null and x is null group by s, cint2 order by min(cint2), s, cint2 limit 10;
+ s | cint2 | min 
+---+-------+-----
+ 2 |     $ |   $
+(1 row)
+
+select s, ss, min(cint2) from agggroup where cint2 is null and x is null group by s, ss order by min(cint2), s, ss limit 10;
+ s | ss | min 
+---+----+-----
+ 2 |  $ |   $
+(1 row)
+
+select s, x, min(cint2) from agggroup where cint2 is null and x is null group by s, x order by min(cint2), s, x limit 10;
+ s | x | min 
+---+---+-----
+ 2 | $ |   $
+(1 row)
+
+select ss, cint2, x, min(cint2) from agggroup where cint2 is null and x is null group by ss, cint2, x order by min(cint2), ss, cint2, x limit 10;
+ ss | cint2 | x | min 
+----+-------+---+-----
+  $ |     $ | $ |   $
+(1 row)
+
+select ss, s, min(cint2) from agggroup where cint2 is null and x is null group by ss, s order by min(cint2), ss, s limit 10;
+ ss | s | min 
+----+---+-----
+  $ | 2 |   $
+(1 row)
+
+select ss, x, cint2, min(cint2) from agggroup where cint2 is null and x is null group by ss, x, cint2 order by min(cint2), ss, x, cint2 limit 10;
+ ss | x | cint2 | min 
+----+---+-------+-----
+  $ | $ |     $ |   $
+(1 row)
+
+select t, s, ss, x, cint4, cint8, cint2, min(cint2) from agggroup where cint2 is null and x is null group by t, s, ss, x, cint4, cint8, cint2 order by min(cint2), t, s, ss, x, cint4, cint8, cint2 limit 10;
+   t   | s | ss | x | cint4  | cint8  | cint2 | min 
+-------+---+----+---+--------+--------+-------+-----
+ 21051 | 2 |  $ | $ |  14385 |   -587 |     $ |   $
+ 22102 | 2 |  $ | $ |  13826 |  -5912 |     $ |   $
+ 23153 | 2 |  $ | $ |  11182 |   4556 |     $ |   $
+ 24204 | 2 |  $ | $ | -15063 |   3990 |     $ |   $
+ 25255 | 2 |  $ | $ |   2876 |   5568 |     $ |   $
+ 26306 | 2 |  $ | $ |   -119 |   -231 |     $ |   $
+ 27357 | 2 |  $ | $ |   9448 |   -312 |     $ |   $
+ 28408 | 2 |  $ | $ |  -7170 |   7723 |     $ |   $
+ 29459 | 2 |  $ | $ | -14443 | -12710 |     $ |   $
+ 30510 | 2 |  $ | $ |  12536 |   8350 |     $ |   $
+(10 rows)
+
+select x, min(cint2) from agggroup where cint2 is null and x is null group by x order by min(cint2), x limit 10;
+ x | min 
+---+-----
+ $ |   $
+(1 row)
+
+reset timescaledb.debug_require_vector_agg;
+-- Test long text columns. Also make one of them a segmentby, so that we can
+-- test the long scalar values.
+create table long(t int, a text, b text, c text, d text);
+select create_hypertable('long', 't');
+NOTICE:  adding not-null constraint to column "t"
+ create_hypertable 
+-------------------
+ (3,public,long,t)
+(1 row)
+
+insert into long select n, a, x, x, x from (
+    select n, 'short' || m a, repeat('1', 100 * 4 + n) x
+    from generate_series(1, 4) n,
+        generate_series(1, 4) m) t
+;
+insert into long values (-1, 'a', 'b', 'c', 'd');
+insert into long values (-2, repeat('long', 1000), 'b', 'c', 'd');
+alter table long set (timescaledb.compress, timescaledb.compress_segmentby = 'a',
+    timescaledb.compress_orderby = 't desc');
+select count(compress_chunk(x)) from show_chunks('long') x;
+ count 
+-------
+     2
+(1 row)
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+-- Various placements of long scalar column
+select sum(t) from long group by a, b, c, d order by 1 limit 10;
+ sum 
+-----
+  -2
+  -1
+   1
+   1
+   1
+   1
+   2
+   2
+   2
+   2
+(10 rows)
+
+select sum(t) from long group by d, b, c, a order by 1 limit 10;
+ sum 
+-----
+  -2
+  -1
+   1
+   1
+   1
+   1
+   2
+   2
+   2
+   2
+(10 rows)
+
+select sum(t) from long group by d, b, a, c order by 1 limit 10;
+ sum 
+-----
+  -2
+  -1
+   1
+   1
+   1
+   1
+   2
+   2
+   2
+   2
+(10 rows)
+
+-- Just the scalar column
+select sum(t) from long group by a order by 1;
+ sum 
+-----
+  -2
+  -1
+  10
+  10
+  10
+  10
+(6 rows)
+
+-- No scalar columns
+select sum(t) from long group by b, c, d order by 1 limit 10;
+ sum 
+-----
+  -3
+   4
+   8
+  12
+  16
+(5 rows)
+
+reset timescaledb.debug_require_vector_agg;
+-- Test various serialized key lengths. We want to touch the transition from short
+-- to long varlena header for the serialized key.
+create table keylength(t int, a text, b text);
+select create_hypertable('keylength', 't');
+NOTICE:  adding not-null constraint to column "t"
+   create_hypertable    
+------------------------
+ (5,public,keylength,t)
+(1 row)
+
+insert into keylength select t, 'a', repeat('b', t) from generate_series(1, 1000) t;
+insert into keylength values (-1, '', ''); -- second chunk
+alter table keylength set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 't desc');
+select count(compress_chunk(x)) from show_chunks('keylength') x;
+ count 
+-------
+     2
+(1 row)
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+select sum(t) from keylength group by a, b order by 1 desc limit 10;
+ sum  
+------
+ 1000
+  999
+  998
+  997
+  996
+  995
+  994
+  993
+  992
+  991
+(10 rows)
+
+select sum(t) from keylength group by b, a order by 1 desc limit 10;
+ sum  
+------
+ 1000
+  999
+  998
+  997
+  996
+  995
+  994
+  993
+  992
+  991
+(10 rows)
+
+reset timescaledb.debug_require_vector_agg;
+-- Add a very simple test for NULLs. We also have some null values in the general
+-- grouping test above.
+create table groupnull(t int, a text, b text);
+select create_hypertable('groupnull', 't');
+NOTICE:  adding not-null constraint to column "t"
+   create_hypertable    
+------------------------
+ (7,public,groupnull,t)
+(1 row)
+
+insert into groupnull values (1, '1', null), (2, null, '2'), (3000000, '3', '3');
+alter table groupnull set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 't desc');
+select count(compress_chunk(x)) from show_chunks('groupnull') x;
+ count 
+-------
+     2
+(1 row)
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+select sum(t), a, b from groupnull group by a, b order by 1;
+   sum   | a | b 
+---------+---+---
+       1 | 1 | $
+       2 | $ | 2
+ 3000000 | 3 | 3
+(3 rows)
+
+select sum(t), a, b from groupnull group by b, a order by 1;
+   sum   | a | b 
+---------+---+---
+       1 | 1 | $
+       2 | $ | 2
+ 3000000 | 3 | 3
+(3 rows)
+
+reset timescaledb.debug_require_vector_agg;

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -541,7 +541,7 @@ SELECT sum(segment_by_value) FROM testtable GROUP BY int_value;
                            Output: _hyper_1_10_chunk.int_value, _hyper_1_10_chunk.segment_by_value
 (63 rows)
 
--- Vectorization not possible with grouping by multiple columns
+-- Vectorization possible with grouping by multiple columns
 :EXPLAIN
 SELECT sum(segment_by_value) FROM testtable GROUP BY int_value, float_value;
                                                                                                                                                            QUERY PLAN                                                                                                                                                           
@@ -553,23 +553,23 @@ SELECT sum(segment_by_value) FROM testtable GROUP BY int_value, float_value;
          Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.float_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
          Workers Planned: 2
          ->  Parallel Append
-               ->  Partial HashAggregate
-                     Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.float_value, PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
-                     Group Key: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.float_value
+               ->  Custom Scan (VectorAgg)
+                     Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.float_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+                     Grouping Policy: hashed with serialized key
                      ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
                            Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.float_value, _hyper_1_1_chunk.segment_by_value
                            ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                                  Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
-               ->  Partial HashAggregate
-                     Output: _hyper_1_2_chunk.int_value, _hyper_1_2_chunk.float_value, PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
-                     Group Key: _hyper_1_2_chunk.int_value, _hyper_1_2_chunk.float_value
+               ->  Custom Scan (VectorAgg)
+                     Output: _hyper_1_2_chunk.int_value, _hyper_1_2_chunk.float_value, (PARTIAL sum(_hyper_1_2_chunk.segment_by_value))
+                     Grouping Policy: hashed with serialized key
                      ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
                            Output: _hyper_1_2_chunk.int_value, _hyper_1_2_chunk.float_value, _hyper_1_2_chunk.segment_by_value
                            ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
                                  Output: compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1, compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value
-               ->  Partial HashAggregate
-                     Output: _hyper_1_3_chunk.int_value, _hyper_1_3_chunk.float_value, PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
-                     Group Key: _hyper_1_3_chunk.int_value, _hyper_1_3_chunk.float_value
+               ->  Custom Scan (VectorAgg)
+                     Output: _hyper_1_3_chunk.int_value, _hyper_1_3_chunk.float_value, (PARTIAL sum(_hyper_1_3_chunk.segment_by_value))
+                     Grouping Policy: hashed with serialized key
                      ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
                            Output: _hyper_1_3_chunk.int_value, _hyper_1_3_chunk.float_value, _hyper_1_3_chunk.segment_by_value
                            ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -123,6 +123,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     feature_flags.sql
     vector_agg_default.sql
     vector_agg_filter.sql
+    vector_agg_grouping.sql
     vector_agg_text.sql
     vector_agg_memory.sql
     vector_agg_segmentby.sql)

--- a/tsl/test/sql/hypercore_vectoragg.sql
+++ b/tsl/test/sql/hypercore_vectoragg.sql
@@ -110,16 +110,12 @@ select location, count(*) from aggdata where location=1 group by location;
 --
 -- Test ordering/grouping on segmentby, orderby columns
 --
--- This grouping is currently NOT supported by VectorAgg
---
 set timescaledb.enable_vectorized_aggregation=true;
 explain (verbose, costs off)
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
-set timescaledb.debug_require_vector_agg to 'forbid';
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
 
 set timecaledb.enable_vectorized_aggregation=false;
-reset timescaledb.debug_require_vector_agg;
 explain (verbose, costs off)
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
 select time, device, sum(temp) from aggdata where device is not null group by time, device order by time, device limit 10;
@@ -127,11 +123,9 @@ select time, device, sum(temp) from aggdata where device is not null group by ti
 set timescaledb.enable_vectorized_aggregation=true;
 explain (verbose, costs off)
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;
-set timescaledb.debug_require_vector_agg to 'forbid';
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;
 
 set timescaledb.enable_vectorized_aggregation=false;
-reset timescaledb.debug_require_vector_agg;
 explain (verbose, costs off)
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;
 select time, device, sum(temp) filter (where device is not null) from aggdata group by time, device order by time, device desc limit 10;

--- a/tsl/test/sql/vector_agg_grouping.sql
+++ b/tsl/test/sql/vector_agg_grouping.sql
@@ -1,0 +1,183 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- helper function: float -> pseudorandom float [-0.5..0.5]
+CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
+    SELECT hashfloat8(x::float8) / pow(2, 32)
+$$ LANGUAGE SQL;
+
+-- To not confuse null with empty strings in the test reference
+\pset null $
+
+\set CHUNKS 2::int
+\set CHUNK_ROWS 100000::int
+\set GROUPING_CARDINALITY 10::int
+
+create table agggroup(t int, s int,
+    cint2 int2, cint4 int4, cint8 int8);
+select create_hypertable('agggroup', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
+
+create view source as
+select s * 10000 + t as t,
+    s,
+    case when t % 1051 = 0 then null
+        else (mix(s + t * 1019) * 32767)::int2 end as cint2,
+    (mix(s + t * 1021) * 32767)::int4 as cint4,
+    (mix(s + t * 1031) * 32767)::int8 as cint8
+from
+    generate_series(1::int, :CHUNK_ROWS * :CHUNKS / :GROUPING_CARDINALITY) t,
+    generate_series(0::int, :GROUPING_CARDINALITY - 1::int) s(s)
+;
+
+insert into agggroup select * from source where s = 1;
+
+alter table agggroup set (timescaledb.compress, timescaledb.compress_orderby = 't',
+    timescaledb.compress_segmentby = 's');
+
+select count(compress_chunk(x)) from show_chunks('agggroup') x;
+
+alter table agggroup add column ss int default 11;
+alter table agggroup add column x text default '11';
+
+insert into agggroup
+select *, ss::text as x from (
+    select *,
+        case
+            -- null in entire batch
+            when s = 2 then null
+            -- null for some rows
+            when s = 3 and t % 1051 = 0 then null
+            -- for some rows same as default
+            when s = 4 and t % 1057 = 0 then 11
+            -- not null for entire batch
+            else s
+        end as ss
+    from source where s != 1
+) t
+;
+select count(compress_chunk(x)) from show_chunks('agggroup') x;
+vacuum freeze analyze agggroup;
+
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference. Note that there are minor discrepancies
+-- on float4 due to different numeric stability in our and PG implementations.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+
+select
+    format('%sselect %s%s(%s) from agggroup%s%s%s;',
+            explain,
+            grouping || ', ',
+            function, variable,
+            ' where ' || condition,
+            ' group by ' || grouping,
+            format(' order by %s(%s), ', function, variable) || grouping || ' limit 10',
+            function, variable)
+from
+    unnest(array[
+        'explain (costs off) ',
+        null]) explain,
+    unnest(array[
+        'cint2',
+        '*']) variable,
+    unnest(array[
+        'min',
+        'count']) function,
+    unnest(array[
+        null,
+        'cint2 > 0',
+        'cint2 is null',
+        'cint2 is null and x is null']) with ordinality as condition(condition, n),
+    unnest(array[
+        'cint4, cint2',
+        'cint4, cint8',
+        'cint2, cint4, cint8',
+        's, cint2',
+        's, ss',
+        's, x',
+        'ss, cint2, x',
+        'ss, s',
+        'ss, x, cint2',
+        't, s, ss, x, cint4, cint8, cint2',
+        'x']) with ordinality as grouping(grouping, n)
+where
+    true
+    and (explain is null /* or condition is null and grouping = 's' */)
+    and (variable != '*' or function = 'count')
+order by explain, condition.n, variable, function, grouping.n
+\gexec
+
+reset timescaledb.debug_require_vector_agg;
+
+
+-- Test long text columns. Also make one of them a segmentby, so that we can
+-- test the long scalar values.
+create table long(t int, a text, b text, c text, d text);
+select create_hypertable('long', 't');
+insert into long select n, a, x, x, x from (
+    select n, 'short' || m a, repeat('1', 100 * 4 + n) x
+    from generate_series(1, 4) n,
+        generate_series(1, 4) m) t
+;
+insert into long values (-1, 'a', 'b', 'c', 'd');
+insert into long values (-2, repeat('long', 1000), 'b', 'c', 'd');
+alter table long set (timescaledb.compress, timescaledb.compress_segmentby = 'a',
+    timescaledb.compress_orderby = 't desc');
+select count(compress_chunk(x)) from show_chunks('long') x;
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+
+-- Various placements of long scalar column
+select sum(t) from long group by a, b, c, d order by 1 limit 10;
+select sum(t) from long group by d, b, c, a order by 1 limit 10;
+select sum(t) from long group by d, b, a, c order by 1 limit 10;
+
+-- Just the scalar column
+select sum(t) from long group by a order by 1;
+
+-- No scalar columns
+select sum(t) from long group by b, c, d order by 1 limit 10;
+
+reset timescaledb.debug_require_vector_agg;
+
+
+-- Test various serialized key lengths. We want to touch the transition from short
+-- to long varlena header for the serialized key.
+create table keylength(t int, a text, b text);
+select create_hypertable('keylength', 't');
+insert into keylength select t, 'a', repeat('b', t) from generate_series(1, 1000) t;
+insert into keylength values (-1, '', ''); -- second chunk
+alter table keylength set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 't desc');
+select count(compress_chunk(x)) from show_chunks('keylength') x;
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+
+select sum(t) from keylength group by a, b order by 1 desc limit 10;
+select sum(t) from keylength group by b, a order by 1 desc limit 10;
+
+reset timescaledb.debug_require_vector_agg;
+
+
+-- Add a very simple test for NULLs. We also have some null values in the general
+-- grouping test above.
+create table groupnull(t int, a text, b text);
+select create_hypertable('groupnull', 't');
+insert into groupnull values (1, '1', null), (2, null, '2'), (3000000, '3', '3');
+alter table groupnull set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 't desc');
+select count(compress_chunk(x)) from show_chunks('groupnull') x;
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+
+select sum(t), a, b from groupnull group by a, b order by 1;
+select sum(t), a, b from groupnull group by b, a order by 1;
+reset timescaledb.debug_require_vector_agg;

--- a/tsl/test/sql/vectorized_aggregation.sql
+++ b/tsl/test/sql/vectorized_aggregation.sql
@@ -65,7 +65,7 @@ SELECT sum(segment_by_value) FROM testtable GROUP BY float_value;
 :EXPLAIN
 SELECT sum(segment_by_value) FROM testtable GROUP BY int_value;
 
--- Vectorization not possible with grouping by multiple columns
+-- Vectorization possible with grouping by multiple columns
 :EXPLAIN
 SELECT sum(segment_by_value) FROM testtable GROUP BY int_value, float_value;
 


### PR DESCRIPTION
Vectorized grouping by multiple column (#7754)

Paste the values together and use the umash hash of the resulting value for grouping, like we do for the text keys.