### PR TITLE
Don't create hypertable for implicitly published tables

### DIFF
--- a/.unreleased/pr_7928
+++ b/.unreleased/pr_7928
@@ -1,0 +1,2 @@
+Fixes: #7928 Don't create hypertable for implicitly published tables
+Thanks: @arajkumar for reporting that implicitly published tables were still able to create hypertables

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1867,7 +1867,7 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 	/*
 	 * Check that the table is not part of any publication
 	 */
-	if (GetRelationPublications(table_relid) != NIL)
+	if (GetRelationPublications(table_relid) != NIL || GetAllTablesPublications() != NIL)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -1138,7 +1138,7 @@ ERROR:  cannot create a unique index without the column "time" (used in partitio
 HINT:  If you're creating a hypertable on a table with a primary key, ensure the partitioning column is part of the primary or composite key.
 \set ON_ERROR_STOP 1
 DROP TABLE test_schema.partition_not_pk;
--- test hypertable is not created for a table that is a part of a publication
+-- test hypertable is not created for a table that is a part of a publication explicitly
 SET client_min_messages = ERROR;
 CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
 CREATE PUBLICATION publication_test;
@@ -1165,5 +1165,22 @@ ALTER PUBLICATION publication_test1 DROP TABLE test;
 ALTER PUBLICATION publication_test2 DROP TABLE test;
 DROP PUBLICATION publication_test1;
 DROP PUBLICATION publication_test2;
+DROP TABLE test;
+-- test hypertable is not created for a table that is a part of a publication implicitly
+CREATE PUBLICATION publication_test FOR ALL tables;
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+ERROR:  cannot create hypertable for table "test" because it is part of a publication
+\set ON_ERROR_STOP 1
+DROP PUBLICATION publication_test;
+DROP TABLE test;
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+CREATE PUBLICATION publication_test FOR ALL tables;
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+ERROR:  cannot create hypertable for table "test" because it is part of a publication
+\set ON_ERROR_STOP 1
+DROP PUBLICATION publication_test;
 DROP TABLE test;
 RESET client_min_messages;

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -682,7 +682,7 @@ select create_hypertable ('test_schema.partition_not_pk', 'time');
 \set ON_ERROR_STOP 1
 DROP TABLE test_schema.partition_not_pk;
 
--- test hypertable is not created for a table that is a part of a publication
+-- test hypertable is not created for a table that is a part of a publication explicitly
 SET client_min_messages = ERROR;
 CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
 CREATE PUBLICATION publication_test;
@@ -708,5 +708,22 @@ ALTER PUBLICATION publication_test1 DROP TABLE test;
 ALTER PUBLICATION publication_test2 DROP TABLE test;
 DROP PUBLICATION publication_test1;
 DROP PUBLICATION publication_test2;
+DROP TABLE test;
+
+-- test hypertable is not created for a table that is a part of a publication implicitly
+CREATE PUBLICATION publication_test FOR ALL tables;
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+\set ON_ERROR_STOP 1
+DROP PUBLICATION publication_test;
+DROP TABLE test;
+
+CREATE TABLE test (timestamp TIMESTAMPTZ NOT NULL);
+CREATE PUBLICATION publication_test FOR ALL tables;
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('test', 'timestamp');
+\set ON_ERROR_STOP 1
+DROP PUBLICATION publication_test;
 DROP TABLE test;
 RESET client_min_messages;


### PR DESCRIPTION
Previously, only explicitly published tables were blocked from creating hypertables. Logical Replication of hypertables is not supported (for implementation reasons). We do not allow creation of hypertables with publications and now throw an error if attempted.


Thanks @arajkumar for highlighting the issue https://github.com/timescale/timescaledb/pull/7911#issuecomment-2782864246