### PR TITLE
Add batch size limiting during compression

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -154,6 +154,7 @@ bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = false;
+TSDLLEXPORT bool ts_guc_enable_compression_batch_size_limiting = false;
 
 /* Only settable in debug mode for testing */
 TSDLLEXPORT bool ts_guc_enable_null_compression = true;
@@ -785,6 +786,22 @@ _guc_init(void)
 							 "Enable experimental bool compression functionality",
 							 "Enable bool compression",
 							 &ts_guc_enable_bool_compression,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compression_batch_size_limiting"),
+							 "Enable compression batch size limiting functionality",
+							 "This enables limiting batch size for variable size column "
+							 "types which are compressed using array compression. Depending on the "
+							 "datum values being "
+							 "compressed, we can go over allocation hard limits (1GB). To get "
+							 "around this, we limit "
+							 "batches on this size in in conjunction with existing row count "
+							 "limits.",
+							 &ts_guc_enable_compression_batch_size_limiting,
 							 false,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -71,6 +71,7 @@ extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
+extern TSDLLEXPORT bool ts_guc_enable_compression_batch_size_limiting;
 #if PG16_GE
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif

--- a/tsl/src/compression/algorithms/array.c
+++ b/tsl/src/compression/algorithms/array.c
@@ -140,6 +140,26 @@ array_compressor_append_null_value(Compressor *compressor)
 	array_compressor_append_null(extended->internal);
 }
 
+static bool
+array_compressor_is_full(Compressor *compressor, Datum val)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = array_compressor_alloc(extended->element_type);
+
+	Size datum_size_and_align;
+	ArrayCompressor *array_comp = (ArrayCompressor *) extended->internal;
+	if (datum_serializer_value_may_be_toasted(array_comp->serializer))
+		val = PointerGetDatum(PG_DETOAST_DATUM_PACKED(val));
+
+	datum_size_and_align =
+		datum_get_bytes_size(array_comp->serializer, array_comp->data.num_elements, val) -
+		array_comp->data.num_elements;
+
+	/* If we can't fit new datum in the max size, we are full */
+	return (datum_size_and_align + array_comp->data.num_elements) > MAX_ARRAY_COMPRESSOR_SIZE_BYTES;
+}
+
 static void *
 array_compressor_finish_and_reset(Compressor *compressor)
 {
@@ -153,6 +173,7 @@ array_compressor_finish_and_reset(Compressor *compressor)
 const Compressor array_compressor = {
 	.append_val = array_compressor_append_datum,
 	.append_null = array_compressor_append_null_value,
+	.is_full = array_compressor_is_full,
 	.finish = array_compressor_finish_and_reset,
 };
 

--- a/tsl/src/compression/algorithms/array.h
+++ b/tsl/src/compression/algorithms/array.h
@@ -14,8 +14,11 @@
 
 #include <postgres.h>
 #include <fmgr.h>
+#include <utils/memutils.h>
 
 #include "compression/compression.h"
+
+#define MAX_ARRAY_COMPRESSOR_SIZE_BYTES MaxAllocSize
 
 typedef struct StringInfoData StringInfoData;
 typedef StringInfoData *StringInfo;

--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -47,11 +47,14 @@ static void bool_compressor_append_bool(Compressor *compressor, Datum val);
 
 static void bool_compressor_append_null_value(Compressor *compressor);
 
+static bool bool_compressor_is_full(Compressor *compressor, Datum val);
+
 static void *bool_compressor_finish_and_reset(Compressor *compressor);
 
 const Compressor bool_compressor_initializer = {
 	.append_val = bool_compressor_append_bool,
 	.append_null = bool_compressor_append_null_value,
+	.is_full = bool_compressor_is_full,
 	.finish = bool_compressor_finish_and_reset,
 };
 
@@ -338,6 +341,13 @@ bool_compressor_append_null_value(Compressor *compressor)
 		extended->internal = bool_compressor_alloc();
 
 	bool_compressor_append_null(extended->internal);
+}
+
+static bool
+bool_compressor_is_full(Compressor *compressor, Datum val)
+{
+	/* No limit */
+	return false;
 }
 
 static void *

