### PR TITLE
New order option for Incremental CAgg Refresh Policy

### DIFF
--- a/.unreleased/pr_7915
+++ b/.unreleased/pr_7915
@@ -1,0 +1,1 @@
+Implements: #7915 New option `refresh_newest_first` to CAgg refresh policy API

--- a/sql/policy_api.sql
+++ b/sql/policy_api.sql
@@ -90,7 +90,8 @@ CREATE OR REPLACE FUNCTION @extschema@.add_continuous_aggregate_policy(
     timezone TEXT = NULL,
     include_tiered_data BOOL = NULL,
     buckets_per_batch INTEGER = NULL,
-    max_batches_per_execution INTEGER = NULL
+    max_batches_per_execution INTEGER = NULL,
+    refresh_newest_first BOOL = NULL
 )
 RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_policy_refresh_cagg_add'

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,4 +1,33 @@
-
 DROP FUNCTION IF EXISTS _timescaledb_internal.create_chunk_table;
 DROP FUNCTION IF EXISTS _timescaledb_functions.create_chunk_table;
 
+-- New option `refresh_newest_first` for incremental cagg refresh policy
+DROP FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL,
+    initial_start TIMESTAMPTZ,
+    timezone TEXT,
+    include_tiered_data BOOL,
+    buckets_per_batch INTEGER,
+    max_batches_per_execution INTEGER
+);
+
+CREATE FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL = false,
+    initial_start TIMESTAMPTZ = NULL,
+    timezone TEXT = NULL,
+    include_tiered_data BOOL = NULL,
+    buckets_per_batch INTEGER = NULL,
+    max_batches_per_execution INTEGER = NULL,
+    refresh_newest_first BOOL = NULL
+)
+RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
+LANGUAGE C VOLATILE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,3 +1,33 @@
-
 CREATE FUNCTION _timescaledb_internal.create_chunk_table(hypertable REGCLASS, slices JSONB, schema_name NAME, table_name NAME) RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_update_placeholder' LANGUAGE C VOLATILE;
 CREATE FUNCTION _timescaledb_functions.create_chunk_table(hypertable REGCLASS, slices JSONB, schema_name NAME, table_name NAME) RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_update_placeholder' LANGUAGE C VOLATILE;
+
+-- Revert new option `refresh_newest_first` from incremental cagg refresh policy
+DROP FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL,
+    initial_start TIMESTAMPTZ,
+    timezone TEXT,
+    include_tiered_data BOOL,
+    buckets_per_batch INTEGER,
+    max_batches_per_execution INTEGER,
+    refresh_newest_first BOOL
+);
+
+CREATE FUNCTION @extschema@.add_continuous_aggregate_policy(
+    continuous_aggregate REGCLASS,
+    start_offset "any",
+    end_offset "any",
+    schedule_interval INTERVAL,
+    if_not_exists BOOL = false,
+    initial_start TIMESTAMPTZ = NULL,
+    timezone TEXT = NULL,
+    include_tiered_data BOOL = NULL,
+    buckets_per_batch INTEGER = NULL,
+    max_batches_per_execution INTEGER = NULL
+)
+RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
+LANGUAGE C VOLATILE;

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -23,6 +23,7 @@ int64 policy_refresh_cagg_get_refresh_end(const Dimension *dim, const Jsonb *con
 bool policy_refresh_cagg_get_include_tiered_data(const Jsonb *config, bool *isnull);
 int32 policy_refresh_cagg_get_buckets_per_batch(const Jsonb *config);
 int32 policy_refresh_cagg_get_max_batches_per_execution(const Jsonb *config);
+bool policy_refresh_cagg_get_refresh_newest_first(const Jsonb *config);
 bool policy_refresh_cagg_refresh_start_lt(int32 materialization_id, Oid cmp_type,
 										  Datum cmp_interval);
 bool policy_refresh_cagg_exists(int32 materialization_id);
@@ -31,5 +32,6 @@ Datum policy_refresh_cagg_add_internal(
 	Oid cagg_oid, Oid start_offset_type, NullableDatum start_offset, Oid end_offset_type,
 	NullableDatum end_offset, Interval refresh_interval, bool if_not_exists, bool fixed_schedule,
 	TimestampTz initial_start, const char *timezone, NullableDatum include_tiered_data,
-	NullableDatum buckets_per_batch, NullableDatum max_batches_per_execution);
+	NullableDatum buckets_per_batch, NullableDatum max_batches_per_execution,
+	NullableDatum refresh_newest_first);
 Datum policy_refresh_cagg_remove_internal(Oid cagg_oid, bool if_exists);

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -40,6 +40,7 @@ typedef struct PolicyContinuousAggData
 	bool include_tiered_data_isnull;
 	int32 buckets_per_batch;
 	int32 max_batches_per_execution;
+	bool refresh_newest_first;
 } PolicyContinuousAggData;
 
 typedef struct PolicyCompressionData

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -209,6 +209,7 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 		NullableDatum include_tiered_data = { .isnull = true };
 		NullableDatum nbuckets_per_refresh = { .isnull = true };
 		NullableDatum max_batches_per_execution = { .isnull = true };
+		NullableDatum refresh_newest_first = { .isnull = true };
 
 		if (all_policies.is_alter_policy)
 			policy_refresh_cagg_remove_internal(all_policies.rel_oid, if_exists);
@@ -224,7 +225,8 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 														  NULL,
 														  include_tiered_data,
 														  nbuckets_per_refresh,
