### PR TITLE
Implement SkipScan for distinct aggregates

### DIFF
--- a/.unreleased/pr_7874
+++ b/.unreleased/pr_7874
@@ -1,0 +1,1 @@
+Implements: #7874 Support for SkipScan for distinct aggregates over the same column

--- a/src/guc.c
+++ b/src/guc.c
@@ -163,6 +163,9 @@ TSDLLEXPORT bool ts_guc_enable_null_compression = true;
 TSDLLEXPORT bool ts_guc_enable_columnarscan = true;
 TSDLLEXPORT int ts_guc_bgw_log_level = WARNING;
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
+#if PG16_GE
+TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates = true;
+#endif
 static char *ts_guc_default_segmentby_fn = NULL;
 static char *ts_guc_default_orderby_fn = NULL;
 TSDLLEXPORT bool ts_guc_enable_job_execution_logging = false;
@@ -651,7 +654,18 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
-
+#if PG16_GE
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_skipscan_for_distinct_aggregates"),
+							 "Enable SkipScan for DISTINCT aggregates",
+							 "Enable SkipScan for DISTINCT aggregates",
+							 &ts_guc_enable_skip_scan_for_distinct_aggregates,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+#endif
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compression_wal_markers"),
 							 "Enable WAL markers for compression ops",
 							 "Enable the generation of markers in the WAL stream which mark the "

--- a/src/guc.h
+++ b/src/guc.h
@@ -71,6 +71,9 @@ extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
+#if PG16_GE
+extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
+#endif
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -16,6 +16,7 @@
 #include <optimizer/pathnode.h>
 #include <optimizer/paths.h>
 #include <optimizer/planmain.h>
+#include <optimizer/prep.h>
 #include <optimizer/restrictinfo.h>
 #include <optimizer/tlist.h>
 #include <parser/parse_coerce.h>
@@ -50,13 +51,21 @@ typedef struct SkipScanPath
 	Var *distinct_var;
 } SkipScanPath;
 
+typedef struct DistinctPathInfo
+{
+	UpperRelationKind stage; /* What kind of Upper distinct path we are dealing with */
+	Path *unique_path;		 /* If not NULL, valid Upper distinct path */
+	Expr *distinct_expr;	 /* If not NULL, valid distinct expression for Upper distinct path */
+} DistinctPathInfo;
+
 static int get_idx_key(IndexOptInfo *idxinfo, AttrNumber attno);
 static List *sort_indexquals(IndexOptInfo *indexinfo, List *quals);
 static OpExpr *fix_indexqual(IndexOptInfo *index, RestrictInfo *rinfo, AttrNumber scankey_attno);
 static bool build_skip_qual(PlannerInfo *root, SkipScanPath *skip_scan_path, IndexPath *index_path,
 							Var *var);
-static List *build_subpath(PlannerInfo *root, List *subpaths, double ndistinct);
-static Var *get_distinct_var(PlannerInfo *root, IndexPath *index_path,
+static List *build_subpath(PlannerInfo *root, List *subpaths, DistinctPathInfo *dpinfo,
+						   List *top_pathkeys);
+static Var *get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_path,
 							 SkipScanPath *skip_scan_path);
 static TargetEntry *tlist_member_match_var(Var *var, List *targetlist);
 
@@ -135,8 +144,233 @@ static CustomPathMethods skip_scan_path_methods = {
 	.PlanCustomPath = skip_scan_plan_create,
 };
 