--- a/tsl/src/compression/algorithms/deltadelta.c
+++ b/tsl/src/compression/algorithms/deltadelta.c
@@ -164,6 +164,13 @@ deltadelta_compressor_append_null_value(Compressor *compressor)
 	delta_delta_compressor_append_null(extended->internal);
 }
 
+static bool
+deltadelta_compressor_is_full(Compressor *compressor, Datum val)
+{
+	/* No limit */
+	return false;
+}
+
 static void *
 deltadelta_compressor_finish_and_reset(Compressor *compressor)
 {
@@ -177,40 +184,47 @@ deltadelta_compressor_finish_and_reset(Compressor *compressor)
 const Compressor deltadelta_bool_compressor = {
 	.append_val = deltadelta_compressor_append_bool,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_uint16_compressor = {
 	.append_val = deltadelta_compressor_append_int16,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 const Compressor deltadelta_uint32_compressor = {
 	.append_val = deltadelta_compressor_append_int32,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 const Compressor deltadelta_uint64_compressor = {
 	.append_val = deltadelta_compressor_append_int64,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_date_compressor = {
 	.append_val = deltadelta_compressor_append_date,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_timestamp_compressor = {
 	.append_val = deltadelta_compressor_append_timestamp,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_timestamptz_compressor = {
 	.append_val = deltadelta_compressor_append_timestamptz,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = deltadelta_compressor_is_full,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 

--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -86,11 +86,13 @@ typedef struct DictionaryCompressor
 {
 	dictionary_hash *dictionary_items;
 	uint32 next_index;
+	uint32 dict_val_size;
 	Oid type;
 	int16 typlen;
 	bool typbyval;
 	char typalign;
 	bool has_nulls;
+	DatumSerializer *serializer;
 	Simple8bRleCompressor dictionary_indexes;
 	Simple8bRleCompressor nulls;
 } DictionaryCompressor;
@@ -122,6 +124,26 @@ dictionary_compressor_append_null_value(Compressor *compressor)
 	dictionary_compressor_append_null(extended->internal);
 }
 
+static bool
+dictionary_compressor_is_full(Compressor *compressor, Datum val)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = dictionary_compressor_alloc(extended->element_type);
+
+	Size datum_size_and_align;
+	DictionaryCompressor *dict_comp = (DictionaryCompressor *) extended->internal;
+	if (datum_serializer_value_may_be_toasted(dict_comp->serializer))
+		val = PointerGetDatum(PG_DETOAST_DATUM_PACKED(val));
+
+	datum_size_and_align =
+		datum_get_bytes_size(dict_comp->serializer, dict_comp->dict_val_size, val) -
+		dict_comp->dict_val_size;
+
+	/* If we can't fit new datum in the max size, we are full */
+	return (datum_size_and_align + dict_comp->dict_val_size) > MAX_ARRAY_COMPRESSOR_SIZE_BYTES;
+}
+
 static void *
 dictionary_compressor_finish_and_reset(Compressor *compressor)
 {
@@ -135,6 +157,7 @@ dictionary_compressor_finish_and_reset(Compressor *compressor)
 const Compressor dictionary_compressor = {
 	.append_val = dictionary_compressor_append_datum,
 	.append_null = dictionary_compressor_append_null_value,
+	.is_full = dictionary_compressor_is_full,
 	.finish = dictionary_compressor_finish_and_reset,
 };
 
@@ -157,6 +180,7 @@ dictionary_compressor_alloc(Oid type)
 		lookup_type_cache(type, TYPECACHE_EQ_OPR_FINFO | TYPECACHE_HASH_PROC_FINFO);
 
 	compressor->next_index = 0;
+	compressor->dict_val_size = 0;
 	compressor->has_nulls = false;
 	compressor->type = type;
 	compressor->typlen = tentry->typlen;
@@ -164,6 +188,7 @@ dictionary_compressor_alloc(Oid type)
 	compressor->typalign = tentry->typalign;
 
 	compressor->dictionary_items = dictionary_hash_alloc(tentry);
+	compressor->serializer = create_datum_serializer(type);
 
 	simple8brle_compressor_init(&compressor->dictionary_indexes);
 	simple8brle_compressor_init(&compressor->nulls);
@@ -185,6 +210,9 @@ dictionary_compressor_append(DictionaryCompressor *compressor, Datum val)
 
 	Assert(compressor != NULL);
 
+	if (datum_serializer_value_may_be_toasted(compressor->serializer))
+		val = PointerGetDatum(PG_DETOAST_DATUM_PACKED(val));
+
 	dict_item = dictionary_insert(compressor->dictionary_items, val, &found);
 
 	if (!found)
@@ -195,6 +223,12 @@ dictionary_compressor_append(DictionaryCompressor *compressor, Datum val)
 		Assert(compressor->next_index <= INT16_MAX - 1);
 		compressor->next_index += 1;
 	}
+
+	Size datum_size_and_align =
+		datum_get_bytes_size(compressor->serializer, compressor->dict_val_size, val) -
+		compressor->dict_val_size;
+
+	compressor->dict_val_size += datum_size_and_align;
 
 	simple8brle_compressor_append(&compressor->dictionary_indexes, dict_item->index);
 	simple8brle_compressor_append(&compressor->nulls, 0);

--- a/tsl/src/compression/algorithms/gorilla.c
+++ b/tsl/src/compression/algorithms/gorilla.c
@@ -189,6 +189,13 @@ gorilla_compressor_append_null_value(Compressor *compressor)
 	gorilla_compressor_append_null(extended->internal);
 }
 
+static bool
+gorilla_compressor_is_full(Compressor *compressor, Datum val)
+{
+	/* No limit */
+	return false;
+}
+
 static void *
 gorilla_compressor_finish_and_reset(Compressor *compressor)
 {
@@ -202,27 +209,32 @@ gorilla_compressor_finish_and_reset(Compressor *compressor)
 const Compressor gorilla_float_compressor = {
 	.append_val = gorilla_compressor_append_float,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = gorilla_compressor_is_full,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 
 const Compressor gorilla_double_compressor = {
 	.append_val = gorilla_compressor_append_double,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = gorilla_compressor_is_full,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 const Compressor gorilla_uint16_compressor = {
 	.append_val = gorilla_compressor_append_int16,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = gorilla_compressor_is_full,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 const Compressor gorilla_uint32_compressor = {
 	.append_val = gorilla_compressor_append_int32,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = gorilla_compressor_is_full,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 const Compressor gorilla_uint64_compressor = {
 	.append_val = gorilla_compressor_append_int64,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = gorilla_compressor_is_full,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -67,6 +67,7 @@ struct Compressor
 {
 	void (*append_null)(Compressor *compressord);
 	void (*append_val)(Compressor *compressor, Datum val);
+	bool (*is_full)(Compressor *compressor, Datum val);
 	void *(*finish)(Compressor *data);
 };
 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2905,3 +2905,34 @@ SELECT count(*) FROM :CHUNK;
 (1 row)
 
 RESET timescaledb.enable_delete_after_compression;
+-- test limiting array compression to 1GB uncompressed data per batch
+-- Test decompression with DML which compares int8 to int4
+CREATE TABLE hyper_85 (time timestamptz, device int8, value text);
+SELECT create_hypertable('hyper_85', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable    
+------------------------
+ (55,public,hyper_85,t)
+(1 row)
+
+INSERT INTO hyper_85
+VALUES
+	('2025-01-01 00:00:00', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:01', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:02', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:03', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:04', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:05', 1, repeat(md5(random()::text), 32*1024*200));
+ALTER TABLE hyper_85 SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+NOTICE:  default order by for hypertable "hyper_85" is set to ""time" DESC"
+\set ON_ERROR_STOP 0
+SELECT compress_chunk(ch) FROM show_chunks('hyper_85') ch;
+ERROR:  vector allocation overflow
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_compression_batch_size_limiting TO ON;
+SELECT compress_chunk(ch) FROM show_chunks('hyper_85') ch;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_55_113_chunk
+(1 row)
+


### PR DESCRIPTION
For dictionary and array compression algorithms, you could potentially hit allocation limits if you try to compress too much data in a single column. Usually we limit batches based on number of rows but with this feature, we can limit them based on the size as well. Feature is behind a GUC due to potential performance impact it could have.