### PR TITLE
Add callback is_current_xact_tuple to Arrow TTS

### DIFF
--- a/.unreleased/pr_7850
+++ b/.unreleased/pr_7850
@@ -1,0 +1,1 @@
+Fixes: #7850 Add is_current_xact_tuple to Arrow TTS


### PR DESCRIPTION
PG17 introduced the TTS callback `is_current_xact_tuple` but it was missing in our Arrow TTS definition.

https://github.com/postgres/postgres/commit/0997e0af273d80add75bcf5616eee000d0a78397