### PR TITLE
CREATE TABLE WITH

### DIFF
--- a/.unreleased/pr_7929
+++ b/.unreleased/pr_7929
@@ -1,0 +1,1 @@
+Implements: #7929 Add CREATE TABLE ... WITH API for creating hypertables

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     chunk_index.c
     chunk_scan.c
     constraint.c
+    create_table_with_clause.c
     cross_module_fn.c
     copy.c
     compression_with_clause.c

--- a/src/create_table_with_clause.c
+++ b/src/create_table_with_clause.c
@@ -1,0 +1,25 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <catalog/pg_type.h>
+
+#include "compat/compat.h"
+#include "create_table_with_clause.h"
+#include "with_clause_parser.h"
+
+static const WithClauseDefinition create_table_with_clauses_def[] = {
+	[CreateTableFlagHypertable] = {.arg_names = {"hypertable", NULL}, .type_id = BOOLOID,},
+	[CreateTableFlagTimeColumn] = {.arg_names = {"time_column", NULL}, .type_id = TEXTOID,},
+};
+
+WithClauseResult *
+ts_create_table_with_clause_parse(const List *defelems)
+{
+	return ts_with_clauses_parse(defelems,
+								 create_table_with_clauses_def,
+								 TS_ARRAY_LEN(create_table_with_clauses_def));
+}

--- a/src/create_table_with_clause.h
+++ b/src/create_table_with_clause.h
@@ -1,0 +1,18 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include "with_clause_parser.h"
+
+typedef enum CreateTableFlags
+{
+	CreateTableFlagHypertable = 0,
+	CreateTableFlagTimeColumn,
+} CreateTableFlags;
+
+WithClauseResult *ts_create_table_with_clause_parse(const List *defelems);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -58,6 +58,7 @@
 #include "chunk_index.h"
 #include "compression_with_clause.h"
 #include "copy.h"
+#include "create_table_with_clause.h"
 #include "cross_module_fn.h"
 #include "debug_assert.h"
 #include "debug_point.h"
@@ -100,6 +101,19 @@ static bool expect_chunk_modification = false;
 static ProcessUtilityContext last_process_utility_context = PROCESS_UTILITY_TOPLEVEL;
 static DDLResult process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht);
 static DDLResult process_altertable_reset_options(AlterTableCmd *cmd, Hypertable *ht);
+
+static Oid
+get_sizing_func_oid()
+{
+	const char *sizing_func_name = "calculate_chunk_interval";
+	const int sizing_func_nargs = 3;
+	static Oid sizing_func_arg_types[] = { INT4OID, INT8OID, INT8OID };
+
+	return ts_get_function_oid(sizing_func_name,
+							   INTERNAL_SCHEMA_NAME,
+							   sizing_func_nargs,
+							   sizing_func_arg_types);
+}
 
 /* Call the default ProcessUtility and handle PostgreSQL version differences */
 static void
@@ -3665,6 +3679,13 @@ process_cluster_start(ProcessUtilityArgs *args)
 	return result;
 }
 
+typedef struct CreateTableInfo
+{
+	bool hypertable;
+	NameData time_column;
+} CreateTableInfo;
+
+static CreateTableInfo create_table_info = { 0 };
 /*
  * Process create table statements.
  *
@@ -3708,6 +3729,35 @@ process_create_table_end(Node *parsetree)
 			default:
 				break;
 		}
+	}
+
+	if (create_table_info.hypertable)
+	{
+		Oid table_relid = RangeVarGetRelid(stmt->relation, NoLock, true);
+
+		DimensionInfo *open_dim_info =
+			ts_dimension_info_create_open(table_relid,
+										  &create_table_info.time_column, /* column name */
+										  -1,							  /* interval */
+										  InvalidOid,					  /* interval type */
+										  InvalidOid					  /* partitioning func */
+			);
+
+		ChunkSizingInfo chunk_sizing_info = {
+			.table_relid = table_relid,
+			.func = get_sizing_func_oid(),
+			.colname = NameStr(create_table_info.time_column),
+		};
+
+		ts_hypertable_create_from_info(table_relid,
+									   INVALID_HYPERTABLE_ID,
+									   0,			  /* flags */
+									   open_dim_info, /* open_dim_info */
+									   NULL,		  /* closed_dim_info */
+									   NULL,		  /* associated_schema_name */
+									   NULL,		  /* associated_table_prefix */
+									   &chunk_sizing_info);
+		create_table_info.hypertable = false;
 	}
 }
 
