### PR TITLE
Add GUC to enable exclusive locking recompression

### DIFF
--- a/.unreleased/pr_7844
+++ b/.unreleased/pr_7844
@@ -1,0 +1,1 @@
+Implements: #7844 Add GUC to enable exclusive locking recompression

--- a/src/guc.c
+++ b/src/guc.c
@@ -152,6 +152,7 @@ TSDLLEXPORT bool ts_guc_auto_sparse_indexes = true;
 TSDLLEXPORT bool ts_guc_default_hypercore_use_access_method = false;
 bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
+TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = false;
 
 /* Only settable in debug mode for testing */
@@ -747,6 +748,17 @@ _guc_init(void)
 							 "Enable segmentwise recompression",
 							 &ts_guc_enable_segmentwise_recompression,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_exclusive_locking_recompression"),
+							 "Enable exclusive locking recompression",
+							 "Enable getting exclusive lock on chunk during segmentwise "
+							 "recompression",
+							 &ts_guc_enable_exclusive_locking_recompression,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -69,6 +69,7 @@ extern TSDLLEXPORT bool ts_guc_enable_delete_after_compression;
 extern TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh;
 extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
+extern TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
 
 /* Only settable in debug mode for testing */

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -133,11 +133,13 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 			(errmsg("acquiring locks for recompression: \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),
 					NameStr(uncompressed_chunk->fd.table_name))));
+
+	LOCKMODE recompression_lockmode =
+		ts_guc_enable_exclusive_locking_recompression ? ExclusiveLock : ShareUpdateExclusiveLock;
 	/* lock both chunks, compressed and uncompressed */
 	Relation uncompressed_chunk_rel =
-		table_open(uncompressed_chunk->table_id, ShareUpdateExclusiveLock);
-	Relation compressed_chunk_rel =
-		table_open(compressed_chunk->table_id, ShareUpdateExclusiveLock);
+		table_open(uncompressed_chunk->table_id, recompression_lockmode);
+	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, recompression_lockmode);
 
 	bool has_unique_constraints =
 		ts_indexing_relation_has_primary_or_unique_index(uncompressed_chunk_rel);
@@ -256,7 +258,9 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 		 "Using index \"%s\" for recompression",
 		 get_rel_name(row_compressor.index_oid));
 
