### PR TITLE
Implement vectorized decompression for bools

### DIFF
--- a/.unreleased/pr_7899
+++ b/.unreleased/pr_7899
@@ -1,0 +1,1 @@
+Implements: #7899 Vectorized decompression and filtering for boolean columns

--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -8,6 +8,7 @@
 #include "compression/arrow_c_data_interface.h"
 #include "compression/compression.h"
 #include "simple8b_rle.h"
+#include "simple8b_rle_bitarray.h"
 #include "simple8b_rle_bitmap.h"
 
 typedef struct BoolCompressed
@@ -315,6 +316,55 @@ tsl_bool_compressor_finish(PG_FUNCTION_ARGS)
 	if (compressed == NULL)
 		PG_RETURN_NULL();
 	PG_RETURN_POINTER(compressed);
+}
+
+extern ArrowArray *
+bool_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
+{
+	MemoryContext old_context;
+	Simple8bRleBitArray value_bits;
+	Simple8bRleBitArray validity_bits;
+
+	Simple8bRleSerialized *serialized_values = NULL;
+	Simple8bRleSerialized *serialized_validity_bitmap = NULL;
+
+	ArrowArray *result = NULL;
+	uint64 *validity_bitmap = NULL;
+	uint64 *decompressed_values = NULL;
+
+	void *detoasted = PG_DETOAST_DATUM(compressed);
+	StringInfoData si = { .data = detoasted, .len = VARSIZE(compressed) };
+	BoolCompressed *header = consumeCompressedData(&si, sizeof(BoolCompressed));
+
+	Assert(header->has_nulls == 0 || header->has_nulls == 1);
+	Assert(element_type == BOOLOID);
+
+	serialized_values = bytes_deserialize_simple8b_and_advance(&si);
+	const bool has_nulls = header->has_nulls == 1;
+
+	if (has_nulls)
+	{
+		serialized_validity_bitmap = bytes_deserialize_simple8b_and_advance(&si);
+	}
+
+	/* Decompress the values directly to bit arrays */
+	old_context = MemoryContextSwitchTo(dest_mctx);
+	value_bits = simple8brle_bitarray_decompress(serialized_values, /* inverted*/ false);
+	decompressed_values = value_bits.data;
+	validity_bits =
+		simple8brle_bitarray_decompress(serialized_validity_bitmap, /* inverted*/ false);
+	validity_bitmap = validity_bits.data;
+	MemoryContextSwitchTo(old_context);
+
+	result = MemoryContextAllocZero(dest_mctx, sizeof(ArrowArray) + sizeof(void *) * 2);
+	const void **buffers = (const void **) &result[1];
+	buffers[0] = validity_bitmap;
+	buffers[1] = decompressed_values;
+	result->n_buffers = 2;
+	result->buffers = buffers;
+	result->length = value_bits.num_elements;
+	result->null_count = has_nulls ? (result->length - validity_bits.num_ones) : 0;
+	return result;
 }
 
 /*

--- a/tsl/src/compression/algorithms/bool_compress.h
+++ b/tsl/src/compression/algorithms/bool_compress.h
@@ -51,6 +51,8 @@ extern DecompressResult bool_decompression_iterator_try_next_reverse(Decompressi
 extern DecompressionIterator *bool_decompression_iterator_from_datum_reverse(Datum bool_compressed,
 																			 Oid element_type);
 
+extern ArrowArray *bool_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx);
+
 extern void bool_compressed_send(CompressedDataHeader *header, StringInfo buffer);
 
 extern Datum bool_compressed_recv(StringInfo buf);
@@ -61,7 +63,7 @@ extern Compressor *bool_compressor_for_type(Oid element_type);
 	{                                                                                              \
 		.iterator_init_forward = bool_decompression_iterator_from_datum_forward,                   \
 		.iterator_init_reverse = bool_decompression_iterator_from_datum_reverse,                   \
-		.decompress_all = NULL, .compressed_data_send = bool_compressed_send,                      \
+		.decompress_all = bool_decompress_all, .compressed_data_send = bool_compressed_send,       \
 		.compressed_data_recv = bool_compressed_recv,                                              \
 		.compressor_for_type = bool_compressor_for_type,                                           \
 		.compressed_data_storage = TOAST_STORAGE_EXTERNAL,                                         \

--- a/tsl/src/compression/algorithms/simple8b_rle_bitarray.h
+++ b/tsl/src/compression/algorithms/simple8b_rle_bitarray.h
@@ -1,0 +1,227 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+#include "simple8b_rle.h"
+
+/*
+ * This is a specialization of Simple8bRLE decoder for encoded 1 bit values
+ * as they are used to store NULL flags in the compression methods as well as
+ * the values for bool compression.
+ *
+ * Note that in the bool compression we store a validity map instead of a NULL
+ * map, which is the same except the bits are inverted.
+ *
+ * The goal of this decoder is to support the following use cases:
+ *
+ *  1. Decompress the validity map of the bool compression method.
+ *  2. Decompress the values of the bool compression method.
+ *  3. Decompress the NULL map of the other compression methods into a validity
+ *     map in the ArrowArray. In this case the bits will be inverted.
+ *
+ * The reason we don't use the Simple8bRleBitmap is that the end result is an
+ * array of bits and not bools.
+ *
+ * The complication comes from the RLE encoding of Simple8b while in the Arrow
+ * validity bitmaps we have a straight array of bits.
+ */
+
+typedef struct Simple8bRleBitArray
+{
+	uint64 *data;
+	uint32 num_elements;
+	uint32 num_blocks;
+	uint16 num_ones;
+} Simple8bRleBitArray;
+
+static Simple8bRleBitArray
+simple8brle_bitarray_decompress(Simple8bRleSerialized *compressed, bool inverted)
+{
+	Simple8bRleBitArray result = { 0 };
+	if (!compressed)
+	{
+		return result;
+	}
+
+	CheckCompressedData(compressed->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+	CheckCompressedData(compressed->num_blocks <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+
+	const uint32 num_elements = compressed->num_elements;
+
+	const uint32 num_selector_slots =
+		simple8brle_num_selector_slots_for_num_blocks(compressed->num_blocks);
+	const uint64 *compressed_data = compressed->slots + num_selector_slots;
+
+	const uint32 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
+	const uint32 num_blocks = compressed->num_blocks;
+
+	result.data = palloc0(num_elements_padded / 64 * sizeof(uint64));
+	result.num_elements = num_elements;
+	result.num_blocks = num_blocks;
+
+	uint64 *restrict current_output_ptr = result.data;
+	uint32 decompressed_index = 0;
+	uint32 bit_position = 0;
+
+	for (uint32 block_index = 0; block_index < num_blocks; block_index++)
+	{
+		const uint32 selector_slot = block_index / SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint32 selector_pos_in_slot = block_index % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint64 slot_value = compressed->slots[selector_slot];
+		const uint8 selector_shift = selector_pos_in_slot * SIMPLE8B_BITS_PER_SELECTOR;
+		const uint64 selector_mask = 0xFULL << selector_shift;
+		const uint8 selector_value = (slot_value & selector_mask) >> selector_shift;
+		Assert(selector_value < 16);
+
+		uint64 block_data = compressed_data[block_index];
+
+		if (simple8brle_selector_is_rle(selector_value))
+		{
+			/*
+			 * RLE block.
+			 */
+			uint32 repeat_count = simple8brle_rledata_repeatcount(block_data);
+			CheckCompressedData(repeat_count <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+
+			/*
+			 * We might get an incorrect value from the corrupt data. Explicitly
+			 * truncate it to 0/1 in case the bool is not a standard bool type
+			 * which would have done it for us.
+			 */
+			const bool repeated_value = simple8brle_rledata_value(block_data) & 1;
+			const bool bit_value = repeated_value ^ inverted;
+
+			CheckCompressedData(decompressed_index + repeat_count <= num_elements);
+
+			if (bit_value)
+			{
+				result.num_ones += repeat_count;
+
+				/* Repeated 'ones' repeat_count times */
+				if (repeat_count >= 64)
+				{
+					/* Head: Fill the remaining bits in the current word if not aligned */
+					if (bit_position > 0)
+					{
+						uint64_t head_bits = 64 - bit_position;
+						uint64_t head_mask = (1ULL << head_bits) - 1;
+						*current_output_ptr |= (head_mask << bit_position);
+						repeat_count -= head_bits;
+						decompressed_index += head_bits;
+						current_output_ptr++;
+						bit_position = 0;
+					}
+
+					/* Middle: Fill complete words */
+					uint64_t full_words = repeat_count / 64;
+					for (uint64_t j = 0; j < full_words; j++)
+					{
+						*current_output_ptr = 0xFFFFFFFFFFFFFFFF;
+						current_output_ptr++;
+					}
+
+					decompressed_index += full_words * 64;
+					repeat_count -= full_words * 64;
+				}
+
+				/* Tail: Handle remaining bits (less than 64) */
+				if (repeat_count > 0)
+				{
+					uint64_t tail_mask = (1ULL << repeat_count) - 1;
+					*current_output_ptr |= (tail_mask << bit_position);
+
+					decompressed_index += repeat_count;
+					bit_position = (bit_position + repeat_count) % 64;
+					if (bit_position == 0)
+					{
+						current_output_ptr++;
+					}
+					else
+					{
+						current_output_ptr = result.data + (decompressed_index / 64);
+					}
+				}
+			}
+			else
+			{
+				decompressed_index += repeat_count;
+				bit_position = decompressed_index % 64;
+				current_output_ptr = result.data + (decompressed_index / 64);
+			}
+			Assert(decompressed_index <= num_elements);
+		}
+		else
+		{
+			/*
+			 * Bit-packed block. Since this is a bitmap, this block has 64 bits
+			 * packed. The last block might contain less than maximal possible
+			 * number of elements, but we have 64 bytes of padding on the right
+			 * so we don't care.
+			 */
+			CheckCompressedData(selector_value == 1);
+
+			Assert(SIMPLE8B_BIT_LENGTH[selector_value] == 1);
+			Assert(SIMPLE8B_NUM_ELEMENTS[selector_value] == 64);
+
+			/*
+			 * We should require at least one element from the block. Previous
+			 * blocks might have had incorrect lengths, so this is not an
+			 * assertion.
+			 */
+			CheckCompressedData(decompressed_index < num_elements);
+			CheckCompressedData(decompressed_index + 64 < num_elements_padded);
+
+			/* Have to zero out the unused bits, so that the popcnt works properly. */
+			const int elements_this_block = Min(64, num_elements - decompressed_index);
+			Assert(elements_this_block <= 64);
+			Assert(elements_this_block > 0);
+
+			block_data = block_data ^ -(uint64_t) inverted;
+			block_data &= (~0ULL) >> (64 - elements_this_block);
+
+			if (bit_position == 0)
+			{
+				/* The decoding is on exact 64bit boundaries */
+				*current_output_ptr = block_data;
+			}
+			else
+			{
+				/* We need to split the word */
+				uint64_t bits_remaining_in_word = 64 - bit_position;
+
+				/* First part goes at the end of the current word */
+				*current_output_ptr |= (block_data << bit_position);
+
+				/* Second part goes at the beginning of the next word */
+				*(current_output_ptr + 1) |= block_data >> bits_remaining_in_word;
+			}
+
+#ifdef HAVE__BUILTIN_POPCOUNT
+			result.num_ones += __builtin_popcountll(block_data);
+#else
+			for (uint16 i = 0; i < 64; i++)
+				result.num_ones += ((block_data >> i) & 1);
+#endif
+			decompressed_index += 64;
+			bit_position = decompressed_index % 64;
+			current_output_ptr = result.data + (decompressed_index / 64);
+		}
+	}
+
+	/*
+	 * We might have unpacked more because we work in full blocks, but at least
+	 * we shouldn't have unpacked less.
+	 */
+	CheckCompressedData(decompressed_index >= num_elements);
+	Assert(decompressed_index <= num_elements_padded);
+
+	/*
+	 * Might happen if we have stray ones in the higher unused bits of the last
+	 * block.
+	 */
+	CheckCompressedData(result.num_ones <= num_elements);
+	return result;
+}

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -15,6 +15,11 @@ typedef struct ArrowArray ArrowArray;
 /* How to obtain the decompressed datum for individual row. */
 typedef enum
 {
+	/*
+	 * The decompressed value is a boolean and is stored as a vector of bits.
+	 */
+	DT_ArrowBits = -5,
+
 	DT_ArrowTextDict = -4,
 
 	DT_ArrowText = -3,

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -679,9 +679,23 @@ vector_qual_make(Node *qual, const VectorQualInfo *vqinfo)
 		{
 			/*
 			 * NOT should be removed by Postgres for all operators we can
-			 * vectorize (see prepqual.c), so we don't support it.
+			 * vectorize (see prepqual.c) except when the where clause is
+			 * something like 'COL = false' for bool columns. In this case, we
+			 * have to check if it was transformed to BoolExpr(NOT_EXPR, Var) so
+			 * we can vectorize it, provided that the column supports bulk
+			 * decompression.
 			 */
-			return NULL;
+			if (list_length(boolexpr->args) == 1 && IsA(linitial(boolexpr->args), Var))
+			{
+				if (!vqinfo->vector_attrs[castNode(Var, linitial(boolexpr->args))->varattno])
+				{
+					return NULL;
+				}
+			}
+			else
+			{
+				return NULL;
+			}
 		}
 
 		bool need_copy = false;
@@ -716,7 +730,8 @@ vector_qual_make(Node *qual, const VectorQualInfo *vqinfo)
 
 	/*
 	 * Among the simple predicates, we vectorize some "Var op Const" binary
-	 * predicates, scalar array operations with these predicates, and null test.
+	 * predicates, scalar array operations with these predicates, boolean variables
+	 * and null test.
 	 */
 	NullTest *nulltest = NULL;
 	OpExpr *opexpr = NULL;
@@ -724,6 +739,7 @@ vector_qual_make(Node *qual, const VectorQualInfo *vqinfo)
 	Node *arg1 = NULL;
 	Node *arg2 = NULL;
 	Oid opno = InvalidOid;
+	Var *var = NULL;
 	if (IsA(qual, OpExpr))
 	{
 		opexpr = castNode(OpExpr, qual);
@@ -747,6 +763,33 @@ vector_qual_make(Node *qual, const VectorQualInfo *vqinfo)
 	{
 		nulltest = castNode(NullTest, qual);
 		arg1 = (Node *) nulltest->arg;
+	}
+	else if (IsA(qual, BooleanTest))
+	{
+		BooleanTest *booltest = castNode(BooleanTest, qual);
+		if (IsA(booltest->arg, Var))
+		{
+			var = castNode(Var, booltest->arg);
+			if (!vqinfo->vector_attrs[var->varattno])
+			{
+				return NULL;
+			}
+			return (Node *) booltest;
+		}
+		else
+		{
+			return NULL;
+		}
+	}
+	else if (IsA(qual, Var) && (castNode(Var, qual))->vartype == BOOLOID)
+	{
+		/* We can vectorize boolean variables if bulk decompression is possible. */
+		var = castNode(Var, qual);
+		if (!vqinfo->vector_attrs[var->varattno])
+		{
+			return NULL;
+		}
+		return (Node *) var;
 	}
 	else
 	{
@@ -785,7 +828,7 @@ vector_qual_make(Node *qual, const VectorQualInfo *vqinfo)
 		return NULL;
 	}
 
-	Var *var = castNode(Var, arg1);
+	var = castNode(Var, arg1);
 	if ((Index) var->varno != vqinfo->rti)
 	{
 		/*
@@ -1323,17 +1366,23 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 #ifdef TS_DEBUG
 	if (ts_guc_debug_require_vector_qual == DRO_Forbid && list_length(vectorized_quals) > 0)
 	{
-		elog(ERROR, "debug: encountered vector quals when they are disabled");
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("debug: encountered vector quals when they are disabled")));
 	}
 	else if (ts_guc_debug_require_vector_qual == DRO_Require)
 	{
 		if (list_length(decompress_plan->scan.plan.qual) > 0)
 		{
-			elog(ERROR, "debug: encountered non-vector quals when they are disabled");
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("debug: encountered non-vector quals when they are disabled")));
 		}
 		if (list_length(vectorized_quals) == 0)
 		{
-			elog(ERROR, "debug: did not encounter vector quals when they are required");
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("debug: did not encounter vector quals when they are required")));
 		}
 	}
 #endif

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.h
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.h
@@ -18,6 +18,12 @@ void vector_array_predicate(VectorPredicate *vector_const_predicate, bool is_or,
 
 void vector_nulltest(const ArrowArray *arrow, int test_type, uint64 *restrict result);
 
+/* this implements the vectorized BooleanTest, where NULLs are handled in a special way:
+ * for example IS_NOT_TRUE(NULL) is true and IS_NOT_FALSE(NULL) is true, plus there are
+ * NULL test types, like IS_UNKNOWN and IS_NOT_UNKNOWN.
+ */
+void vector_booleantest(const ArrowArray *arrow, int test_type, uint64 *restrict result);
+
 typedef enum VectorQualSummary
 {
 	AllRowsPass,

--- a/tsl/test/expected/compression_bool_vectorized.out
+++ b/tsl/test/expected/compression_bool_vectorized.out
@@ -1,0 +1,132 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+set timescaledb.enable_bool_compression = on;
+create table t1 (ts int, b bool);
+select create_hypertable('t1','ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (1,public,t1,t)
+(1 row)
+
+alter table t1 set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t1" is set to ""
+insert into t1 values (1, true);
+insert into t1 values (2, false);
+insert into t1 values (3, NULL);
+insert into t1 values (4, true);
+insert into t1 values (5, false);
+insert into t1 values (6, NULL);
+select compress_chunk(show_chunks('t1'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+select * from t1 order by 1;
+ ts | b 
+----+---
+  1 | t
+  2 | f
+  3 | 
+  4 | t
+  5 | f
+  6 | 
+(6 rows)
+
+select * from t1 where b is null order by 1;
+ ts | b 
+----+---
+  3 | 
+  6 | 
+(2 rows)
+
+select * from t1 where b = true order by 1;
+ ts | b 
+----+---
+  1 | t
+  4 | t
+(2 rows)
+
+select * from t1 where b = false order by 1;
+ ts | b 
+----+---
+  2 | f
+  5 | f
+(2 rows)
+
+select * from t1 where ts > 3 and b is null order by 1;
+ ts | b 
+----+---
+  6 | 
+(1 row)
+
+select * from t1 where ts > 3 and b = true order by 1;
+ ts | b 
+----+---
+  4 | t
+(1 row)
+
+select * from t1 where ts > 3 and b = false order by 1;
+ ts | b 
+----+---
+  5 | f
+(1 row)
+
+-- delete all null values and compress again
+delete from t1 where b is null;
+select compress_chunk(show_chunks('t1'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+select * from t1 order by 1;
+ ts | b 
+----+---
+  1 | t
+  2 | f
+  4 | t
+  5 | f
+(4 rows)
+
+select * from t1 where b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from t1 where b = true order by 1;
+ ts | b 
+----+---
+  1 | t
+  4 | t
+(2 rows)
+
+select * from t1 where b = false order by 1;
+ ts | b 
+----+---
+  2 | f
+  5 | f
+(2 rows)
+
+select * from t1 where ts > 3 and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from t1 where ts > 3 and b = true order by 1;
+ ts | b 
+----+---
+  4 | t
+(1 row)
+
+select * from t1 where ts > 3 and b = false order by 1;
+ ts | b 
+----+---
+  5 | f
+(1 row)
+

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -2916,3 +2916,600 @@ select sum(t) from nans where cfloat8 >= '+inf'::numeric;
 
 reset timescaledb.debug_require_vector_qual;
 reset timescaledb.enable_bulk_decompression;
+-- Test predicates on boolean columns can be vectorized
+-- with the bool compression enabled.
+set timescaledb.enable_bulk_decompression to on;
+set timescaledb.enable_bool_compression = on;
+create table bool_table(ts int, b bool);
+select create_hypertable('bool_table', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+    create_hypertable     
+--------------------------
+ (13,public,bool_table,t)
+(1 row)
+
+alter table bool_table set (timescaledb.compress);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "bool_table" is set to ""
+NOTICE:  default order by for hypertable "bool_table" is set to "ts DESC"
+insert into bool_table values (100, true), (101, false), (102, null);
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+ count 
+-------
+     1
+(1 row)
+
+set timescaledb.debug_require_vector_qual to 'require';
+-- BooleanTest expressions
+select * from bool_table where b is true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not true order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+ 102 | 
+(2 rows)
+
+select * from bool_table where b is not false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 102 | 
+(2 rows)
+
+select * from bool_table where b is unknown order by 1;
+ ts  | b 
+-----+---
+ 102 | 
+(1 row)
+
+select * from bool_table where b is not unknown order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+-- Combinations of nulls and bool exprs
+select * from bool_table where b = true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b = false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b = false order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true or b is null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 102 | 
+(2 rows)
+
+select * from bool_table where b = true or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true and b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+ 102 | 
+(2 rows)
+
+select * from bool_table where b = false or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = false and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = false and b is not null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is null order by 1;
+ ts  | b 
+-----+---
+ 102 | 
+(1 row)
+
+select * from bool_table where b is null or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+ 102 | 
+(3 rows)
+
+select * from bool_table where b is null and b is not null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+delete from bool_table where b is null;
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+ count 
+-------
+     1
+(1 row)
+
+select * from bool_table where b is true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not true order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is unknown order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not unknown order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b = false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b = false order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true or b is null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true and b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = false and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = false and b is not null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is null or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b is null and b is not null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+reset timescaledb.debug_require_vector_qual;
+reset timescaledb.enable_bulk_decompression;
+reset timescaledb.enable_bool_compression;
+-- Check that the bool compression changes didn't mess up the
+-- array compression support for the bools.
+delete from bool_table;
+set timescaledb.enable_bool_compression = off;
+insert into bool_table values (100, true), (101, false), (102, null);
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+ count 
+-------
+     1
+(1 row)
+
+select * from bool_table where b is true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not true order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+ 102 | 
+(2 rows)
+
+select * from bool_table where b is not false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 102 | 
+(2 rows)
+
+select * from bool_table where b is unknown order by 1;
+ ts  | b 
+-----+---
+ 102 | 
+(1 row)
+
+select * from bool_table where b is not unknown order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b = false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b = false order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true or b is null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 102 | 
+(2 rows)
+
+select * from bool_table where b = true or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true and b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+ 102 | 
+(2 rows)
+
+select * from bool_table where b = false or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = false and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = false and b is not null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is null order by 1;
+ ts  | b 
+-----+---
+ 102 | 
+(1 row)
+
+select * from bool_table where b is null or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+ 102 | 
+(3 rows)
+
+select * from bool_table where b is null and b is not null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+delete from bool_table where b is null;
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+ count 
+-------
+     1
+(1 row)
+
+select * from bool_table where b is true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not true order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is unknown order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not unknown order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b = false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b = false order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true or b is null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true and b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = false and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = false and b is not null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is null or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b is null and b is not null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+reset timescaledb.enable_bool_compression;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -115,6 +115,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compression_algos.sql
     compression_bgw.sql
     compression_bools.sql
+    compression_bool_vectorized.sql
     compression_ddl.sql
     compression_errors.sql
     compression_hypertable.sql

--- a/tsl/test/sql/compression_bool_vectorized.sql
+++ b/tsl/test/sql/compression_bool_vectorized.sql
@@ -1,0 +1,40 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+drop table if exists t1;
+set timescaledb.enable_bool_compression = on;
+create table t1 (ts int, b bool);
+select create_hypertable('t1','ts');
+alter table t1 set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into t1 values (1, true);
+insert into t1 values (2, false);
+insert into t1 values (3, NULL);
+insert into t1 values (4, true);
+insert into t1 values (5, false);
+insert into t1 values (6, NULL);
+select compress_chunk(show_chunks('t1'));
+
+select * from t1 order by 1;
+
+select * from t1 where b is null order by 1;
+select * from t1 where b = true order by 1;
+select * from t1 where b = false order by 1;
+
+select * from t1 where ts > 3 and b is null order by 1;
+select * from t1 where ts > 3 and b = true order by 1;
+select * from t1 where ts > 3 and b = false order by 1;
+
+-- delete all null values and compress again
+delete from t1 where b is null;
+select compress_chunk(show_chunks('t1'));
+
+select * from t1 order by 1;
+
+select * from t1 where b is null order by 1;
+select * from t1 where b = true order by 1;
+select * from t1 where b = false order by 1;
+
+select * from t1 where ts > 3 and b is null order by 1;
+select * from t1 where ts > 3 and b = true order by 1;
+select * from t1 where ts > 3 and b = false order by 1;

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -542,3 +542,129 @@ from
 reset timescaledb.debug_require_vector_qual;
 reset timescaledb.enable_bulk_decompression;
 
+-- Test predicates on boolean columns can be vectorized
+-- with the bool compression enabled.
+set timescaledb.enable_bulk_decompression to on;
+set timescaledb.enable_bool_compression = on;
+
+create table bool_table(ts int, b bool);
+select create_hypertable('bool_table', 'ts');
+alter table bool_table set (timescaledb.compress);
+insert into bool_table values (100, true), (101, false), (102, null);
+
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+set timescaledb.debug_require_vector_qual to 'require';
+
+-- BooleanTest expressions
+select * from bool_table where b is true order by 1;
+select * from bool_table where b is false order by 1;
+select * from bool_table where b is not true order by 1;
+select * from bool_table where b is not false order by 1;
+select * from bool_table where b is unknown order by 1;
+select * from bool_table where b is not unknown order by 1;
+
+-- Combinations of nulls and bool exprs
+select * from bool_table where b = true order by 1;
+select * from bool_table where b = true or b = false order by 1;
+select * from bool_table where b = true and b = false order by 1;
+select * from bool_table where b = true or b is null order by 1;
+select * from bool_table where b = true or b is not null order by 1;
+select * from bool_table where b = true and b is null order by 1;
+select * from bool_table where b = true and b is not null order by 1;
+select * from bool_table where b = false order by 1;
+select * from bool_table where b = false or b is null order by 1;
+select * from bool_table where b = false or b is not null order by 1;
+select * from bool_table where b = false and b is null order by 1;
+select * from bool_table where b = false and b is not null order by 1;
+select * from bool_table where b is null order by 1;
+select * from bool_table where b is null or b is not null order by 1;
+select * from bool_table where b is null and b is not null order by 1;
+select * from bool_table where b is not null order by 1;
+
+delete from bool_table where b is null;
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+
+select * from bool_table where b is true order by 1;
+select * from bool_table where b is false order by 1;
+select * from bool_table where b is not true order by 1;
+select * from bool_table where b is not false order by 1;
+select * from bool_table where b is unknown order by 1;
+select * from bool_table where b is not unknown order by 1;
+select * from bool_table where b = true order by 1;
+select * from bool_table where b = true or b = false order by 1;
+select * from bool_table where b = true and b = false order by 1;
+select * from bool_table where b = true or b is null order by 1;
+select * from bool_table where b = true or b is not null order by 1;
+select * from bool_table where b = true and b is null order by 1;
+select * from bool_table where b = true and b is not null order by 1;
+select * from bool_table where b = false order by 1;
+select * from bool_table where b = false or b is null order by 1;
+select * from bool_table where b = false or b is not null order by 1;
+select * from bool_table where b = false and b is null order by 1;
+select * from bool_table where b = false and b is not null order by 1;
+select * from bool_table where b is null order by 1;
+select * from bool_table where b is null or b is not null order by 1;
+select * from bool_table where b is null and b is not null order by 1;
+select * from bool_table where b is not null order by 1;
+
+reset timescaledb.debug_require_vector_qual;
+reset timescaledb.enable_bulk_decompression;
+reset timescaledb.enable_bool_compression;
+
+-- Check that the bool compression changes didn't mess up the
+-- array compression support for the bools.
+delete from bool_table;
+set timescaledb.enable_bool_compression = off;
+insert into bool_table values (100, true), (101, false), (102, null);
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+
+select * from bool_table where b is true order by 1;
+select * from bool_table where b is false order by 1;
+select * from bool_table where b is not true order by 1;
+select * from bool_table where b is not false order by 1;
+select * from bool_table where b is unknown order by 1;
+select * from bool_table where b is not unknown order by 1;
+select * from bool_table where b = true order by 1;
+select * from bool_table where b = true or b = false order by 1;
+select * from bool_table where b = true and b = false order by 1;
+select * from bool_table where b = true or b is null order by 1;
+select * from bool_table where b = true or b is not null order by 1;
+select * from bool_table where b = true and b is null order by 1;
+select * from bool_table where b = true and b is not null order by 1;
+select * from bool_table where b = false order by 1;
+select * from bool_table where b = false or b is null order by 1;
+select * from bool_table where b = false or b is not null order by 1;
+select * from bool_table where b = false and b is null order by 1;
+select * from bool_table where b = false and b is not null order by 1;
+select * from bool_table where b is null order by 1;
+select * from bool_table where b is null or b is not null order by 1;
+select * from bool_table where b is null and b is not null order by 1;
+select * from bool_table where b is not null order by 1;
+
+delete from bool_table where b is null;
+select count(compress_chunk(x, true)) from show_chunks('bool_table') x;
+
+select * from bool_table where b is true order by 1;
+select * from bool_table where b is false order by 1;
+select * from bool_table where b is not true order by 1;
+select * from bool_table where b is not false order by 1;
+select * from bool_table where b is unknown order by 1;
+select * from bool_table where b is not unknown order by 1;
+select * from bool_table where b = true order by 1;
+select * from bool_table where b = true or b = false order by 1;
+select * from bool_table where b = true and b = false order by 1;
+select * from bool_table where b = true or b is null order by 1;
+select * from bool_table where b = true or b is not null order by 1;
+select * from bool_table where b = true and b is null order by 1;
+select * from bool_table where b = true and b is not null order by 1;
+select * from bool_table where b = false order by 1;
+select * from bool_table where b = false or b is null order by 1;
+select * from bool_table where b = false or b is not null order by 1;
+select * from bool_table where b = false and b is null order by 1;
+select * from bool_table where b = false and b is not null order by 1;
+select * from bool_table where b is null order by 1;
+select * from bool_table where b is null or b is not null order by 1;
+select * from bool_table where b is null and b is not null order by 1;
+select * from bool_table where b is not null order by 1;
+
+reset timescaledb.enable_bool_compression;


### PR DESCRIPTION
This change decompresses into an array of uint64 values and add the supporting code into Simple8bRleBitArray. With this the ArrowArray stores bits and not bytes. A new DecompressionType was added: DT_ArrowBits to inform the decompression logic about the data format.

The TSL planner is also modified so it generates the vectorized decompression and filtering ops to take advantage of these. The Postgres planner creates plan nodes for boolean columns that we didn't handle before. For BoolCol = True it reduces the expression to a single Var, while for BoolCol = False it creates a BoolExpr(Not, Var) node. With this change we handle both cases.