### PR TITLE
Add support for splitting a chunk

### DIFF
--- a/.unreleased/pr_7946
+++ b/.unreleased/pr_7946
@@ -1,0 +1,1 @@
+Implements: #7946 Add support for splitting a chunk

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -65,6 +65,11 @@ CREATE OR REPLACE PROCEDURE @extschema@.merge_chunks(
     chunks REGCLASS[]
 ) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_merge_chunks';
 
+CREATE OR REPLACE PROCEDURE @extschema@.split_chunk(
+    chunk REGCLASS,
+    split_at "any" = NULL
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_split_chunk';
+
 CREATE OR REPLACE FUNCTION _timescaledb_functions.recompress_chunk_segmentwise(
     uncompressed_chunk REGCLASS,
     if_compressed BOOLEAN = true

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,6 +1,7 @@
 DROP FUNCTION IF EXISTS _timescaledb_internal.create_chunk_table;
 DROP FUNCTION IF EXISTS _timescaledb_functions.create_chunk_table;
 
+
 -- New option `refresh_newest_first` for incremental cagg refresh policy
 DROP FUNCTION @extschema@.add_continuous_aggregate_policy(
     continuous_aggregate REGCLASS,
@@ -38,3 +39,10 @@ DROP VIEW IF EXISTS timescaledb_information.hypertables;
 
 -- Rename Columnstore Policy jobs to Compression Policy
 UPDATE _timescaledb_config.bgw_job SET application_name = replace(application_name, 'Compression Policy', 'Columnstore Policy') WHERE application_name LIKE '%Compression Policy%';
+
+-- Split chunk
+CREATE PROCEDURE @extschema@.split_chunk(
+    chunk REGCLASS,
+    split_at "any" = NULL
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_update_placeholder';
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -228,3 +228,6 @@ BEGIN
   END CASE;
 END;
 $$ LANGUAGE PLPGSQL;
+
+-- Split chunk
+DROP PROCEDURE IF EXISTS @extschema@.split_chunk(chunk REGCLASS, split_at "any");

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -100,6 +100,7 @@ CROSSMODULE_WRAPPER(chunk_unfreeze_chunk);
 CROSSMODULE_WRAPPER(recompress_chunk_segmentwise);
 CROSSMODULE_WRAPPER(get_compressed_chunk_index_for_recompression);
 CROSSMODULE_WRAPPER(merge_chunks);
+CROSSMODULE_WRAPPER(split_chunk);
 
 /* hypercore */
 CROSSMODULE_WRAPPER(is_compressed_tid);
@@ -434,6 +435,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.get_compressed_chunk_index_for_recompression = error_no_default_fn_pg_community,
 	.preprocess_query_tsl = preprocess_query_tsl_default_fn_community,
 	.merge_chunks = error_no_default_fn_pg_community,
+	.split_chunk = error_no_default_fn_pg_community,
 };
 
 TSDLLEXPORT CrossModuleFunctions *ts_cm_functions = &ts_cm_functions_default;

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -167,6 +167,7 @@ typedef struct CrossModuleFunctions
 	PGFunction get_compressed_chunk_index_for_recompression;
 	void (*preprocess_query_tsl)(Query *parse, int *cursor_opts);
 	PGFunction merge_chunks;
+	PGFunction split_chunk;
 } CrossModuleFunctions;
 
 extern TSDLLEXPORT CrossModuleFunctions *ts_cm_functions;

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -14,3 +14,4 @@ extern Datum chunk_unfreeze_chunk(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type,
 									bool use_creation_time);
 extern Datum chunk_merge_chunks(PG_FUNCTION_ARGS);
+extern Datum chunk_split_chunk(PG_FUNCTION_ARGS);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -194,6 +194,7 @@ CrossModuleFunctions tsl_cm_functions = {
 		tsl_get_compressed_chunk_index_for_recompression,
 	.preprocess_query_tsl = tsl_preprocess_query,
 	.merge_chunks = chunk_merge_chunks,
+	.split_chunk = chunk_split_chunk,
 };
 
 static void

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -1,0 +1,408 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ACCESS METHOD testam TYPE TABLE HANDLER heap_tableam_handler;
+set role :ROLE_DEFAULT_PERM_USER;
+create view chunk_slices as
+select
+    h.table_name as hypertable_name,
+    c.table_name as chunk_name,
+    _timescaledb_functions.to_timestamp(ds.range_start) as range_start,
+    _timescaledb_functions.to_timestamp(ds.range_end) as range_end
+from _timescaledb_catalog.chunk c
+join _timescaledb_catalog.chunk_constraint cc on (cc.chunk_id = c.id)
+join _timescaledb_catalog.dimension_slice ds on (ds.id = cc.dimension_slice_id)
+join _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
+order by range_start, range_end;
+create table splitme (time timestamptz not null, device int, location int, temp float, comment text);
+select create_hypertable('splitme', 'time', chunk_time_interval => interval '1 week');
+  create_hypertable   
+----------------------
+ (1,public,splitme,t)
+(1 row)
+
+alter table splitme set (timescaledb.compress_orderby='time', timescaledb.compress_segmentby='device');
+--
+-- Insert data to create two chunks with time ranges like this:
+-- _____________
+-- |     |     |
+-- |  1  |  2  |
+-- |_____|_____|
+---
+--- Make sure we have a long text value to create toast table
+insert into splitme values
+       ('2024-01-03 22:00', 1, 1, 1.0, 'foo'),
+       ('2024-01-09 15:00', 1, 2, 2.0, 'barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar');
+-- Remove a column to ensure that split can handle it
+alter table splitme drop column location;
+-- All data in single chunk
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(1 row)
+
+select time, device, temp from _timescaledb_internal._hyper_1_1_chunk order by time;
+             time             | device | temp 
+------------------------------+--------+------
+ Wed Jan 03 22:00:00 2024 PST |      1 |    1
+ Tue Jan 09 15:00:00 2024 PST |      1 |    2
+(2 rows)
+
+select * from chunk_slices where hypertable_name = 'splitme';
+ hypertable_name |    chunk_name    |         range_start          |          range_end           
+-----------------+------------------+------------------------------+------------------------------
+ splitme         | _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(1 row)
+
+\set ON_ERROR_STOP 0
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 1);
+ERROR:  invalid type 'integer' for split_at argument
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 1::int);
+ERROR:  invalid type 'integer' for split_at argument
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => '2024-01-04 00:00'::timestamp);
+ERROR:  invalid type 'timestamp without time zone' for split_at argument
+-- Split at start of chunk range
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 'Wed Jan 03 16:00:00 2024 PST');
+ERROR:  cannot split chunk at Wed Jan 03 16:00:00 2024 PST
+-- Split at end of chunk range
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 'Wed Jan 10 16:00:00 2024 PST');
+ERROR:  cannot split chunk at Wed Jan 10 16:00:00 2024 PST
+-- Split at multiple points. Not supported yet.
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => '{ 2024-01-04 10:00, 2024-01-07 12:00 }'::timestamptz[]);
+ERROR:  invalid type 'timestamp with time zone[]' for split_at argument
+-- Try to split something which is not a chunk
+call split_chunk('splitme');
+ERROR:  chunk not found
+-- Split a chunk with unsupported access method
+alter table _timescaledb_internal._hyper_1_1_chunk set access method testam;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ERROR:  access method "testam" is not supported for split
+alter table _timescaledb_internal._hyper_1_1_chunk set access method heap;
+-- Split an OSM chunk is not supported
+reset role;
+update _timescaledb_catalog.chunk ch set osm_chunk = true where table_name = '_hyper_1_1_chunk';
+set role :ROLE_DEFAULT_PERM_USER;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ERROR:  cannot split OSM chunks
+reset role;
+update _timescaledb_catalog.chunk ch set osm_chunk = false where table_name = '_hyper_1_1_chunk';
+set role :ROLE_DEFAULT_PERM_USER;
+-- Split a frozen chunk is not supported
+select _timescaledb_functions.freeze_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ freeze_chunk 
+--------------
+ t
+(1 row)
+
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ERROR:  cannot split frozen chunk "_timescaledb_internal._hyper_1_1_chunk" scheduled for tiering
+select _timescaledb_functions.unfreeze_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
+-- Split a compressed/columnstore chunk is not supported
+begin;
+call convert_to_columnstore('_timescaledb_internal._hyper_1_1_chunk');
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ERROR:  splitting a compressed chunk is not supported
+rollback;
+-- Split by non-owner is not allowed
+set role :ROLE_1;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ERROR:  must be owner of table _hyper_1_1_chunk
+set role :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 1
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => '2024-01-04 00:00');
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 00:00:00 2024 PST
+ _hyper_1_3_chunk | Thu Jan 04 00:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(2 rows)
+
+select * from chunk_slices where hypertable_name = 'splitme';
+ hypertable_name |    chunk_name    |         range_start          |          range_end           
+-----------------+------------------+------------------------------+------------------------------
+ splitme         | _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 00:00:00 2024 PST
+ splitme         | _hyper_1_3_chunk | Thu Jan 04 00:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(2 rows)
+
+-- Show that the two tuples ended up in different chunks
+select time, device, temp from _timescaledb_internal._hyper_1_1_chunk order by time;
+             time             | device | temp 
+------------------------------+--------+------
+ Wed Jan 03 22:00:00 2024 PST |      1 |    1
+(1 row)
+
+select time, device, temp from _timescaledb_internal._hyper_1_3_chunk order by time;
+             time             | device | temp 
+------------------------------+--------+------
+ Tue Jan 09 15:00:00 2024 PST |      1 |    2
+(1 row)
+
+select setseed(0.2);
+ setseed 
+---------
+ 
+(1 row)
+
+-- Test split with bigger data set and chunks with more blocks
+insert into splitme (time, device, temp)
+select t, ceil(random()*10), random()*40
+from generate_series('2024-01-03 23:00'::timestamptz, '2024-01-10 01:00', '10s') t;
+select count(*) from splitme;
+ count 
+-------
+ 52563
+(1 row)
+
+-- Add back location just to make things more difficult
+alter table splitme add column location int default 1;
+-- There are two space partitions (device), so several chunks will
+-- have the same time ranges
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 00:00:00 2024 PST
+ _hyper_1_3_chunk | Thu Jan 04 00:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(2 rows)
+
+-- Split chunk 2. Save count to compare after split.
+select count(*) from _timescaledb_internal._hyper_1_3_chunk;
+ count 
+-------
+ 52202
+(1 row)
+
+select count(*) orig_count from _timescaledb_internal._hyper_1_3_chunk \gset
+-- Generate some garbage so that we can see that it gets cleaned up
+-- during split
+update  _timescaledb_internal._hyper_1_3_chunk set temp = temp+1 where temp > 10;
+-- This will split in two equal size chunks
+call split_chunk('_timescaledb_internal._hyper_1_3_chunk');
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 00:00:00 2024 PST
+ _hyper_1_3_chunk | Thu Jan 04 00:00:00 2024 PST | Sun Jan 07 08:00:00 2024 PST
+ _hyper_1_4_chunk | Sun Jan 07 08:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(3 rows)
+
+-- Check that the counts in the two result partitions is the same as
+-- in the original partition and that the tuple counts are roughly the
+-- same across the partitions.
+with counts as (
+    select (select count(*) from _timescaledb_internal._hyper_1_3_chunk) count1,
+            (select count(*) from _timescaledb_internal._hyper_1_4_chunk) count2
+) select
+  c.count1, c.count2,
+  c.count1 + c.count2 as total_count,
+  (c.count1 + c.count2) = :orig_count as is_same_count
+from counts c;
+ count1 | count2 | total_count | is_same_count 
+--------+--------+-------------+---------------
+  28800 |  23402 |       52202 | t
+(1 row)
+
+-- Check that both rels return proper data and no columns are messed
+-- up
+select time, device, location, temp from _timescaledb_internal._hyper_1_3_chunk order by time, device limit 3;
+             time             | device | location |       temp       
+------------------------------+--------+----------+------------------
+ Thu Jan 04 00:00:00 2024 PST |      2 |        1 | 25.6730424335366
+ Thu Jan 04 00:00:10 2024 PST |      6 |        1 | 15.0341761730165
+ Thu Jan 04 00:00:20 2024 PST |      6 |        1 | 27.5663547962209
+(3 rows)
+
+select time, device, location, temp from _timescaledb_internal._hyper_1_4_chunk order by time, device limit 3;
+             time             | device | location |       temp       
+------------------------------+--------+----------+------------------
+ Sun Jan 07 08:00:00 2024 PST |     10 |        1 | 4.03503358112434
+ Sun Jan 07 08:00:10 2024 PST |      8 |        1 |  17.726969596003
+ Sun Jan 07 08:00:20 2024 PST |      6 |        1 | 9.63191118430237
+(3 rows)
+
+--
+-- Test split with integer time
+--
+create table splitme_int (time int not null, device int, temp float);
+select create_hypertable('splitme_int', 'time', chunk_time_interval => 10::int);
+    create_hypertable     
+--------------------------
+ (3,public,splitme_int,t)
+(1 row)
+
+insert into splitme_int values (1, 1, 1.0), (8, 8, 8.0);
+select ch as int_chunk from show_chunks('splitme_int') ch order by ch limit 1 \gset
+select * from chunk_slices where hypertable_name = 'splitme_int';
+ hypertable_name |    chunk_name    |         range_start          |             range_end              
+-----------------+------------------+------------------------------+------------------------------------
+ splitme_int     | _hyper_3_5_chunk | Wed Dec 31 16:00:00 1969 PST | Wed Dec 31 16:00:00.00001 1969 PST
+(1 row)
+
+\set ON_ERROR_STOP 0
+call split_chunk(:'int_chunk', split_at => 0);
+ERROR:  cannot split chunk at 0
+call split_chunk(:'int_chunk', split_at => 10);
+ERROR:  cannot split chunk at 10
+\set ON_ERROR_STOP 1
+call split_chunk(:'int_chunk', split_at => '5');
+select * from chunk_slices where hypertable_name = 'splitme_int';
+ hypertable_name |    chunk_name    |             range_start             |              range_end              
+-----------------+------------------+-------------------------------------+-------------------------------------
+ splitme_int     | _hyper_3_5_chunk | Wed Dec 31 16:00:00 1969 PST        | Wed Dec 31 16:00:00.000005 1969 PST
+ splitme_int     | _hyper_3_6_chunk | Wed Dec 31 16:00:00.000005 1969 PST | Wed Dec 31 16:00:00.00001 1969 PST
+(2 rows)
+
+select * from :int_chunk order by time;
+ time | device | temp 
+------+--------+------
+    1 |      1 |    1
+(1 row)
+
+select * from splitme_int order by time;
+ time | device | temp 
+------+--------+------
+    1 |      1 |    1
+    8 |      8 |    8
+(2 rows)
+
+-- Split with one empty chunk
+call split_chunk(:'int_chunk', split_at => 3);
+select * from chunk_slices where hypertable_name = 'splitme_int';
+ hypertable_name |    chunk_name    |             range_start             |              range_end              
+-----------------+------------------+-------------------------------------+-------------------------------------
+ splitme_int     | _hyper_3_5_chunk | Wed Dec 31 16:00:00 1969 PST        | Wed Dec 31 16:00:00.000003 1969 PST
+ splitme_int     | _hyper_3_7_chunk | Wed Dec 31 16:00:00.000003 1969 PST | Wed Dec 31 16:00:00.000005 1969 PST
+ splitme_int     | _hyper_3_6_chunk | Wed Dec 31 16:00:00.000005 1969 PST | Wed Dec 31 16:00:00.00001 1969 PST
+(3 rows)
+
+select * from :int_chunk order by time;
+ time | device | temp 
+------+--------+------
+    1 |      1 |    1
+(1 row)
+
+select ch as int_chunk from show_chunks('splitme_int') ch order by ch limit 1 offset 2 \gset
+\echo :int_chunk
+_timescaledb_internal._hyper_3_7_chunk
+select * from :int_chunk order by time;
+ time | device | temp 
+------+--------+------
+(0 rows)
+
+-- Insert data into the empty chunk
+insert into splitme_int values (4, 4, 4.0);
+select * from :int_chunk order by time;
+ time | device | temp 
+------+--------+------
+    4 |      4 |    4
+(1 row)
+
+--
+-- Try with more data after split
+--
+create view chunk_info as
+select relname as chunk, amname as tam, con.conname, pg_get_expr(conbin, ch) checkconstraint
+from pg_class cl
+join pg_am am on (cl.relam = am.oid)
+join show_chunks('splitme') ch on (cl.oid = ch)
+join pg_constraint con on (con.conrelid = ch)
+where con.contype = 'c'
+order by 1,2,3 desc;
+-- Remove comment column to generate dropped column
+alter table splitme drop column comment;
+select * from chunk_info;
+      chunk       | tam  |   conname    |                                                                checkconstraint                                                                 
+------------------+------+--------------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | constraint_1 | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 00:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | heap | constraint_3 | (("time" >= 'Thu Jan 04 00:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap | constraint_5 | (("time" >= 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 10 16:00:00 2024 PST'::timestamp with time zone))
+(3 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+set role :ROLE_DEFAULT_PERM_USER;
+select * from chunk_slices where hypertable_name = 'splitme';
+ hypertable_name |    chunk_name    |         range_start          |          range_end           
+-----------------+------------------+------------------------------+------------------------------
+ splitme         | _hyper_1_1_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 00:00:00 2024 PST
+ splitme         | _hyper_1_3_chunk | Thu Jan 04 00:00:00 2024 PST | Sun Jan 07 08:00:00 2024 PST
+ splitme         | _hyper_1_4_chunk | Sun Jan 07 08:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(3 rows)
+
+insert into splitme (time, device, location, temp)
+select t, ceil(random()*10), ceil(random()*20), random()*40
+from generate_series('2024-01-03'::timestamptz, '2024-01-10', '10s') t;
+select * from chunk_info;
+      chunk       | tam  |    conname    |                                                                checkconstraint                                                                 
+------------------+------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | constraint_1  | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 00:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | heap | constraint_3  | (("time" >= 'Thu Jan 04 00:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap | constraint_5  | (("time" >= 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 10 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_8_chunk | heap | constraint_11 | (("time" >= 'Wed Dec 27 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone))
+(4 rows)
+
+call split_chunk('_timescaledb_internal._hyper_1_3_chunk');
+select * from chunk_info;
+      chunk       | tam  |    conname    |                                                                checkconstraint                                                                 
+------------------+------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------
+ _hyper_1_1_chunk | heap | constraint_1  | (("time" >= 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 04 00:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_3_chunk | heap | constraint_3  | (("time" >= 'Thu Jan 04 00:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 05 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_4_chunk | heap | constraint_5  | (("time" >= 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 10 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_8_chunk | heap | constraint_11 | (("time" >= 'Wed Dec 27 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone))
+ _hyper_1_9_chunk | heap | constraint_13 | (("time" >= 'Fri Jan 05 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone))
+(5 rows)
+
+--
+-- Test multi-dimensional hypertable
+--
+-- Currently not supported because the subspace cache cannot handle
+-- tuple routing when there are two overlapping primary dimension
+-- ranges. This can happen when the "time" range is split in one space
+-- partition but not the other.
+--
+create table splitme_md (time timestamptz not null, device int, location int, temp float);
+select create_hypertable('splitme_md', 'time', 'device', 2, chunk_time_interval => interval '1 week');
+    create_hypertable    
+-------------------------
+ (4,public,splitme_md,t)
+(1 row)
+
+insert into splitme_md values
+       ('2024-01-03 22:00', 1, 1, 1.0),
+       ('2024-01-09 15:00', 1, 2, 2.0);
+select ch as chunk_md from show_chunks('splitme_md') ch limit 1 \gset
+select * from chunk_slices where hypertable_name = 'splitme_md';
+ hypertable_name |    chunk_name     |         range_start          |              range_end              
+-----------------+-------------------+------------------------------+-------------------------------------
+ splitme_md      | _hyper_4_10_chunk | -infinity                    | Wed Dec 31 16:17:53.741823 1969 PST
+ splitme_md      | _hyper_4_10_chunk | Wed Jan 03 16:00:00 2024 PST | Wed Jan 10 16:00:00 2024 PST
+(2 rows)
+
+\set ON_ERROR_STOP 0
+-- Currently can't split multi-dimensional chunks due to bug/limitation in subspace store.
+call split_chunk(:'chunk_md');
+ERROR:  cannot split chunk in multi-dimensional hypertable
+\set ON_ERROR_STOP 1
+-- Split when insert in progress
+begin;
+insert into splitme values ('2024-01-04 22:00', 20, 20, 20.0);
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+rollback;
+-- Split when delete in progress
+begin;
+delete from splitme where device = 1;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+rollback;

--- a/tsl/test/isolation/expected/split_chunk_concurrent.out
+++ b/tsl/test/isolation/expected/split_chunk_concurrent.out
@@ -1,0 +1,614 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s3_query_data s3_wp_at_end_on s2_split_chunk s1_insert_into_existing_chunk s3_wp_at_end_off s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s3_wp_at_end_on: select debug_waitpoint_enable('split_chunk_at_end');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_insert_into_existing_chunk: 
+    insert into readings values ('2024-01-12 01:05', 12, 12.0);
+
+step s3_wp_at_end_off: select debug_waitpoint_release('split_chunk_at_end');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_split_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ("Fri Jan 12 01:05:00 2024 PST",12,12)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s3_wp_before_routing_on s2_split_chunk s1_insert_into_existing_chunk s3_wp_before_routing_off s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s3_wp_before_routing_on: select debug_waitpoint_enable('split_chunk_before_tuple_routing');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_insert_into_existing_chunk: 
+    insert into readings values ('2024-01-12 01:05', 12, 12.0);
+
+step s3_wp_before_routing_off: select debug_waitpoint_release('split_chunk_before_tuple_routing');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_split_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ("Fri Jan 12 01:05:00 2024 PST",12,12)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s3_wp_at_end_on s2_split_chunk s1_insert_into_new_chunk s3_wp_at_end_off s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s3_wp_at_end_on: select debug_waitpoint_enable('split_chunk_at_end');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_insert_into_new_chunk: 
+    insert into readings values ('2024-01-18 10:00', 13, 13.0);
+ <waiting ...>
+step s3_wp_at_end_off: select debug_waitpoint_release('split_chunk_at_end');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_split_chunk: <... completed>
+step s1_insert_into_new_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 3 [ Wed Jan 17 16:00:00 2024 PST : Wed Jan 24 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 18 10:00:00 2024 PST",13,13)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s3_wp_before_routing_on s2_split_chunk s1_insert_into_new_chunk s3_wp_before_routing_off s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s3_wp_before_routing_on: select debug_waitpoint_enable('split_chunk_before_tuple_routing');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_insert_into_new_chunk: 
+    insert into readings values ('2024-01-18 10:00', 13, 13.0);
+ <waiting ...>
+step s3_wp_before_routing_off: select debug_waitpoint_release('split_chunk_before_tuple_routing');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_split_chunk: <... completed>
+step s1_insert_into_new_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 3 [ Wed Jan 17 16:00:00 2024 PST : Wed Jan 24 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 18 10:00:00 2024 PST",13,13)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s3_wp_at_end_on s2_split_chunk s1_insert_into_splitting_chunk s3_wp_at_end_off s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s3_wp_at_end_on: select debug_waitpoint_enable('split_chunk_at_end');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_insert_into_splitting_chunk: 
+    insert into readings values ('2024-01-05 01:05', 10, 10.0), ('2024-01-09 01:05', 11, 11.0);
+ <waiting ...>
+step s3_wp_at_end_off: select debug_waitpoint_release('split_chunk_at_end');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_split_chunk: <... completed>
+step s1_insert_into_splitting_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Fri Jan 05 01:05:00 2024 PST",10,10)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ("Tue Jan 09 01:05:00 2024 PST",11,11)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s3_wp_before_routing_on s2_split_chunk s1_insert_into_splitting_chunk s3_wp_before_routing_off s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s3_wp_before_routing_on: select debug_waitpoint_enable('split_chunk_before_tuple_routing');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_insert_into_splitting_chunk: 
+    insert into readings values ('2024-01-05 01:05', 10, 10.0), ('2024-01-09 01:05', 11, 11.0);
+ <waiting ...>
+step s3_wp_before_routing_off: select debug_waitpoint_release('split_chunk_before_tuple_routing');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_split_chunk: <... completed>
+step s1_insert_into_splitting_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Fri Jan 05 01:05:00 2024 PST",10,10)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ("Tue Jan 09 01:05:00 2024 PST",11,11)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s1_begin s1_insert_into_splitting_chunk s2_split_chunk s1_commit s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s1_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+step s1_insert_into_splitting_chunk: 
+    insert into readings values ('2024-01-05 01:05', 10, 10.0), ('2024-01-09 01:05', 11, 11.0);
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_commit: commit;
+step s2_split_chunk: <... completed>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Fri Jan 05 01:05:00 2024 PST",10,10)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ("Tue Jan 09 01:05:00 2024 PST",11,11)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s4_begin s3_query_data s1_begin s1_delete_from_splitting_chunk s2_split_chunk s1_commit s3_query_data s4_query s4_commit s4_query
+step s4_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s1_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+step s1_delete_from_splitting_chunk: 
+    delete from readings where device = 1;
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+step s1_commit: commit;
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Thu Jan 04 01:00:00 2024 PST|     1|   1
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(5 rows)
+
+step s4_commit: commit;
+step s2_split_chunk: <... completed>
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(4 rows)
+
+
+starting permutation: s4_begin s3_query_data s1_delete_from_splitting_chunk s2_split_chunk s3_query_data s4_query s4_commit s4_query
+step s4_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s1_delete_from_splitting_chunk: 
+    delete from readings where device = 1;
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+ <waiting ...>
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Thu Jan 04 01:00:00 2024 PST|     1|   1
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(5 rows)
+
+step s4_commit: commit;
+step s2_split_chunk: <... completed>
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(4 rows)
+
+
+starting permutation: s3_query_data s4_begin s1_delete_from_splitting_chunk s2_split_chunk s3_query_data s4_query s4_commit s4_query s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s4_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+step s1_delete_from_splitting_chunk: 
+    delete from readings where device = 1;
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Thu Jan 04 01:00:00 2024 PST|     1|   1
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(5 rows)
+
+step s4_commit: commit;
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(4 rows)
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s3_query_data s4_begin s1_update_splitting_chunk s2_split_chunk s3_query_data s4_query s4_commit s4_query s3_query_data
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s4_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+step s1_update_splitting_chunk: 
+    update readings set device = 1 where device = 2;
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Thu Jan 04 01:00:00 2024 PST|     1|   1
+Fri Jan 05 02:00:00 2024 PST|     2|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(5 rows)
+
+step s4_commit: commit;
+step s4_query: 
+    select * from readings order by time, device;
+
+time                        |device|temp
+----------------------------+------+----
+Thu Jan 04 01:00:00 2024 PST|     1|   1
+Fri Jan 05 02:00:00 2024 PST|     1|   2
+Mon Jan 08 02:00:00 2024 PST|     3|   3
+Thu Jan 11 01:01:00 2024 PST|     4|   4
+Mon Jan 15 02:00:00 2024 PST|     5|   5
+(5 rows)
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Sun Jan 07 04:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",1,2)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+s3: NOTICE:  ---- chunk 2 [ Sun Jan 07 04:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+s3: NOTICE:  ("Mon Jan 08 02:00:00 2024 PST",3,3)
+step s3_query_data: 
+    call show_all_chunks('readings');
+
+
+starting permutation: s2_begin s2_insert_into_splitting_chunk s2_split_chunk s3_query_data s2_commit
+step s2_begin: 
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+
+?column?
+--------
+t       
+(1 row)
+
+step s2_insert_into_splitting_chunk: 
+    insert into readings values ('2024-01-05 01:05', 15, 15.0);
+
+step s2_split_chunk: 
+    call split_first_chunk('readings');
+
+s3: NOTICE:  ---- chunk 0 [ Wed Jan 03 16:00:00 2024 PST : Wed Jan 10 16:00:00 2024 PST ]
+step s3_query_data: 
+    call show_all_chunks('readings');
+ <waiting ...>
+step s2_commit: commit;
+s3: NOTICE:  ("Thu Jan 04 01:00:00 2024 PST",1,1)
+s3: NOTICE:  ("Fri Jan 05 02:00:00 2024 PST",2,2)
+s3: NOTICE:  ("Fri Jan 05 01:05:00 2024 PST",15,15)
+s3: NOTICE:  ---- chunk 1 [ Wed Jan 10 16:00:00 2024 PST : Wed Jan 17 16:00:00 2024 PST ]
+s3: NOTICE:  ("Thu Jan 11 01:01:00 2024 PST",4,4)
+s3: NOTICE:  ("Mon Jan 15 02:00:00 2024 PST",5,5)
+step s3_query_data: <... completed>

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -44,7 +44,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compression_merge_race.spec
     compression_recompress.spec
     decompression_chunk_and_parallel_query_wo_idx.spec
-    merge_chunks_concurrent.spec)
+    merge_chunks_concurrent.spec
+    split_chunk_concurrent.spec)
   if(PG_VERSION VERSION_GREATER_EQUAL "14.0")
     list(APPEND TEST_FILES freeze_chunk.spec compression_dml_iso.spec)
   endif()

--- a/tsl/test/isolation/specs/split_chunk_concurrent.spec
+++ b/tsl/test/isolation/specs/split_chunk_concurrent.spec
@@ -1,0 +1,191 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+setup
+{
+    create extension if not exists pageinspect;
+    create table readings (time timestamptz, device int, temp float) with (fillfactor = 30);
+    select create_hypertable('readings', 'time', chunk_time_interval => interval '1 week');
+    insert into readings values ('2024-01-04 01:00', 1, 1.0), ('2024-01-05 02:00', 2, 2.0), ('2024-01-08 02:00', 3, 3.0), ('2024-01-11 01:01', 4, 4.0), ('2024-01-15 02:00', 5, 5.0);
+    alter table readings set (timescaledb.compress_orderby='time', timescaledb.compress_segmentby='device');
+    create index on readings (device);
+
+    create or replace procedure drop_one_chunk(hypertable regclass) as $$
+    declare
+        chunk regclass;
+    begin
+        select cl.oid into chunk
+           from pg_class cl
+           join pg_inherits inh
+           on (cl.oid = inh.inhrelid)
+           where inh.inhparent = hypertable
+           limit 1;
+        execute format('drop table %s cascade', chunk);
+    end;
+    $$ LANGUAGE plpgsql;
+
+    create or replace procedure split_first_chunk(hypertable regclass) as $$
+    declare
+        chunk regclass;
+    begin
+        select cl.oid into chunk
+           from pg_class cl
+           join pg_inherits inh
+           on (cl.oid = inh.inhrelid)
+           where inh.inhparent = hypertable
+           limit 1;
+        execute format('call split_chunk(%L)', chunk);
+    end;
+    $$ LANGUAGE plpgsql;
+
+    create or replace procedure show_all_chunks(hypertable regclass) as $$
+    declare
+       chunk regclass;
+       chunk_info timescaledb_information.chunks;
+       n int = 0;
+       row record;
+    begin
+        for chunk_info in
+            select *
+                   from timescaledb_information.chunks
+                   where format('%I.%I', hypertable_schema, hypertable_name)::regclass = hypertable
+        loop
+            raise notice '---- chunk % [ % : % ]', n,  chunk_info.range_start, chunk_info.range_end;
+            for row in
+                execute format('select * from %I.%I', chunk_info.chunk_schema, chunk_info.chunk_name)
+            loop
+                raise notice '%', row;
+            end loop;
+
+            n = n + 1;
+        end loop;
+    end;
+    $$ LANGUAGE plpgsql;
+}
+
+teardown {
+    drop table readings;
+}
+
+session "s1"
+setup	{
+    set local lock_timeout = '5000ms';
+    set local deadlock_timeout = '10ms';
+}
+
+# The transaction will not "pick" a snapshot until the first query, so
+# do a simple select on pg_class to pick one for the transaction. We
+# don't want to query any tables involved in the test since that will
+# grab locks on them.
+step "s1_begin" {
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+}
+
+step "s1_commit" { commit; }
+
+# Insert two tuples that each go into different parts of the split chunk
+step "s1_insert_into_splitting_chunk" {
+    insert into readings values ('2024-01-05 01:05', 10, 10.0), ('2024-01-09 01:05', 11, 11.0);
+}
+
+step "s1_insert_into_existing_chunk" {
+    insert into readings values ('2024-01-12 01:05', 12, 12.0);
+}
+
+step "s1_insert_into_new_chunk" {
+    insert into readings values ('2024-01-18 10:00', 13, 13.0);
+}
+
+step "s1_update_splitting_chunk" {
+    update readings set device = 1 where device = 2;
+}
+
+step "s1_delete_from_splitting_chunk" {
+    delete from readings where device = 1;
+}
+
+session "s2"
+setup	{
+    set local lock_timeout = '500ms';
+    set local deadlock_timeout = '100ms';
+}
+
+step "s2_begin" {
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+}
+
+step "s2_commit" { commit; }
+
+step "s2_split_chunk" {
+    call split_first_chunk('readings');
+}
+
+step "s2_insert_into_splitting_chunk" {
+    insert into readings values ('2024-01-05 01:05', 15, 15.0);
+}
+
+session "s3"
+setup	{
+    set local lock_timeout = '500ms';
+    set local deadlock_timeout = '100ms';
+}
+
+step "s3_query_data" {
+    call show_all_chunks('readings');
+}
+
+step "s3_wp_before_routing_on" { select debug_waitpoint_enable('split_chunk_before_tuple_routing'); }
+step "s3_wp_before_routing_off" { select debug_waitpoint_release('split_chunk_before_tuple_routing'); }
+
+step "s3_wp_at_end_on" { select debug_waitpoint_enable('split_chunk_at_end'); }
+step "s3_wp_at_end_off" { select debug_waitpoint_release('split_chunk_at_end'); }
+
+step "s4_begin" {
+    start transaction isolation level repeatable read;
+    select count(*) > 0 from pg_stat_activity;
+}
+
+step "s4_query" {
+    select * from readings order by time, device;
+}
+
+step "s4_commit" { commit; }
+
+# Concurrent insert into existing chunk while another chunk is being
+# split. The inserting process should not be blocked.
+permutation "s3_query_data" "s3_wp_at_end_on" "s2_split_chunk" "s1_insert_into_existing_chunk" "s3_wp_at_end_off" "s3_query_data"
+permutation "s3_query_data" "s3_wp_before_routing_on" "s2_split_chunk" "s1_insert_into_existing_chunk" "s3_wp_before_routing_off" "s3_query_data"
+
+# Concurrent insert into new chunk while another chunk is being
+# split. The inserting process is blocked because the split process
+# takes ShareUpdateExclusive lock on the hypertable root to attach the
+# new chunk from the split.
+permutation "s3_query_data" "s3_wp_at_end_on" "s2_split_chunk" "s1_insert_into_new_chunk" "s3_wp_at_end_off" "s3_query_data"
+permutation "s3_query_data" "s3_wp_before_routing_on" "s2_split_chunk" "s1_insert_into_new_chunk" "s3_wp_before_routing_off" "s3_query_data"
+
+
+# Concurrent insert into chunk being split. The inserting process
+# should be blocked and the two inserted tuples should end up in their
+# corresponding parts of the split chunk.
+permutation "s3_query_data" "s3_wp_at_end_on" "s2_split_chunk" "s1_insert_into_splitting_chunk" "s3_wp_at_end_off" "s3_query_data"
+permutation "s3_query_data" "s3_wp_before_routing_on" "s2_split_chunk" "s1_insert_into_splitting_chunk" "s3_wp_before_routing_off" "s3_query_data"
+
+# Concurrent insert into chunk being split. The inserting process
+# locks the chunk first so the split should be blocked.
+permutation "s3_query_data" "s1_begin" "s1_insert_into_splitting_chunk" "s2_split_chunk" "s1_commit" "s3_query_data"
+
+# Delete from splitting chunk
+permutation "s4_begin" "s3_query_data" "s1_begin" "s1_delete_from_splitting_chunk" "s2_split_chunk" "s1_commit" "s3_query_data" "s4_query" "s4_commit" "s4_query"
+permutation "s4_begin" "s3_query_data" "s1_delete_from_splitting_chunk" "s2_split_chunk" "s3_query_data" "s4_query" "s4_commit" "s4_query"
+
+# Delete and update on splitting chunk and concurrent query in
+# repeatable read. The querying process should see the old data after
+# split (including deleted tuple). After commit it sees the update/delete.
+permutation "s3_query_data" "s4_begin" "s1_delete_from_splitting_chunk" "s2_split_chunk" "s3_query_data" "s4_query" "s4_commit" "s4_query" "s3_query_data"
+permutation "s3_query_data" "s4_begin" "s1_update_splitting_chunk" "s2_split_chunk" "s3_query_data" "s4_query" "s4_commit" "s4_query" "s3_query_data"
+
+# Insert into splitting chunk by splitting process
+permutation "s2_begin" "s2_insert_into_splitting_chunk" "s2_split_chunk" "s3_query_data" "s2_commit"

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -274,6 +274,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  set_partitioning_interval(regclass,anyelement,name)
  show_chunks(regclass,"any","any","any","any")
  show_tablespaces(regclass)
+ split_chunk(regclass,"any")
  time_bucket(bigint,bigint)
  time_bucket(bigint,bigint,bigint)
  time_bucket(integer,integer)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -73,6 +73,7 @@ set(TEST_FILES
     reorder.sql
     size_utils_tsl.sql
     skip_scan.sql
+    split_chunk.sql
     transparent_decompression_join_index.sql
     vector_agg_functions.sql
     vector_agg_groupagg.sql

--- a/tsl/test/sql/split_chunk.sql
+++ b/tsl/test/sql/split_chunk.sql
@@ -1,0 +1,249 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ACCESS METHOD testam TYPE TABLE HANDLER heap_tableam_handler;
+set role :ROLE_DEFAULT_PERM_USER;
+
+create view chunk_slices as
+select
+    h.table_name as hypertable_name,
+    c.table_name as chunk_name,
+    _timescaledb_functions.to_timestamp(ds.range_start) as range_start,
+    _timescaledb_functions.to_timestamp(ds.range_end) as range_end
+from _timescaledb_catalog.chunk c
+join _timescaledb_catalog.chunk_constraint cc on (cc.chunk_id = c.id)
+join _timescaledb_catalog.dimension_slice ds on (ds.id = cc.dimension_slice_id)
+join _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
+order by range_start, range_end;
+
+
+create table splitme (time timestamptz not null, device int, location int, temp float, comment text);
+select create_hypertable('splitme', 'time', chunk_time_interval => interval '1 week');
+alter table splitme set (timescaledb.compress_orderby='time', timescaledb.compress_segmentby='device');
+
+--
+-- Insert data to create two chunks with time ranges like this:
+-- _____________
+-- |     |     |
+-- |  1  |  2  |
+-- |_____|_____|
+---
+--- Make sure we have a long text value to create toast table
+insert into splitme values
+       ('2024-01-03 22:00', 1, 1, 1.0, 'foo'),
+       ('2024-01-09 15:00', 1, 2, 2.0, 'barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar');
+
+-- Remove a column to ensure that split can handle it
+alter table splitme drop column location;
+
+-- All data in single chunk
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+select time, device, temp from _timescaledb_internal._hyper_1_1_chunk order by time;
+select * from chunk_slices where hypertable_name = 'splitme';
+
+\set ON_ERROR_STOP 0
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 1);
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 1::int);
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => '2024-01-04 00:00'::timestamp);
+
+-- Split at start of chunk range
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 'Wed Jan 03 16:00:00 2024 PST');
+-- Split at end of chunk range
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => 'Wed Jan 10 16:00:00 2024 PST');
+-- Split at multiple points. Not supported yet.
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => '{ 2024-01-04 10:00, 2024-01-07 12:00 }'::timestamptz[]);
+-- Try to split something which is not a chunk
+call split_chunk('splitme');
+-- Split a chunk with unsupported access method
+alter table _timescaledb_internal._hyper_1_1_chunk set access method testam;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+alter table _timescaledb_internal._hyper_1_1_chunk set access method heap;
+
+-- Split an OSM chunk is not supported
+reset role;
+update _timescaledb_catalog.chunk ch set osm_chunk = true where table_name = '_hyper_1_1_chunk';
+set role :ROLE_DEFAULT_PERM_USER;
+
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+reset role;
+update _timescaledb_catalog.chunk ch set osm_chunk = false where table_name = '_hyper_1_1_chunk';
+set role :ROLE_DEFAULT_PERM_USER;
+
+-- Split a frozen chunk is not supported
+select _timescaledb_functions.freeze_chunk('_timescaledb_internal._hyper_1_1_chunk');
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+select _timescaledb_functions.unfreeze_chunk('_timescaledb_internal._hyper_1_1_chunk');
+
+-- Split a compressed/columnstore chunk is not supported
+begin;
+call convert_to_columnstore('_timescaledb_internal._hyper_1_1_chunk');
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+rollback;
+
+-- Split by non-owner is not allowed
+set role :ROLE_1;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+set role :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 1
+
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk', split_at => '2024-01-04 00:00');
+
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+select * from chunk_slices where hypertable_name = 'splitme';
+
+-- Show that the two tuples ended up in different chunks
+select time, device, temp from _timescaledb_internal._hyper_1_1_chunk order by time;
+select time, device, temp from _timescaledb_internal._hyper_1_3_chunk order by time;
+
+select setseed(0.2);
+-- Test split with bigger data set and chunks with more blocks
+insert into splitme (time, device, temp)
+select t, ceil(random()*10), random()*40
+from generate_series('2024-01-03 23:00'::timestamptz, '2024-01-10 01:00', '10s') t;
+select count(*) from splitme;
+
+-- Add back location just to make things more difficult
+alter table splitme add column location int default 1;
+
+-- There are two space partitions (device), so several chunks will
+-- have the same time ranges
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+
+-- Split chunk 2. Save count to compare after split.
+select count(*) from _timescaledb_internal._hyper_1_3_chunk;
+select count(*) orig_count from _timescaledb_internal._hyper_1_3_chunk \gset
+
+-- Generate some garbage so that we can see that it gets cleaned up
+-- during split
+update  _timescaledb_internal._hyper_1_3_chunk set temp = temp+1 where temp > 10;
+
+-- This will split in two equal size chunks
+call split_chunk('_timescaledb_internal._hyper_1_3_chunk');
+
+select chunk_name, range_start, range_end
+from timescaledb_information.chunks
+order by chunk_name, range_start, range_end;
+
+-- Check that the counts in the two result partitions is the same as
+-- in the original partition and that the tuple counts are roughly the
+-- same across the partitions.
+with counts as (
+    select (select count(*) from _timescaledb_internal._hyper_1_3_chunk) count1,
+            (select count(*) from _timescaledb_internal._hyper_1_4_chunk) count2
+) select
+  c.count1, c.count2,
+  c.count1 + c.count2 as total_count,
+  (c.count1 + c.count2) = :orig_count as is_same_count
+from counts c;
+
+-- Check that both rels return proper data and no columns are messed
+-- up
+select time, device, location, temp from _timescaledb_internal._hyper_1_3_chunk order by time, device limit 3;
+select time, device, location, temp from _timescaledb_internal._hyper_1_4_chunk order by time, device limit 3;
+
+--
+-- Test split with integer time
+--
+create table splitme_int (time int not null, device int, temp float);
+select create_hypertable('splitme_int', 'time', chunk_time_interval => 10::int);
+
+insert into splitme_int values (1, 1, 1.0), (8, 8, 8.0);
+select ch as int_chunk from show_chunks('splitme_int') ch order by ch limit 1 \gset
+
+select * from chunk_slices where hypertable_name = 'splitme_int';
+
+\set ON_ERROR_STOP 0
+call split_chunk(:'int_chunk', split_at => 0);
+call split_chunk(:'int_chunk', split_at => 10);
+\set ON_ERROR_STOP 1
+
+call split_chunk(:'int_chunk', split_at => '5');
+
+select * from chunk_slices where hypertable_name = 'splitme_int';
+
+select * from :int_chunk order by time;
+select * from splitme_int order by time;
+
+-- Split with one empty chunk
+call split_chunk(:'int_chunk', split_at => 3);
+select * from chunk_slices where hypertable_name = 'splitme_int';
+
+select * from :int_chunk order by time;
+select ch as int_chunk from show_chunks('splitme_int') ch order by ch limit 1 offset 2 \gset
+\echo :int_chunk
+select * from :int_chunk order by time;
+-- Insert data into the empty chunk
+insert into splitme_int values (4, 4, 4.0);
+select * from :int_chunk order by time;
+
+
+--
+-- Try with more data after split
+--
+
+create view chunk_info as
+select relname as chunk, amname as tam, con.conname, pg_get_expr(conbin, ch) checkconstraint
+from pg_class cl
+join pg_am am on (cl.relam = am.oid)
+join show_chunks('splitme') ch on (cl.oid = ch)
+join pg_constraint con on (con.conrelid = ch)
+where con.contype = 'c'
+order by 1,2,3 desc;
+
+-- Remove comment column to generate dropped column
+alter table splitme drop column comment;
+
+select * from chunk_info;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+set role :ROLE_DEFAULT_PERM_USER;
+
+select * from chunk_slices where hypertable_name = 'splitme';
+
+insert into splitme (time, device, location, temp)
+select t, ceil(random()*10), ceil(random()*20), random()*40
+from generate_series('2024-01-03'::timestamptz, '2024-01-10', '10s') t;
+
+select * from chunk_info;
+call split_chunk('_timescaledb_internal._hyper_1_3_chunk');
+select * from chunk_info;
+
+--
+-- Test multi-dimensional hypertable
+--
+-- Currently not supported because the subspace cache cannot handle
+-- tuple routing when there are two overlapping primary dimension
+-- ranges. This can happen when the "time" range is split in one space
+-- partition but not the other.
+--
+create table splitme_md (time timestamptz not null, device int, location int, temp float);
+select create_hypertable('splitme_md', 'time', 'device', 2, chunk_time_interval => interval '1 week');
+insert into splitme_md values
+       ('2024-01-03 22:00', 1, 1, 1.0),
+       ('2024-01-09 15:00', 1, 2, 2.0);
+
+select ch as chunk_md from show_chunks('splitme_md') ch limit 1 \gset
+select * from chunk_slices where hypertable_name = 'splitme_md';
+\set ON_ERROR_STOP 0
+-- Currently can't split multi-dimensional chunks due to bug/limitation in subspace store.
+call split_chunk(:'chunk_md');
+\set ON_ERROR_STOP 1
+
+-- Split when insert in progress
+begin;
+insert into splitme values ('2024-01-04 22:00', 20, 20, 20.0);
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+rollback;
+
+-- Split when delete in progress
+begin;
+delete from splitme where device = 1;
+call split_chunk('_timescaledb_internal._hyper_1_1_chunk');
+rollback;


### PR DESCRIPTION
A chunk can be split with a new procedure called split_chunk(). In this initial version, a chunk can be split in two given a split point:

```
call split_chunk('chunk_1', split_at => '2025-03-01 00:00');
```

If no split point is given, the chunk is split in two equal size partition ranges. The partitioning dimension/column to split along will be the primary dimension (time). Future updates to split_chunk() can add the ability to split also along other dimensions, e.g., space partitions.

Currently, it is not possible split a compressed chunk, but this will be added in a future update. Note that splitting a chunk takes an AccessExclusive lock on the chunk being split. A ShareUpdateExclusive lock is also taken on the hypertable root to attach new chunk partitions (this is mandated by PostgreSQL inheritance). The root lock prevents concurrent modifications to the table hierarchy, for example, it prevents new chunks being created while the split is ongoing.

Future improvements could include the possibility to read the chunk while it is being split. For example, a two-transactional approach could be used where the time consuming rewrite is done in TX1 under weak locks (split in progress) while a shorter TX2 concludes the split under heavy locking (split finalize).