### PR TITLE
Add some sanity checks for potential release commits/tags

### DIFF
--- a/.github/workflows/prerelease-sanity.yaml
+++ b/.github/workflows/prerelease-sanity.yaml
@@ -1,0 +1,42 @@
+name: Prerelease Sanity
+"on":
+  push:
+    branches:
+      - prerelease_test
+  pull_request:
+    branches: "?.*.x"
+    paths:
+      - version.config
+      - .github/workflows/prerelease-sanity.yaml
+  workflow_dispatch:
+
+
+jobs:
+  check_release_commit:
+    name: Check Release Commit
+    runs-on: ubuntu-22.04
+
+    steps:
+    # The combined changelog must reference all changes, and the respective
+    # change files in the .unreleased folder must be deleted.
+    - name: Check that no .unreleased files are left behind
+      run: |
+        ! compgen .unreleased/*
+
+    # The commit and tag message must start with Release <version>.
+    # If this is the release tag, it must point to the release commit
+    # and not something else.
+    - name: Check that the commit message references the respecitve version
+      run: |
+        required_title=$(sed -n "s/^version = /Release /p" version.config)
+        echo $required_title
+
+        tag_title=$(git log --oneline -1 --pretty=format:%s)
+        echo $tag_title
+        grep "$required_title" <<<"$tag_title"
+
+        # Our reference might be a tag, so check the pointed-to commit as well,
+        # using the ^0 git path specification to find it.
+        commit_title=$(git log --oneline -1 --pretty=format:%s @^0)
+        echo $commit_title
+        grep "$required_title" <<<"$commit_title"

--- a/.github/workflows/prerelease-sanity.yaml
+++ b/.github/workflows/prerelease-sanity.yaml
@@ -10,23 +10,32 @@ name: Prerelease Sanity
       - .github/workflows/prerelease-sanity.yaml
   workflow_dispatch:
 
-
 jobs:
   check_release_commit:
     name: Check Release Commit
-    runs-on: ubuntu-22.04
+    runs-on: timescaledb-runner-arm64
 
     steps:
+    - name: Checkout TimescaleDB
+      uses: actions/checkout@v4
+      # GitHub creates an empty merge commit even for fast-fordward merges, which
+      # makes it needlessly difficult to inspect the actual commit title. Since
+      # we require the PRs to release branches to be up to date before merging,
+      # we can just work with the PR head here.
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 2
+
     # The combined changelog must reference all changes, and the respective
     # change files in the .unreleased folder must be deleted.
-    - name: Check that no .unreleased files are left behind
+    - name: No .unreleased files are left behind
       run: |
-        ! compgen .unreleased/*
+        ! compgen -G .unreleased/*
 
-    # The commit and tag message must start with Release <version>.
+    # The messages of the release commit and tag must start with Release <version>.
     # If this is the release tag, it must point to the release commit
     # and not something else.
-    - name: Check that the commit message references the respecitve version
+    - name: The release commit message references the respective version
       run: |
         required_title=$(sed -n "s/^version = /Release /p" version.config)
         echo $required_title
@@ -40,3 +49,10 @@ jobs:
         commit_title=$(git log --oneline -1 --pretty=format:%s @^0)
         echo $commit_title
         grep "$required_title" <<<"$commit_title"
+
+    # The release commit must modify the version.config
+    - name: The release commit modifies the version.config
+      run: |
+        git log --oneline -1 @^0
+        git log --oneline -1 @^0~
+        ! git diff --exit-code @^0~ @^0 -- version.config


### PR DESCRIPTION
* Must have no leftover .unreleased files

* The commit title must start with "Release \<version\>"

* The tag must point to the actual release commit and not something else.

* The release commit must modify version.config

Tested manually here https://github.com/timescale/timescaledb/pull/7969


Disable-check: force-changelog-file