### PR TITLE
2.19.1 (2025-04-01)

### DIFF
--- a/.unreleased/hash-grouping-multiple
+++ b/.unreleased/hash-grouping-multiple
@@ -1,1 +1,0 @@
-Implements: #7754 Vectorized aggregation with grouping by several columns

--- a/.unreleased/pr_7632
+++ b/.unreleased/pr_7632
@@ -1,1 +1,0 @@
-Implements: #7632 Optimize recompression for chunks without segmentby

--- a/.unreleased/pr_7655
+++ b/.unreleased/pr_7655
@@ -1,1 +1,0 @@
-Implements: #7655 Support vectorized aggregation on Hypercore TAM

--- a/.unreleased/pr_7665
+++ b/.unreleased/pr_7665
@@ -1,1 +1,0 @@
-Fixes: #7665 Block merging of frozen chunks

--- a/.unreleased/pr_7669
+++ b/.unreleased/pr_7669
@@ -1,1 +1,0 @@
-Implements: #7669 Add support for merging compressed chunks

--- a/.unreleased/pr_7673
+++ b/.unreleased/pr_7673
@@ -1,2 +1,0 @@
-Fixes: #7673 Don't abort additional INSERTs when hitting first conflict
-Thanks: @bjornuppeke for reporting a problem with INSERT INTO ... ON CONFLICT DO NOTHING on compressed chunks

--- a/.unreleased/pr_7701
+++ b/.unreleased/pr_7701
@@ -1,1 +1,0 @@
-Implements: #7701 Implement a custom compression algorithm for bool columns. It is experimental and can undergo backwards-incompatible changes. For testing, enable it using timescaledb.enable_bool_compression = on.

--- a/.unreleased/pr_7707
+++ b/.unreleased/pr_7707
@@ -1,1 +1,0 @@
-Implements: #7707 Support ALTER COLUMN SET NOT NULL on compressed chunks

--- a/.unreleased/pr_7746
+++ b/.unreleased/pr_7746
@@ -1,1 +1,0 @@
-Fixes: #7747 Block TAM rewrites with incompatible GUC setting

--- a/.unreleased/pr_7764
+++ b/.unreleased/pr_7764
@@ -1,1 +1,0 @@
-Fixes: #7764 Fix compression settings handling in Hypercore TAM

--- a/.unreleased/pr_7765
+++ b/.unreleased/pr_7765
@@ -1,1 +1,0 @@
-Implements: #7765 Allow tsdb as alias for timescaledb in WITH and SET clauses

--- a/.unreleased/pr_7768
+++ b/.unreleased/pr_7768
@@ -1,1 +1,0 @@
-Fixes: #7768 Remove costing index scan of hypertable parent

--- a/.unreleased/pr_7786
+++ b/.unreleased/pr_7786
@@ -1,1 +1,0 @@
-Implements: #7786 Show warning for inefficient compress_chunk_time_interval configuration

--- a/.unreleased/pr_7788
+++ b/.unreleased/pr_7788
@@ -1,1 +1,0 @@
-Implements: #7788 Add callback to mem_guard for background workers

--- a/.unreleased/pr_7789
+++ b/.unreleased/pr_7789
@@ -1,2 +1,0 @@
-Implements: #7789 Do not recompress segmentwise when default order by is empty
-Fixes: #7748 Crash in the segmentwise recompression

--- a/.unreleased/pr_7790
+++ b/.unreleased/pr_7790
@@ -1,1 +1,0 @@
-Implements: #7790 Add configurable Incremental CAgg Refresh Policy

--- a/.unreleased/pr_7798
+++ b/.unreleased/pr_7798
@@ -1,1 +1,0 @@
-Fixes: #7714 Fixes a wrong result when compressed NULL values were confused with default values. This happened in very special circumstances with alter table added a new column with a default value, an update and compression in a very particular order.

--- a/.unreleased/pr_7799
+++ b/.unreleased/pr_7799
@@ -1,2 +1,0 @@
-Fixes: #7799 Handle DEFAULT table access name in ALTER TABLE
-Thanks: @kav23alex for reporting a segmentation fault on ALTER TABLE with DEFAULT

--- a/.unreleased/pr_7806
+++ b/.unreleased/pr_7806
@@ -1,1 +1,0 @@
-Implements: #7806 Allow adding unique constraints to compressed chunks

--- a/.unreleased/pr_7816
+++ b/.unreleased/pr_7816
@@ -1,1 +1,0 @@
-Fixes: #7816 Fix ORDER BY for direct queries on partial chunks

