### PR TITLE
Release 2.100.99

### DIFF
--- a/.github/workflows/prerelease-sanity.yaml
+++ b/.github/workflows/prerelease-sanity.yaml
@@ -1,0 +1,58 @@
+name: Prerelease Sanity
+"on":
+  push:
+    branches:
+      - prerelease_test
+  pull_request:
+    branches: "?.*.x"
+    paths:
+      - version.config
+      - .github/workflows/prerelease-sanity.yaml
+  workflow_dispatch:
+
+jobs:
+  check_release_commit:
+    name: Check Release Commit
+    runs-on: timescaledb-runner-arm64
+
+    steps:
+    - name: Checkout TimescaleDB
+      uses: actions/checkout@v4
+      # GitHub creates an empty merge commit even for fast-fordward merges, which
+      # makes it needlessly difficult to inspect the actual commit title. Since
+      # we require the PRs to release branches to be up to date before merging,
+      # we can just work with the PR head here.
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 2
+
+    # The combined changelog must reference all changes, and the respective
+    # change files in the .unreleased folder must be deleted.
+    - name: No .unreleased files are left behind
+      run: |
+        ! compgen -G .unreleased/*
+
+    # The messages of the release commit and tag must start with Release <version>.
+    # If this is the release tag, it must point to the release commit
+    # and not something else.
+    - name: The release commit message references the respective version
+      run: |
+        required_title=$(sed -n "s/^version = /Release /p" version.config)
+        echo $required_title
+
+        tag_title=$(git log --oneline -1 --pretty=format:%s)
+        echo $tag_title
+        grep "$required_title" <<<"$tag_title"
+
+        # Our reference might be a tag, so check the pointed-to commit as well,
+        # using the ^0 git path specification to find it.
+        commit_title=$(git log --oneline -1 --pretty=format:%s @^0)
+        echo $commit_title
+        grep "$required_title" <<<"$commit_title"
+
+    # The release commit must modify the version.config
+    - name: The release commit modifies the version.config
+      run: |
+        git log --oneline -1 @^0
+        git log --oneline -1 @^0~
+        ! git diff --exit-code @^0~ @^0 -- version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
-version = 2.19.3
+version = 2.100.99
 update_from_version = 2.19.2
 downgrade_to_version = 2.19.2


### PR DESCRIPTION
A very advanced version of TimescaleDB

Tested https://github.com/timescale/timescaledb/pull/7968 manually on this PR:
- [x] no unreleased changelog files (check fails)
- [x] no unreleased changelog files (check passes)
- [x] proper version in the title (check fails)
- [x] proper version in the title (check passes)
- [x] version file modified (check fails)
- [x] version file modified (check passes)
- [x] all passes if all good