### PR TITLE
Allow adding CHECK constraints to compressed chunks

### DIFF
--- a/.unreleased/pr_7864
+++ b/.unreleased/pr_7864
@@ -1,0 +1,1 @@
+Implements: #7864 Allow adding CHECK constraints to compressed chunks

--- a/tsl/test/expected/compression_constraints.out
+++ b/tsl/test/expected/compression_constraints.out
@@ -326,3 +326,53 @@ INSERT INTO events SELECT '2025-03-01','d1','';
 ERROR:  insert or update on table "events" violates foreign key constraint "events_fk"
 \set ON_ERROR_STOP 1
 ROLLBACK;
+DROP TABLE metrics CASCADE;
+DROP TABLE device CASCADE;
+DROP TABLE events CASCADE;
+-- test CHECK constraints
+CREATE TABLE metrics(time timestamptz not null, device text, value float);
+SELECT create_hypertable('metrics','time');
+  create_hypertable   
+----------------------
+ (7,public,metrics,t)
+(1 row)
+
+ALTER TABLE metrics SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+INSERT INTO metrics SELECT '2025-01-01','d1',1;
+INSERT INTO metrics SELECT '2025-01-01','d1',NULL;
+\set ON_ERROR_STOP 0
+ALTER TABLE metrics ADD CONSTRAINT metrics_check CHECK (value > 9000);
+ERROR:  check constraint "metrics_check" of relation "_hyper_7_30_chunk" is violated by some row
+ALTER TABLE metrics ADD CONSTRAINT metrics_check CHECK (time > '2026-01-01' AND value > 0);
+ERROR:  check constraint "metrics_check" of relation "_hyper_7_30_chunk" is violated by some row
+\set ON_ERROR_STOP 1
+BEGIN;
+ALTER TABLE metrics ADD CONSTRAINT metrics_check CHECK (value > 0.9);
+ALTER TABLE metrics ADD CONSTRAINT metrics_check2 CHECK (time >= '2025-01-01' AND value > 0);
+INSERT INTO metrics SELECT '2025-01-01','d1',2;
+\set ON_ERROR_STOP 0
+INSERT INTO metrics SELECT '2025-01-01','d1',0;
+ERROR:  new row for relation "_hyper_7_30_chunk" violates check constraint "metrics_check"
+\set ON_ERROR_STOP 1
+ROLLBACK;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 0
+ALTER TABLE metrics ADD CONSTRAINT metrics_check CHECK (value > 9000);
+ERROR:  check constraint "metrics_check" of relation "_hyper_7_30_chunk" is violated by some row
+ALTER TABLE metrics ADD CONSTRAINT metrics_check CHECK (time > '2026-01-01' AND value > 0);
+ERROR:  check constraint "metrics_check" of relation "_hyper_7_30_chunk" is violated by some row
+\set ON_ERROR_STOP 1
+BEGIN;
+ALTER TABLE metrics ADD CONSTRAINT metrics_check CHECK (value > 0.9);
+ALTER TABLE metrics ADD CONSTRAINT metrics_check2 CHECK (time >= '2025-01-01' AND value > 0);
+INSERT INTO metrics SELECT '2025-01-01','d1',2;
+\set ON_ERROR_STOP 0
+INSERT INTO metrics SELECT '2025-01-01','d1',0;
+ERROR:  new row for relation "_hyper_7_30_chunk" violates check constraint "metrics_check"
+\set ON_ERROR_STOP 1
+ROLLBACK;

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -292,10 +292,6 @@ NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
---adding these constraints when there is compressed data should fail
-ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
-ERROR:  operation not supported on hypertables that have compressed data
-HINT:  Decompress the data before retrying the operation.
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -292,10 +292,6 @@ NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
---adding these constraints when there is compressed data should fail
-ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
-ERROR:  operation not supported on hypertables that have compressed data
-HINT:  Decompress the data before retrying the operation.
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.

--- a/tsl/test/expected/compression_errors-17.out
+++ b/tsl/test/expected/compression_errors-17.out
@@ -292,10 +292,6 @@ NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
---adding these constraints when there is compressed data should fail
-ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
-ERROR:  operation not supported on hypertables that have compressed data
-HINT:  Decompress the data before retrying the operation.
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.

--- a/tsl/test/sql/compression_errors.sql.in
+++ b/tsl/test/sql/compression_errors.sql.in
@@ -142,9 +142,6 @@ select compress_chunk(:'CHUNK_NAME');
 select compress_chunk(:'CHUNK_NAME', if_not_compressed=>false);
 select compress_chunk(:'CHUNK_NAME');
 
---adding these constraints when there is compressed data should fail
-ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
-
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');


### PR DESCRIPTION
Allow adding CHECK constraints to hypertables that have compressed
chunks. Previously this would require decompressing any compressed
chunks before adding the CHECK constraint.
