### PR TITLE
Don't block non-immutable functions in caggs

### DIFF
--- a/.unreleased/pr_7878
+++ b/.unreleased/pr_7878
@@ -1,0 +1,1 @@
+Implements: #7878 Don't block non-immutable functions in continuous aggregates

--- a/tsl/src/continuous_aggs/finalize.c
+++ b/tsl/src/continuous_aggs/finalize.c
@@ -236,13 +236,9 @@ mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input, int original_q
 
 	if (contain_mutable_functions(input))
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("only immutable functions supported in continuous aggregate view"),
-				 errhint("Make sure all functions in the continuous aggregate definition"
-						 " have IMMUTABLE volatility. Note that functions or expressions"
-						 " may be IMMUTABLE for one data type, but STABLE or VOLATILE for"
-						 " another.")));
+		ereport(WARNING,
+				(errmsg("using non-immutable functions in continuous aggregate view may lead to "
+						"inconsistent results on rematerialization")));
 	}
 
 	switch (nodeTag(input))

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2160,3 +2160,34 @@ SELECT column_name, time_interval FROM timescaledb_information.dimensions WHERE 
  cagg_interval_setter | @ 360 days
 (1 row)
 
+-- test cagg with stable functions
+CREATE MATERIALIZED VIEW cagg_stable WITH (tsdb.continuous) AS
+SELECT sum(temperature), max(time + INTERVAL '1h')
+FROM conditions
+GROUP BY time_bucket('1week', time), location;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+NOTICE:  refreshing continuous aggregate "cagg_stable"
+SELECT * FROM cagg_stable t ORDER BY t;
+ sum |             max              
+-----+------------------------------
+  65 | Tue Jan 02 10:10:00 2018 UTC
+ 100 | Tue Jan 02 10:30:00 2018 UTC
+ 120 | Tue Jan 02 10:20:00 2018 UTC
+ 355 | Fri Nov 02 11:30:00 2018 UTC
+(4 rows)
+
+--aggregate without combine function but stable function
+CREATE MATERIALIZED VIEW cagg_json_agg WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT json_agg(location) from conditions group by time_bucket('1week', time), location WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql' STABLE AS 'SELECT $1 + 10';
+CREATE MATERIALIZED VIEW cagg_stable2 WITH (tsdb.continuous) AS
+SELECT sum(test_stablefunc(temperature::int)), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time) WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+CREATE MATERIALIZED VIEW cagg_stable3 WITH (tsdb.continuous) AS
+SELECT sum(temperature), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2160,3 +2160,34 @@ SELECT column_name, time_interval FROM timescaledb_information.dimensions WHERE 
  cagg_interval_setter | @ 360 days
 (1 row)
 
+-- test cagg with stable functions
+CREATE MATERIALIZED VIEW cagg_stable WITH (tsdb.continuous) AS
+SELECT sum(temperature), max(time + INTERVAL '1h')
+FROM conditions
+GROUP BY time_bucket('1week', time), location;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+NOTICE:  refreshing continuous aggregate "cagg_stable"
+SELECT * FROM cagg_stable t ORDER BY t;
+ sum |             max              
+-----+------------------------------
+  65 | Tue Jan 02 10:10:00 2018 UTC
+ 100 | Tue Jan 02 10:30:00 2018 UTC
+ 120 | Tue Jan 02 10:20:00 2018 UTC
+ 355 | Fri Nov 02 11:30:00 2018 UTC
+(4 rows)
+
+--aggregate without combine function but stable function
+CREATE MATERIALIZED VIEW cagg_json_agg WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT json_agg(location) from conditions group by time_bucket('1week', time), location WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql' STABLE AS 'SELECT $1 + 10';
+CREATE MATERIALIZED VIEW cagg_stable2 WITH (tsdb.continuous) AS
+SELECT sum(test_stablefunc(temperature::int)), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time) WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+CREATE MATERIALIZED VIEW cagg_stable3 WITH (tsdb.continuous) AS
+SELECT sum(temperature), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -2160,3 +2160,34 @@ SELECT column_name, time_interval FROM timescaledb_information.dimensions WHERE 
  cagg_interval_setter | @ 360 days
 (1 row)
 
