### PR TITLE
Backport to 2.19.x #7923: Add compression batch size limit GUC

### DIFF
--- a/.unreleased/pr_7923
+++ b/.unreleased/pr_7923
@@ -1,0 +1,1 @@
+Implements: #7923 Add compression batch size limit GUC

--- a/src/guc.c
+++ b/src/guc.c
@@ -154,6 +154,7 @@ bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = false;
+TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 
 /* Only settable in debug mode for testing */
 TSDLLEXPORT bool ts_guc_enable_null_compression = true;
@@ -775,6 +776,23 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+	DefineCustomIntVariable(MAKE_EXTOPTION("compression_batch_size_limit"),
+							"The max number of tuples that can be batched together during "
+							"compression",
+							"Setting this option to a number between 1 and 999 will force "
+							"compression "
+							"to limit the size of compressed batches to that amount of "
+							"uncompressed tuples."
+							"Setting this to 0 defaults to the max batch size of 1000.",
+							&ts_guc_compression_batch_size_limit,
+							1000,
+							1,
+							1000,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
 
 #ifdef TS_DEBUG
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_null_compression"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -71,6 +71,7 @@ extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
+extern TSDLLEXPORT int ts_guc_compression_batch_size_limit;
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -894,8 +894,8 @@ row_compressor_process_ordered_slot(RowCompressor *row_compressor, TupleTableSlo
 		row_compressor->first_iteration = false;
 	}
 	bool changed_groups = row_compressor_new_row_is_in_new_group(row_compressor, slot);
-	bool compressed_row_is_full =
-		row_compressor->rows_compressed_into_current_value >= TARGET_COMPRESSED_BATCH_SIZE;
+	bool compressed_row_is_full = row_compressor->rows_compressed_into_current_value >=
+								  (uint32) ts_guc_compression_batch_size_limit;
 	if (compressed_row_is_full || changed_groups)
 	{
 		if (row_compressor->rows_compressed_into_current_value > 0)

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2905,3 +2905,74 @@ SELECT count(*) FROM :CHUNK;
 (1 row)
 
 RESET timescaledb.enable_delete_after_compression;
+-- Test batch size limiting GUC
+CREATE TABLE hyper_85 (time timestamptz, device int8, location int8, temp float8);
+SELECT create_hypertable('hyper_85', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable    
+------------------------
+ (55,public,hyper_85,t)
+(1 row)
+
+INSERT INTO hyper_85
+SELECT t, 1, 1, 1.0
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-02'::timestamptz, '20 sec'::interval) t;
+ALTER TABLE hyper_85 SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+NOTICE:  default order by for hypertable "hyper_85" is set to ""time" DESC"
+-- first without the limit
+BEGIN;
+SELECT compress_chunk(ch) FROM show_chunks('hyper_85') ch;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_55_113_chunk
+(1 row)
+
+SELECT ch1.id "CHUNK_ID"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'hyper_85'
+ORDER BY ch1.id
+LIMIT 1 \gset
+select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
+where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
+ _ts_meta_count 
+----------------
+           1000
+           1000
+           1000
+           1000
+            321
+(5 rows)
+
+ROLLBACK;
+-- now lets set the limit
+SET timescaledb.compression_batch_size_limit = 505;
+BEGIN;
+SELECT compress_chunk(ch) FROM show_chunks('hyper_85') ch;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_55_113_chunk
+(1 row)
+
+SELECT ch1.id "CHUNK_ID"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'hyper_85'
+ORDER BY ch1.id
+LIMIT 1 \gset
+select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
+where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
+ _ts_meta_count 
+----------------
+            505
+            505
+            505
+            505
+            505
+            505
+            505
+            505
+            281
+(9 rows)
+
+ROLLBACK;


### PR DESCRIPTION
This GUC can be used to set the limit of rows batched together during compression. Valid values are 1-999 with 0 disabling limiting and using the default 1000 row limit.

