### PR TITLE
Don't run package test as part of prerelease

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -12,7 +12,6 @@ name: APT ARM64 packages
     branches:
     - release_test
     - trigger/package_test
-    - prerelease_test
   workflow_dispatch:
 jobs:
   apt_tests:

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -12,7 +12,6 @@ name: APT packages
     branches:
     - release_test
     - trigger/package_test
-    - prerelease_test
   workflow_dispatch:
 jobs:
   apt_tests:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -15,7 +15,6 @@ name: Test Docker images
     branches:
     - release_test
     - trigger/package_test
-    - prerelease_test
   workflow_dispatch:
 jobs:
   docker_tests:

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -11,7 +11,6 @@ name: Homebrew
     - release_test
     - trigger/package_test
     - trigger/homebrew_test
-    - prerelease_test
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -12,7 +12,6 @@ name: RPM packages
     branches:
     - release_test
     - trigger/package_test
-    - prerelease_test
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -12,7 +12,6 @@ name: Windows Packages
     branches:
     - release_test
     - trigger/windows_packages
-    - prerelease_test
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The package tests verify that the published version from the
official sources is installable and matches the expected version,
so these tests will always fail as part of prerelease since no
packages are being published as part of the procedure.

Disable-check: force-changelog-file