-	Relation index_rel = index_open(row_compressor.index_oid, ExclusiveLock);
+	LOCKMODE index_lockmode =
+		ts_guc_enable_exclusive_locking_recompression ? ExclusiveLock : RowExclusiveLock;
+	Relation index_rel = index_open(row_compressor.index_oid, index_lockmode);
 	ereport(DEBUG1,
 			(errmsg("locks acquired for recompression: \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -719,3 +719,67 @@ NOTICE:  segmentwise recompression is disabled, performing full recompression on
  _timescaledb_internal._hyper_22_24_chunk
 (1 row)
 
+RESET timescaledb.enable_segmentwise_recompression;
+--- Test behaviour of enable_exclusive_locking_recompression GUC
+CREATE TABLE exclusive_test(time timestamptz not null, a int, b int, c int);
+SELECT create_hypertable('exclusive_test', by_range('time', INTERVAL '1 day'));
+ create_hypertable 
+-------------------
+ (24,t)
+(1 row)
+
+ALTER TABLE guc_test set (timescaledb.compress, timescaledb.compress_segmentby = 'a, b');
+INSERT INTO guc_test VALUES ('2024-10-30 14:04:00.501519-06'::timestamptz, 1, 1, 1);
+SELECT show_chunks as chunk_to_compress FROM show_chunks('guc_test') LIMIT 1 \gset
+SELECT compress_chunk(:'chunk_to_compress');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_22_24_chunk
+(1 row)
+
+INSERT INTO guc_test VALUES ('2024-10-30 14:14:00.501519-06'::timestamptz, 1, 1, 2);
+-- Default behavior will try to get exclusive lock at the end of operation
+-- in order to change the chunk status. Here it will succeed since there
+-- isn't any concurrent operations.
+RESET timescaledb.enable_exclusive_locking_recompression;
+BEGIN;
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+       recompress_chunk_segmentwise       
+------------------------------------------
+ _timescaledb_internal._hyper_22_24_chunk
+(1 row)
+
+SELECT c.relname FROM pg_locks l
+INNER JOIN pg_class c ON c.oid = l.relation
+WHERE locktype = 'relation' AND mode = 'ExclusiveLock'
+ORDER BY 1;
+      relname       
+--------------------
+ _hyper_22_24_chunk
+(1 row)
+
+ROLLBACK;
+-- If we enable this GUC, it should get exclusive locks on 3 relations:
+-- uncompressed chunk table, compressed chunk table, and compressed chunk index.
+-- This is done so that we keep locking consistency to legacy way of locking.
+SET timescaledb.enable_exclusive_locking_recompression TO ON;
+BEGIN;
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+       recompress_chunk_segmentwise       
+------------------------------------------
+ _timescaledb_internal._hyper_22_24_chunk
+(1 row)
+
+SELECT c.relname FROM pg_locks l
+INNER JOIN pg_class c ON c.oid = l.relation
+WHERE locktype = 'relation' AND mode = 'ExclusiveLock'
+ORDER BY 1;
+                             relname                             
+-----------------------------------------------------------------
+ _hyper_22_24_chunk
+ compress_hyper_23_26_chunk
+ compress_hyper_23_26_chunk_a_b__ts_meta_min_1__ts_meta_max__idx
+(3 rows)
+
+ROLLBACK;
+RESET timescaledb.enable_exclusive_locking_recompression;

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -346,4 +346,41 @@ SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress')
 -- When GUC is OFF, entire chunk should be fully uncompressed and compressed instead
 SELECT compress_chunk(:'chunk_to_compress');
 
+RESET timescaledb.enable_segmentwise_recompression;
 
+--- Test behaviour of enable_exclusive_locking_recompression GUC
+CREATE TABLE exclusive_test(time timestamptz not null, a int, b int, c int);
+SELECT create_hypertable('exclusive_test', by_range('time', INTERVAL '1 day'));
+
+ALTER TABLE guc_test set (timescaledb.compress, timescaledb.compress_segmentby = 'a, b');
+INSERT INTO guc_test VALUES ('2024-10-30 14:04:00.501519-06'::timestamptz, 1, 1, 1);
+SELECT show_chunks as chunk_to_compress FROM show_chunks('guc_test') LIMIT 1 \gset
+SELECT compress_chunk(:'chunk_to_compress');
+
+INSERT INTO guc_test VALUES ('2024-10-30 14:14:00.501519-06'::timestamptz, 1, 1, 2);
+
+-- Default behavior will try to get exclusive lock at the end of operation
+-- in order to change the chunk status. Here it will succeed since there
+-- isn't any concurrent operations.
+RESET timescaledb.enable_exclusive_locking_recompression;
+BEGIN;
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+SELECT c.relname FROM pg_locks l
+INNER JOIN pg_class c ON c.oid = l.relation
+WHERE locktype = 'relation' AND mode = 'ExclusiveLock'
+ORDER BY 1;
+ROLLBACK;
+
+-- If we enable this GUC, it should get exclusive locks on 3 relations:
+-- uncompressed chunk table, compressed chunk table, and compressed chunk index.
+-- This is done so that we keep locking consistency to legacy way of locking.
+SET timescaledb.enable_exclusive_locking_recompression TO ON;
+BEGIN;
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+SELECT c.relname FROM pg_locks l
+INNER JOIN pg_class c ON c.oid = l.relation
+WHERE locktype = 'relation' AND mode = 'ExclusiveLock'
+ORDER BY 1;
+ROLLBACK;
+
+RESET timescaledb.enable_exclusive_locking_recompression;


### PR DESCRIPTION
With reduction of locking during segmentwise recompression, we are no longer getting ExclusiveLocks on relations at the start of the operation. This GUC can be used to enable this behavior in order to replicate legacy locking style if necessary.