### PR TITLE
Simplify version.config

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -70,12 +70,12 @@ jobs:
       id: versions
       run: |
         # read expected version from version.config
-        # version will only be a proper version in a release branch so we use update_from_version
+        # version will only be a proper version in a release branch so we use previous_version
         # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
-          version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
+          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
         fi
         echo "version=${version}" >>$GITHUB_OUTPUT
 

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -64,12 +64,12 @@ jobs:
       id: versions
       run: |
         # read expected version from version.config
-        # version will only be a proper version in a release branch so we use update_from_version
+        # version will only be a proper version in a release branch so we use previous_version
         # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
-          version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
+          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
         fi
         echo "version=${version}" >>$GITHUB_OUTPUT
 

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -53,12 +53,12 @@ jobs:
       id: versions
       run: |
         # read expected version from version.config
-        # version will only be a proper version in a release branch so we use update_from_version
+        # version will only be a proper version in a release branch so we use previous_version
         # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
-          version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
+          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
         fi
         echo "version=${version}" >>$GITHUB_OUTPUT
 

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -52,7 +52,7 @@ jobs:
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
-          version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
+          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
         fi
         installed_version=$(psql -X -t \
             -c "SELECT extversion FROM pg_extension WHERE extname='timescaledb';" \

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -53,15 +53,10 @@ jobs:
 
     - name: Build timescaledb sqlfiles
       run: |
-        downgrade_to=$(grep '^downgrade_to_version = ' version.config | sed -e 's!^[^=]\+ = !!')
+        previous_version=$(grep '^previous_version = ' version.config | sed -e 's!^[^=]\+ = !!')
         git fetch --tags
         ./bootstrap -DGENERATE_DOWNGRADE_SCRIPT=ON
-        # We use downgrade_to_version instead of update_from_version because
-        # when the release PR for a new version has been merged to main but
-        # the version is not tagged yet update_from_version will not exist yet.
-        # In all other situations update_from_version and downgrade_to_version
-        # should point to the same version.
-        git checkout ${downgrade_to}
+        git checkout ${previous_version}
         make -C build sqlfile sqlupdatescripts
         git checkout ${GITHUB_SHA}
         make -C build sqlfile sqlupdatescripts
@@ -70,19 +65,19 @@ jobs:
     - name: Run pgspot
       run: |
         version=$(grep '^version = ' version.config | sed -e 's!^[^=]\+ = !!')
-        downgrade_to=$(grep '^downgrade_to_version = ' version.config | sed -e 's!^[^=]\+ = !!')
+        previous_version=$(grep '^previous_version = ' version.config | sed -e 's!^[^=]\+ = !!')
 
         # Show files used
-        ls -la build/sql/timescaledb--${version}.sql build/sql/timescaledb--${downgrade_to}--${version}.sql \
-          build/sql/timescaledb--${version}--${downgrade_to}.sql
+        ls -la build/sql/timescaledb--${version}.sql build/sql/timescaledb--${previous_version}--${version}.sql \
+          build/sql/timescaledb--${version}--${previous_version}.sql
 
         # The next pgspot execution tests the installation script by itself
         pgspot ${{ env.PGSPOT_OPTS }} build/sql/timescaledb--${version}.sql
         # The next pgspot execution tests the update script to the latest version
         # we prepend the installation script here so pgspot can correctly keep track of created objects
-        pgspot ${{ env.PGSPOT_OPTS }} -a build/sql/timescaledb--${downgrade_to}.sql \
-          build/sql/timescaledb--${downgrade_to}--${version}.sql
+        pgspot ${{ env.PGSPOT_OPTS }} -a build/sql/timescaledb--${previous_version}.sql \
+          build/sql/timescaledb--${previous_version}--${version}.sql
         # The next pgspot execution tests the downgrade script to the previous version
         # we prepend the installation script here so pgspot can correctly keep track of created objects
         pgspot ${{ env.PGSPOT_OPTS }} -a build/sql/timescaledb--${version}.sql \
-          build/sql/timescaledb--${version}--${downgrade_to}.sql
+          build/sql/timescaledb--${version}--${previous_version}.sql

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -71,12 +71,12 @@ jobs:
       id: versions
       run: |
         # read expected version from version.config
-        # version will only be a proper version in a release branch so we use update_from_version
+        # version will only be a proper version in a release branch so we use previous_version
         # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
-          version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
+          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
         fi
         echo "version=${version}" >>$GITHUB_OUTPUT
 

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -57,13 +57,13 @@ jobs:
     - name: Get version
       id: version
       run: |
-        # version will only be a proper version in a release branch so we use update_from_version
+        # version will only be a proper version in a release branch so we use previous_version
         # as fallback for main
         if (grep '^version = [0-9.]\+$' version.config)
         {
           $version=sed -n 's!^version = !!p' version.config
         } else {
-          $version=sed -n 's!^update_from_version = !!p' version.config
+          $version=sed -n 's!^previous_version = !!p' version.config
         }
         cat version.config
         echo "Determined version: "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,18 +76,20 @@ if(VERSION_CONFIG
   endif()
 endif()
 
-if(VERSION_CONFIG
-   MATCHES
-   ".*update_from_version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.[0-9]+(-[a-z]+[0-9]*)?).*"
-)
-  set(UPDATE_FROM_VERSION ${CMAKE_MATCH_1})
-endif()
-
+# fallback for < 2.20 downgrade can be removed after we release 2.20
 if(VERSION_CONFIG
    MATCHES
    ".*downgrade_to_version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.[0-9]+(-[a-z]+[0-9]*)?).*"
 )
+  set(UPDATE_FROM_VERSION ${CMAKE_MATCH_1})
   set(DOWNGRADE_TO_VERSION ${CMAKE_MATCH_1})
+  set(PREVIOUS_VERSION ${CMAKE_MATCH_1})
+endif()
+
+if(VERSION_CONFIG MATCHES
+   ".*previous_version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.[0-9]+(-[a-z]+[0-9]*)?).*"
+)
+  set(PREVIOUS_VERSION ${CMAKE_MATCH_1})
 endif()
 
 # a hack to avoid change of SQL extschema variable
@@ -119,7 +121,7 @@ endif()
 
 message(
   STATUS
-    "TimescaleDB version ${PROJECT_VERSION_MOD}. Can be updated from version ${UPDATE_FROM_VERSION}"
+    "TimescaleDB version ${PROJECT_VERSION_MOD}. Can be updated from version ${PREVIOUS_VERSION}"
 )
 message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
 

--- a/scripts/changelog/generate.sh
+++ b/scripts/changelog/generate.sh
@@ -18,7 +18,7 @@ get_version_config_var() {
 }
 
 RELEASE_NEXT=$(get_version_config_var '^version')
-RELEASE_PREVIOUS=$(get_version_config_var '^update_from_version')
+RELEASE_PREVIOUS=$(get_version_config_var '^previous_version')
 
 echo "Building CHANGELOG"
 {

--- a/scripts/test_downgrade.sh
+++ b/scripts/test_downgrade.sh
@@ -16,7 +16,7 @@ fi
 BUILD_DIR="build_update_pg${PG_MAJOR_VERSION}"
 
 CURRENT_VERSION=$(grep '^version ' version.config | awk '{ print $3 }')
-PREV_VERSION=$(grep '^downgrade_to_version ' version.config | awk '{ print $3 }')
+PREV_VERSION=$(grep '^previous_version ' version.config | awk '{ print $3 }')
 
 if [ ! -d "${BUILD_DIR}" ]; then
   echo "Initializing build directory"

--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -9,7 +9,7 @@
 set -e
 set -u
 
-FROM_VERSION=${FROM_VERSION:-$(grep '^downgrade_to_version ' version.config | awk '{ print $3 }')}
+FROM_VERSION=${FROM_VERSION:-$(grep '^previous_version ' version.config | awk '{ print $3 }')}
 TO_VERSION=${TO_VERSION:-$(grep '^version ' version.config | awk '{ print $3 }')}
 
 TEST_REPAIR=${TEST_REPAIR:-false}

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -18,7 +18,7 @@ VERSIONS=""
 FAILED_VERSIONS=""
 
 ALL_VERSIONS=$(git tag --sort=taggerdate | grep -P '^[2]\.[0-9]+\.[0-9]+$')
-MAX_VERSION=$(grep '^downgrade_to_version ' version.config | awk '{ print $3 }')
+MAX_VERSION=$(grep '^previous_version ' version.config | awk '{ print $3 }')
 
 # major version is always 2 atm
 max_minor_version=$(echo "${MAX_VERSION}" | awk -F. '{print $2}')

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
     SOURCE_VERSION
     ${PROJECT_VERSION_MOD}
     TARGET_VERSION
-    ${DOWNGRADE_TO_VERSION}
+    ${PREVIOUS_VERSION}
     INPUT_DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/updates
     FILES
@@ -235,12 +235,12 @@ set(MOD_FILE_REGEX
 
 # We'd like to process the updates in reverse (descending) order
 if(EXISTS
-   "${CMAKE_CURRENT_SOURCE_DIR}/updates/${UPDATE_FROM_VERSION}--${PROJECT_VERSION_MOD}.sql"
+   "${CMAKE_CURRENT_SOURCE_DIR}/updates/${PREVIOUS_VERSION}--${PROJECT_VERSION_MOD}.sql"
 )
   set(MOD_FILES_LIST ${MOD_FILES_VERSIONED})
 else()
   set(MOD_FILES_LIST
-      "${MOD_FILES_VERSIONED};updates/${UPDATE_FROM_VERSION}--${PROJECT_VERSION_MOD}.sql"
+      "${MOD_FILES_VERSIONED};updates/${PREVIOUS_VERSION}--${PROJECT_VERSION_MOD}.sql"
   )
 endif()
 
@@ -259,7 +259,7 @@ set(CURR_MOD_FILES "${LASTEST_MOD_VERSIONED}")
 foreach(transition_mod_file ${MOD_FILES_LIST})
 
   if(NOT (${transition_mod_file} MATCHES ${MOD_FILE_REGEX}))
-    message(FATAL_ERROR "Cannot parse update file name ${mod_file}")
+    message(FATAL_ERROR "Cannot parse update file name ${transition_mod_file}")
   endif()
 
   set(START_VERSION ${CMAKE_MATCH_1})

--- a/sql/updates/README.md
+++ b/sql/updates/README.md
@@ -82,7 +82,7 @@ not to any other preceeding versions.
 
 The source and target versions are found in be found in the file
 `version.config` file in the root of the source tree, where `version`
-is the source version and `downgrade_to_version` is the target
+is the source version and `previous_version` is the target
 version. Note that we have a separate field for the downgrade.
 
 A downgrade file consists of:
@@ -122,7 +122,7 @@ script to the immediately preceeding version.
 ### When releasing a new version
 
 When releasing a new version, please rename the file `reverse-dev.sql`
-to `<version>--<downgrade_to_version>.sql` and add that name to
+to `<version>--<previous_version>.sql` and add that name to
 `REV_FILES` variable in the `sql/CMakeLists.txt`. This will allow
 generation of downgrade scripts for any version in that list, but it
 is currently not added.

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.20.0-dev
-update_from_version = 2.19.2
+previous_version = 2.19.2
 downgrade_to_version = 2.19.2


### PR DESCRIPTION
Since we adjusted our release procedure recently we do no longer
need to keep track of update and downgrade version separately and
can instead combine them as previous_version, simplifying the
version.config file.

Disable-check: force-changelog-file