### PR TITLE
Check that no new internal program errors are introduced in CI

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -341,17 +341,6 @@ elif len(sys.argv) > 2:
                     "coverage": False,
                     "installcheck_args": installcheck_args,
                     "name": "Flaky Check Debug",
-                    "pg": PG16_LATEST,
-                    "pginstallcheck": False,
-                }
-            )
-        )
-        m["include"].append(
-            build_debug_config(
-                {
-                    "coverage": False,
-                    "installcheck_args": installcheck_args,
-                    "name": "Flaky Check Debug",
                     "pg": PG17_LATEST,
                     "pginstallcheck": False,
                 }

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -299,6 +299,19 @@ jobs:
           build/test/tmp_check/log
           build/tsl/test/tmp_check/log
 
+    - name: Find internal program errors in the server log
+      run: |
+        # This is used to save the IPEs into the CI checks database, and also to
+        # check that no new IPEs were introduced in the Flaky Check.
+        jq 'select(.state_code == "XX000" and .error_severity != "LOG")
+            | [env.JOB_DATE, .message, .func_name,  .statement] | @tsv
+        ' -r postmaster.json > ipe.tsv ||:
+
+    - name: Check that no new internal program errors are introduced
+      if: contains(matrix.name, 'Flaky')
+      run: |
+        ! [ -s ipe.tsv ]
+
     - name: Upload test results to the database
       # Don't upload the results of the flaky check, because the db schema only
       # supports running one test once per job.

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -310,7 +310,7 @@ jobs:
     - name: Check that no new internal program errors are introduced
       if: contains(matrix.name, 'Flaky')
       run: |
-        ! [ -s ipe.tsv ]
+        ! grep . ipe.tsv
 
     - name: Upload test results to the database
       # Don't upload the results of the flaky check, because the db schema only

--- a/.github/workflows/shellcheck-ignored.yaml
+++ b/.github/workflows/shellcheck-ignored.yaml
@@ -3,13 +3,14 @@
 # executed because some files were ignored.
 name: Shellcheck
 "on":
-  push:
-    branches:
-      - main
+  pull_request:
     paths-ignore:
       - '**.sh'
       - .github/workflows/shellcheck.yaml
-  pull_request:
+  push:
+    branches:
+      - main
+      - prerelease_test
     paths-ignore:
       - '**.sh'
       - .github/workflows/shellcheck.yaml

--- a/scripts/upload_ci_stats.sh
+++ b/scripts/upload_ci_stats.sh
@@ -173,10 +173,6 @@ done
 # Save a snippet of logs where a backend was terminated by signal.
 grep -C40 "was terminated by signal" postmaster.log > postgres-failure.log ||:
 
-# Find internal program errors in Postgres logs.
-jq 'select(.state_code == "XX000" and .error_severity != "LOG")
-    | [env.JOB_DATE, .message, .func_name,  .statement] | @tsv
-' -r postmaster.json > ipe.tsv ||:
 "${PSQL[@]}" -c "\copy ipe from ipe.tsv"
 
 # Upload the logs.

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -393,7 +393,7 @@ extern int decompress_batch(RowDecompressor *decompressor);
  */
 #ifndef TS_COMPRESSION_FUZZING
 #define CORRUPT_DATA_MESSAGE(X)                                                                    \
-	(errmsg("the compressed data is corrupt"), errdetail("%s", X), errcode(ERRCODE_INTERNAL_ERROR))
+	(errmsg("the compressed data is corrupt"), errdetail("%s", X), errcode(ERRCODE_DATA_CORRUPTED))
 #else
 #define CORRUPT_DATA_MESSAGE(X) (errcode(ERRCODE_DATA_CORRUPTED))
 #endif

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -393,7 +393,7 @@ extern int decompress_batch(RowDecompressor *decompressor);
  */
 #ifndef TS_COMPRESSION_FUZZING
 #define CORRUPT_DATA_MESSAGE(X)                                                                    \
-	(errmsg("the compressed data is corrupt"), errdetail("%s", X), errcode(ERRCODE_DATA_CORRUPTED))
+	(errmsg("the compressed data is corrupt"), errdetail("%s", X), errcode(ERRCODE_INTERNAL_ERROR))
 #else
 #define CORRUPT_DATA_MESSAGE(X) (errcode(ERRCODE_DATA_CORRUPTED))
 #endif

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -1773,8 +1773,8 @@ group by 2, 3 order by 1 desc
 ;
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
-   143 | XX001       | true
-    82 | XX001       | XX001
+   143 | XX000       | true
+    82 | XX000       | XX000
     54 | true        | true
     23 | 08P01       | 08P01
 (4 rows)
@@ -1789,9 +1789,9 @@ group by 2, 3 order by 1 desc
 ;
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
-   106 | XX001       | XX001
+   106 | XX000       | XX000
     69 | true        | true
-    62 | XX001       | true
+    62 | XX000       | true
     13 | 08P01       | 08P01
      1 | false       | false
 (5 rows)
@@ -1807,7 +1807,7 @@ group by 2, 3 order by 1 desc
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
     18 | true        | true
-    15 | XX001       | XX001
+    15 | XX000       | XX000
      8 | 08P01       | 08P01
      2 | 3F000       | 3F000
      1 | 22021       | 22021
@@ -1824,8 +1824,8 @@ group by 2, 3 order by 1 desc
 ;
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
-    76 | XX001       | XX001
-     9 | XX001       | true
+    76 | XX000       | XX000
+     9 | XX000       | true
      5 | 08P01       | 08P01
      4 | true        | true
      3 | 22021       | 22021

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -1758,6 +1758,8 @@ as :TSL_MODULE_PATHNAME, 'ts_read_compressed_data_file' language c;
 \set ON_ERROR_STOP 0
 select ts_read_compressed_data_file('gorilla', 'float8', '--nonexistent');
 ERROR:  could not open the file '--nonexistent'
+select ts_read_compressed_data_file('gorilla', 'float8', (:'TEST_INPUT_DIR' || '/fuzzing/compression/gorilla-float8/1f09f12d930daae8e5fd34e11e7b2303e1705b2e')::cstring);
+ERROR:  the compressed data is corrupt
 \set ON_ERROR_STOP 1
 create or replace function ts_read_compressed_data_directory(cstring, regtype, cstring, bool)
 returns table(path text, bytes int, rows int, sqlstate text, location text)

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -1758,6 +1758,7 @@ as :TSL_MODULE_PATHNAME, 'ts_read_compressed_data_file' language c;
 \set ON_ERROR_STOP 0
 select ts_read_compressed_data_file('gorilla', 'float8', '--nonexistent');
 ERROR:  could not open the file '--nonexistent'
+-- Just some random file that returns "compressed data is corrupt", for one-off testing.
 select ts_read_compressed_data_file('gorilla', 'float8', (:'TEST_INPUT_DIR' || '/fuzzing/compression/gorilla-float8/1f09f12d930daae8e5fd34e11e7b2303e1705b2e')::cstring);
 ERROR:  the compressed data is corrupt
 \set ON_ERROR_STOP 1
@@ -1775,8 +1776,8 @@ group by 2, 3 order by 1 desc
 ;
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
-   143 | XX000       | true
-    82 | XX000       | XX000
+   143 | XX001       | true
+    82 | XX001       | XX001
     54 | true        | true
     23 | 08P01       | 08P01
 (4 rows)
@@ -1791,9 +1792,9 @@ group by 2, 3 order by 1 desc
 ;
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
-   106 | XX000       | XX000
+   106 | XX001       | XX001
     69 | true        | true
-    62 | XX000       | true
+    62 | XX001       | true
     13 | 08P01       | 08P01
      1 | false       | false
 (5 rows)
@@ -1809,7 +1810,7 @@ group by 2, 3 order by 1 desc
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
     18 | true        | true
-    15 | XX000       | XX000
+    15 | XX001       | XX001
      8 | 08P01       | 08P01
      2 | 3F000       | 3F000
      1 | 22021       | 22021
@@ -1826,8 +1827,8 @@ group by 2, 3 order by 1 desc
 ;
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
-    76 | XX000       | XX000
-     9 | XX000       | true
+    76 | XX001       | XX001
+     9 | XX001       | true
      5 | 08P01       | 08P01
      4 | true        | true
      3 | 22021       | 22021

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -426,6 +426,7 @@ as :TSL_MODULE_PATHNAME, 'ts_read_compressed_data_file' language c;
 
 \set ON_ERROR_STOP 0
 select ts_read_compressed_data_file('gorilla', 'float8', '--nonexistent');
+-- Just some random file that returns "compressed data is corrupt", for one-off testing.
 select ts_read_compressed_data_file('gorilla', 'float8', (:'TEST_INPUT_DIR' || '/fuzzing/compression/gorilla-float8/1f09f12d930daae8e5fd34e11e7b2303e1705b2e')::cstring);
 \set ON_ERROR_STOP 1
 

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -426,6 +426,7 @@ as :TSL_MODULE_PATHNAME, 'ts_read_compressed_data_file' language c;
 
 \set ON_ERROR_STOP 0
 select ts_read_compressed_data_file('gorilla', 'float8', '--nonexistent');
+select ts_read_compressed_data_file('gorilla', 'float8', (:'TEST_INPUT_DIR' || '/fuzzing/compression/gorilla-float8/1f09f12d930daae8e5fd34e11e7b2303e1705b2e')::cstring);
 \set ON_ERROR_STOP 1
 
 create or replace function ts_read_compressed_data_directory(cstring, regtype, cstring, bool)


### PR DESCRIPTION
In Flaky Check specifically. The internal program errors (XX000) are reserved for bugs, we shouldn't encounter them during normal operation. We already have some places where this code is used incorrectly, so only check it for the newly introduced tests.


Disable-check: force-changelog-file