### PR TITLE
Use -a for grep when picking test files

### DIFF
--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -85,7 +85,7 @@ elif [[ -z ${TESTS} && ( -n ${SKIPS} || -n ${IGNORES} ) ]]; then
 
   echo > ${TEMP_SCHEDULE}
 
-  ALL_TESTS=$(grep '^test: ' ${TEST_SCHEDULE} 2>/dev/null | sed -e 's!^test: !!' |tr '\n' ' ')
+  ALL_TESTS=$(grep -a '^test: ' ${TEST_SCHEDULE} | sed -e 's!^test: !!' |tr '\n' ' ')
 
   # to support wildcards in IGNORES we match the IGNORES
   # list against the actual list of tests
@@ -119,7 +119,7 @@ elif [[ -z ${TESTS} && ( -n ${SKIPS} || -n ${IGNORES} ) ]]; then
 else
   # TESTS was specified so we need to create a new schedule based on that
 
-  ALL_TESTS=$(grep '^test: ' ${TEST_SCHEDULE} 2>/dev/null | sed -e 's!^test: !!' |tr '\n' ' ')
+  ALL_TESTS=$(grep -a '^test: ' ${TEST_SCHEDULE} | sed -e 's!^test: !!' |tr '\n' ' ')
 
   if [[ -z "${TESTS}" ]]; then
     TESTS=${ALL_TESTS}

--- a/test/runner_cleanup_output.sh
+++ b/test/runner_cleanup_output.sh
@@ -11,12 +11,12 @@ sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
      -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' \
      -e '/Heap Fetches: [0-9]\{1,\}/d' \
      -e '/found [0-9]\{1,\} removable, [0-9]\{1,\} nonremovable row versions in [0-9]\{1,\} pages/d' | \
-grep -v 'DEBUG:  rehashing catalog cache id' 2>/dev/null | \
-grep -v 'DEBUG:  compacted fsync request queue from' 2>/dev/null | \
-grep -v 'DEBUG:  creating and filling new WAL file' 2>/dev/null | \
-grep -v 'DEBUG:  done creating and filling new WAL file' 2>/dev/null | \
-grep -v 'DEBUG:  flushed relation because a checkpoint occurred concurrently' 2>/dev/null | \
-grep -v 'NOTICE:  cancelling the background worker for job' 2>/dev/null | \
+grep -av 'DEBUG:  rehashing catalog cache id' | \
+grep -av 'DEBUG:  compacted fsync request queue from' | \
+grep -av 'DEBUG:  creating and filling new WAL file' | \
+grep -av 'DEBUG:  done creating and filling new WAL file' | \
+grep -av 'DEBUG:  flushed relation because a checkpoint occurred concurrently' | \
+grep -av 'NOTICE:  cancelling the background worker for job' | \
 if [ "${RUNNER}" = "shared" ]; then \
     sed -e '/^-\{1,\}$/d' \
         -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \


### PR DESCRIPTION
When selecting test files, it is possible that one more more of the files are considered binary files by grep. In these cases, we should still grep the file as if it was a text file to make sure that we do not ignore any tests that should be included.

Disable-check: force-changelog-file