### PR TITLE
Don't process hard errors in with-clause parser

### DIFF
--- a/.unreleased/pr_7893
+++ b/.unreleased/pr_7893
@@ -1,0 +1,1 @@
+Fixes: #7893 Don't capture hard errors in with-clause parser

--- a/test/src/test_with_clause_parser.c
+++ b/test/src/test_with_clause_parser.c
@@ -10,15 +10,47 @@
 #include <commands/defrem.h>
 #include <fmgr.h>
 #include <funcapi.h>
+#include <postgres_ext.h>
 #include <utils/array.h>
 #include <utils/builtins.h>
+#include <utils/elog.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
+#include <utils/regproc.h>
 
 #include "annotations.h"
 #include "export.h"
 #include "test_utils.h"
 #include "with_clause_parser.h"
+
+TS_FUNCTION_INFO_V1(ts_sqlstate_raise_in);
+TS_FUNCTION_INFO_V1(ts_sqlstate_raise_out);
+
+/*
+ * Input function that will raise the error code give. This means that you can
+ * trigger an error when reading and converting a string to this type.
+ */
+Datum
+ts_sqlstate_raise_in(PG_FUNCTION_ARGS)
+{
+	char *code = PG_GETARG_CSTRING(0);
+	if (strlen(code) != 5)
+		ereport(ERROR,
+				errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("error code \"%s\" was not of length 5", code));
+	int sqlstate = MAKE_SQLSTATE(code[0], code[1], code[2], code[3], code[4]);
+	ereport(ERROR, errcode(sqlstate), errmsg("raised requested error code \"%s\"", code));
+	return 0;
+}
+
+/*
+ * Dummy function, we do not store values of this type anywhere.
+ */
+Datum
+ts_sqlstate_raise_out(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_CSTRING("uninteresting");
+}
 
 static DefElem *
 def_elem_from_texts(Datum *texts, int nelems)
@@ -177,6 +209,7 @@ typedef enum TestArgs
 	TestArgDefault,
 	TestArgName,
 	TestArgRegclass,
+	TestArgRaise,
 } TestArgs;
 
 static WithClauseDefinition test_args[] = {
@@ -188,8 +221,14 @@ static WithClauseDefinition test_args[] = {
 						 .type_id = INT4OID,
 						 .default_val = (Datum)-100 },
 	[TestArgName] = { .arg_names = {"name", NULL}, .type_id = NAMEOID, },
-	[TestArgRegclass] = { .arg_names = {"regclass", NULL},
-						  .type_id = REGCLASSOID },
+	[TestArgRegclass] = {
+		.arg_names = {"regclass", NULL},
+		.type_id = REGCLASSOID,
+	},
+	[TestArgRaise] = {
+		.arg_names = {"sqlstate_raise", NULL},
+		.type_id = InvalidOid,
+	},
 };
 
 typedef struct WithClauseValue
@@ -206,6 +245,32 @@ TS_TEST_FN(ts_test_with_clause_parse)
 	bool *nulls;
 	HeapTuple tuple;
 	WithClauseValue *result;
