### PR TITLE
Remove blocker for unique constraints with ADD COLUMN

### DIFF
--- a/.unreleased/pr_7877
+++ b/.unreleased/pr_7877
@@ -1,0 +1,1 @@
+Implements: #7877 Remove blocker for unique constraints with ADD COLUMN

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -328,6 +328,14 @@ check_altertable_add_column_for_compressed(Hypertable *ht, ColumnDef *col)
 			switch (constraint->contype)
 			{
 				/*
+				 * These will fail in combination with ADD COLUMN because this will
+				 * be a single column constraint and we require all partitioning
+				 * columns to be part if the unique/primary key constraint.
+				 */
+				case CONSTR_PRIMARY:
+				case CONSTR_UNIQUE:
+					break;
+				/*
 				 * We can safelly ignore NULL constraints because it does nothing
 				 * and according to Postgres docs is useless and exist just for
 				 * compatibility with other database systems

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -366,9 +366,11 @@ alter table table_constr drop constraint table_constr_exclu ;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');
 -- ddl ADD column variants that are not supported
 ALTER TABLE table_constr ADD COLUMN newcol integer UNIQUE;
-ERROR:  cannot add column with constraints to a hypertable that has compression enabled
+ERROR:  cannot create a unique index without the column "timec" (used in partitioning)
+HINT:  If you're creating a hypertable on a table with a primary key, ensure the partitioning column is part of the primary or composite key.
 ALTER TABLE table_constr ADD COLUMN newcol integer PRIMARY KEY;
-ERROR:  cannot add column with constraints to a hypertable that has compression enabled
+ERROR:  cannot create a unique index without the column "timec" (used in partitioning)
+HINT:  If you're creating a hypertable on a table with a primary key, ensure the partitioning column is part of the primary or composite key.
 ALTER TABLE table_constr ADD COLUMN newcol integer NOT NULL;
 ERROR:  cannot add column with NOT NULL constraint without default to a hypertable that has compression enabled
 ALTER TABLE table_constr ADD COLUMN newcol integer DEFAULT random() + random();


### PR DESCRIPTION
Remove special handling for ADD COLUMN with unique/primary key
constraints on compressed hypertables. This patch makes the behaviour
consistent with uncompressed hypertable where ADD COLUMN with unique/
primary key constraint is blocked because those constraints require
all partitioning columns to be included.
