### PR TITLE
chore: update runner version image

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # run only on the 3 latest PG versions as we have rate limit on coverity
         pg: [15, 16, 17]
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     steps:
     - name: Install Dependencies
       run: |

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -9,7 +9,7 @@ name: Memory tests
 jobs:
   memory_leak:
     name: Memory leak on insert PG${{ matrix.pg }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         pg: [15, 16, 17]


### PR DESCRIPTION
Change runner image to 24.04 since 20.04 has been deprecated. 

Ref: https://github.com/actions/runner-images/issues/11101