+#if PG16_GE
+typedef struct FindAggrefsContext
+{
+	List *aggrefs; /* all non-nested Aggrefs found in a node */
+} FindAggrefsContext;
+
+static bool
+find_aggrefs_walker(Node *node, FindAggrefsContext *context)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Aggref))
+	{
+		context->aggrefs = lappend(context->aggrefs, node);
+		/* don't recurse inside Aggrefs */
+		return false;
+	}
+
+	return expression_tree_walker(node, find_aggrefs_walker, context);
+}
+#endif
+/* We can get upper path Distinct expression once for upper path,
+ * rather than repeat this check for each child path of an upper path input
+ */
+static Expr *
+get_upper_distinct_expr(PlannerInfo *root, UpperRelationKind stage)
+{
+	ListCell *lc;
+	int num_vars = 0;
+	Expr *tlexpr = NULL;
+
+	if (stage == UPPERREL_DISTINCT && root->parse->distinctClause)
+	{
+		foreach (lc, root->parse->distinctClause)
+		{
+			SortGroupClause *clause = lfirst_node(SortGroupClause, lc);
+			Node *expr = get_sortgroupclause_expr(clause, root->parse->targetList);
+
+			/* we ignore any columns that can be constified to allow for cases like DISTINCT 'abc',
+			 * column */
+			if (IsA(estimate_expression_value(root, expr), Const))
+				continue;
+
+			num_vars++;
+			if (num_vars > 1)
+				return NULL;
+
+			/* We ignore binary-compatible relabeling */
+			tlexpr = (Expr *) expr;
+			while (tlexpr && IsA(tlexpr, RelabelType))
+				tlexpr = ((RelabelType *) tlexpr)->arg;
+		}
+	}
+#if PG16_GE
+	else if (stage == UPPERREL_GROUP_AGG)
+	{
+		/* Find all non-nested Aggrefs in the query target list */
+		FindAggrefsContext agg_ctx = { NULL };
+		find_aggrefs_walker((Node *) root->parse->targetList, &agg_ctx);
+
+		foreach (lc, agg_ctx.aggrefs)
+		{
+			Aggref *agg = lfirst_node(Aggref, lc);
+			/* Only distinct aggs with 1 sorted argument are eligible*/
+			if (agg->aggdistinct && agg->aggpresorted && list_length(agg->args) == 1)
+			{
+				TargetEntry *tle = (TargetEntry *) linitial(agg->args);
+
+				Expr *expr = tle->expr;
+				/* We ignore binary-compatible relabeling */
+				while (expr && IsA(expr, RelabelType))
+					expr = ((RelabelType *) expr)->arg;
+
+				/* Distinct agg over a Const is OK */
+				if (IsA(estimate_expression_value(root, (Node *) expr), Const))
+					continue;
+
+				/* Don't support no-var arguments */
+				if (!IsA(expr, Var))
+					return NULL;
+
+				/* Don't support multiple distinct aggs over different columns */
+				if (tlexpr && !tlist_member_match_var((Var *) tlexpr, agg->args))
+					return NULL;
+
+				/* If Distinct agg path has a groupby column, it needs to match Distinct agg column
+				 */
+				if (root->processed_groupClause)
+				{
+					/* Should have bailed out on gby exprs > 1 earlier */
+					Assert(list_length(root->processed_groupClause) == 1);
+					SortGroupClause *sortcl =
+						(SortGroupClause *) linitial(root->processed_groupClause);
+					Expr *gbykey = (Expr *) get_sortgroupclause_expr(sortcl, root->processed_tlist);
+					if (!equal(gbykey, expr))
+						return NULL;
+				}
+				/* Found a valid distinct agg over a valid Var */
+				if (!tlexpr)
+				{
+					tlexpr = expr;
+					num_vars = 1;
+				}
+			}
+			else
+			{
+				return NULL;
+			}
+		}
+	}
+#endif
+	if (num_vars != 1)
+		return NULL;
+
+	/* SkipScan on expressions not supported */
+	if (!tlexpr || !IsA(tlexpr, Var))
+		return NULL;
+
+	return tlexpr;
+}
+
+static void
+obtain_upper_distinct_path(PlannerInfo *root, RelOptInfo *output_rel, DistinctPathInfo *dpinfo)
+{
+	ListCell *lc;
+
+	/*
+	 * look for Unique Path so we dont have to repeat some of
+	 * the calculations done by postgres and can also assume
+	 * that the DISTINCT clause is eligible for sort based
+	 * DISTINCT
+	 */
+	if (dpinfo->stage == UPPERREL_DISTINCT)
+	{
+		if (!ts_guc_enable_skip_scan)
+			return;
+
+		foreach (lc, output_rel->pathlist)
+		{
+			if (IsA(lfirst(lc), UpperUniquePath))
+			{
+				UpperUniquePath *unique = (UpperUniquePath *) lfirst_node(UpperUniquePath, lc);
+
+				/* currently we do not handle DISTINCT on more than one key. To do so,
+				 * we would need to break down the SkipScan into subproblems: first
+				 * find the minimal tuple then for each prefix find all unique suffix
+				 * tuples. For instance, if we are searching over (int, int), we would
+				 * first find (0, 0) then find (0, N) for all N in the domain, then
+				 * find (1, N), then (2, N), etc
+				 */
+				if (unique->numkeys > 1)
+					return;
+
+				dpinfo->unique_path = (Path *) unique;
+				break;
+			}
+		}
+	}
+	/* Sorted inputs for Distinct aggs weren't supported until PG16 */
+#if PG16_GE
+	/* Look for Aggpath with eligible Distinct aggregates */
+	else if (dpinfo->stage == UPPERREL_GROUP_AGG)
+	{
+		if (!ts_guc_enable_skip_scan_for_distinct_aggregates)
+			return;
+
+		/* Cannot apply SkipScan to more than one key */
+		if (list_length(root->group_pathkeys) > 1)
+			return;
+
+		foreach (lc, output_rel->pathlist)
+		{
+			if (IsA(lfirst(lc), AggPath))
+			{
+				AggPath *unique = (AggPath *) lfirst_node(AggPath, lc);
+
+				/* If Distinct agg path has a group key, it must match Distinct aggregate input sort
+				 * key, otherwise cannot apply SkipScan
+				 */
+				if (unique->path.pathkeys &&
+					!pathkeys_contained_in(unique->path.pathkeys, unique->subpath->pathkeys))
+				{
+					return;
+				}
+
+				dpinfo->unique_path = (Path *) lfirst_node(AggPath, lc);
+				break;
+			}
+		}
+	}
+#endif
+	else
+		return;
+
+	if (!dpinfo->unique_path)
+		return;
+
+	/* Check if we have valid distinct expression to source from the underlying index */
+	dpinfo->distinct_expr = get_upper_distinct_expr(root, dpinfo->stage);
+	if (!dpinfo->distinct_expr)
+	{
+		dpinfo->unique_path = NULL;
+		return;
+	}
+
+	/* Need to make a copy of the unique path here because add_path() in the
+	 * pathlist loop below might prune it if the new unique path
+	 * (SkipScanPath) dominates the old one. When the unique path is pruned,
+	 * the pointer will no longer be valid in the next iteration of the
+	 * pathlist loop. Fortunately, the Path object is not deeply freed, so a
+	 * shallow copy is enough. */
+	if (dpinfo->stage == UPPERREL_DISTINCT)
+	{
+		UpperUniquePath *unique = makeNode(UpperUniquePath);
+		memcpy(unique, lfirst_node(UpperUniquePath, lc), sizeof(UpperUniquePath));
+		dpinfo->unique_path = (Path *) unique;
+	}
+	else if (dpinfo->stage == UPPERREL_GROUP_AGG)
+	{
+		AggPath *dist_agg_path = makeNode(AggPath);
+		memcpy(dist_agg_path, lfirst_node(AggPath, lc), sizeof(AggPath));
+		dpinfo->unique_path = (Path *) dist_agg_path;
+	}
+}
+
 static SkipScanPath *skip_scan_path_create(PlannerInfo *root, IndexPath *index_path,
-										   double ndistinct);
+										   DistinctPathInfo *dpinfo);
 
 /*
  * Create SkipScan paths based on existing Unique paths.
@@ -170,74 +404,51 @@ static SkipScanPath *skip_scan_path_create(PlannerInfo *root, IndexPath *index_p
  *                ->  Index Scan using _hyper_2_2_chunk_idx on _hyper_2_2_chunk
  */
 void
-tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output_rel)
+tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output_rel,
+						UpperRelationKind stage)
 {
+	DistinctPathInfo dpinfo = { stage, NULL, NULL };
+	obtain_upper_distinct_path(root, output_rel, &dpinfo);
+	if (!dpinfo.unique_path)
+		return;
+
+	Assert(IsA(dpinfo.unique_path, UpperUniquePath) || IsA(dpinfo.unique_path, AggPath));
 	ListCell *lc;
-	UpperUniquePath *unique = NULL;
-
-	if (!ts_guc_enable_skip_scan)
-		return;
-
-	/*
-	 * look for Unique Path so we dont have repeat some of
-	 * the calculations done by postgres and can also assume
-	 * that the DISTINCT clause is eligible for sort based
-	 * DISTINCT
-	 */
-	foreach (lc, output_rel->pathlist)
-	{
-		if (IsA(lfirst(lc), UpperUniquePath))
-		{
-			unique = lfirst_node(UpperUniquePath, lc);
-
-			/* currently we do not handle DISTINCT on more than one key. To do so,
-			 * we would need to break down the SkipScan into subproblems: first
-			 * find the minimal tuple then for each prefix find all unique suffix
-			 * tuples. For instance, if we are searching over (int, int), we would
-			 * first find (0, 0) then find (0, N) for all N in the domain, then
-			 * find (1, N), then (2, N), etc
-			 */
-			if (unique->numkeys > 1)
-				return;
-
-			break;
-		}
-	}
-
-	/* no UniquePath found so this query might not be
-	 * eligible for sort-based DISTINCT and therefore
-	 * not eligible for SkipScan either */
-	if (!unique)
-		return;
-
-	/* Need to make a copy of the unique path here because add_path() in the
-	 * pathlist loop below might prune it if the new unique path
-	 * (SkipScanPath) dominates the old one. When the unique path is pruned,
-	 * the pointer will no longer be valid in the next iteration of the
-	 * pathlist loop. Fortunately, the Path object is not deeply freed, so a
-	 * shallow copy is enough. */
-	unique = makeNode(UpperUniquePath);
-	memcpy(unique, lfirst_node(UpperUniquePath, lc), sizeof(UpperUniquePath));
-
 	foreach (lc, input_rel->pathlist)
 	{
-		bool project = false;
 		bool has_caa = false;
 
 		Path *subpath = lfirst(lc);
 
-		if (!pathkeys_contained_in(unique->path.pathkeys, subpath->pathkeys))
-			continue;
+		List *top_pathkeys = NULL;
+
+		/* Unique path has to be sorted on at least DISTINCT ON key */
+		if (IsA(dpinfo.unique_path, UpperUniquePath))
+		{
+			if (!pathkeys_contained_in(dpinfo.unique_path->pathkeys, subpath->pathkeys))
+				continue;
+		}
+		/* AggPath with distinct aggs may not be sorted, but the input into distinct aggs needs to
+		 * be sorted */
+		else if (IsA(dpinfo.unique_path, AggPath))
+		{
+			if (!subpath->pathkeys ||
+				!pathkeys_contained_in(dpinfo.unique_path->pathkeys, subpath->pathkeys))
+				continue;
+			/* Need to check sortedness for inputs of Distinct aggs, so we'll keep track of the
+			 * input pathkeys  */
+			top_pathkeys = subpath->pathkeys;
+		}
 
 		/* If path is a ProjectionPath we strip it off for processing
 		 * but also add a ProjectionPath on top of the SKipScanPaths
 		 * later.
 		 */
+		ProjectionPath *proj = NULL;
 		if (IsA(subpath, ProjectionPath))
 		{
-			ProjectionPath *proj = castNode(ProjectionPath, subpath);
+			proj = castNode(ProjectionPath, subpath);
 			subpath = proj->subpath;
-			project = true;
 		}
 
 		/* Path might be wrapped in a ConstraintAwareAppendPath if this
@@ -256,14 +467,15 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 		{
 			IndexPath *index_path = castNode(IndexPath, subpath);
 
-			subpath = (Path *) skip_scan_path_create(root, index_path, unique->path.rows);
+			subpath = (Path *) skip_scan_path_create(root, index_path, &dpinfo);
 			if (!subpath)
 				continue;
 		}
 		else if (IsA(subpath, MergeAppendPath))
 		{
 			MergeAppendPath *merge_path = castNode(MergeAppendPath, subpath);
-			List *new_paths = build_subpath(root, merge_path->subpaths, unique->path.rows);
+
+			List *new_paths = build_subpath(root, merge_path->subpaths, &dpinfo, top_pathkeys);
 
 			/* build_subpath returns NULL when no SkipScanPath was created */
 			if (!new_paths)
@@ -279,7 +491,7 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 		else if (ts_is_chunk_append_path(subpath))
 		{
 			ChunkAppendPath *ca = (ChunkAppendPath *) subpath;
-			List *new_paths = build_subpath(root, ca->cpath.custom_paths, unique->path.rows);
+			List *new_paths = build_subpath(root, ca->cpath.custom_paths, &dpinfo, top_pathkeys);
 			/* ChunkAppend should never be wrapped in ConstraintAwareAppendPath */
 			Assert(!has_caa);
 
@@ -302,22 +514,56 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 		if (has_caa)
 			subpath = ts_constraint_aware_append_path_create(root, subpath);
 
-		Path *new_unique = (Path *)
-			create_upper_unique_path(root, output_rel, subpath, unique->numkeys, unique->path.rows);
-		new_unique->pathtarget = unique->path.pathtarget;
+		Path *new_unique = NULL;
 
-		if (project)
-			new_unique = (Path *) create_projection_path(root,
-														 output_rel,
-														 new_unique,
-														 copy_pathtarget(new_unique->pathtarget));
+		if (IsA(dpinfo.unique_path, UpperUniquePath))
+		{
+			UpperUniquePath *unique = (UpperUniquePath *) dpinfo.unique_path;
+			new_unique = (Path *) create_upper_unique_path(root,
+														   output_rel,
+														   subpath,
+														   unique->numkeys,
+														   unique->path.rows);
+			new_unique->pathtarget = unique->path.pathtarget;
+
+			if (proj)
+				new_unique =
+					(Path *) create_projection_path(root,
+													output_rel,
+													new_unique,
+													copy_pathtarget(new_unique->pathtarget));
+		}
+		else if (IsA(dpinfo.unique_path, AggPath))
+		{
+			AggPath *dist_agg_path = (AggPath *) dpinfo.unique_path;
+			if (proj)
+			{
+				proj->subpath = subpath;
+				subpath = (Path *) proj;
+			}
+			/* Is there a better way to cost new AggPath w/o recreating AggClauseCosts from the new
+			 * input? */
+			AggClauseCosts agg_costs;
+			MemSet(&agg_costs, 0, sizeof(AggClauseCosts));
+			get_agg_clause_costs(root, dist_agg_path->aggsplit, &agg_costs);
+			new_unique = (Path *) create_agg_path(root,
+												  output_rel,
+												  subpath,
+												  dist_agg_path->path.pathtarget,
+												  dist_agg_path->aggstrategy,
+												  dist_agg_path->aggsplit,
+												  dist_agg_path->groupClause,
+												  dist_agg_path->qual,
+												  (const AggClauseCosts *) &agg_costs,
+												  dist_agg_path->numGroups);
+		}
 
 		add_path(output_rel, new_unique);
 	}
 }
 
 static SkipScanPath *
-skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, double ndistinct)
+skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, DistinctPathInfo *dpinfo)
 {
 	double startup = index_path->path.startup_cost;
 	double total = index_path->path.total_cost;
@@ -332,7 +578,7 @@ skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, double ndistinct
 		return NULL;
 
 	SkipScanPath *skip_scan_path = (SkipScanPath *) newNode(sizeof(SkipScanPath), T_CustomPath);
-
+	int ndistinct = dpinfo->unique_path->rows;
 	skip_scan_path->cpath.path.pathtype = T_CustomScan;
 	skip_scan_path->cpath.path.pathkeys = index_path->path.pathkeys;
 	skip_scan_path->cpath.path.pathtarget = index_path->path.pathtarget;
@@ -363,7 +609,7 @@ skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, double ndistinct
 	 * free so reusing the IndexPath here is safe. */
 	skip_scan_path->index_path = index_path;
 
-	Var *var = get_distinct_var(root, index_path, skip_scan_path);
+	Var *var = get_distinct_var(root, dpinfo, index_path, skip_scan_path);
 
 	if (!var)
 		return NULL;
@@ -379,35 +625,12 @@ skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, double ndistinct
 
 /* Extract the Var to use for the SkipScan and do attno mapping if required. */
 static Var *
-get_distinct_var(PlannerInfo *root, IndexPath *index_path, SkipScanPath *skip_scan_path)
+get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_path,
+				 SkipScanPath *skip_scan_path)
 {
-	ListCell *lc;
-	int num_vars = 0;
 	RelOptInfo *rel = index_path->path.parent;
-	Expr *tlexpr = NULL;
+	Expr *tlexpr = dpinfo->distinct_expr;
 
-	foreach (lc, root->parse->distinctClause)
-	{
-		SortGroupClause *clause = lfirst_node(SortGroupClause, lc);
-		Node *expr = get_sortgroupclause_expr(clause, root->parse->targetList);
-
-		/* we ignore any columns that can be constified to allow for cases like DISTINCT 'abc',
-		 * column */
-		if (IsA(estimate_expression_value(root, expr), Const))
-			continue;
-
-		num_vars++;
-
-		/* We ignore binary-compatible relabeling */
-		tlexpr = (Expr *) expr;
-		while (tlexpr && IsA(tlexpr, RelabelType))
-			tlexpr = ((RelabelType *) tlexpr)->arg;
-	}
-
-	if (num_vars != 1)
-		return NULL;
-
-	/* SkipScan on expressions not supported */
 	if (!tlexpr || !IsA(tlexpr, Var))
 		return NULL;
 
@@ -474,7 +697,7 @@ get_distinct_var(PlannerInfo *root, IndexPath *index_path, SkipScanPath *skip_sc
  * otherwise returns list of new paths
  */
 static List *
-build_subpath(PlannerInfo *root, List *subpaths, double ndistinct)
+build_subpath(PlannerInfo *root, List *subpaths, DistinctPathInfo *dpinfo, List *top_pathkeys)
 {
 	bool has_skip_path = false;
 	List *new_paths = NIL;
@@ -485,8 +708,12 @@ build_subpath(PlannerInfo *root, List *subpaths, double ndistinct)
 		Path *child = lfirst(lc);
 		if (IsA(child, IndexPath))
 		{
+			if (top_pathkeys &&
+				!pathkeys_contained_in(top_pathkeys, castNode(IndexPath, child)->path.pathkeys))
+				continue;
+
 			SkipScanPath *skip_path =
-				skip_scan_path_create(root, castNode(IndexPath, child), ndistinct);
+				skip_scan_path_create(root, castNode(IndexPath, child), dpinfo);
 
 			if (skip_path)
 			{
@@ -623,6 +850,7 @@ sort_indexquals(IndexOptInfo *indexinfo, List *quals)
 {
 	List *indexclauses[INDEX_MAX_KEYS] = { 0 };
 	List *ordered_list = NIL;
+	int quals_len = list_length(quals);
 	ListCell *lc;
 	int i;
 
@@ -636,7 +864,7 @@ sort_indexquals(IndexOptInfo *indexinfo, List *quals)
 		indexclauses[i] = lappend(indexclauses[i], lfirst(lc));
 	}
 
-	for (i = 0; i < INDEX_MAX_KEYS; i++)
+	for (i = 0; i < quals_len; i++)
 	{
 		if (indexclauses[i] != NIL)
 			ordered_list = list_concat(ordered_list, indexclauses[i]);

--- a/tsl/src/nodes/skip_scan/skip_scan.h
+++ b/tsl/src/nodes/skip_scan/skip_scan.h
@@ -9,6 +9,6 @@
 #include <nodes/plannodes.h>
 
 extern void tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel,
-									RelOptInfo *output_rel);
+									RelOptInfo *output_rel, UpperRelationKind stage);
 extern Node *tsl_skip_scan_state_create(CustomScan *cscan);
 extern void _skip_scan_init(void);

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -85,13 +85,18 @@ tsl_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptIn
 			{
 				tsl_pushdown_partial_agg(root, ht, input_rel, output_rel, extra);
 			}
+
+			if (root->numOrderedAggs && !IS_DUMMY_REL(input_rel) && output_rel != NULL)
+			{
+				tsl_skip_scan_paths_add(root, input_rel, output_rel, stage);
+			}
 			break;
 		case UPPERREL_WINDOW:
 			if (IsA(linitial(input_rel->pathlist), CustomPath))
 				gapfill_adjust_window_targetlist(root, input_rel, output_rel);
 			break;
 		case UPPERREL_DISTINCT:
-			tsl_skip_scan_paths_add(root, input_rel, output_rel);
+			tsl_skip_scan_paths_add(root, input_rel, output_rel, stage);
 			break;
 		default:
 			break;

--- a/tsl/test/expected/decompress_index.out
+++ b/tsl/test/expected/decompress_index.out
@@ -95,6 +95,8 @@ select distinct on (device) device, time from :CHUNK order by 1, 2;
       2 | Mon May 18 00:00:01.013087 2020 PDT
 (2 rows)
 
+-- To avoid differences in PG15 output which doesn't support this feature
+SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
 -- check that the indexes are used
 explain (costs off) select count(distinct tag) from :CHUNK;
                                 QUERY PLAN                                
@@ -112,4 +114,5 @@ explain (costs off) select distinct on (device) device, time from :CHUNK order b
                Index Cond: (device > NULL::integer)
 (4 rows)
 
+RESET timescaledb.enable_skipscan_for_distinct_aggregates;
 drop table ht_metrics_compressed;

--- a/tsl/test/expected/plan_skip_scan_dagg.out
+++ b/tsl/test/expected/plan_skip_scan_dagg.out
@@ -1,0 +1,3139 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan set (autovacuum_enabled = off);
+alter table skip_scan_nulls set (autovacuum_enabled = off);
+alter table skip_scan_ht set (autovacuum_enabled = off);
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set TABLE skip_scan
+\ir include/skip_scan_dagg_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+(6 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+(6 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(6 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=2000 loops=1)
+         Sort Key: dev_name
+         Sort Method: quicksort 
+         ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
+               Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               Heap Blocks: exact=13
+               ->  Bitmap Index Scan on skip_scan_idx_hash (actual rows=2000 loops=1)
+                     Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(9 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Index Scan using skip_scan_expr_idx on skip_scan (actual rows=10022 loops=1)
+(2 rows)
+
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=4 loops=1)
+   Group Key: (dev % 3)
+   ->  Index Scan using skip_scan_expr_idx on skip_scan (actual rows=10022 loops=1)
+(3 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Sort (actual rows=12 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=12 loops=1)
+         Group Key: dev, count(DISTINCT dev)
+         Batches: 1 
+         ->  GroupAggregate (actual rows=12 loops=1)
+               Group Key: dev
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(12 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10022 loops=1)
+(2 rows)
+
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=10022 loops=1)
+(3 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, dev
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: (time_bucket(10, "time"))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: (length(dev_name))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: ((3 * "time"))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort (actual rows=12 loops=1)
+   Sort Key: ((dev + 1))
+   Sort Method: quicksort 
+   ->  GroupAggregate (actual rows=12 loops=1)
+         Group Key: dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(9 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1002 loops=1)
+   Group Key: "time"
+   ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=10022 loops=1)
+(4 rows)
+
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev, tableoid
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev, tableoid
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: dev_name, tableoid
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, tableoid
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+               Filter: (dev = 1)
+               Rows Removed by Filter: 9022
+(6 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=4 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(7 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+               ->  Index Only Scan Backward using skip_scan_dev_idx on skip_scan (actual rows=4 loops=1)
+                     Index Cond: (dev < NULL::integer)
+(7 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+(6 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1001 loops=1)
+   Group Key: "time"
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+(6 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  GroupAggregate (actual rows=12 loops=1)
+         Group Key: skip_scan.dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(7 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  GroupAggregate (actual rows=12 loops=1)
+         Group Key: skip_scan.dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(7 rows)
+
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  GroupAggregate (actual rows=12 loops=1)
+         Group Key: skip_scan.dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan Backward using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev < NULL::integer)
+(7 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: skip_scan.dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5))
+(7 rows)
+
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: skip_scan.dev
+         Filter: (sum(DISTINCT skip_scan.dev) > 2)
+         Rows Removed by Filter: 4
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(9 rows)
+
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: skip_scan.dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5))
+(7 rows)
+
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: skip_scan.dev
+         Filter: (sum(DISTINCT skip_scan.dev) > 2)
+         Rows Removed by Filter: 4
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(9 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=9 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > 1))
+(5 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=8 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=8 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > int_func_stable()))
+(5 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev = ANY (inta_func_stable())))
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Filter: (dev = ANY (inta_func_volatile()))
+               Rows Removed by Filter: 7022
+(7 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > 20))
+(5 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: (dev > 5)
+               Filter: ("time" > 200)
+               Rows Removed by Filter: 1000
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=2 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=2 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev >= 5) AND (dev < 7) AND (dev >= 2))
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=4 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=4 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+(5 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+(5 rows)
+
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1000 loops=1)
+         Index Cond: (dev = 1)
+(4 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1000 loops=1)
+         Index Cond: (dev = 1)
+(4 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=12 loops=1)
+   Group Key: skip_scan.dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(6 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Nested Loop (actual rows=20022 loops=1)
+               Join Filter: (skip_scan."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 22
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10022 loops=1)
+               ->  Materialize (actual rows=2 loops=10022)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(8 rows)
+
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (dev <> "*VALUES*".column1)
+                     Rows Removed by Filter: 1021
+(9 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= "*VALUES*".column1))
+(7 rows)
+
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=1002 loops=1)
+               ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan skip_scan_1 (actual rows=1002 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+(11 rows)
+
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=12 loops=1)
+   ->  GroupAggregate (actual rows=12 loops=1)
+         Group Key: skip_scan.dev
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+   ->  Aggregate (actual rows=1 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+(12 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=12 loops=1)
+         ->  GroupAggregate (actual rows=12 loops=1)
+               Group Key: skip_scan.dev
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(8 rows)
+
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+(5 rows)
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_dagg_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(9 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+(20 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+(20 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Index Cond: ("time" = 100)
+(5 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=2000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         Sort Method: quicksort 
+         ->  Append (actual rows=2000 loops=1)
+               ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_1_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_2_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_2_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_3_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_3_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_4_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_4_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(25 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: ((_hyper_1_1_chunk.dev % 3))
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_expr_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_expr_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_expr_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_expr_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(7 rows)
+
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=4 loops=1)
+   Group Key: ((_hyper_1_1_chunk.dev % 3))
+   ->  Result (actual rows=10020 loops=1)
+         ->  Merge Append (actual rows=10020 loops=1)
+               Sort Key: ((_hyper_1_1_chunk.dev % 3))
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_expr_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_expr_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_expr_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_expr_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(9 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_ht
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, count(DISTINCT _hyper_1_1_chunk.dev)
+         Batches: 1 
+         ->  GroupAggregate (actual rows=11 loops=1)
+               Group Key: _hyper_1_1_chunk.dev
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+(26 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_ht
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(7 rows)
+
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: (time_bucket(10, _hyper_1_1_chunk."time"))
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: (length(_hyper_1_1_chunk.dev_name))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: ((3 * _hyper_1_1_chunk."time"))
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: ((_hyper_1_1_chunk.dev + 1))
+   Sort Method: quicksort 
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(23 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1000 loops=1)
+   Group Key: _hyper_1_1_chunk."time"
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(12 rows)
+
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ GroupAggregate (actual rows=44 loops=1)
+   Group Key: _hyper_1_1_chunk.dev, skip_scan_ht.tableoid
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, skip_scan_ht.tableoid
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ GroupAggregate (actual rows=44 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name, skip_scan_ht.tableoid
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, skip_scan_ht.tableoid
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: _hyper_1_1_chunk.dev_name
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+(20 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_ht
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=13 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(21 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=13 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev DESC
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev < NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev < NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev < NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=4 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=4 loops=1)
+                           Index Cond: (dev < NULL::integer)
+(21 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_ht
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+(12 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+(6 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_4_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+(6 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan_ht
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1000 loops=1)
+   Group Key: _hyper_1_1_chunk."time"
+   ->  Merge Append (actual rows=1000 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+(20 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_ht
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(21 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev DESC
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev < NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev < NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev < NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev < NULL::integer)
+(21 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=20 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         Filter: (sum(DISTINCT _hyper_1_1_chunk.dev) > 2)
+         Rows Removed by Filter: 3
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(23 rows)
+
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=20 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > 5))
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         Filter: (sum(DISTINCT _hyper_1_1_chunk.dev) > 2)
+         Rows Removed by Filter: 3
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(23 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 1))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 1))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 1))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 1))
+(19 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=32 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=8 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > int_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=8 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > int_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=8 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > int_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=8 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev > int_func_stable()))
+(22 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev = ANY (inta_func_stable())))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev = ANY (inta_func_stable())))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev = ANY (inta_func_stable())))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: ((dev > NULL::integer) AND (dev = ANY (inta_func_stable())))
+(22 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+(30 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 20))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 20))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 20))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 20))
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+         Index Cond: (("time" = 100) AND (dev > 5))
+(4 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=0 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+               Rows Removed by Filter: 396
+(7 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+(19 rows)
+
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=1000 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+(14 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=1000 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+(14 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(20 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_1_1_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(13 rows)
+
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Merge Append (actual rows=36 loops=2)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 255
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 255
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 255
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
+                           Index Cond: (dev > NULL::integer)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 255
+(29 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Merge Append (actual rows=38 loops=2)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=2)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=2)
+                           Index Cond: ((dev > NULL::integer) AND (dev >= "*VALUES*".column1))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=2)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=10 loops=2)
+                           Index Cond: ((dev > NULL::integer) AND (dev >= "*VALUES*".column1))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=2)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=10 loops=2)
+                           Index Cond: ((dev > NULL::integer) AND (dev >= "*VALUES*".column1))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=2)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=10 loops=2)
+                           Index Cond: ((dev > NULL::integer) AND (dev >= "*VALUES*".column1))
+(21 rows)
+
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1000 loops=1)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=250 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=250 loops=1)
+                           Index Cond: ("time" > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=250 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=250 loops=1)
+                           Index Cond: ("time" > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=250 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=250 loops=1)
+                           Index Cond: ("time" > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=250 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=250 loops=1)
+                           Index Cond: ("time" > NULL::integer)
+(39 rows)
+
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+   ->  Aggregate (actual rows=1 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+(40 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  GroupAggregate (actual rows=11 loops=1)
+               Group Key: _hyper_1_1_chunk.dev
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 Index Cond: (dev > NULL::integer)
+(22 rows)
+
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+(5 rows)
+
+\ir include/skip_scan_dagg_query_ht.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(time);
+-- IndexPath without pathkeys doesnt use SkipScan
+EXPLAIN (costs off, timing off, summary off) SELECT count(DISTINCT 1) FROM pg_rewrite;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Aggregate
+   ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
+(2 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE where dev=1;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=1000 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=250 loops=1)
+               Index Cond: (dev = 1)
+(14 rows)
+
+-- SkipScan with ordered append
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE GROUP BY time ORDER BY time;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1000 loops=1)
+   Group Key: skip_scan_ht."time"
+   ->  Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=1000 loops=1)
+         Order: skip_scan_ht."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+(20 rows)
+
+--baseline query with skipscan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- compression doesnt prevent skipscan
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=2538 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(17 rows)
+
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+--baseline query with skipscan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- partial indexes don't prevent skipscan
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx1;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_time_idx;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=2538 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+