@@ -4929,6 +4979,43 @@ process_create_stmt(ProcessUtilityArgs *args)
 				errhint("It does not make sense to set the default access method for all "
 						"tables to \"%s\" since it is only supported for hypertables.",
 						TS_HYPERCORE_TAM_NAME));
+
+	List *pg_options = NIL, *hypertable_options = NIL;
+	ts_with_clause_filter(stmt->options, &hypertable_options, &pg_options);
+	stmt->options = pg_options;
+
+	/*
+	 * We can only convert the table into a hypertable after postgres has created
+	 * the initial table so we store the information passed in the WITH clause
+	 * and do some initial sanity check and do the actual work of creating the hypertable
+	 * in process_create_table_end.
+	 */
+	if (hypertable_options)
+	{
+		WithClauseResult *parsed_with_clauses =
+			ts_create_table_with_clause_parse(hypertable_options);
+		create_table_info.hypertable =
+			DatumGetBool(parsed_with_clauses[CreateTableFlagHypertable].parsed);
+
+		if (!parsed_with_clauses[CreateTableFlagHypertable].parsed)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("timescaledb options requires hypertable option"),
+					 errhint("Use \"timescaledb.hypertable\" to enable creating a hypertable.")));
+
+		if (create_table_info.hypertable)
+		{
+			if (!parsed_with_clauses[CreateTableFlagTimeColumn].parsed)
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_COLUMN),
+						 errmsg("hypertable option requires time_column"),
+						 errhint("Use \"timescaledb.time_column\" to specify the column to use as "
+								 "partitioning column.")));
+
+			namestrcpy(&create_table_info.time_column,
+					   TextDatumGetCString(parsed_with_clauses[CreateTableFlagTimeColumn].parsed));
+		}
+	}
 
 	return DDL_CONTINUE;
 }

--- a/test/expected/create_table_with.out
+++ b/test/expected/create_table_with.out
@@ -1,0 +1,38 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- create table with non-tsdb option should not be affected
+CREATE TABLE t1(time timestamptz, device text, value float) WITH (autovacuum_enabled);
+-- test error cases
+\set ON_ERROR_STOP 0
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
+ERROR:  hypertable option requires time_column
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
+ERROR:  hypertable option requires time_column
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column=NULL);
+ERROR:  column "null" does not exist
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='');
+ERROR:  column "" does not exist
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='foo');
+ERROR:  column "foo" does not exist
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.time_column='time');
+ERROR:  timescaledb options requires hypertable option
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.time_column='time');
+ERROR:  timescaledb options requires hypertable option
+\set ON_ERROR_STOP 1
+CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
+CREATE TABLE t4(time timestamp, device text, value float) WITH (tsdb.hypertable,timescaledb.time_column='time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+NOTICE:  adding not-null constraint to column "time"
+CREATE TABLE t5(time date, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',autovacuum_enabled);
+NOTICE:  adding not-null constraint to column "time"
+CREATE TABLE t6(time timestamptz NOT NULL, device text, value float) WITH (timescaledb.hypertable,tsdb.time_column='time');
+SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
+ hypertable_name 
+-----------------
+ t3
+ t4
+ t5
+ t6
+(4 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_FILES
     create_chunks.sql
     create_hypertable.sql
     create_table.sql
+    create_table_with.sql
     constraint.sql
     copy.sql
     copy_where.sql

--- a/test/sql/create_table_with.sql
+++ b/test/sql/create_table_with.sql
@@ -1,0 +1,26 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- create table with non-tsdb option should not be affected
+CREATE TABLE t1(time timestamptz, device text, value float) WITH (autovacuum_enabled);
+
+-- test error cases
+\set ON_ERROR_STOP 0
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column=NULL);
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='');
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='foo');
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.time_column='time');
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.time_column='time');
+\set ON_ERROR_STOP 1
+
+
+CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
+CREATE TABLE t4(time timestamp, device text, value float) WITH (tsdb.hypertable,timescaledb.time_column='time');
+CREATE TABLE t5(time date, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',autovacuum_enabled);
+CREATE TABLE t6(time timestamptz NOT NULL, device text, value float) WITH (timescaledb.hypertable,tsdb.time_column='time');
+
+SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
+


### PR DESCRIPTION
This is the first patch to add support for CREATE TABLE ... WITH
for creating a hypertable. This patch only adds hypertable AND
time_column as options. The other timescaledb related configuration
settings will be added in followup patches.
