### PR TITLE
Add vectorized filtering to constraint checking

### DIFF
--- a/.unreleased/pr_7972
+++ b/.unreleased/pr_7972
@@ -1,0 +1,1 @@
+Implements: #7972 Add vectorized filtering for constraint checking while backfilling into compressed chunks

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -388,6 +388,8 @@ extern enum CompressionAlgorithms compress_get_default_algorithm(Oid typeoid);
 extern int decompress_batch(RowDecompressor *decompressor);
 extern bool decompress_batch_next_row(RowDecompressor *decompressor, AttrNumber *attnos,
 									  int num_attnos);
+extern ArrowArray *decompress_single_column(RowDecompressor *decompressor, AttrNumber attno,
+											bool *default_value);
 /*
  * A convenience macro to throw an error about the corrupted compressed data, if
  * the argument is false. When fuzzing is enabled, we don't show the message not

--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -28,7 +28,11 @@ typedef struct tuple_filtering_constraints
 	OnConflictAction on_conflict;
 	Oid index_relid; /* used for better error messages */
 	bool nullsnotdistinct;
+	bool vectorized_filtering;
 } tuple_filtering_constraints;
+
+typedef bool(BatchMatcher)(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scankeys,
+						   tuple_filtering_constraints *constraints, bool *skip_current_tuple);
 
 bool slot_key_test(TupleTableSlot *slot, ScanKey skey);
 

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -17,6 +17,7 @@
 #include "debug_assert.h"
 #include "guc.h"
 #include "nodes/decompress_chunk/compressed_batch.h"
+#include "nodes/decompress_chunk/vector_dict.h"
 #include "nodes/decompress_chunk/vector_predicates.h"
 #include "nodes/decompress_chunk/vector_quals.h"
 
@@ -416,50 +417,6 @@ compressed_batch_get_arrow_array(VectorQualState *vqstate, Expr *expr, bool *is_
 		*is_default_value = false;
 
 	return vector;
-}
-
-/*
- * When we have a dictionary-encoded Arrow Array, and have run a predicate on
- * the dictionary, this function is used to translate the dictionary predicate
- * result to the final predicate result.
- */
-static void
-translate_bitmap_from_dictionary(const ArrowArray *arrow, const uint64 *dict_result,
-								 uint64 *restrict final_result)
-{
-	Assert(arrow->dictionary != NULL);
-
-	const size_t n = arrow->length;
-	const int16 *indices = (int16 *) arrow->buffers[1];
-	for (size_t outer = 0; outer < n / 64; outer++)
-	{
-		uint64 word = 0;
-		for (size_t inner = 0; inner < 64; inner++)
-		{
-			const size_t row = (outer * 64) + inner;
-			const size_t bit_index = inner;
-#define INNER_LOOP                                                                                 \
-	const int16 index = indices[row];                                                              \
-	const bool valid = arrow_row_is_valid(dict_result, index);                                     \
-	word |= ((uint64) valid) << bit_index;
-
-			INNER_LOOP
-		}
-		final_result[outer] &= word;
-	}
-
-	if (n % 64)
-	{
-		uint64 word = 0;
-		for (size_t row = (n / 64) * 64; row < n; row++)
-		{
-			const size_t bit_index = row % 64;
-
-			INNER_LOOP
-		}
-		final_result[n / 64] &= word;
-	}
-#undef INNER_LOOP
 }
 
 static void