+
+	/*
+	 * Look up any missing type ids before using it below to allow
+	 * user-defined types.
+	 *
+	 * Note that this will not look up types we have found in previous calls
+	 * of this function.
+	 *
+	 * We use the slightly more complicated way of calling to_regtype since
+	 * that exists on all versions of PostgreSQL. We cannot use regtypein
+	 * since that can generate errors and we do not want to deal with that.
+	 */
+	for (unsigned int i = 0; i < TS_ARRAY_LEN(test_args); ++i)
+	{
+		LOCAL_FCINFO(fcinfo_in, 1);
+		Datum result;
+		if (!OidIsValid(test_args[i].type_id))
+		{
+			InitFunctionCallInfoData(*fcinfo_in, NULL, 1, InvalidOid, NULL, NULL);
+			fcinfo_in->args[0].value = CStringGetTextDatum(test_args[i].arg_names[0]);
+			fcinfo_in->args[0].isnull = false;
+			result = to_regtype(fcinfo_in);
+			if (!fcinfo_in->isnull)
+				test_args[i].type_id = DatumGetObjectId(result);
+		}
+	}
 
 	if (SRF_IS_FIRSTCALL())
 	{

--- a/tsl/test/shared/expected/with_clause_parser.out
+++ b/tsl/test/shared/expected/with_clause_parser.out
@@ -2,6 +2,22 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- We have support for a dedicated type whos only purpose is to
+-- generate error. You pass in the error code you want and it will be
+-- raised from inside the input function.
+CREATE TYPE sqlstate_raise;
+CREATE FUNCTION ts_sqlstate_raise_in(cstring)
+    RETURNS sqlstate_raise
+    AS :MODULE_PATHNAME LANGUAGE C STABLE STRICT;
+NOTICE:  return type sqlstate_raise is only a shell
+CREATE FUNCTION ts_sqlstate_raise_out(sqlstate_raise)
+    RETURNS cstring
+    AS :MODULE_PATHNAME LANGUAGE C STABLE STRICT;
+NOTICE:  argument type sqlstate_raise is only a shell
+CREATE TYPE sqlstate_raise (
+    input = ts_sqlstate_raise_in,
+    output = ts_sqlstate_raise_out
+);
 CREATE OR REPLACE FUNCTION test_with_clause_filter(with_clauses TEXT[][])
     RETURNS TABLE(namespace TEXT, name TEXT, value TEXT, filtered BOOLEAN)
     AS :MODULE_PATHNAME, 'ts_test_with_clause_filter' LANGUAGE C VOLATILE STRICT;
@@ -85,115 +101,125 @@ ERROR:  argument "timescaledb.unimplemented" not implemented
 \set ON_ERROR_STOP 1
 -- bool parsing
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool", "true"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | t    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | t    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool", "false"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | f    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | f    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool", "on"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | t    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | t    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool", "off"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | f    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | f    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool", "1"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | t    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | t    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool", "0"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | f    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | f    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "bool"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        | t    |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | t    |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 -- int32 parsing
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "int32", "1"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |     1 |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |     1 |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "int32", "572"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |   572 |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |   572 |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "int32", "-10"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |   -10 |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |   -10 |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "int32", "true"}}');
@@ -205,59 +231,64 @@ ERROR:  parameter "timescaledb.int32" must have a value
 \set ON_ERROR_STOP 1
 -- name parsing
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "name", "1"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      | 1        | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      | 1        | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "name", "572"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      | 572      | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      | 572      | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "name", "-10"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      | -10      | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      | -10      | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "name", "true"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      | true     | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      | true     | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "name", "bar"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      | bar      | 
- regclass      |        |      |       |      |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      | bar      | 
+ regclass       |        |      |       |      |          | 
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "name"}}');
@@ -265,26 +296,28 @@ ERROR:  parameter "timescaledb.name" must have a value
 \set ON_ERROR_STOP 1
 -- REGCLASS parsing
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "regclass", "pg_type"}}');
-     name      | unimpl | bool | int32 | def  | name_arg |  regc   
----------------+--------+------+-------+------+----------+---------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | pg_type
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg |  regc   
+----------------+--------+------+-------+------+----------+---------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | pg_type
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "regclass", "1"}}');
-     name      | unimpl | bool | int32 | def  | name_arg | regc 
----------------+--------+------+-------+------+----------+------
- unimplemented |        |      |       |      |          | 
- bool          |        |      |       |      |          | 
- int32         |        |      |       |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      |          | 
- regclass      |        |      |       |      |          | 1
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg | regc 
+----------------+--------+------+-------+------+----------+------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        |      |       |      |          | 
+ int32          |        |      |       |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      |          | 
+ regclass       |        |      |       |      |          | 1
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "regclass", "-10"}}');
@@ -296,39 +329,52 @@ ERROR:  invalid value for timescaledb.regclass 'bar'
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "regclass"}}');
 ERROR:  parameter "timescaledb.regclass" must have a value
 \set ON_ERROR_STOP 1
+-- Test errors generated from inside the input function
+\set ON_ERROR_STOP 0
+-- Out of memory, "hard" error.
+SELECT * FROM test_with_clause_parse('{{"timescaledb", "sqlstate_raise", "53200"}}');
+ERROR:  raised requested error code "53200"
+-- Division by zero, "soft" error. Shows invalid value message (with a
+-- strange message in this case).
+SELECT * FROM test_with_clause_parse('{{"timescaledb", "sqlstate_raise", "22012"}}');
+ERROR:  invalid value for timescaledb.sqlstate_raise '22012'
+\set ON_ERROR_STOP 1
 -- defaults get overridden
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "default", "1"}}');
-     name      | unimpl | bool | int32 | def | name_arg | regc 
----------------+--------+------+-------+-----+----------+------
- unimplemented |        |      |       |     |          | 
- bool          |        |      |       |     |          | 
- int32         |        |      |       |     |          | 
- default       |        |      |       |   1 |          | 
- name          |        |      |       |     |          | 
- regclass      |        |      |       |     |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def | name_arg | regc 
+----------------+--------+------+-------+-----+----------+------
+ unimplemented  |        |      |       |     |          | 
+ bool           |        |      |       |     |          | 
+ int32          |        |      |       |     |          | 
+ default        |        |      |       |   1 |          | 
+ name           |        |      |       |     |          | 
+ regclass       |        |      |       |     |          | 
+ sqlstate_raise |        |      |       |     |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "default", "572"}}');
-     name      | unimpl | bool | int32 | def | name_arg | regc 
----------------+--------+------+-------+-----+----------+------
- unimplemented |        |      |       |     |          | 
- bool          |        |      |       |     |          | 
- int32         |        |      |       |     |          | 
- default       |        |      |       | 572 |          | 
- name          |        |      |       |     |          | 
- regclass      |        |      |       |     |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def | name_arg | regc 
+----------------+--------+------+-------+-----+----------+------
+ unimplemented  |        |      |       |     |          | 
+ bool           |        |      |       |     |          | 
+ int32          |        |      |       |     |          | 
+ default        |        |      |       | 572 |          | 
+ name           |        |      |       |     |          | 
+ regclass       |        |      |       |     |          | 
+ sqlstate_raise |        |      |       |     |          | 
+(7 rows)
 
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "default", "-10"}}');
-     name      | unimpl | bool | int32 | def | name_arg | regc 
----------------+--------+------+-------+-----+----------+------
- unimplemented |        |      |       |     |          | 
- bool          |        |      |       |     |          | 
- int32         |        |      |       |     |          | 
- default       |        |      |       | -10 |          | 
- name          |        |      |       |     |          | 
- regclass      |        |      |       |     |          | 
-(6 rows)
+      name      | unimpl | bool | int32 | def | name_arg | regc 
+----------------+--------+------+-------+-----+----------+------
+ unimplemented  |        |      |       |     |          | 
+ bool           |        |      |       |     |          | 
+ int32          |        |      |       |     |          | 
+ default        |        |      |       | -10 |          | 
+ name           |        |      |       |     |          | 
+ regclass       |        |      |       |     |          | 
+ sqlstate_raise |        |      |       |     |          | 
+(7 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "default", "true"}}');
@@ -350,13 +396,17 @@ SELECT * FROM test_with_clause_parse('{
     {"c", "name", "bar"},
     {"d", "regclass", "pg_type"}
 }');
