### PR TITLE
Don't create hypertable for published tables

### DIFF
--- a/.unreleased/pr_7911
+++ b/.unreleased/pr_7911
@@ -1,0 +1,2 @@
+Fixes: #7911 Don't create hypertable for published tables
+Thanks: @soedirgo for reporting that published tables don't get dropped when they have a hypertable

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1864,6 +1864,18 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 			ereport(ERROR, (errcode(ERRCODE_WRONG_OBJECT_TYPE), errmsg("invalid relation type")));
 	}
 
+	/*
+	 * Check that the table is not part of any publication
+	 */
+	if (GetRelationPublications(table_relid) != NIL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
+				 errmsg("cannot create hypertable for table \"%s\" because it is part of a "
+						"publication",
+						get_rel_name(table_relid))));
+	}
+
 	/* Check that the table doesn't have any unsupported constraints */
 	hypertable_validate_constraints(table_relid);
 

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -1121,6 +1121,7 @@ SELECT * FROM show_chunks('test') ch, LATERAL test.show_indexes(ch) ORDER BY 1, 
  _timescaledb_internal._hyper_25_24_chunk | _timescaledb_internal._hyper_25_24_chunk_test_val_idx | {val}   |      | f      | f       | f         | 
 (1 row)
 
+DROP TABLE test;
 -- test creating a hypertable with a primary key where the partitioning column is not part of the primary key
 CREATE TABLE test_schema.partition_not_pk (id INT NOT NULL, device_id INT NOT NULL, time TIMESTAMPTZ NOT NULL, a TEXT NOT NULL, PRIMARY KEY (id));
 \set ON_ERROR_STOP 0
@@ -1137,3 +1138,32 @@ ERROR:  cannot create a unique index without the column "time" (used in partitio
 HINT:  If you're creating a hypertable on a table with a primary key, ensure the partitioning column is part of the primary or composite key.
 \set ON_ERROR_STOP 1
 DROP TABLE test_schema.partition_not_pk;
+-- test hypertable is not created for a table that is a part of a publication
+SET client_min_messages = ERROR;
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+CREATE PUBLICATION publication_test;
+ALTER PUBLICATION publication_test ADD TABLE test;
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+ERROR:  cannot create hypertable for table "test" because it is part of a publication
+\set ON_ERROR_STOP 1
+INSERT INTO test (timestamp) values (now());
+ALTER PUBLICATION publication_test DROP TABLE test;
+DROP PUBLICATION publication_test;
+DROP TABLE test;
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+CREATE PUBLICATION publication_test1;
+CREATE PUBLICATION publication_test2;
+ALTER PUBLICATION publication_test1 ADD TABLE test;
+ALTER PUBLICATION publication_test2 ADD TABLE test;
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+ERROR:  cannot create hypertable for table "test" because it is part of a publication
+\set ON_ERROR_STOP 1
+INSERT INTO test (timestamp) values (now());
+ALTER PUBLICATION publication_test1 DROP TABLE test;
+ALTER PUBLICATION publication_test2 DROP TABLE test;
+DROP PUBLICATION publication_test1;
+DROP PUBLICATION publication_test2;
+DROP TABLE test;
+RESET client_min_messages;

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -666,6 +666,7 @@ SELECT FROM create_hypertable('test', 'time', create_default_indexes => FALSE, m
 -- only user indexes should be returned
 SELECT * FROM test.show_indexes('test') ORDER BY 1;
 SELECT * FROM show_chunks('test') ch, LATERAL test.show_indexes(ch) ORDER BY 1, 2;
+DROP TABLE test;
 
 -- test creating a hypertable with a primary key where the partitioning column is not part of the primary key
 CREATE TABLE test_schema.partition_not_pk (id INT NOT NULL, device_id INT NOT NULL, time TIMESTAMPTZ NOT NULL, a TEXT NOT NULL, PRIMARY KEY (id));
@@ -680,3 +681,32 @@ CREATE TABLE test_schema.partition_not_pk (id INT NOT NULL, device_id INT NOT NU
 select create_hypertable ('test_schema.partition_not_pk', 'time');
 \set ON_ERROR_STOP 1
 DROP TABLE test_schema.partition_not_pk;
+
+-- test hypertable is not created for a table that is a part of a publication
+SET client_min_messages = ERROR;
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+CREATE PUBLICATION publication_test;
+ALTER PUBLICATION publication_test ADD TABLE test;
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+\set ON_ERROR_STOP 1
+INSERT INTO test (timestamp) values (now());
+ALTER PUBLICATION publication_test DROP TABLE test;
+DROP PUBLICATION publication_test;
+DROP TABLE test;
+
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+CREATE PUBLICATION publication_test1;
+CREATE PUBLICATION publication_test2;
+ALTER PUBLICATION publication_test1 ADD TABLE test;
+ALTER PUBLICATION publication_test2 ADD TABLE test;
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+\set ON_ERROR_STOP 1
+INSERT INTO test (timestamp) values (now());
+ALTER PUBLICATION publication_test1 DROP TABLE test;
+ALTER PUBLICATION publication_test2 DROP TABLE test;
+DROP PUBLICATION publication_test1;
+DROP PUBLICATION publication_test2;
+DROP TABLE test;
+RESET client_min_messages;


### PR DESCRIPTION
Logical Replication of hypertables is not supported (for implementation reasons). We do not allow creation of hypertables
with publications and now throw an error if attempted.

Closes #7208