+-- test cagg with stable functions
+CREATE MATERIALIZED VIEW cagg_stable WITH (tsdb.continuous) AS
+SELECT sum(temperature), max(time + INTERVAL '1h')
+FROM conditions
+GROUP BY time_bucket('1week', time), location;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+NOTICE:  refreshing continuous aggregate "cagg_stable"
+SELECT * FROM cagg_stable t ORDER BY t;
+ sum |             max              
+-----+------------------------------
+  65 | Tue Jan 02 10:10:00 2018 UTC
+ 100 | Tue Jan 02 10:30:00 2018 UTC
+ 120 | Tue Jan 02 10:20:00 2018 UTC
+ 355 | Fri Nov 02 11:30:00 2018 UTC
+(4 rows)
+
+--aggregate without combine function but stable function
+CREATE MATERIALIZED VIEW cagg_json_agg WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT json_agg(location) from conditions group by time_bucket('1week', time), location WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql' STABLE AS 'SELECT $1 + 10';
+CREATE MATERIALIZED VIEW cagg_stable2 WITH (tsdb.continuous) AS
+SELECT sum(test_stablefunc(temperature::int)), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time) WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+CREATE MATERIALIZED VIEW cagg_stable3 WITH (tsdb.continuous) AS
+SELECT sum(temperature), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -103,15 +103,6 @@ from conditions
  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  Window functions are not supported by continuous aggregates.
---aggregate without combine function but stable function
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select json_agg(location)
-from conditions
- group by time_bucket('1week', timec) , location WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-;
 -- using subqueries
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
@@ -223,30 +214,6 @@ group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
 HINT:  Define multiple continuous aggregates with different grouping levels.
---NO immutable functions -- check all clauses
-CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
-       STABLE AS 'SELECT $1 + 10';
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select sum(humidity), max(timec + INTERVAL '1h')
-from conditions
-group by time_bucket('1week', timec) , location   WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select sum( test_stablefunc(humidity::int) ), min(location)
-from conditions
-group by time_bucket('1week', timec) WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select sum( temperature ), min(location)
-from conditions
-group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
 CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 week', timec)

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -174,30 +174,10 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 --
 -- Dealing with timezones
 --
--- You cannot use any functions that depend on the local timezone setting inside a continuous aggregate.
--- For example you cannot cast to the local time. This is because
--- a timezone setting can alter from user-to-user and thus
--- cannot be materialized.
-DROP MATERIALIZED VIEW device_summary;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
-CREATE MATERIALIZED VIEW device_summary
-WITH (timescaledb.continuous, timescaledb.materialized_only=true)
-AS
-SELECT
-  time_bucket('1 hour', observation_time) as bucket,
-  min(observation_time::timestamp) as min_time, --note the cast to localtime
-  device_id,
-  avg(metric) as metric_avg,
-  max(metric)-min(metric) as metric_spread
-FROM
-  device_readings
-GROUP BY bucket, device_id WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
---note the error.
--- You have two options:
+-- You have three options:
 -- Option 1: be explicit in your timezone:
 DROP MATERIALIZED VIEW device_summary;
-ERROR:  materialized view "device_summary" does not exist
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
 CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
@@ -234,6 +214,24 @@ SELECT min(min_time)::timestamp FROM device_summary;
  Sat Dec 01 00:00:00 2018
 (1 row)
 
+-- Option 3: use stable expressions in the cagg definition
+-- in this case it is up to the user to ensure cagg refreshes
+-- run with consistent values
+DROP MATERIALIZED VIEW device_summary;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_7_chunk
+CREATE MATERIALIZED VIEW device_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  min(observation_time::timestamp) as min_time, --note the cast to localtime
+  device_id,
+  avg(metric) as metric_avg,
+  max(metric)-min(metric) as metric_spread
+FROM
+  device_readings
+GROUP BY bucket, device_id WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
 --
 -- test just in time aggregate / materialization only view
 --
