### PR TITLE
Fix column mapping in column stats calculation

### DIFF
--- a/.unreleased/pr_7941
+++ b/.unreleased/pr_7941
@@ -1,0 +1,2 @@
+Fixes: #7941 Fix column mapping in column stats calculation
+Thanks: @pantonis for reporting the issue with column stats calculation

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -763,7 +763,7 @@ ts_chunk_column_stats_calculate(const Hypertable *ht, const Chunk *chunk)
 		/* Get the attribute number in the HT for this column, and map to the chunk */
 		attno = get_attnum(ht->main_table_relid, col_name);
 		attno = ts_map_attno(ht->main_table_relid, chunk->table_id, attno);
-		col_type = get_atttype(ht->main_table_relid, attno);
+		col_type = get_atttype(chunk->table_id, attno);
 
 		/* calculate the min/max range for this column on this chunk */
 		if (ts_chunk_get_minmax(chunk->table_id, col_type, attno, "column range", minmax))

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -780,3 +780,46 @@ SELECT * FROM disable_chunk_skipping('sample_table1', 'sensor_id');
 (1 row)
 
 ALTER TABLE sample_table1 ALTER COLUMN sensor_id TYPE TEXT;
+-- Check that column mapping between hypertable and chunk doesn't break when
+-- hypertable has dropped columns
+-- See: https://github.com/timescale/timescaledb/issues/7932
+CREATE TABLE sample_table (
+    time TIMESTAMPTZ NOT NULL,
+    sensor_id INTEGER,
+    cpu NUMERIC,
+    temperature BIGINT);
+CREATE INDEX ON sample_table (temperature);
+SELECT create_hypertable('sample_table', 'time', chunk_time_interval=>'7 days'::interval);
+     create_hypertable     
+---------------------------
+ (4,public,sample_table,t)
+(1 row)
+
+ALTER TABLE sample_table DROP COLUMN sensor_id;
+INSERT INTO sample_table VALUES
+    (now(), 1, 366),
+    (now(), 2, 501);
+ALTER TABLE sample_table SET (timescaledb.compress, timescaledb.compress_orderby='time');
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: Please make sure temperature is not a unique column and appropriate for a segment by
+NOTICE:  default segment by for hypertable "sample_table" is set to "temperature"
+set timescaledb.enable_chunk_skipping = on;
+SELECT enable_chunk_skipping('sample_table', 'temperature');
+ enable_chunk_skipping 
+-----------------------
+ (11,t)
+(1 row)
+
+SELECT show_chunks('sample_table') AS "CH_NAME" order by 1 limit 1 \gset
+SELECT compress_chunk(:'CH_NAME');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_4_8_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.chunk_column_stats;
+ id | hypertable_id | chunk_id | column_name |     range_start      |      range_end      | valid 
+----+---------------+----------+-------------+----------------------+---------------------+-------
+ 11 |             4 |        0 | temperature | -9223372036854775808 | 9223372036854775807 | t
+ 12 |             4 |        8 | temperature |                  366 |                 502 | t
+(2 rows)
+

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -288,3 +288,24 @@ ALTER TABLE sample_table1 ALTER COLUMN sensor_id TYPE TEXT;
 
 SELECT * FROM disable_chunk_skipping('sample_table1', 'sensor_id');
 ALTER TABLE sample_table1 ALTER COLUMN sensor_id TYPE TEXT;
+
+-- Check that column mapping between hypertable and chunk doesn't break when
+-- hypertable has dropped columns
+-- See: https://github.com/timescale/timescaledb/issues/7932
+CREATE TABLE sample_table (
+    time TIMESTAMPTZ NOT NULL,
+    sensor_id INTEGER,
+    cpu NUMERIC,
+    temperature BIGINT);
+CREATE INDEX ON sample_table (temperature);
+SELECT create_hypertable('sample_table', 'time', chunk_time_interval=>'7 days'::interval);
+ALTER TABLE sample_table DROP COLUMN sensor_id;
+INSERT INTO sample_table VALUES
+    (now(), 1, 366),
+    (now(), 2, 501);
+ALTER TABLE sample_table SET (timescaledb.compress, timescaledb.compress_orderby='time');
+set timescaledb.enable_chunk_skipping = on;
+SELECT enable_chunk_skipping('sample_table', 'temperature');
+SELECT show_chunks('sample_table') AS "CH_NAME" order by 1 limit 1 \gset
+SELECT compress_chunk(:'CH_NAME');
+SELECT * FROM _timescaledb_catalog.chunk_column_stats;


### PR DESCRIPTION
Column stats calculation code mistakingly used column type from hypertable based on attribute number from chunk. In many cases it worked fine unless hypertable had dropped columns that new chunks didn't have. In that case column type could be identified incorrectly causing errors or segfaults.

See #7932