### PR TITLE
Allow scheduler restarts to be disabled

### DIFF
--- a/.unreleased/pr_7954
+++ b/.unreleased/pr_7954
@@ -1,0 +1,1 @@
+Fixes: #7954 Allow scheduler restarts to be disabled

--- a/tsl/test/expected/bgw_scheduler_restart.out
+++ b/tsl/test/expected/bgw_scheduler_restart.out
@@ -53,14 +53,23 @@ CREATE PROCEDURE ts_terminate_launcher() AS $$
 SELECT pg_terminate_backend(pid) FROM tsdb_bgw
  WHERE backend_type LIKE '%Launcher%';
 $$ LANGUAGE SQL;
--- Show the default scheduler restart time and set it to a lower
--- value.
+-- Show the default scheduler restart time
 SHOW timescaledb.bgw_scheduler_restart_time;
  timescaledb.bgw_scheduler_restart_time 
 ----------------------------------------
- 1min
+ -1
 (1 row)
 
+-- Test that it cannot be set to something between -1 and 10
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '5s';
+ERROR:  invalid value for parameter "timescaledb.bgw_scheduler_restart_time": 5
+DETAIL:  Scheduler restart time must be be either -1 or at least 10 seconds.
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+-- Set scheduler restart time to a lower value to make the test a
+-- little faster.
 ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '10s';
 ALTER SYSTEM SET timescaledb.debug_bgw_scheduler_exit_status TO 1;
 SELECT pg_reload_conf();

--- a/tsl/test/sql/bgw_scheduler_restart.sql
+++ b/tsl/test/sql/bgw_scheduler_restart.sql
@@ -59,9 +59,16 @@ SELECT pg_terminate_backend(pid) FROM tsdb_bgw
  WHERE backend_type LIKE '%Launcher%';
 $$ LANGUAGE SQL;
 
--- Show the default scheduler restart time and set it to a lower
--- value.
+-- Show the default scheduler restart time
 SHOW timescaledb.bgw_scheduler_restart_time;
+-- Test that it cannot be set to something between -1 and 10
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '5s';
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+-- Set scheduler restart time to a lower value to make the test a
+-- little faster.
 ALTER SYSTEM SET timescaledb.bgw_scheduler_restart_time TO '10s';
 ALTER SYSTEM SET timescaledb.debug_bgw_scheduler_exit_status TO 1;
 SELECT pg_reload_conf();


### PR DESCRIPTION
You can set the scheduler restart time using the option `timescaledb.bgw_scheduler_restart_time` but there are no means to disable it entirely.

This commit allow `timescaledb.bgw_scheduler_restart_time` to be set to zero, denoting that scheduler restarts should be disabled.

The default is set to not restart schedulers by default.

Disable-check: loader-change