@@ -248,7 +246,7 @@ SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
- (5,public,device_readings_int,t)
+ (6,public,device_readings_int,t)
 (1 row)
 
 SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
@@ -366,7 +364,7 @@ CREATE TABLE whatever(time TIMESTAMPTZ NOT NULL, metric INTEGER);
 SELECT * FROM create_hypertable('whatever', 'time');
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-             8 | public      | whatever   | t
+             9 | public      | whatever   | t
 (1 row)
 
 CREATE MATERIALIZED VIEW whatever_summary WITH (timescaledb.continuous) AS
@@ -381,9 +379,9 @@ SELECT (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'whatever_summary' \gset
 SELECT relname FROM pg_class WHERE oid = :mat_table;
-          relname           
-----------------------------
- _materialized_hypertable_9
+           relname           
+-----------------------------
+ _materialized_hypertable_10
 (1 row)
 
 ----------------------------------------------------------------
@@ -437,18 +435,6 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 INSERT INTO metrics SELECT generate_series('1999-12-20'::timestamptz,'2000-02-01'::timestamptz,'12 day'::interval), 'dev1', 0.25;
-SELECT current_setting('timezone');
- current_setting 
------------------
- PST8PDT
-(1 row)
-
--- should be blocked because non-immutable expression
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
-SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
-ERROR:  only immutable expressions allowed in time bucket function
-\set ON_ERROR_STOP 1
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
 SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
@@ -505,10 +491,10 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_17_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | f       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
@@ -525,7 +511,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_17_chunk
+ _timescaledb_internal._hyper_12_17_chunk
 (1 row)
 
 -- should return 3 chunks
@@ -537,9 +523,9 @@ WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | f       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (3 rows)
 
 -- let's update the catalog to fake an old format cagg (finalized=false)
@@ -561,7 +547,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_18_chunk
+ _timescaledb_internal._hyper_12_18_chunk
 (1 row)
 
 -- should return 3 chunks and one of them should be marked as dropped
@@ -573,14 +559,14 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | t       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | t       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (3 rows)
 
 -- remove the fake old format cagg
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_21_chunk
 -- no more old format caggs (finalized=false)
 SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
@@ -594,7 +580,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_19_chunk
+ _timescaledb_internal._hyper_12_19_chunk
 (1 row)
 
 -- should return 2 chunks and one of them should be marked as dropped
@@ -607,7 +593,7 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | t       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | t       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (2 rows)
 

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -174,30 +174,10 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 --
 -- Dealing with timezones
 --
--- You cannot use any functions that depend on the local timezone setting inside a continuous aggregate.
--- For example you cannot cast to the local time. This is because
--- a timezone setting can alter from user-to-user and thus
--- cannot be materialized.
-DROP MATERIALIZED VIEW device_summary;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
-CREATE MATERIALIZED VIEW device_summary
-WITH (timescaledb.continuous, timescaledb.materialized_only=true)
-AS
-SELECT
-  time_bucket('1 hour', observation_time) as bucket,
-  min(observation_time::timestamp) as min_time, --note the cast to localtime
-  device_id,
-  avg(metric) as metric_avg,
-  max(metric)-min(metric) as metric_spread
-FROM
-  device_readings
-GROUP BY bucket, device_id WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
---note the error.
--- You have two options:
+-- You have three options:
 -- Option 1: be explicit in your timezone:
 DROP MATERIALIZED VIEW device_summary;
-ERROR:  materialized view "device_summary" does not exist
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
 CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
@@ -234,6 +214,24 @@ SELECT min(min_time)::timestamp FROM device_summary;
  Sat Dec 01 00:00:00 2018
 (1 row)
 
+-- Option 3: use stable expressions in the cagg definition
+-- in this case it is up to the user to ensure cagg refreshes
+-- run with consistent values
+DROP MATERIALIZED VIEW device_summary;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_7_chunk
+CREATE MATERIALIZED VIEW device_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  min(observation_time::timestamp) as min_time, --note the cast to localtime
+  device_id,
+  avg(metric) as metric_avg,
+  max(metric)-min(metric) as metric_spread
+FROM
+  device_readings
+GROUP BY bucket, device_id WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
 --
 -- test just in time aggregate / materialization only view
 --
@@ -248,7 +246,7 @@ SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
- (5,public,device_readings_int,t)
+ (6,public,device_readings_int,t)
 (1 row)
 
 SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
@@ -366,7 +364,7 @@ CREATE TABLE whatever(time TIMESTAMPTZ NOT NULL, metric INTEGER);
 SELECT * FROM create_hypertable('whatever', 'time');
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-             8 | public      | whatever   | t
+             9 | public      | whatever   | t
 (1 row)
 
 CREATE MATERIALIZED VIEW whatever_summary WITH (timescaledb.continuous) AS
@@ -381,9 +379,9 @@ SELECT (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'whatever_summary' \gset
 SELECT relname FROM pg_class WHERE oid = :mat_table;
-          relname           
-----------------------------
- _materialized_hypertable_9
+           relname           
+-----------------------------
+ _materialized_hypertable_10
 (1 row)
 
 ----------------------------------------------------------------
@@ -437,18 +435,6 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 INSERT INTO metrics SELECT generate_series('1999-12-20'::timestamptz,'2000-02-01'::timestamptz,'12 day'::interval), 'dev1', 0.25;
-SELECT current_setting('timezone');
- current_setting 
------------------
- PST8PDT
-(1 row)
-
--- should be blocked because non-immutable expression
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
-SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
-ERROR:  only immutable expressions allowed in time bucket function
-\set ON_ERROR_STOP 1
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
 SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
@@ -505,10 +491,10 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_17_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | f       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
@@ -525,7 +511,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_17_chunk
+ _timescaledb_internal._hyper_12_17_chunk
 (1 row)
 
 -- should return 3 chunks
@@ -537,9 +523,9 @@ WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | f       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (3 rows)
 
 -- let's update the catalog to fake an old format cagg (finalized=false)
@@ -561,7 +547,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_18_chunk
+ _timescaledb_internal._hyper_12_18_chunk
 (1 row)
 
 -- should return 3 chunks and one of them should be marked as dropped
@@ -573,14 +559,14 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | t       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | t       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (3 rows)
 
 -- remove the fake old format cagg
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_21_chunk
 -- no more old format caggs (finalized=false)
 SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
@@ -594,7 +580,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_19_chunk
+ _timescaledb_internal._hyper_12_19_chunk
 (1 row)
 
 -- should return 2 chunks and one of them should be marked as dropped
@@ -607,7 +593,7 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | t       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | t       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (2 rows)
 

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -174,30 +174,10 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 --
 -- Dealing with timezones
 --
--- You cannot use any functions that depend on the local timezone setting inside a continuous aggregate.
--- For example you cannot cast to the local time. This is because
--- a timezone setting can alter from user-to-user and thus
--- cannot be materialized.
-DROP MATERIALIZED VIEW device_summary;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
-CREATE MATERIALIZED VIEW device_summary
-WITH (timescaledb.continuous, timescaledb.materialized_only=true)
-AS
-SELECT
-  time_bucket('1 hour', observation_time) as bucket,
-  min(observation_time::timestamp) as min_time, --note the cast to localtime
-  device_id,
-  avg(metric) as metric_avg,
-  max(metric)-min(metric) as metric_spread
-FROM
-  device_readings
-GROUP BY bucket, device_id WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
---note the error.
--- You have two options:
+-- You have three options:
 -- Option 1: be explicit in your timezone:
 DROP MATERIALIZED VIEW device_summary;
-ERROR:  materialized view "device_summary" does not exist
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
 CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
@@ -234,6 +214,24 @@ SELECT min(min_time)::timestamp FROM device_summary;
  Sat Dec 01 00:00:00 2018
 (1 row)
 
+-- Option 3: use stable expressions in the cagg definition
+-- in this case it is up to the user to ensure cagg refreshes
+-- run with consistent values
+DROP MATERIALIZED VIEW device_summary;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_7_chunk
+CREATE MATERIALIZED VIEW device_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  min(observation_time::timestamp) as min_time, --note the cast to localtime
+  device_id,
+  avg(metric) as metric_avg,
+  max(metric)-min(metric) as metric_spread
+FROM
+  device_readings
+GROUP BY bucket, device_id WITH NO DATA;
+WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
 --
 -- test just in time aggregate / materialization only view
 --
@@ -248,7 +246,7 @@ SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
- (5,public,device_readings_int,t)
+ (6,public,device_readings_int,t)
 (1 row)
 
 SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
@@ -366,7 +364,7 @@ CREATE TABLE whatever(time TIMESTAMPTZ NOT NULL, metric INTEGER);
 SELECT * FROM create_hypertable('whatever', 'time');
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-             8 | public      | whatever   | t
+             9 | public      | whatever   | t
 (1 row)
 
 CREATE MATERIALIZED VIEW whatever_summary WITH (timescaledb.continuous) AS
@@ -381,9 +379,9 @@ SELECT (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'whatever_summary' \gset
 SELECT relname FROM pg_class WHERE oid = :mat_table;
-          relname           
-----------------------------
- _materialized_hypertable_9
+           relname           
+-----------------------------
+ _materialized_hypertable_10
 (1 row)
 
 ----------------------------------------------------------------
@@ -437,18 +435,6 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 INSERT INTO metrics SELECT generate_series('1999-12-20'::timestamptz,'2000-02-01'::timestamptz,'12 day'::interval), 'dev1', 0.25;
-SELECT current_setting('timezone');
- current_setting 
------------------
- PST8PDT
-(1 row)
-
--- should be blocked because non-immutable expression
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
-SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
-ERROR:  only immutable expressions allowed in time bucket function
-\set ON_ERROR_STOP 1
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
 SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
@@ -505,10 +491,10 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_17_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | f       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
@@ -525,7 +511,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_17_chunk
+ _timescaledb_internal._hyper_12_17_chunk
 (1 row)
 
 -- should return 3 chunks
@@ -537,9 +523,9 @@ WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | f       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (3 rows)
 
 -- let's update the catalog to fake an old format cagg (finalized=false)
@@ -561,7 +547,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_18_chunk
+ _timescaledb_internal._hyper_12_18_chunk
 (1 row)
 
 -- should return 3 chunks and one of them should be marked as dropped
@@ -573,14 +559,14 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | t       |        
- _hyper_11_19_chunk |            0 | f       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | t       |        
+ _hyper_12_19_chunk |            0 | f       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (3 rows)
 
 -- remove the fake old format cagg
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_21_chunk
 -- no more old format caggs (finalized=false)
 SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
@@ -594,7 +580,7 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_19_chunk
+ _timescaledb_internal._hyper_12_19_chunk
 (1 row)
 
 -- should return 2 chunks and one of them should be marked as dropped
@@ -607,7 +593,7 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | t       |        
- _hyper_11_20_chunk |            0 | f       |        
+ _hyper_12_18_chunk |            0 | t       |        
+ _hyper_12_20_chunk |            0 | f       |        
 (2 rows)
 

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1373,3 +1373,28 @@ SELECT column_name, time_interval FROM timescaledb_information.dimensions WHERE 
 
 ALTER MATERIALIZED VIEW cagg_set SET (tsdb.chunk_time_interval='1 year');
 SELECT column_name, time_interval FROM timescaledb_information.dimensions WHERE column_name='cagg_interval_setter';
+
+-- test cagg with stable functions
+CREATE MATERIALIZED VIEW cagg_stable WITH (tsdb.continuous) AS
+SELECT sum(temperature), max(time + INTERVAL '1h')
+FROM conditions
+GROUP BY time_bucket('1week', time), location;
+
+SELECT * FROM cagg_stable t ORDER BY t;
+
+--aggregate without combine function but stable function
+CREATE MATERIALIZED VIEW cagg_json_agg WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT json_agg(location) from conditions group by time_bucket('1week', time), location WITH NO DATA;
+
+CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql' STABLE AS 'SELECT $1 + 10';
+
+CREATE MATERIALIZED VIEW cagg_stable2 WITH (tsdb.continuous) AS
+SELECT sum(test_stablefunc(temperature::int)), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time) WITH NO DATA;
+
+CREATE MATERIALIZED VIEW cagg_stable3 WITH (tsdb.continuous) AS
+SELECT sum(temperature), min(location)
+FROM conditions
+GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
+

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -97,14 +97,6 @@ Select avg(temperature) over( order by humidity)
 from conditions
  WITH NO DATA;
 
---aggregate without combine function but stable function
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select json_agg(location)
-from conditions
- group by time_bucket('1week', timec) , location WITH NO DATA;
-;
-
 -- using subqueries
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
@@ -202,28 +194,6 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
 group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
-
---NO immutable functions -- check all clauses
-CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
-       STABLE AS 'SELECT $1 + 10';
-
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select sum(humidity), max(timec + INTERVAL '1h')
-from conditions
-group by time_bucket('1week', timec) , location   WITH NO DATA;
-
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select sum( test_stablefunc(humidity::int) ), min(location)
-from conditions
-group by time_bucket('1week', timec) WITH NO DATA;
-
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
-AS
-Select sum( temperature ), min(location)
-from conditions
-group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
 
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
 CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -97,28 +97,7 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 --
 -- Dealing with timezones
 --
-
--- You cannot use any functions that depend on the local timezone setting inside a continuous aggregate.
--- For example you cannot cast to the local time. This is because
--- a timezone setting can alter from user-to-user and thus
--- cannot be materialized.
-
-DROP MATERIALIZED VIEW device_summary;
-CREATE MATERIALIZED VIEW device_summary
-WITH (timescaledb.continuous, timescaledb.materialized_only=true)
-AS
-SELECT
-  time_bucket('1 hour', observation_time) as bucket,
-  min(observation_time::timestamp) as min_time, --note the cast to localtime
-  device_id,
-  avg(metric) as metric_avg,
-  max(metric)-min(metric) as metric_spread
-FROM
-  device_readings
-GROUP BY bucket, device_id WITH NO DATA;
---note the error.
-
--- You have two options:
+-- You have three options:
 -- Option 1: be explicit in your timezone:
 
 DROP MATERIALIZED VIEW device_summary;
@@ -154,6 +133,23 @@ FROM
 GROUP BY bucket, device_id WITH DATA;
 
 SELECT min(min_time)::timestamp FROM device_summary;
+
+-- Option 3: use stable expressions in the cagg definition
+-- in this case it is up to the user to ensure cagg refreshes
+-- run with consistent values
+DROP MATERIALIZED VIEW device_summary;
+CREATE MATERIALIZED VIEW device_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  min(observation_time::timestamp) as min_time, --note the cast to localtime
+  device_id,
+  avg(metric) as metric_avg,
+  max(metric)-min(metric) as metric_spread
+FROM
+  device_readings
+GROUP BY bucket, device_id WITH NO DATA;
 
 --
 -- test just in time aggregate / materialization only view
@@ -288,14 +284,6 @@ DROP TABLE sensor_data;
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');
 INSERT INTO metrics SELECT generate_series('1999-12-20'::timestamptz,'2000-02-01'::timestamptz,'12 day'::interval), 'dev1', 0.25;
-
-SELECT current_setting('timezone');
-
--- should be blocked because non-immutable expression
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
-SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
-\set ON_ERROR_STOP 1
 
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
 SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;


### PR DESCRIPTION
Throw a warning when we encounter non-immutable functions in cagg
definition instead of blocking it.