### PR TITLE
Remove unused argument from process_compress_table

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -174,8 +174,7 @@ tsl_postprocess_plan_stub(PlannedStmt *stmt)
 }
 
 static bool
-process_compress_table_default(AlterTableCmd *cmd, Hypertable *ht,
-							   WithClauseResult *with_clause_options)
+process_compress_table_default(Hypertable *ht, WithClauseResult *with_clause_options)
 {
 	error_no_default_fn_community();
 	pg_unreachable();

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -123,8 +123,7 @@ typedef struct CrossModuleFunctions
 	PGFunction compressed_data_out;
 	PGFunction compressed_data_info;
 	PGFunction compressed_data_has_nulls;
-	bool (*process_compress_table)(AlterTableCmd *cmd, Hypertable *ht,
-								   WithClauseResult *with_clause_options);
+	bool (*process_compress_table)(Hypertable *ht, WithClauseResult *with_clause_options);
 	void (*process_altertable_cmd)(Hypertable *ht, const AlterTableCmd *cmd);
 	void (*process_rename_cmd)(Oid relid, Cache *hcache, const RenameStmt *stmt);
 	PGFunction create_compressed_chunk;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4824,7 +4824,7 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 
 	parse_results = ts_compress_hypertable_set_clause_parse(compress_options);
 
-	ts_cm_functions->process_compress_table(cmd, ht, parse_results);
+	ts_cm_functions->process_compress_table(ht, parse_results);
 	return DDL_DONE;
 }
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -763,8 +763,7 @@ update_compress_chunk_time_interval(Hypertable *ht, WithClauseResult *with_claus
  * 4. Copy constraints to internal compression table
  */
 bool
-tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
-						   WithClauseResult *with_clause_options)
+tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options)
 {
 	int32 compress_htid;
 	bool compress_disable = !with_clause_options[CompressEnabled].is_default &&

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -18,8 +18,7 @@
 
 #define COMPRESSION_COLUMN_METADATA_PATTERN_V1 "_ts_meta_%s_%d"
 
-bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
-								WithClauseResult *with_clause_options);
+bool tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options);
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
 void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -148,13 +148,7 @@ cagg_alter_compression(ContinuousAgg *agg, Hypertable *mat_ht, List *compress_de
 		}
 	}
 
-	AlterTableCmd alter_cmd = {
-		.type = T_AlterTableCmd,
-		.subtype = AT_SetRelOptions,
-		.def = (Node *) compress_defelems,
-	};
-
-	tsl_process_compress_table(&alter_cmd, mat_ht, with_clause_options);
+	tsl_process_compress_table(mat_ht, with_clause_options);
 }
 
 void


### PR DESCRIPTION
AlterTableCmd was never used in the function so this patch removes
it from the signature.

Disable-check: force-changelog-file