### PR TITLE
Allow TAM chunk creation as non-owner

### DIFF
--- a/.unreleased/pr_7913
+++ b/.unreleased/pr_7913
@@ -1,0 +1,1 @@
+Fixes: #7913 Allow TAM chunk creation as non-owner

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -139,11 +139,11 @@ compression_chunk_create(Chunk *src_chunk, Chunk *chunk, List *column_defs, Oid 
 		transformRelOptions((Datum) 0, create->options, "toast", validnsps, true, false);
 	(void) heap_reloptions(RELKIND_TOASTVALUE, toast_options, true);
 	NewRelationCreateToastTable(chunk->table_id, toast_options);
-	ts_catalog_restore_user(&sec_ctx);
-	modify_compressed_toast_table_storage(settings, column_defs, chunk->table_id);
 
+	modify_compressed_toast_table_storage(settings, column_defs, chunk->table_id);
 	set_statistics_on_compressed_chunk(chunk->table_id);
 	set_toast_tuple_target_on_chunk(chunk->table_id);
+	ts_catalog_restore_user(&sec_ctx);
 
 	create_compressed_chunk_indexes(chunk, settings);
 

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+set role :ROLE_1; -- Run test with role_1 because it has CREATEROLE
+                  -- privileges that is needed further down
 \ir include/hypercore_helpers.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -1097,3 +1100,101 @@ select count(*) from :chunk;
 (1 row)
 
 \set ON_ERROR_STOP 1
+set timescaledb.enable_transparent_decompression=true;
+-- Test chunk creation with non-owner user
+CREATE TABLE conditions (	-- create a regular table
+    time        timestamptz not null,
+    location    text not null,
+    temperature double precision null
+);
+select create_hypertable('conditions', 'time');	-- turn it into a hypertable
+    create_hypertable     
+--------------------------
+ (12,public,conditions,t)
+(1 row)
+
+alter table conditions set (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'location,temperature',
+  timescaledb.compress_orderby = 'time'
+);
+-------------------------------------------------------------------------------
+-- Set hypercore access method on the hypertable
+-------------------------------------------------------------------------------
+alter table conditions set access method hypercore;
+-----------------------
+-- Create a new user
+-----------------------
+create role testuser;
+-- Switch to testuser and show that it can't insert into conditions
+set role testuser;
+\set ON_ERROR_STOP 0
+insert into conditions values ('2024-01-02', 'school', 99.5);
+ERROR:  permission denied for table conditions
+\set ON_ERROR_STOP 1
+--
+-- Now grant privileges to work on conditions
+--
+reset role;
+grant select,insert,update,delete on conditions to testuser;
+set role testuser;
+select current_user;
+ current_user 
+--------------
+ testuser
+(1 row)
+
+select * from show_chunks('conditions') ch
+join _timescaledb_catalog.compression_settings cs on (cs.relid = ch);
+ ch | relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----+-------+----------------+-----------+---------+--------------+--------------------
+(0 rows)
+
+-- An insert should create a new hypercore chunk, including the compressed chunk
+insert into conditions values ('2024-01-02', 'school', 99.5);
+-- Show hypertable owner
+select relname, relowner::regrole
+from pg_class
+where relname = 'conditions';
+  relname   |  relowner   
+------------+-------------
+ conditions | test_role_1
+(1 row)
+
+-- Show that the new chunk has same owner as hypertable, although
+-- testuser did the insert.
+select chunk, am.amname, cs.compress_relid, cl.relowner::regrole as chunk_owner, ccl.relowner::regrole as compress_chunk_owner
+  from show_chunks('conditions') as chunk
+  join _timescaledb_catalog.compression_settings cs on (cs.relid = chunk)
+  join pg_class cl on (cl.oid = chunk)
+  join pg_class ccl on (ccl.oid = cs.compress_relid)
+  join pg_am am on (cl.relam = am.oid);
+                  chunk                   |  amname   |                  compress_relid                  | chunk_owner | compress_chunk_owner 
+------------------------------------------+-----------+--------------------------------------------------+-------------+----------------------
+ _timescaledb_internal._hyper_12_49_chunk | hypercore | _timescaledb_internal.compress_hyper_13_50_chunk | test_role_1 | test_role_1
+(1 row)
+
+-- Data is not compressed
+select _timescaledb_debug.is_compressed_tid(ctid), * from conditions;
+ is_compressed_tid |             time             | location | temperature 
+-------------------+------------------------------+----------+-------------
+ f                 | Tue Jan 02 00:00:00 2024 PST | school   |        99.5
+(1 row)
+
+select compress_chunk(ch) from show_chunks('conditions') ch;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_12_49_chunk
+(1 row)
+
+-- Now the data is compressed
+select _timescaledb_debug.is_compressed_tid(ctid), * from conditions;
+ is_compressed_tid |             time             | location | temperature 
+-------------------+------------------------------+----------+-------------
+ t                 | Tue Jan 02 00:00:00 2024 PST | school   |        99.5
+(1 row)
+
+reset role;
+-- Need to revoke privileges to drop user
+revoke all on conditions from testuser;
+drop role testuser;

--- a/tsl/test/sql/hypercore_create.sql
+++ b/tsl/test/sql/hypercore_create.sql
@@ -2,6 +2,10 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+set role :ROLE_1; -- Run test with role_1 because it has CREATEROLE
+                  -- privileges that is needed further down
+
 \ir include/hypercore_helpers.sql
 select setseed(0.3);
 
@@ -529,3 +533,74 @@ alter table :chunk set access method heap;
 vacuum full :chunk;
 select count(*) from :chunk;
 \set ON_ERROR_STOP 1
+
+set timescaledb.enable_transparent_decompression=true;
+
+-- Test chunk creation with non-owner user
+CREATE TABLE conditions (	-- create a regular table
+    time        timestamptz not null,
+    location    text not null,
+    temperature double precision null
+);
+
+select create_hypertable('conditions', 'time');	-- turn it into a hypertable
+
+alter table conditions set (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'location,temperature',
+  timescaledb.compress_orderby = 'time'
+);
+
+-------------------------------------------------------------------------------
+-- Set hypercore access method on the hypertable
+-------------------------------------------------------------------------------
+alter table conditions set access method hypercore;
+
+-----------------------
+-- Create a new user
+-----------------------
+create role testuser;
+
+-- Switch to testuser and show that it can't insert into conditions
+set role testuser;
+\set ON_ERROR_STOP 0
+insert into conditions values ('2024-01-02', 'school', 99.5);
+\set ON_ERROR_STOP 1
+
+--
+-- Now grant privileges to work on conditions
+--
+reset role;
+grant select,insert,update,delete on conditions to testuser;
+set role testuser;
+select current_user;
+select * from show_chunks('conditions') ch
+join _timescaledb_catalog.compression_settings cs on (cs.relid = ch);
+
+-- An insert should create a new hypercore chunk, including the compressed chunk
+insert into conditions values ('2024-01-02', 'school', 99.5);
+
+-- Show hypertable owner
+select relname, relowner::regrole
+from pg_class
+where relname = 'conditions';
+
+-- Show that the new chunk has same owner as hypertable, although
+-- testuser did the insert.
+select chunk, am.amname, cs.compress_relid, cl.relowner::regrole as chunk_owner, ccl.relowner::regrole as compress_chunk_owner
+  from show_chunks('conditions') as chunk
+  join _timescaledb_catalog.compression_settings cs on (cs.relid = chunk)
+  join pg_class cl on (cl.oid = chunk)
+  join pg_class ccl on (ccl.oid = cs.compress_relid)
+  join pg_am am on (cl.relam = am.oid);
+
+-- Data is not compressed
+select _timescaledb_debug.is_compressed_tid(ctid), * from conditions;
+select compress_chunk(ch) from show_chunks('conditions') ch;
+-- Now the data is compressed
+select _timescaledb_debug.is_compressed_tid(ctid), * from conditions;
+reset role;
+
+-- Need to revoke privileges to drop user
+revoke all on conditions from testuser;
+drop role testuser;


### PR DESCRIPTION
When using Hypercore TAM on the hypertable, new chunks are created as hypercore chunks, including the compressed relation. This means that the compressed relation is created as the inserting user. However, if the inserting user is not the table owner, this operation failed.

The reason it failed was because some toast settings were changed on the compressed chunk during its creation without switching to a role with proper permissions. This is easily fixed by extending the section of code that is executed under the permissive role.