--- a/tsl/test/expected/skip_scan_dagg.out
+++ b/tsl/test/expected/skip_scan_dagg.out
@@ -1,0 +1,821 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to adjust statistics in load script
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\set TEST_BASE_NAME skip_scan
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_dagg_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_dagg_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNOPTIMIZED",
+    format('%s/results/%s_dagg_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_OPTIMIZED" \gset
+SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') AS "DIFF_CMD" \gset
+\ir :TEST_LOAD_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan set (autovacuum_enabled = off);
+alter table skip_scan_nulls set (autovacuum_enabled = off);
+alter table skip_scan_ht set (autovacuum_enabled = off);
+-- run tests on normal table and diff results
+\set TABLE skip_scan
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+\qecho ordered append on :TABLE
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+\qecho ordered append on :TABLE
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+RESET timescaledb.enable_skipscan_for_distinct_aggregates;
+-- compare SkipScan results on normal table
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_skipscan 
+ -----------------
+- off
++ on
+ (1 row)
+ 
+  count 
+-- run tests on hypertable and diff results
+\set TABLE skip_scan_ht
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+\qecho ordered append on :TABLE
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+\qecho ordered append on :TABLE
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+RESET timescaledb.enable_skipscan_for_distinct_aggregates;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_skipscan 
+ -----------------
+- off
++ on
+ (1 row)
+ 
+  count 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -175,8 +175,14 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
-  list(APPEND TEST_FILES cagg_planning.sql hypercore_parallel.sql
-       hypercore_vectoragg.sql)
+  list(
+    APPEND
+    TEST_FILES
+    cagg_planning.sql
+    hypercore_parallel.sql
+    hypercore_vectoragg.sql
+    skip_scan_dagg.sql
+    plan_skip_scan_dagg.sql)
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))

