### PR TITLE
Ignore frozen chunks in compression policy

### DIFF
--- a/.unreleased/pr_7837
+++ b/.unreleased/pr_7837
@@ -1,0 +1,1 @@
+Fixes: #7837 Ignore frozen chunks in compression policy

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -933,7 +933,7 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 	if (ts_chunk_is_compressed(chunk))
 	{
 		CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
-		bool valid_orderby_settings = chunk_settings->fd.orderby;
+		bool valid_orderby_settings = chunk_settings && chunk_settings->fd.orderby;
 		if (recompress)
 		{
 			CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -677,6 +677,100 @@ SELECT delete_job(:JOB_RECOMPRESS);
  
 (1 row)
 
+--TEST 7
+--compression policy should ignore frozen partially compressed chunks
+CREATE TABLE test_table_frozen(time TIMESTAMPTZ, val SMALLINT);
+SELECT create_hypertable('test_table_frozen', 'time', chunk_time_interval => '1 day'::interval);
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (18,public,test_table_frozen,t)
+(1 row)
+
+INSERT INTO test_table_frozen SELECT time, (random()*10)::smallint
+FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '10 min') AS time;
+ALTER TABLE test_table_frozen SET (timescaledb.compress);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "test_table_frozen" is set to ""
+NOTICE:  default order by for hypertable "test_table_frozen" is set to ""time" DESC"
+select add_compression_policy( 'test_table_frozen', compress_after=> '1 day'::interval ) as compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |     proc_name      |       owner       | scheduled | fixed_schedule | initial_start | hypertable_id |                       config                       |      check_schema      |        check_name        | timezone 
+------+---------------------------+-------------------+-------------+-------------+--------------+------------------------+--------------------+-------------------+-----------+----------------+---------------+---------------+----------------------------------------------------+------------------------+--------------------------+----------
+ 1008 | Compression Policy [1008] | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression | default_perm_user | t         | f              |               |            18 | {"hypertable_id": 18, "compress_after": "@ 1 day"} | _timescaledb_functions | policy_compression_check | 
+(1 row)
+
+SELECT show_chunks('test_table_frozen') as first_chunk LIMIT 1 \gset
+--will compress all chunks that need compression
+CALL run_job(:compressjob_id);
+-- make the chunks partial
+INSERT INTO test_table_frozen SELECT time, (random()*10)::smallint
+FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '10 min') AS time;
+SELECT c.id, c.status
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
+WHERE h.table_name = 'test_table_frozen'
+ORDER BY c.id
+LIMIT 1;
+ id | status 
+----+--------
+ 69 |      9
+(1 row)
+
+-- freeze first chunk
+SELECT _timescaledb_functions.freeze_chunk(:'first_chunk');
+ freeze_chunk 
+--------------
+ t
+(1 row)
+
+-- first chunk status is  1 (Compressed) + 8 (Partially compressed) + 4 (Frozen) = 13
+SELECT c.id, c.status
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
+WHERE h.table_name = 'test_table_frozen'
+ORDER BY c.id
+LIMIT 1;
+ id | status 
+----+--------
+ 69 |     13
+(1 row)
+
+--should recompress all chunks except first since its frozen
+CALL run_job(:compressjob_id);
+-- first chunk status is unchanged
+SELECT c.id, c.status
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
+WHERE h.table_name = 'test_table_frozen'
+ORDER BY c.id
+LIMIT 1;
+ id | status 
+----+--------
+ 69 |     13
+(1 row)
+
+-- unfreeze first chunk
+SELECT _timescaledb_functions.unfreeze_chunk(:'first_chunk');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
+-- should be able to recompress the chunk since its unfrozen
+CALL run_job(:compressjob_id);
+-- first chunk status is Compressed (1)
+SELECT c.id, c.status
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
+WHERE h.table_name = 'test_table_frozen'
+ORDER BY c.id
+LIMIT 1;
+ id | status 
+----+--------
+ 69 |      1
+(1 row)
+
 -- Teardown test
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REVOKE CREATE ON SCHEMA public FROM NOLOGIN_ROLE;

--- a/tsl/test/expected/hypercore_policy.out
+++ b/tsl/test/expected/hypercore_policy.out
@@ -114,8 +114,7 @@ where time = '2022-06-01 10:14' and device = 1;
 -- Add a new policy that doesn't specify hypercore. It should still
 -- recompress hypercores.
 select add_compression_policy('readings',
-                              compress_after => '1 day'::interval,
-                              hypercore_use_access_method => false)
+                              compress_after => '1 day'::interval)
 as compression_job \gset
 -- Run the policy job again to recompress
 call run_job(:'compression_job');

--- a/tsl/test/sql/hypercore_policy.sql
+++ b/tsl/test/sql/hypercore_policy.sql
@@ -75,8 +75,7 @@ where time = '2022-06-01 10:14' and device = 1;
 -- Add a new policy that doesn't specify hypercore. It should still
 -- recompress hypercores.
 select add_compression_policy('readings',
-                              compress_after => '1 day'::interval,
-                              hypercore_use_access_method => false)
+                              compress_after => '1 day'::interval)
 as compression_job \gset
 
 -- Run the policy job again to recompress


### PR DESCRIPTION
Freezing a partially compressed chunk prevents us from compressing it back to fully compressed. If the chunk was frozen, we can just ignore them and continue with the rest of the chunks.