### PR TITLE
Fix flaky rowsecurity test

### DIFF
--- a/test/expected/rowsecurity-15.out
+++ b/test/expected/rowsecurity-15.out
@@ -4793,11 +4793,11 @@ INSERT INTO r2 VALUES (10), (20);
 CREATE POLICY p1 ON r2 USING (false);
 ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
--- Updates records in both
+-- Updates records in both (terse output to not print CONTEXT, which can be different).
+\set VERBOSITY terse
 UPDATE r1 SET a = a+5;
 ERROR:  new row for relation "_hyper_28_117_chunk" violates check constraint "constraint_117"
-DETAIL:  Failing row contains (15).
-CONTEXT:  SQL statement "UPDATE ONLY "regress_rls_schema"."r2" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
+\set VERBOSITY default
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -4793,11 +4793,11 @@ INSERT INTO r2 VALUES (10), (20);
 CREATE POLICY p1 ON r2 USING (false);
 ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
--- Updates records in both
+-- Updates records in both (terse output to not print CONTEXT, which can be different).
+\set VERBOSITY terse
 UPDATE r1 SET a = a+5;
 ERROR:  new row for relation "_hyper_28_117_chunk" violates check constraint "constraint_117"
-DETAIL:  Failing row contains (15).
-CONTEXT:  SQL statement "UPDATE ONLY "regress_rls_schema"."r2" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
+\set VERBOSITY default
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/test/expected/rowsecurity-17.out
+++ b/test/expected/rowsecurity-17.out
@@ -4793,11 +4793,11 @@ INSERT INTO r2 VALUES (10), (20);
 CREATE POLICY p1 ON r2 USING (false);
 ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
--- Updates records in both
+-- Updates records in both (terse output to not print CONTEXT, which can be different).
+\set VERBOSITY terse
 UPDATE r1 SET a = a+5;
 ERROR:  new row for relation "_hyper_28_117_chunk" violates check constraint "constraint_117"
-DETAIL:  Failing row contains (15).
-CONTEXT:  SQL statement "UPDATE ONLY "regress_rls_schema"."r2" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
+\set VERBOSITY default
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/test/sql/rowsecurity.sql.in
+++ b/test/sql/rowsecurity.sql.in
@@ -1695,8 +1695,10 @@ CREATE POLICY p1 ON r2 USING (false);
 ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
 
--- Updates records in both
+-- Updates records in both (terse output to not print CONTEXT, which can be different).
+\set VERBOSITY terse
 UPDATE r1 SET a = a+5;
+\set VERBOSITY default
 
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
The rowsecurity tests prints different CONTEXT statement depending on timing during execution, triggering flakes.

This reduces the verbosity to "terse" for the offending statement, but keeps the verbosity for the rest of the test.

Disable-check: force-changelog-file