### PR TITLE
Fix serialized hashing for scalar fixed-width by-reference columns (#7964)

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -63,6 +63,7 @@ jobs:
           vector_agg_groupagg
           vector_agg_grouping
           vector_agg_text
+          vector_agg_uuid_segmentby
           vectorized_aggregation
         SKIPS: chunk_adaptive histogram_test-*
         EXTENSIONS: "postgres_fdw test_decoding pageinspect pgstattuple"

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -67,6 +67,7 @@ jobs:
             vector_agg_groupagg
             vector_agg_grouping
             vector_agg_text
+            vector_agg_uuid_segmentby
             vectorized_aggregation
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         include:

--- a/.unreleased/uuid-segmentby-grouping-segfault
+++ b/.unreleased/uuid-segmentby-grouping-segfault
@@ -1,0 +1,1 @@
+Fixes: #7964 Crash when grouping by multiple columns of a compressed table, one of which is a UUID segmentby column.

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -372,7 +372,9 @@ compressed_batch_get_arrow_array(VectorQualState *vqstate, Expr *expr, bool *is_
 		Assert(column_values->decompression_type != DT_Invalid);
 	}
 
-	Assert(column_values->decompression_type != DT_Iterator);
+	Ensure(column_values->decompression_type != DT_Iterator,
+		   "expected arrow array but got iterator for column index %d",
+		   column_index);
 
 	/*
 	 * Prepare to compute the vector predicate. We have to handle the

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -249,7 +249,7 @@ follow_uncompressed_output_tlist(const DecompressionMapContext *context)
  * attnos.
  */
 static void
-build_decompression_map(DecompressionMapContext *context, List *compressed_scan_tlist)
+build_decompression_map(DecompressionMapContext *context, List *compressed_output_tlist)
 {
 	DecompressChunkPath *path = context->decompress_path;
 	const CompressionInfo *info = path->info;
@@ -305,7 +305,7 @@ build_decompression_map(DecompressionMapContext *context, List *compressed_scan_
 	 */
 	context->have_bulk_decompression_columns = false;
 	context->decompression_map = NIL;
-	foreach (lc, compressed_scan_tlist)
+	foreach (lc, compressed_output_tlist)
 	{
 		TargetEntry *target = (TargetEntry *) lfirst(lc);
 		if (!IsA(target->expr, Var))
@@ -480,7 +480,7 @@ build_decompression_map(DecompressionMapContext *context, List *compressed_scan_
 	 * into several lists so that it can be passed through the custom path
 	 * settings.
 	 */
-	foreach (lc, compressed_scan_tlist)
+	foreach (lc, compressed_output_tlist)
 	{
 		TargetEntry *target = (TargetEntry *) lfirst(lc);
 		Var *var = castNode(Var, target->expr);

--- a/tsl/src/nodes/vector_agg/grouping_policy_batch.c
+++ b/tsl/src/nodes/vector_agg/grouping_policy_batch.c
@@ -135,7 +135,9 @@ compute_single_aggregate(GroupingPolicyBatch *policy, TupleTableSlot *vector_slo
 			vector_slot_get_compressed_column_values(vector_slot, attnum);
 
 		Assert(values->decompression_type != DT_Invalid);
-		Assert(values->decompression_type != DT_Iterator);
+		Ensure(values->decompression_type != DT_Iterator,
+			   "expected arrow array but got iterator for attnum %d",
+			   attnum);
 
 		if (values->arrow != NULL)
 		{

--- a/tsl/src/nodes/vector_agg/grouping_policy_hash.c
+++ b/tsl/src/nodes/vector_agg/grouping_policy_hash.c
@@ -144,7 +144,9 @@ compute_single_aggregate(GroupingPolicyHash *policy, TupleTableSlot *vector_slot
 			vector_slot_get_compressed_column_values(vector_slot, attnum);
 
 		Assert(values->decompression_type != DT_Invalid);
-		Assert(values->decompression_type != DT_Iterator);
+		Ensure(values->decompression_type != DT_Iterator,
+			   "expected arrow array but got iterator for attnum %d",
+			   attnum);
 
 		if (values->arrow != NULL)
 		{

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -250,7 +250,9 @@ tsl_postprocess_plan(PlannedStmt *stmt)
 		 */
 		if ((has_normal_agg || has_vector_agg) && (has_vector_agg != should_have_vector_agg))
 		{
-			elog(ERROR, "vector aggregation inconsistent with debug_require_vector_agg GUC");
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("vector aggregation inconsistent with debug_require_vector_agg GUC")));
 		}
 	}
 #endif

--- a/tsl/test/expected/vector_agg_uuid_segmentby.out
+++ b/tsl/test/expected/vector_agg_uuid_segmentby.out
@@ -1,0 +1,105 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test grouping by uuid segmentby column (scalar by-reference fixed-width column).
+CREATE TABLE public.plan_plus(
+  "time"        timestamp with time zone NOT NULL,
+  device        uuid                     NOT NULL,
+  field         text                     NOT NULL,
+  value_numeric double precision,
+  value_bool    boolean,
+  value_string  text,
+  value_geo     point,
+  created       timestamp with time zone DEFAULT now()
+);
+CREATE INDEX plan_plus_device_time_idx
+  ON public.plan_plus
+  USING btree (device, "time" DESC);
+CREATE INDEX plan_plus_time_idx
+  ON public.plan_plus
+  USING btree ("time" DESC);
+SELECT public.create_hypertable(
+  relation => 'public.plan_plus',
+  time_column_name => 'time',
+  create_default_indexes => false
+);
+   create_hypertable    
+------------------------
+ (1,public,plan_plus,t)
+(1 row)
+
+ALTER TABLE public.plan_plus SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.compress_orderby='"time" DESC'
+);
+INSERT INTO plan_plus
+WITH devices AS (
+  select gen_random_uuid() AS device from generate_series(1, 10)
+),
+fields AS (
+  select 'field '||f AS field from generate_series(1,100) AS f
+)
+SELECT
+  t, device, field, 10, true, 'value', null, '2025-04-15 00:00:00'::timestamptz
+FROM
+  generate_series('2025-04-15 00:00:00'::timestamptz - interval '1 month',
+    '2025-04-15 00:00:00'::timestamptz, interval '12 hour') AS t,
+  devices, fields;
+-- Compress data
+SELECT count(compress_chunk(c)) FROM show_chunks('plan_plus') AS c;
+ count 
+-------
+     5
+(1 row)
+
+-- Get one of the UUIDs
+SELECT device FROM plan_plus LIMIT 1 \gset
+SET timescaledb.debug_require_vector_agg = 'require';
+-- Used to segfault
+SELECT
+    device = :'device'::uuid,
+    field,
+    SUM(value_numeric) AS value
+FROM plan_plus
+WHERE
+    device=:'device'::uuid
+    AND field='field 1'
+    AND time > '2024-03-31T00:00:00+00:00'::timestamptz
+    AND time < '2025-04-01T00:01:00+00:00'::timestamptz
+GROUP BY device, field
+LIMIT 1;
+ ?column? |  field  | value 
+----------+---------+-------
+ t        | field 1 |   340
+(1 row)
+
+SELECT
+    device = :'device'::uuid,
+    SUM(value_numeric) AS value
+FROM plan_plus
+WHERE
+    device=:'device'::uuid
+    AND field='field 1'
+    AND time > '2024-03-31T00:00:00+00:00'::timestamptz
+    AND time < '2025-04-01T00:01:00+00:00'::timestamptz
+GROUP BY device
+LIMIT 1;
+ ?column? | value 
+----------+-------
+ t        |   340
+(1 row)
+
+RESET timescaledb.debug_require_vector_agg;
+SELECT count(*) FROM (SELECT device FROM plan_plus GROUP BY device) t;
+ count 
+-------
+    10
+(1 row)
+
+SELECT count(*) FROM (SELECT device, field FROM plan_plus GROUP BY device, field) t;
+ count 
+-------
+  1000
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -127,7 +127,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     vector_agg_grouping.sql
     vector_agg_text.sql
     vector_agg_memory.sql
-    vector_agg_segmentby.sql)
+    vector_agg_segmentby.sql
+    vector_agg_uuid_segmentby.sql)
 
   list(
     APPEND

--- a/tsl/test/sql/vector_agg_uuid_segmentby.sql
+++ b/tsl/test/sql/vector_agg_uuid_segmentby.sql
@@ -1,0 +1,90 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test grouping by uuid segmentby column (scalar by-reference fixed-width column).
+
+CREATE TABLE public.plan_plus(
+  "time"        timestamp with time zone NOT NULL,
+  device        uuid                     NOT NULL,
+  field         text                     NOT NULL,
+  value_numeric double precision,
+  value_bool    boolean,
+  value_string  text,
+  value_geo     point,
+  created       timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX plan_plus_device_time_idx
+  ON public.plan_plus
+  USING btree (device, "time" DESC);
+
+CREATE INDEX plan_plus_time_idx
+  ON public.plan_plus
+  USING btree ("time" DESC);
+
+SELECT public.create_hypertable(
+  relation => 'public.plan_plus',
+  time_column_name => 'time',
+  create_default_indexes => false
+);
+
+ALTER TABLE public.plan_plus SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.compress_orderby='"time" DESC'
+);
+
+INSERT INTO plan_plus
+WITH devices AS (
+  select gen_random_uuid() AS device from generate_series(1, 10)
+),
+fields AS (
+  select 'field '||f AS field from generate_series(1,100) AS f
+)
+SELECT
+  t, device, field, 10, true, 'value', null, '2025-04-15 00:00:00'::timestamptz
+FROM
+  generate_series('2025-04-15 00:00:00'::timestamptz - interval '1 month',
+    '2025-04-15 00:00:00'::timestamptz, interval '12 hour') AS t,
+  devices, fields;
+
+-- Compress data
+SELECT count(compress_chunk(c)) FROM show_chunks('plan_plus') AS c;
+
+-- Get one of the UUIDs
+SELECT device FROM plan_plus LIMIT 1 \gset
+
+SET timescaledb.debug_require_vector_agg = 'require';
+
+-- Used to segfault
+SELECT
+    device = :'device'::uuid,
+    field,
+    SUM(value_numeric) AS value
+FROM plan_plus
+WHERE
+    device=:'device'::uuid
+    AND field='field 1'
+    AND time > '2024-03-31T00:00:00+00:00'::timestamptz
+    AND time < '2025-04-01T00:01:00+00:00'::timestamptz
+GROUP BY device, field
+LIMIT 1;
+
+SELECT
+    device = :'device'::uuid,
+    SUM(value_numeric) AS value
+FROM plan_plus
+WHERE
+    device=:'device'::uuid
+    AND field='field 1'
+    AND time > '2024-03-31T00:00:00+00:00'::timestamptz
+    AND time < '2025-04-01T00:01:00+00:00'::timestamptz
+GROUP BY device
+LIMIT 1;
+
+RESET timescaledb.debug_require_vector_agg;
+
+SELECT count(*) FROM (SELECT device FROM plan_plus GROUP BY device) t;
+
+SELECT count(*) FROM (SELECT device, field FROM plan_plus GROUP BY device, field) t;


### PR DESCRIPTION
This case was handled incorrectly and led to a segfault when grouping by multiple columns, one of which is a UUID segmentby column.

(cherry picked from commit 0768b33ab3e793c884572479e3c943beff12df2a)

backport of https://github.com/timescale/timescaledb/pull/7964