### PR TITLE
Add experimental support for window functions in caggs

### DIFF
--- a/.unreleased/pr_7880
+++ b/.unreleased/pr_7880
@@ -1,0 +1,1 @@
+Implements: #7880 Add experimental support for window functions in caggs

--- a/src/guc.c
+++ b/src/guc.c
@@ -128,6 +128,7 @@ bool ts_guc_enable_runtime_exclusion = true;
 bool ts_guc_enable_constraint_exclusion = true;
 bool ts_guc_enable_qual_propagation = true;
 bool ts_guc_enable_cagg_reorder_groupby = true;
+TSDLLEXPORT bool ts_guc_enable_cagg_window_functions = false;
 bool ts_guc_enable_now_constify = true;
 bool ts_guc_enable_foreign_key_propagation = true;
 #if PG16_GE
@@ -696,6 +697,17 @@ _guc_init(void)
 							 "Enable group by clause reordering for continuous aggregates",
 							 &ts_guc_enable_cagg_reorder_groupby,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_cagg_window_functions"),
+							 "Enable window functions in continuous aggregates",
+							 "Allow window functions in continuous aggregate views",
+							 &ts_guc_enable_cagg_window_functions,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -41,6 +41,7 @@ extern bool ts_guc_enable_qual_propagation;
 extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;
+extern TSDLLEXPORT bool ts_guc_enable_cagg_window_functions;
 extern TSDLLEXPORT int ts_guc_cagg_max_individual_materializations;
 extern bool ts_guc_enable_now_constify;
 extern bool ts_guc_enable_foreign_key_propagation;

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -517,9 +517,20 @@ cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail, con
 
 	if (query->hasWindowFuncs)
 	{
-		appendStringInfoString(detail,
-							   "Window functions are not supported by continuous aggregates.");
-		return false;
+		if (ts_guc_enable_cagg_window_functions)
+		{
+			elog(WARNING,
+				 "window function support is experimental and may result in unexpected results "
+				 "depending on the functions used.");
+		}
+		else
+		{
+			appendStringInfoString(detail, "Window function support not enabled.");
+			appendStringInfoString(hint,
+								   "Enable experimental window function support by setting "
+								   "timescaledb.enable_cagg_window_functions.");
+			return false;
+		}
 	}
 
 	if (query->hasDistinctOn || query->distinctClause)

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2191,3 +2191,27 @@ SELECT sum(temperature), min(location)
 FROM conditions
 GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
 WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+-- test window functions in caggs
+-- first do sanity check that we error without the GUC
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW cagg_window WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+ERROR:  invalid continuous aggregate query
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_cagg_window_functions TO on;
+CREATE MATERIALIZED VIEW cagg_window_1 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_1"
+CREATE MATERIALIZED VIEW cagg_window_2 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time), location) FROM conditions GROUP BY 1, location;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_2"
+CREATE MATERIALIZED VIEW cagg_window_3 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1, location;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_3"
+CREATE MATERIALIZED VIEW cagg_window_4 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER w FROM conditions GROUP BY 1, location WINDOW w AS (PARTITION BY time_bucket('1 week',time));
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_4"

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2191,3 +2191,27 @@ SELECT sum(temperature), min(location)
 FROM conditions
 GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
 WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+-- test window functions in caggs
+-- first do sanity check that we error without the GUC
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW cagg_window WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+ERROR:  invalid continuous aggregate query
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_cagg_window_functions TO on;
+CREATE MATERIALIZED VIEW cagg_window_1 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_1"
+CREATE MATERIALIZED VIEW cagg_window_2 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time), location) FROM conditions GROUP BY 1, location;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_2"
+CREATE MATERIALIZED VIEW cagg_window_3 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1, location;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_3"
+CREATE MATERIALIZED VIEW cagg_window_4 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER w FROM conditions GROUP BY 1, location WINDOW w AS (PARTITION BY time_bucket('1 week',time));
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_4"

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -2191,3 +2191,27 @@ SELECT sum(temperature), min(location)
 FROM conditions
 GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
 WARNING:  using non-immutable functions in continuous aggregate view may lead to inconsistent results on rematerialization
+-- test window functions in caggs
+-- first do sanity check that we error without the GUC
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW cagg_window WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+ERROR:  invalid continuous aggregate query
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_cagg_window_functions TO on;
+CREATE MATERIALIZED VIEW cagg_window_1 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_1"
+CREATE MATERIALIZED VIEW cagg_window_2 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time), location) FROM conditions GROUP BY 1, location;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_2"
+CREATE MATERIALIZED VIEW cagg_window_3 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1, location;
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_3"
+CREATE MATERIALIZED VIEW cagg_window_4 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER w FROM conditions GROUP BY 1, location WINDOW w AS (PARTITION BY time_bucket('1 week',time));
+WARNING:  window function support is experimental and may result in unexpected results depending on the functions used.
+NOTICE:  refreshing continuous aggregate "cagg_window_4"

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -102,7 +102,8 @@ Select avg(temperature) over( order by humidity)
 from conditions
  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
-DETAIL:  Window functions are not supported by continuous aggregates.
+DETAIL:  Window function support not enabled.
+HINT:  Enable experimental window function support by setting timescaledb.enable_cagg_window_functions.
 -- using subqueries
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1398,3 +1398,23 @@ SELECT sum(temperature), min(location)
 FROM conditions
 GROUP BY time_bucket('1week', time), test_stablefunc(temperature::int) WITH NO DATA;
 
+-- test window functions in caggs
+-- first do sanity check that we error without the GUC
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW cagg_window WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_cagg_window_functions TO on;
+CREATE MATERIALIZED VIEW cagg_window_1 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1;
+
+CREATE MATERIALIZED VIEW cagg_window_2 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time), location) FROM conditions GROUP BY 1, location;
+
+CREATE MATERIALIZED VIEW cagg_window_3 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER (PARTITION BY time_bucket('1 week',time)) FROM conditions GROUP BY 1, location;
+
+CREATE MATERIALIZED VIEW cagg_window_4 WITH (tsdb.continuous)
+AS SELECT time_bucket('1week', time), rank() OVER w FROM conditions GROUP BY 1, location WINDOW w AS (PARTITION BY time_bucket('1 week',time));
+


### PR DESCRIPTION
This patch adds a GUC to allow window functions in continuous
aggregate view definitions. The GUC is turned off by default.
