### PR TITLE
Enable compression for CREATE TABLE ... WITH ()

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -424,6 +424,8 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.hypercore_proxy_handler = process_hypercore_proxy_handler,
 	.is_compressed_tid = error_no_default_fn_pg_community,
 
+	.compression_enable = NULL,
+
 	.show_chunk = error_no_default_fn_pg_community,
 	.create_chunk = error_no_default_fn_pg_community,
 	.chunk_freeze_chunk = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -134,6 +134,9 @@ typedef struct CrossModuleFunctions
 	int (*hypercore_decompress_update_segment)(Relation relation, const ItemPointer ctid,
 											   TupleTableSlot *slot, Snapshot snapshot,
 											   ItemPointer new_tid);
+
+	void (*compression_enable)(Hypertable *ht);
+
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -32,3 +32,5 @@ typedef struct CompressionSettings CompressionSettings;
 int compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_reloid,
 									 AttrNumber chunk_attno, Oid compressed_reloid,
 									 char *metadata_type);
+
+void tsl_compression_enable(Hypertable *ht);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -181,6 +181,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.hypercore_proxy_handler = hypercore_proxy_handler,
 	.hypercore_decompress_update_segment = hypercore_decompress_update_segment,
 	.is_compressed_tid = tsl_is_compressed_tid,
+	.compression_enable = tsl_compression_enable,
 	.ddl_command_start = tsl_ddl_command_start,
 	.ddl_command_end = tsl_ddl_command_end,
 	.show_chunk = chunk_show,

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -1,6 +1,6 @@
--- This file and its contents are licensed under the Apache License 2.0.
+-- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
+-- LICENSE-TIMESCALE for a copy of the license.
 -- our user needs permission to create schema for the schema tests
 \c :TEST_DBNAME :ROLE_SUPERUSER
 GRANT CREATE ON DATABASE :TEST_DBNAME TO :ROLE_DEFAULT_PERM_USER;
@@ -201,8 +201,8 @@ INSERT INTO t11 SELECT '2025-01-01', 'd1', 0.1;
 SELECT relname from pg_class where relnamespace = 'abc'::regnamespace ORDER BY 1;
             relname             
 --------------------------------
- _hyper_18_1_chunk
- _hyper_18_1_chunk_t11_time_idx
+ _hyper_35_1_chunk
+ _hyper_35_1_chunk_t11_time_idx
 (2 rows)
 
 ROLLBACK;
@@ -219,8 +219,8 @@ INSERT INTO t11 SELECT '2025-01-01', 'd1', 0.1;
 SELECT relname from pg_class where relnamespace = 'abc2'::regnamespace ORDER BY 1;
             relname             
 --------------------------------
- _hyper_19_2_chunk
- _hyper_19_2_chunk_t11_time_idx
+ _hyper_37_2_chunk
+ _hyper_37_2_chunk_t11_time_idx
 (2 rows)
 
 ROLLBACK;
@@ -230,7 +230,7 @@ CREATE TABLE t12(time timestamptz NOT NULL, device text, value float) WITH (tsdb
 SELECT associated_table_prefix FROM _timescaledb_catalog.hypertable WHERE table_name = 't12';
  associated_table_prefix 
 -------------------------
- _hyper_20
+ _hyper_39
 (1 row)
 
 ROLLBACK;
@@ -249,5 +249,42 @@ SELECT relname from pg_class where relnamespace = 'abc'::regnamespace ORDER BY 1
  tbl_prefix_3_chunk
  tbl_prefix_3_chunk_t12_time_idx
 (2 rows)
+
+ROLLBACK;
+-- verify compression
+BEGIN;
+CREATE TABLE t13(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
+SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables;
+ hypertable_name | compression_enabled 
+-----------------+---------------------
+ t13             | t
+(1 row)
+
+INSERT INTO t13 SELECT '2025-01-01','d1',0.1;
+SELECT compress_chunk(show_chunks('t13'));
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "t13" is set to ""
+NOTICE:  default order by for hypertable "t13" is set to ""time" DESC"
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_43_4_chunk
+(1 row)
+
+ROLLBACK;
+BEGIN;
+CREATE TABLE t13(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
+SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables;
+ hypertable_name | compression_enabled 
+-----------------+---------------------
+ t13             | t
+(1 row)
+
+ALTER TABLE t13 SET (tsdb.compress_segmentby='device',tsdb.compress_orderby='time DESC');
+INSERT INTO t13 SELECT '2025-01-01','d1',0.1;
+SELECT compress_chunk(show_chunks('t13'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_45_6_chunk
+(1 row)
 
 ROLLBACK;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_FILES
     compression.sql
     compression_trigger.sql
     compress_sort_transform.sql
+    create_table_with.sql
     custom_hashagg.sql
     decompress_index.sql
     foreign_keys.sql

--- a/tsl/test/sql/create_table_with.sql
+++ b/tsl/test/sql/create_table_with.sql
@@ -1,253 +1,166 @@
--- This file and its contents are licensed under the Apache License 2.0.
+-- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
+-- LICENSE-TIMESCALE for a copy of the license.
+
 -- our user needs permission to create schema for the schema tests
 \c :TEST_DBNAME :ROLE_SUPERUSER
 GRANT CREATE ON DATABASE :TEST_DBNAME TO :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
 -- create table with non-tsdb option should not be affected
 CREATE TABLE t1(time timestamptz, device text, value float) WITH (autovacuum_enabled);
 DROP TABLE t1;
+
 -- test error cases
 \set ON_ERROR_STOP 0
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
-ERROR:  hypertable option requires time_column
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
-ERROR:  hypertable option requires time_column
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column=NULL);
-ERROR:  column "null" does not exist
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='');
-ERROR:  column "" does not exist
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='foo');
-ERROR:  column "foo" does not exist
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.time_column='time');
-ERROR:  timescaledb options requires hypertable option
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.time_column='time');
-ERROR:  timescaledb options requires hypertable option
 CREATE TABLE t2(time timestamptz , device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval='foo');
