### PR TITLE
Fix not using SkipScan over one chunk

### DIFF
--- a/.unreleased/pr_7910
+++ b/.unreleased/pr_7910
@@ -1,0 +1,1 @@
+Fixes: #7910 Fix not using SkipScan over one chunk

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -1465,20 +1465,22 @@ DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
@@ -2929,12 +2931,13 @@ WHERE CLAUSES
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=5 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
-         Index Cond: (("time" = 100) AND (dev > 5))
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+(5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
                                                            QUERY PLAN                                                           

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -1464,20 +1464,22 @@ DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
@@ -2928,12 +2930,13 @@ WHERE CLAUSES
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=5 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
-         Index Cond: (("time" = 100) AND (dev > 5))
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+(5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
                                                            QUERY PLAN                                                           

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -1465,20 +1465,22 @@ DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
@@ -2929,12 +2931,13 @@ WHERE CLAUSES
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=5 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
-         Index Cond: (("time" = 100) AND (dev > 5))
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+(5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
                                                            QUERY PLAN                                                           

--- a/tsl/test/expected/plan_skip_scan_dagg.out
+++ b/tsl/test/expected/plan_skip_scan_dagg.out
@@ -1227,21 +1227,23 @@ DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=11 loops=1)
    Group Key: _hyper_1_1_chunk.dev
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
-         Index Cond: ("time" = 100)
-(5 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(6 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
@@ -2492,12 +2494,13 @@ WHERE CLAUSES
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
-         Index Cond: (("time" = 100) AND (dev > 5))
-(4 rows)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+(5 rows)
 
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
                                                            QUERY PLAN                                                           
@@ -3039,7 +3042,7 @@ EXPLAIN (costs off, timing off, summary off) SELECT count(DISTINCT 1) FROM pg_re
                      Index Cond: (dev > NULL::integer)
 (19 rows)
 
--- compression doesnt prevent skipscan
+-- compression on one chunk doesnt prevent skipscan on other chunks
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
              compress_chunk             
 ----------------------------------------
@@ -3065,11 +3068,33 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
                      Index Cond: (dev > NULL::integer)
 (17 rows)
 
+-- compression on one chunk will prevent skipscan if it's the only chunk remaining
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Vectorized Filter: ("time" = 100)
+         Rows Removed by Filter: 2494
+         ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(6 rows)
+
 SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
             decompress_chunk            
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
+
+-- skipscan will be applied on decompressed chunk if it's the only chunk remaining
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
 
 --baseline query with skipscan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;

--- a/tsl/test/sql/include/skip_scan_dagg_query_ht.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_query_ht.sql
@@ -15,10 +15,16 @@ EXPLAIN (costs off, timing off, summary off) SELECT count(DISTINCT 1) FROM pg_re
 --baseline query with skipscan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 
--- compression doesnt prevent skipscan
+-- compression on one chunk doesnt prevent skipscan on other chunks
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+
+-- compression on one chunk will prevent skipscan if it's the only chunk remaining
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+
+-- skipscan will be applied on decompressed chunk if it's the only chunk remaining
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 
 --baseline query with skipscan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;


### PR DESCRIPTION
Fixes this issue (SkipScan plan not chosen when only 1 chunk remains): https://github.com/timescale/timescaledb/issues/7778

Root cause: not considering AppendPath over one child. This AppendPath will be removed later during plan optimizations but it is still present when we try to apply SkipScan. Now we consider this scenario as well.

Disable-check: approval-count