### PR TITLE
Update wording on logs during recompression

### DIFF
--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -428,9 +428,8 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 													snapshot))
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-							 errmsg(
-								 "cannot proceed with recompression due to concurrent updates on "
-								 "compressed data")));
+							 errmsg("aborting recompression due to concurrent updates on "
+									"compressed data, retrying with next policy run")));
 				CommandCounterIncrement();
 
 				if (should_free)
@@ -581,8 +580,8 @@ finish:
 		 */
 		ereport(ERROR,
 				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-				 errmsg("cannot proceed with recompression due to concurrent DML on uncompressed "
-						"data")));
+				 errmsg("aborting recompression due to concurrent DML on uncompressed "
+						"data, retrying with next policy run")));
 	}
 
 	table_close(uncompressed_chunk_rel, NoLock);
@@ -676,9 +675,8 @@ fetch_uncompressed_chunk_into_tuplesort(Tuplesortstate *tuplesortstate,
 		if (!delete_tuple_for_recompression(uncompressed_chunk_rel, &slot->tts_tid, snapshot))
 			ereport(ERROR,
 					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-					 errmsg("cannot proceed with recompression due to concurrent updates on "
-							"uncompressed "
-							"data")));
+					 errmsg("aborting recompression due to concurrent updates on "
+							"uncompressed data, retrying with next policy run")));
 	}
 	ExecDropSingleTupleTableSlot(slot);
 	table_endscan(scan);

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -1563,7 +1563,7 @@ step I1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step I1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1652,7 +1652,7 @@ step I1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step I1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1741,7 +1741,7 @@ step I1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step I1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1830,7 +1830,7 @@ step Iu1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Iu1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -1919,7 +1919,7 @@ step Iu1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Iu1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2014,7 +2014,7 @@ step Iu1:
  <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Iu1: <... completed>
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2106,7 +2106,7 @@ step RC:
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) ON CONFLICT DO NOTHING; <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step IN1: <... completed>
 step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2192,7 +2192,7 @@ step RC:
 step INu1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 99) ON CONFLICT(time, device) DO UPDATE SET value = 99; <waiting ...>
 step UnlockChunk: ROLLBACK;
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step INu1: <... completed>
 step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
@@ -2288,7 +2288,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step I1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2377,7 +2377,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step I1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2466,7 +2466,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step I1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2555,7 +2555,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step Iu1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2650,7 +2650,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step Iu1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2745,7 +2745,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step Iu1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2837,7 +2837,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step IN1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
@@ -2923,7 +2923,7 @@ step RC:
 step UnlockChunk: ROLLBACK;
 step INu1: <... completed>
 step RC: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks

--- a/tsl/test/isolation/expected/compression_recompress.out
+++ b/tsl/test/isolation/expected/compression_recompress.out
@@ -155,7 +155,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_insert_do_nothing: 
    INSERT INTO sensor_data
    VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) 
@@ -215,7 +215,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_insert_existing_do_nothing: 
    INSERT INTO sensor_data 
    SELECT time, sensor_id, 1.0, 1.0 FROM sensor_data
@@ -274,7 +274,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_wait_for_finish: 
 
 step s2_commit: 
@@ -325,7 +325,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_wait_for_finish: 
 
 step s2_commit: 
@@ -410,7 +410,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_wait_for_finish: 
 
 step s2_commit: 
@@ -580,7 +580,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_upsert: 
    INSERT INTO sensor_data 
    VALUES ('2022-01-01 20:00'::timestamptz, 100, 9999, 9999), ('2022-01-01 21:00'::timestamptz, 101, 9999, 9999) 
@@ -644,7 +644,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_upsert_existing: 
    INSERT INTO sensor_data 
    SELECT time, sensor_id, 9999, 9999 FROM sensor_data
@@ -711,7 +711,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_wait_for_finish: 
 
 step s2_commit: 
@@ -770,7 +770,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_wait_for_finish: 
 
 step s2_commit: 
@@ -849,7 +849,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_wait_for_finish: 
 
 step s2_commit: 
@@ -1136,7 +1136,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_delete_compressed: 
 	DELETE FROM sensor_data WHERE sensor_id = 1;
 
@@ -1190,7 +1190,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_delete_uncompressed: 
 	DELETE FROM sensor_data WHERE sensor_id = 11;
 
@@ -1262,7 +1262,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_delete_recompressed: 
 	DELETE FROM sensor_data WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
 
@@ -1317,7 +1317,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_recompress_chunk: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent updates on uncompressed data
+ERROR:  aborting recompression due to concurrent updates on uncompressed data, retrying with next policy run
 step s1_show_chunk_state: 
    SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
    SELECT count(*) FROM sensor_data;
@@ -1359,7 +1359,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_commit: 
 	COMMIT;
 
@@ -1428,7 +1428,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_recompress_chunk: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent updates on compressed data
+ERROR:  aborting recompression due to concurrent updates on compressed data, retrying with next policy run
 step s1_show_chunk_state: 
    SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
    SELECT count(*) FROM sensor_data;
@@ -1651,7 +1651,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_update_compressed: 
 	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 1;
 
@@ -1713,7 +1713,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_update_uncompressed: 
 	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 11;
 
@@ -1779,7 +1779,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_update_recompressed: 
 	UPDATE sensor_data SET cpu = 9999 WHERE sensor_id = 5 AND time > '2022-01-01 01:00'::timestamptz;
 
@@ -1842,7 +1842,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_recompress_chunk: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent updates on uncompressed data
+ERROR:  aborting recompression due to concurrent updates on uncompressed data, retrying with next policy run
 step s1_show_chunk_state: 
    SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
    SELECT count(*) FROM sensor_data;
@@ -1892,7 +1892,7 @@ step s1_recompress_chunk:
    FROM show_chunks('sensor_data') i
    LIMIT 1;
 
-ERROR:  cannot proceed with recompression due to concurrent DML on uncompressed data
+ERROR:  aborting recompression due to concurrent DML on uncompressed data, retrying with next policy run
 step s2_commit: 
 	COMMIT;
 
@@ -1969,7 +1969,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_recompress_chunk: <... completed>
-ERROR:  cannot proceed with recompression due to concurrent updates on compressed data
+ERROR:  aborting recompression due to concurrent updates on compressed data, retrying with next policy run
 step s1_show_chunk_state: 
    SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
    SELECT count(*) FROM sensor_data;


### PR DESCRIPTION
Adding more context what happens if we end up in
serialization issues during recompression.

Disable-check: force-changelog-file