### PR TITLE
Flush error state before doing anything else

### DIFF
--- a/.unreleased/pr_7890
+++ b/.unreleased/pr_7890
@@ -1,0 +1,1 @@
+Fixes: #7890 Flush error state before doing anything else

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1251,6 +1251,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 		MemoryContextSwitchTo(oldcontext);
 		job_failed = true;
 		edata = CopyErrorData();
+		FlushErrorState();
 
 		/*
 		 * Note that the mark_start happens in the scheduler right before the
@@ -1286,7 +1287,6 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 		elog(LOG, "job %d threw an error", params.job_id);
 
 		CommitTransactionCommand();
-		FlushErrorState();
 		ReThrowError(edata);
 	}
 	PG_END_TRY();

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -411,11 +411,12 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 		MemoryContextSwitchTo(oldctx);
 		CurrentResourceOwner = oldowner;
 		ErrorData *errdata = CopyErrorData();
+		FlushErrorState();
 		ereport(LOG,
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("could not calculate next start on failure: resetting value"),
 				 errdetail("Error: %s.", errdata->message)));
-		FlushErrorState();
+		FreeErrorData(errdata);
 	}
 	PG_END_TRY();
 	Assert(CurrentMemoryContext == oldctx);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3899,9 +3899,9 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 		ErrorData *edata;
 		MemoryContextSwitchTo(oldcontext);
 		edata = CopyErrorData();
+		FlushErrorState();
 		if (edata->sqlerrcode == ERRCODE_LOCK_NOT_AVAILABLE)
 		{
-			FlushErrorState();
 			edata->detail = edata->message;
 			edata->message =
 				psprintf("some chunks could not be read since they are being concurrently updated");

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -1184,6 +1184,7 @@ ts_telemetry_main(const char *host, const char *path, const char *service)
 		/* If the response is malformed, ts_check_version_response() will
 		 * throw an error, so we capture the error here and print debugging
 		 * information. */
+		FlushErrorState();
 		ereport(NOTICE,
 				(errcode(ERRCODE_DATA_EXCEPTION),
 				 errmsg("malformed telemetry response body"),

--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -32,8 +32,7 @@ enum
 #define ORIGIN_PARAMETER_NAME "origin"
 
 static Datum
-create_cagg_validate_query_datum(TupleDesc tupdesc, const bool is_valid_query,
-								 const ErrorData *edata)
+create_cagg_validate_query_datum(TupleDesc tupdesc, const bool is_valid_query, ErrorData *edata)
 {
 	NullableDatum datums[Natts_cagg_validate_query] = { { 0 } };
 	HeapTuple tuple;
@@ -60,7 +59,6 @@ create_cagg_validate_query_datum(TupleDesc tupdesc, const bool is_valid_query,
 
 	Assert(tupdesc->natts == Natts_cagg_validate_query);
 	tuple = ts_heap_form_tuple(tupdesc, datums);
-
 	return HeapTupleGetDatum(tuple);
 }
 

--- a/tsl/test/src/compression_sql_test.c
+++ b/tsl/test/src/compression_sql_test.c
@@ -278,6 +278,7 @@ ts_read_compressed_data_directory(PG_FUNCTION_ARGS)
 			MemoryContextSwitchTo(call_memory_context);
 
 			ErrorData *error = CopyErrorData();
+			FlushErrorState();
 
 			values[out_sqlstate] =
 				PointerGetDatum(cstring_to_text(unpack_sql_state(error->sqlerrcode)));
@@ -289,8 +290,7 @@ ts_read_compressed_data_directory(PG_FUNCTION_ARGS)
 					cstring_to_text(psprintf("%s:%d", error->filename, error->lineno)));
 				nulls[out_location] = false;
 			}
-
-			FlushErrorState();
+			FreeErrorData(error);
 		}
 		PG_END_TRY();
 


### PR DESCRIPTION
If the function `FlushErrorState` is not called immediately after `CopyErrorData`, or at least before doing any serious work that can throw another error, it can exhaust the error stack (which is very small).

This commit moved calls of `FlushErrorState` to immediately after `CopyErrorData` to reset the error stack and avoid exhausting the error stack.

It also adds calls to `FreeErrorData` where applicable, i.e., where the error data is not re-thrown nor saved away.