### PR TITLE
Backport of #7935: Don't capture errors estimating time max spread

### DIFF
--- a/.unreleased/pr_7912
+++ b/.unreleased/pr_7912
@@ -1,0 +1,1 @@
+Fixes: #7912 Don't capture errors estimating time max spread

--- a/src/estimate.c
+++ b/src/estimate.c
@@ -33,8 +33,8 @@ estimate_max_spread_var(PlannerInfo *root, Var *var)
 	VariableStatData vardata;
 	Oid ltop;
 	Datum max_datum, min_datum;
-	volatile int64 max, min;
-	volatile bool valid;
+	int64 max, min;
+	bool valid;
 
 	examine_variable(root, (Node *) var, 0, &vardata);
 	get_sort_group_operators(var->vartype, true, false, false, &ltop, NULL, NULL, NULL);
@@ -44,20 +44,8 @@ estimate_max_spread_var(PlannerInfo *root, Var *var)
 	if (!valid)
 		return INVALID_ESTIMATE;
 
-	PG_TRY();
-	{
-		max = ts_time_value_to_internal(max_datum, var->vartype);
-		min = ts_time_value_to_internal(min_datum, var->vartype);
-	}
-	PG_CATCH();
-	{
-		valid = false;
-		FlushErrorState();
-	}
-	PG_END_TRY();
-
-	if (!valid)
-		return INVALID_ESTIMATE;
+	max = ts_time_value_to_internal(max_datum, var->vartype);
+	min = ts_time_value_to_internal(min_datum, var->vartype);
 
 	return (double) (max - min);
 }

--- a/tsl/test/expected/custom_hashagg.out
+++ b/tsl/test/expected/custom_hashagg.out
@@ -1,0 +1,67 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+create table foo( a integer, b timestamptz);
+select count(*) from create_hypertable('foo', 'b');
+NOTICE:  adding not-null constraint to column "b"
+ count 
+-------
+     1
+(1 row)
+
+insert into foo values
+       (1, '2004-10-19 10:23:54'),
+       (1, '2005-10-19 10:23:54'),
+       (1, '2005-01-01 00:00:00+00'),
+       (2, '2005-01-01 00:00:00+00');
+-- Test that the range estimation functions estimate_max_spread_var()
+-- is used for custom hash aggregates and that they behave in a sane
+-- manner when there are errors.
+--
+-- To trigger a call to the function, the following are required:
+--
+-- timescaledb.enable_custom_hashagg to be true
+--
+-- query should either date_trunc or time_bucket bucket function
+-- with a recognized time type
+--
+-- an aggregation function in the result
+--
+-- a group-by on the bucket created by the date_trunc or time_bucket
+--
+-- statistics recorded for the variable used in the bucketing
+-- function
+set timescaledb.enable_custom_hashagg to true;
+analyze foo;
+explain (costs off)
+select date_trunc('hour', b) bucket, sum(a) from foo group by bucket;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: (date_trunc('hour'::text, _hyper_1_1_chunk.b))
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: date_trunc('hour'::text, _hyper_1_1_chunk.b)
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Partial HashAggregate
+               Group Key: date_trunc('hour'::text, _hyper_1_2_chunk.b)
+               ->  Seq Scan on _hyper_1_2_chunk
+         ->  Partial HashAggregate
+               Group Key: date_trunc('hour'::text, _hyper_1_3_chunk.b)
+               ->  Seq Scan on _hyper_1_3_chunk
+(12 rows)
+
+select date_trunc('hour', b) bucket, sum(a) from foo group by bucket;
+            bucket            | sum 
+------------------------------+-----
+ Fri Dec 31 16:00:00 2004 PST |   3
+ Tue Oct 19 10:00:00 2004 PDT |   1
+ Wed Oct 19 10:00:00 2005 PDT |   1
+(3 rows)
+
+-- Inserting a very large value should trigger an error inside the
+-- range estimation function estimate_max_spread_var() and test that
+-- it works even in the presence of errors.
+insert into foo values
+       (99, 'epoch'::timestamptz + '9223371331200000000'::bigint * '1 microsecond'::interval);
+ERROR:  timestamp out of range

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_FILES
     compression_sorted_merge_columns.sql
     compression_sorted_merge_distinct.sql
     compression_trigger.sql
+    custom_hashagg.sql
     decompress_index.sql
     foreign_keys.sql
     move.sql

--- a/tsl/test/sql/custom_hashagg.sql
+++ b/tsl/test/sql/custom_hashagg.sql
@@ -1,0 +1,47 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+create table foo( a integer, b timestamptz);
+select count(*) from create_hypertable('foo', 'b');
+
+insert into foo values
+       (1, '2004-10-19 10:23:54'),
+       (1, '2005-10-19 10:23:54'),
+       (1, '2005-01-01 00:00:00+00'),
+       (2, '2005-01-01 00:00:00+00');
+
+-- Test that the range estimation functions estimate_max_spread_var()
+-- is used for custom hash aggregates and that they behave in a sane
+-- manner when there are errors.
+--
+-- To trigger a call to the function, the following are required:
+--
+-- timescaledb.enable_custom_hashagg to be true
+--
+-- query should either date_trunc or time_bucket bucket function
+-- with a recognized time type
+--
+-- an aggregation function in the result
+--
+-- a group-by on the bucket created by the date_trunc or time_bucket
+--
+-- statistics recorded for the variable used in the bucketing
+-- function
+
+set timescaledb.enable_custom_hashagg to true;
+analyze foo;
+explain (costs off)
+select date_trunc('hour', b) bucket, sum(a) from foo group by bucket;
+select date_trunc('hour', b) bucket, sum(a) from foo group by bucket;
+
+-- Inserting a very large value should trigger an error inside the
+-- range estimation function estimate_max_spread_var() and test that
+-- it works even in the presence of errors.
+insert into foo values
+       (99, 'epoch'::timestamptz + '9223371331200000000'::bigint * '1 microsecond'::interval);
+\set ON_ERROR_STOP 0
+select date_trunc('hour', b) bucket, sum(a) from foo group by bucket;
+\set ON_ERROR_STOP 1
+delete from foo where a = 99;
+reset timescaledb.enable_custom_hashagg;


### PR DESCRIPTION
In the time utility functions errors were captured to, it seems, handle syntax errors and out-of-range errors, but this also capture hard errors like out-of-memory and continued to execute, which can cause panics as a result of error stack being exhausted.

This commit removes the capture and allow the error to propagate to callers, including out-of-range errors and syntax errors.

The `PG_TRY` in `estimate_max_spread_var` was added in commit 9a29f0436d59fd0f2f0876fec2de89512140c752 but it is not clear in that commit why it was needed but removing it does not cause any test failures.

In addition, an explicit test was added to trigger this function.