--- a/tsl/src/nodes/decompress_chunk/vector_dict.h
+++ b/tsl/src/nodes/decompress_chunk/vector_dict.h
@@ -1,0 +1,52 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include "compression/arrow_c_data_interface.h"
+
+/*
+ * When we have a dictionary-encoded Arrow Array, and have run a predicate on
+ * the dictionary, this function is used to translate the dictionary predicate
+ * result to the final predicate result.
+ */
+static void
+translate_bitmap_from_dictionary(const ArrowArray *arrow, const uint64 *dict_result,
+								 uint64 *restrict final_result)
+{
+	Assert(arrow->dictionary != NULL);
+
+	const size_t n = arrow->length;
+	const int16 *indices = (int16 *) arrow->buffers[1];
+	for (size_t outer = 0; outer < n / 64; outer++)
+	{
+		uint64 word = 0;
+		for (size_t inner = 0; inner < 64; inner++)
+		{
+			const size_t row = (outer * 64) + inner;
+			const size_t bit_index = inner;
+#define INNER_LOOP                                                                                 \
+	const int16 index = indices[row];                                                              \
+	const bool valid = arrow_row_is_valid(dict_result, index);                                     \
+	word |= ((uint64) valid) << bit_index;
+
+			INNER_LOOP
+		}
+		final_result[outer] &= word;
+	}
+
+	if (n % 64)
+	{
+		uint64 word = 0;
+		for (size_t row = (n / 64) * 64; row < n; row++)
+		{
+			const size_t bit_index = row % 64;
+
+			INNER_LOOP
+		}
+		final_result[n / 64] &= word;
+	}
+#undef INNER_LOOP
+}

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1196,6 +1196,7 @@ SELECT count(*) FROM unique_null;
 
 DROP TABLE unique_null;
 -- test insert with UNIQUE constraint and all compression algorithms
+set timescaledb.enable_bool_compression = on;
 CREATE TABLE unique_all(
 	time timestamptz NOT NULL,
 	device_id int,
@@ -1284,3 +1285,60 @@ INSERT INTO unique_all VALUES('2024-01-01 00:04', 1, true, 1.0, 3.0, 'first', 1,
 INSERT INTO unique_all VALUES('2024-01-01 00:05', 1, true, 1.0, 1.0, 'third', 1, '{"first":true}');
 INSERT INTO unique_all VALUES('2024-01-01 00:06', 1, true, 1.0, 1.0, 'first', 3, '{"first":true}');
 INSERT INTO unique_all VALUES('2024-01-01 00:07', 1, true, 1.0, 1.0, 'first', 1, '{"third":true}');
+-- test non-duplicates with non-NULL default values
+ALTER TABLE unique_all ADD COLUMN added_non_null int DEFAULT 4;
+DROP INDEX ultimate_unique;
+CREATE UNIQUE INDEX ultimate_unique ON unique_all(time, device_id, bool_type, numeric_type, float_type, text_type, bigint_type, jsonb_type, added_non_null) NULLS NOT DISTINCT;
+\set ON_ERROR_STOP 0
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 4);
+ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
+\set ON_ERROR_STOP 1
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 5);
+-- make sure everything is correct after recompressing the chunk
+SELECT count(decompress_chunk(c)) FROM show_chunks('unique_all') c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_all') c;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 0
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 4);
+ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
+\set ON_ERROR_STOP 1
+-- test non-duplicates with NULL default values
+ALTER TABLE unique_all ADD COLUMN added_null int DEFAULT NULL;
+DROP INDEX ultimate_unique;
+CREATE UNIQUE INDEX ultimate_unique ON unique_all(time, device_id, bool_type, numeric_type, float_type, text_type, bigint_type, jsonb_type, added_non_null, added_null) NULLS NOT DISTINCT;
+\set ON_ERROR_STOP 0
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 4, NULL);
+ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 5, NULL);
+ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
+\set ON_ERROR_STOP 1
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 6, NULL);
+-- make sure everything is correct after recompressing the chunk
+SELECT count(decompress_chunk(c)) FROM show_chunks('unique_all') c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_all') c;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 0
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 4, NULL);
+ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
+INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1, '{"first":true}', 5, NULL);
+ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
+\set ON_ERROR_STOP 1
+DROP TABLE unique_all;


### PR DESCRIPTION
When backfilling compressed chunks with constraint checking, we need to read and filter compressed tuples in order to confirm constraints are validated. This change adds the ability to do this operation using vectorized decompression and vectorized filtering if the types allow us to do so.