-     name      | unimpl | bool | int32 | def  | name_arg |  regc   
----------------+--------+------+-------+------+----------+---------
- unimplemented |        |      |       |      |          | 
- bool          |        | t    |       |      |          | 
- int32         |        |      |   572 |      |          | 
- default       |        |      |       | -100 |          | 
- name          |        |      |       |      | bar      | 
- regclass      |        |      |       |      |          | pg_type
-(6 rows)
+      name      | unimpl | bool | int32 | def  | name_arg |  regc   
+----------------+--------+------+-------+------+----------+---------
+ unimplemented  |        |      |       |      |          | 
+ bool           |        | t    |       |      |          | 
+ int32          |        |      |   572 |      |          | 
+ default        |        |      |       | -100 |          | 
+ name           |        |      |       |      | bar      | 
+ regclass       |        |      |       |      |          | pg_type
+ sqlstate_raise |        |      |       |      |          | 
+(7 rows)
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP TYPE sqlstate_raise CASCADE;
+NOTICE:  drop cascades to 2 other objects

--- a/tsl/test/shared/sql/with_clause_parser.sql
+++ b/tsl/test/shared/sql/with_clause_parser.sql
@@ -3,6 +3,21 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- We have support for a dedicated type whos only purpose is to
+-- generate error. You pass in the error code you want and it will be
+-- raised from inside the input function.
+CREATE TYPE sqlstate_raise;
+CREATE FUNCTION ts_sqlstate_raise_in(cstring)
+    RETURNS sqlstate_raise
+    AS :MODULE_PATHNAME LANGUAGE C STABLE STRICT;
+CREATE FUNCTION ts_sqlstate_raise_out(sqlstate_raise)
+    RETURNS cstring
+    AS :MODULE_PATHNAME LANGUAGE C STABLE STRICT;
+CREATE TYPE sqlstate_raise (
+    input = ts_sqlstate_raise_in,
+    output = ts_sqlstate_raise_out
+);
+
 CREATE OR REPLACE FUNCTION test_with_clause_filter(with_clauses TEXT[][])
     RETURNS TABLE(namespace TEXT, name TEXT, value TEXT, filtered BOOLEAN)
     AS :MODULE_PATHNAME, 'ts_test_with_clause_filter' LANGUAGE C VOLATILE STRICT;
@@ -96,6 +111,14 @@ SELECT * FROM test_with_clause_parse('{{"timescaledb", "regclass", "bar"}}');
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "regclass"}}');
 \set ON_ERROR_STOP 1
 
+-- Test errors generated from inside the input function
+\set ON_ERROR_STOP 0
+-- Out of memory, "hard" error.
+SELECT * FROM test_with_clause_parse('{{"timescaledb", "sqlstate_raise", "53200"}}');
+-- Division by zero, "soft" error. Shows invalid value message (with a
+-- strange message in this case).
+SELECT * FROM test_with_clause_parse('{{"timescaledb", "sqlstate_raise", "22012"}}');
+\set ON_ERROR_STOP 1
 
 -- defaults get overridden
 SELECT * FROM test_with_clause_parse('{{"timescaledb", "default", "1"}}');
@@ -120,3 +143,6 @@ SELECT * FROM test_with_clause_parse('{
     {"c", "name", "bar"},
     {"d", "regclass", "pg_type"}
 }');
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP TYPE sqlstate_raise CASCADE;


### PR DESCRIPTION
When parsing WITH clause arguments for ALTER TABLE to extract compression parameters, syntax errors in the text format are caught using PG_TRY and PG_CATCH and then processing the errors to add more information.

If an out-of-memory error occurs inside execution of the input function and this error is caught, it can continue executing and potentially cause cascading out-of-memory errors and in the end exhausting the error stack.

This commit solves this by using checking the category of the thrown error and only allow errors in the data exception and the syntax errors and access rules violation category, which are "soft" errors in this case. Hard errors, like out-of-memory errors, are re-thrown allowing the backend to deal with it properly. 