-														  max_batches_per_execution);
+														  max_batches_per_execution,
+														  refresh_newest_first);
 	}
 	if (all_policies.compress && all_policies.compress->create_policy)
 	{

--- a/tsl/src/bgw_policy/policies_v2.h
+++ b/tsl/src/bgw_policy/policies_v2.h
@@ -22,6 +22,7 @@
 #define POL_REFRESH_CONF_KEY_INCLUDE_TIERED_DATA "include_tiered_data"
 #define POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH "buckets_per_batch"
 #define POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION "max_batches_per_execution"
+#define POL_REFRESH_CONF_KEY_REFRESH_NEWEST_FIRST "refresh_newest_first"
 
 #define POLICY_COMPRESSION_PROC_NAME "policy_compression"
 #define POLICY_COMPRESSION_CHECK_NAME "policy_compression_check"

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -23,4 +23,5 @@ extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											bool force);
 extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,
 												 InternalTimeRange *original_refresh_window,
-												 int32 buckets_per_batch);
+												 int32 buckets_per_batch,
+												 bool refresh_newest_first);

--- a/tsl/test/expected/cagg_refresh_policy_incremental.out
+++ b/tsl/test/expected/cagg_refresh_policy_incremental.out
@@ -518,7 +518,8 @@ SELECT
         start_offset => INTERVAL '15 days',
         end_offset => NULL,
         schedule_interval => INTERVAL '1 h',
-        buckets_per_batch => 5
+        buckets_per_batch => 5,
+        refresh_newest_first => true -- explicitly set to true to test the default behavior
     ) AS job_id \gset
 SELECT
     add_continuous_aggregate_policy(
@@ -526,7 +527,7 @@ SELECT
         start_offset => INTERVAL '15 days',
         end_offset => NULL,
         schedule_interval => INTERVAL '1 h'
-    ) AS job_id \gset
+    ) AS job_id_manual \gset
 TRUNCATE bgw_log, conditions_by_day, conditions_by_day_manual_refresh, conditions;
 INSERT INTO conditions
 SELECT
@@ -571,6 +572,96 @@ SELECT * FROM sorted_bgw_log;
       1 |         0 | Refresh Continuous Aggregate Policy [1002] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1002] | inserted 80 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (18 rows)
+
+-- Both continuous aggregates should have the same data
+SELECT count(*) FROM conditions_by_day;
+ count 
+-------
+    80
+(1 row)
+
+SELECT count(*) FROM conditions_by_day_manual_refresh;
+ count 
+-------
+    80
+(1 row)
+
+-- Should have no differences
+SELECT
+    count(*) > 0 AS has_diff
+FROM
+    ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
+    EXCEPT
+    (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+ has_diff 
+----------
+ f
+(1 row)
+
+-- Testing with explicit refresh_newest_first = false (from oldest to newest)
+SELECT delete_job(:job_id);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT delete_job(:job_id_manual);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT
+    add_continuous_aggregate_policy(
+        'conditions_by_day',
+        start_offset => INTERVAL '15 days',
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h',
+        buckets_per_batch => 5,
+        refresh_newest_first => false
+    ) AS job_id \gset
+SELECT
+    config
+FROM
+    timescaledb_information.jobs
+WHERE
+    job_id = :'job_id';
+                                                              config                                                              
+----------------------------------------------------------------------------------------------------------------------------------
+ {"end_offset": null, "start_offset": "@ 15 days", "buckets_per_batch": 5, "mat_hypertable_id": 2, "refresh_newest_first": false}
+(1 row)
+
+TRUNCATE bgw_log, conditions_by_day;
+SELECT ts_bgw_params_reset_time(0, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time |              application_name              |                                                                                  msg                                                                                  
+--------+-----------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |         0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Mon Feb 24 00:00:00 2025 UTC, Sat Mar 01 00:00:00 2025 UTC ] (batch 1 of 4)
+      1 |         0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      2 |         0 | Refresh Continuous Aggregate Policy [1003] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 |         0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Mar 01 00:00:00 2025 UTC, Thu Mar 06 00:00:00 2025 UTC ] (batch 2 of 4)
+      4 |         0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      5 |         0 | Refresh Continuous Aggregate Policy [1003] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      6 |         0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Thu Mar 06 00:00:00 2025 UTC, Tue Mar 11 00:00:00 2025 UTC ] (batch 3 of 4)
+      7 |         0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+      8 |         0 | Refresh Continuous Aggregate Policy [1003] | inserted 25 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      9 |         0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Mar 11 00:00:00 2025 UTC, Wed Mar 12 00:00:00 2025 UTC ] (batch 4 of 4)
+     10 |         0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
+     11 |         0 | Refresh Continuous Aggregate Policy [1003] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+(14 rows)
 
 -- Both continuous aggregates should have the same data
 SELECT count(*) FROM conditions_by_day;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -212,7 +212,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  ts_now_mock()
  add_columnstore_policy(regclass,"any",boolean,interval,timestamp with time zone,text,interval,boolean)
  add_compression_policy(regclass,"any",boolean,interval,timestamp with time zone,text,interval,boolean)
- add_continuous_aggregate_policy(regclass,"any","any",interval,boolean,timestamp with time zone,text,boolean,integer,integer)
+ add_continuous_aggregate_policy(regclass,"any","any",interval,boolean,timestamp with time zone,text,boolean,integer,integer,boolean)
  add_dimension(regclass,_timescaledb_internal.dimension_info,boolean)
  add_dimension(regclass,name,integer,anyelement,regproc,boolean)
  add_job(regproc,interval,jsonb,timestamp with time zone,boolean,regproc,boolean,text)


### PR DESCRIPTION
In the Incremental CAgg Refresh Policy introduced on 2.19.0 the default batches order is from newest data to the oldest and there's no way to change it.

This PR introduce a new option to the CAgg Refresh Policy API `refresh_newest_first = TRUE` to control this behavior. If it's set to `FALSE` then the order of the incremental refresh will be from the oldest data to the newest.