-ERROR:  invalid input syntax for type interval: "foo"
 CREATE TABLE t2(time int2 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval='3 months');
-ERROR:  invalid input syntax for type smallint: "3 months"
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes='time');
-ERROR:  invalid value for tsdb.create_default_indexes 'time'
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes=2);
-ERROR:  invalid value for tsdb.create_default_indexes '2'
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes=-1);
-ERROR:  invalid value for tsdb.create_default_indexes '-1'
 \set ON_ERROR_STOP 1
+
+
 BEGIN;
 CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 CREATE TABLE t4(time timestamp, device text, value float) WITH (tsdb.hypertable,timescaledb.time_column='time');
-NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE t5(time date, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',autovacuum_enabled);
-NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE t6(time timestamptz NOT NULL, device text, value float) WITH (timescaledb.hypertable,tsdb.time_column='time');
-SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
- hypertable_name 
------------------
- t3
- t4
- t5
- t6
-(4 rows)
 
+SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
 ROLLBACK;
+
 -- IF NOT EXISTS
 BEGIN;
 CREATE TABLE IF NOT EXISTS t7(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 CREATE TABLE IF NOT EXISTS t7(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
-NOTICE:  relation "t7" already exists, skipping
 CREATE TABLE IF NOT EXISTS t7(time timestamptz NOT NULL, device text, value float);
-NOTICE:  relation "t7" already exists, skipping
-SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
- hypertable_name 
------------------
- t7
-(1 row)
 
+SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
 ROLLBACK;
+
 -- table won't be converted to hypertable unless it is in the initial CREATE TABLE
 BEGIN;
 CREATE TABLE IF NOT EXISTS t8(time timestamptz NOT NULL, device text, value float);
 CREATE TABLE IF NOT EXISTS t8(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
-NOTICE:  relation "t8" already exists, skipping
 CREATE TABLE IF NOT EXISTS t8(time timestamptz NOT NULL, device text, value float);
-NOTICE:  relation "t8" already exists, skipping
-SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
- hypertable_name 
------------------
-(0 rows)
 
+SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
 ROLLBACK;
+
 -- chunk_time_interval
 BEGIN;
 CREATE TABLE IF NOT EXISTS t9(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval='8weeks');
 SELECT hypertable_name, column_name, column_type, time_interval FROM timescaledb_information.dimensions;
- hypertable_name | column_name |       column_type        | time_interval 
------------------+-------------+--------------------------+---------------
- t9              | time        | timestamp with time zone | @ 56 days
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE IF NOT EXISTS t9(time timestamp NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval='23 days');
 SELECT hypertable_name, column_name, column_type, time_interval FROM timescaledb_information.dimensions;
- hypertable_name | column_name |         column_type         | time_interval 
------------------+-------------+-----------------------------+---------------
- t9              | time        | timestamp without time zone | @ 23 days
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE IF NOT EXISTS t9(time date NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval='3 months');
 SELECT hypertable_name, column_name, column_type, time_interval FROM timescaledb_information.dimensions;
- hypertable_name | column_name | column_type | time_interval 
------------------+-------------+-------------+---------------
- t9              | time        | date        | @ 90 days
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE IF NOT EXISTS t9(time int2 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval=12);
 SELECT hypertable_name, column_name, column_type, integer_interval FROM timescaledb_information.dimensions;
- hypertable_name | column_name | column_type | integer_interval 
------------------+-------------+-------------+------------------
- t9              | time        | smallint    |               12
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE IF NOT EXISTS t9(time int4 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval=3453);
 SELECT hypertable_name, column_name, column_type, integer_interval FROM timescaledb_information.dimensions;
- hypertable_name | column_name | column_type | integer_interval 
------------------+-------------+-------------+------------------
- t9              | time        | integer     |             3453
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE IF NOT EXISTS t9(time int8 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.chunk_time_interval=32768);
 SELECT hypertable_name, column_name, column_type, integer_interval FROM timescaledb_information.dimensions;
- hypertable_name | column_name | column_type | integer_interval 
------------------+-------------+-------------+------------------
- t9              | time        | bigint      |            32768
-(1 row)
-
 ROLLBACK;
+
 -- create_default_indexes
 BEGIN;
 CREATE TABLE t10(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 SELECT indexrelid::regclass from pg_index where indrelid='t10'::regclass ORDER BY indexrelid::regclass::text;
-  indexrelid  
---------------
- t10_time_idx
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE t10(time timestamptz NOT NULL PRIMARY KEY, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 SELECT indexrelid::regclass from pg_index where indrelid='t10'::regclass ORDER BY indexrelid::regclass::text;
- indexrelid 
-------------
- t10_pkey
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE t10(time timestamptz NOT NULL UNIQUE, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 SELECT indexrelid::regclass from pg_index where indrelid='t10'::regclass ORDER BY indexrelid::regclass::text;
-  indexrelid  
---------------
- t10_time_key
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE t10(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.create_default_indexes=true);
 SELECT indexrelid::regclass from pg_index where indrelid='t10'::regclass ORDER BY indexrelid::regclass::text;
-  indexrelid  
---------------
- t10_time_idx
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE t10(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time',tsdb.create_default_indexes=false);
 SELECT indexrelid::regclass from pg_index where indrelid='t10'::regclass ORDER BY indexrelid::regclass::text;
- indexrelid 
-------------
-(0 rows)
-
 ROLLBACK;
+
 -- associated_schema
 BEGIN;
 CREATE TABLE t11(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 SELECT associated_schema_name FROM _timescaledb_catalog.hypertable WHERE table_name = 't11';
- associated_schema_name 
-------------------------
- _timescaledb_internal
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE t11(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time', tsdb.associated_schema='abc');
 SELECT associated_schema_name FROM _timescaledb_catalog.hypertable WHERE table_name = 't11';
- associated_schema_name 
-------------------------
- abc
-(1 row)
-
 INSERT INTO t11 SELECT '2025-01-01', 'd1', 0.1;
 SELECT relname from pg_class where relnamespace = 'abc'::regnamespace ORDER BY 1;
-            relname             
---------------------------------
- _hyper_18_1_chunk
- _hyper_18_1_chunk_t11_time_idx
-(2 rows)
-
 ROLLBACK;
+
 BEGIN;
 CREATE SCHEMA abc2;
 CREATE TABLE t11(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time', tsdb.associated_schema='abc2');
 SELECT associated_schema_name FROM _timescaledb_catalog.hypertable WHERE table_name = 't11';
- associated_schema_name 
-------------------------
- abc2
-(1 row)
-
 INSERT INTO t11 SELECT '2025-01-01', 'd1', 0.1;
 SELECT relname from pg_class where relnamespace = 'abc2'::regnamespace ORDER BY 1;
-            relname             
---------------------------------
- _hyper_19_2_chunk
- _hyper_19_2_chunk_t11_time_idx
-(2 rows)
-
 ROLLBACK;
+
 -- associated_table_prefix
 BEGIN;
 CREATE TABLE t12(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
 SELECT associated_table_prefix FROM _timescaledb_catalog.hypertable WHERE table_name = 't12';
- associated_table_prefix 
--------------------------
- _hyper_20
-(1 row)
-
 ROLLBACK;
+
 BEGIN;
 CREATE TABLE t12(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time', tsdb.associated_schema='abc', tsdb.associated_table_prefix='tbl_prefix');
 SELECT associated_table_prefix FROM _timescaledb_catalog.hypertable WHERE table_name = 't12';
- associated_table_prefix 
--------------------------
- tbl_prefix
-(1 row)
-
 INSERT INTO t12 SELECT '2025-01-01', 'd1', 0.1;
 SELECT relname from pg_class where relnamespace = 'abc'::regnamespace ORDER BY 1;
-             relname             
----------------------------------
- tbl_prefix_3_chunk
- tbl_prefix_3_chunk_t12_time_idx
-(2 rows)
-
 ROLLBACK;
+
+-- verify compression
+BEGIN;
+CREATE TABLE t13(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
+SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables;
+
+INSERT INTO t13 SELECT '2025-01-01','d1',0.1;
+SELECT compress_chunk(show_chunks('t13'));
+ROLLBACK;
+
+BEGIN;
+CREATE TABLE t13(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.time_column='time');
+SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables;
+ALTER TABLE t13 SET (tsdb.compress_segmentby='device',tsdb.compress_orderby='time DESC');
+
+INSERT INTO t13 SELECT '2025-01-01','d1',0.1;
+SELECT compress_chunk(show_chunks('t13'));
+ROLLBACK;
+


### PR DESCRIPTION
On hypertables created with CREATE TABLE ... WITH we enable compression
by default but do not create CompressionSettings immediately assuming
that we have more information available when the first compression
is actually triggered allowing us to generate better compression
settings.

Disable-check: force-changelog-file