--- a/tsl/test/sql/decompress_index.sql
+++ b/tsl/test/sql/decompress_index.sql
@@ -53,10 +53,12 @@ select count(*) from :CHUNK;
 select count(distinct tag) from :CHUNK;
 select distinct on (device) device, time from :CHUNK order by 1, 2;
 
+-- To avoid differences in PG15 output which doesn't support this feature
+SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
 
 -- check that the indexes are used
 explain (costs off) select count(distinct tag) from :CHUNK;
 explain (costs off) select distinct on (device) device, time from :CHUNK order by 1, 2;
 
-
+RESET timescaledb.enable_skipscan_for_distinct_aggregates;
 drop table ht_metrics_compressed;

--- a/tsl/test/sql/include/skip_scan_dagg_query.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_query.sql
@@ -1,0 +1,224 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+DROP INDEX skip_scan_idx_time_dev_idx;
+
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IN ('device_1','device_2');
+DROP INDEX skip_scan_idx_hash;
+
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT count(DISTINCT dev%3) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev%3), dev%3 FROM :TABLE GROUP BY dev%3 ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT time_bucket(10,time)), 'q1_12' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT 3*time), 'q1_14' FROM :TABLE;
+
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+
+\qecho ordered append on :TABLE
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE WHERE time BETWEEN 0 AND 5000  GROUP BY time;
+
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev_name) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+
+--  DISTINCT aggs on different columns in different subqueries
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT time) FROM :TABLE;
+
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT time) ct FROM :TABLE WHERE dev = a.dev) b;
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+
+TRUNCATE skip_scan_insert;
+
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
+
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls WHERE time IS NOT NULL;
+