--- a/.unreleased/pr_7832
+++ b/.unreleased/pr_7832
@@ -1,1 +1,0 @@
-Implements: #7832 Allow setting chunk_time_interval for continuous aggregates during creation

--- a/.unreleased/pr_7834
+++ b/.unreleased/pr_7834
@@ -1,1 +1,0 @@
-Fixes: #7834 Avoid unnecessary scheduler restarts

--- a/.unreleased/pr_7837
+++ b/.unreleased/pr_7837
@@ -1,1 +1,0 @@
-Fixes: #7837 Ignore frozen chunks in compression policy

--- a/.unreleased/pr_7844
+++ b/.unreleased/pr_7844
@@ -1,1 +1,0 @@
-Implements: #7844 Add GUC to enable exclusive locking recompression

--- a/.unreleased/pr_7850
+++ b/.unreleased/pr_7850
@@ -1,1 +1,0 @@
-Fixes: #7850 Add is_current_xact_tuple to Arrow TTS

--- a/.unreleased/pr_7890
+++ b/.unreleased/pr_7890
@@ -1,1 +1,0 @@
-Fixes: #7890 Flush error state before doing anything else

--- a/.unreleased/vectorized-text-grouping
+++ b/.unreleased/vectorized-text-grouping
@@ -1,1 +1,0 @@
-Implements: #7586 Vectorized aggregation with grouping by a single text column.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.19.1 (2025-04-01)
+
+This release contains bug fixes since the 2.19.0 release. We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* [#7816](https://github.com/timescale/timescaledb/pull/7816) Fix `ORDER BY` for direct queries on partial chunks
+* [#7834](https://github.com/timescale/timescaledb/pull/7834) Avoid unnecessary scheduler restarts
+* [#7837](https://github.com/timescale/timescaledb/pull/7837) Ignore frozen chunks in compression policy
+* [#7850](https://github.com/timescale/timescaledb/pull/7850) Add `is_current_xact_tuple` to Arrow TTS
+* [#7890](https://github.com/timescale/timescaledb/pull/7890) Flush error state before doing anything else
+
+**Thanks**
+* @bjornuppeke for reporting a problem with `INSERT INTO ... ON CONFLICT DO NOTHING` on compressed chunks
+* @kav23alex for reporting a segmentation fault on `ALTER TABLE` with `DEFAULT`
+
 ## 2.19.0 (2025-03-18)
 
 This release contains performance improvements and bug fixes since the 2.18.2 release. We recommend that you upgrade at the next available opportunity.

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -49,11 +49,12 @@ set(MOD_FILES
     updates/2.17.2--2.18.0.sql
     updates/2.18.0--2.18.1.sql
     updates/2.18.1--2.18.2.sql
-    updates/2.18.2--2.19.0.sql)
+    updates/2.18.2--2.19.0.sql
+    updates/2.19.0--2.19.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config
-set(CURRENT_REV_FILE 2.19.0--2.18.2.sql)
+set(CURRENT_REV_FILE 2.19.1--2.19.0.sql)
 # Files for generating old downgrade scripts. This should only include files for
 # downgrade from one version to its previous version since we do not support
 # skipping versions when downgrading.
@@ -98,7 +99,8 @@ set(OLD_REV_FILES
     2.18.0--2.17.2.sql
     2.18.1--2.18.0.sql
     2.18.2--2.18.1.sql
-    2.19.0--2.18.2.sql)
+    2.19.0--2.18.2.sql
+    2.19.1--2.19.0.sql)
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")
 set(LOADER_PATHNAME "$libdir/timescaledb")

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
-version = 2.19.0
-update_from_version = 2.18.2
-downgrade_to_version = 2.18.2
+version = 2.19.1
+update_from_version = 2.19.0
+downgrade_to_version = 2.19.0


### PR DESCRIPTION
This release contains bug fixes since the 2.19.0 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#7816](https://github.com/timescale/timescaledb/pull/7816) Fix `ORDER BY` for direct queries on partial chunks
* [#7834](https://github.com/timescale/timescaledb/pull/7834) Avoid unnecessary scheduler restarts
* [#7837](https://github.com/timescale/timescaledb/pull/7837) Ignore frozen chunks in compression policy
* [#7850](https://github.com/timescale/timescaledb/pull/7850) Add `is_current_xact_tuple` to Arrow TTS
* [#7890](https://github.com/timescale/timescaledb/pull/7890) Flush error state before doing anything else

**Thanks**
* @bjornuppeke for reporting a problem with `INSERT INTO ... ON CONFLICT DO NOTHING` on compressed chunks
* @kav23alex for reporting a segmentation fault on `ALTER TABLE` with `DEFAULT`