--- a/tsl/test/sql/include/skip_scan_dagg_query_ht.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_query_ht.sql
@@ -1,0 +1,32 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(time);
+
+-- IndexPath without pathkeys doesnt use SkipScan
+EXPLAIN (costs off, timing off, summary off) SELECT count(DISTINCT 1) FROM pg_rewrite;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE where dev=1;
+
+-- SkipScan with ordered append
+:PREFIX SELECT count(DISTINCT time), time FROM :TABLE GROUP BY time ORDER BY time;
+
+--baseline query with skipscan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+
+-- compression doesnt prevent skipscan
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+
+--baseline query with skipscan
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+
+-- partial indexes don't prevent skipscan
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx1;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_time_idx;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;

--- a/tsl/test/sql/plan_skip_scan_dagg.sql
+++ b/tsl/test/sql/plan_skip_scan_dagg.sql
@@ -1,0 +1,18 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set TABLE skip_scan
+\ir include/skip_scan_dagg_query.sql
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_dagg_query.sql
+\ir include/skip_scan_dagg_query_ht.sql
+
+

--- a/tsl/test/sql/skip_scan_dagg.sql
+++ b/tsl/test/sql/skip_scan_dagg.sql
@@ -1,0 +1,49 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- need superuser to adjust statistics in load script
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+
+\set TEST_BASE_NAME skip_scan
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_dagg_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_dagg_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNOPTIMIZED",
+    format('%s/results/%s_dagg_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_OPTIMIZED" \gset
+
+SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') AS "DIFF_CMD" \gset
+
+\ir :TEST_LOAD_NAME
+
+-- run tests on normal table and diff results
+\set TABLE skip_scan
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+RESET timescaledb.enable_skipscan_for_distinct_aggregates;
+
+-- compare SkipScan results on normal table
+:DIFF_CMD
+
+-- run tests on hypertable and diff results
+\set TABLE skip_scan_ht
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+RESET timescaledb.enable_skipscan_for_distinct_aggregates;
+
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+


### PR DESCRIPTION
Implement SkipScan for eligible distinct aggregates, see https://github.com/timescale/eng-database/issues/692.

We now allow for distinct upper path to also be an AggPath with aggregates which are all distinct and all have the same input column. 

The tests for correct values and correct plans were mostly copied from `skip_scan_query.sql` and `skip_scan_query_ht.sql` and modified to use Distinct aggregates instead of `SELECT DISTINCT`.

SkipScan planner was refactored to allow for different kinds of upper distinct paths.

The parts which need improving:
- _Compute cost for the new AggPath. Right now AggClauseCosts are set to 0 while new cost over new SkipScan input into distinct aggregates is applied to new AggPath. I'm not sure if we want to fully recreate old AggPath at this point, we just need to give it a new SkipScan-based input path and adjust the cost._   - Done.
- _Should we allow for expressions over Distinct aggregates? We should for something like `SELECT count(DISTINCT index_col) +1 FROM t`_  -Done.