### PR TITLE
Add fuzzing for bool compression

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -128,6 +128,7 @@ jobs:
             { algo: array     , pgtype: text  , bulk: true , runs:   10000000 },
             { algo: dictionary, pgtype: text  , bulk: false, runs:  100000000 },
             { algo: dictionary, pgtype: text  , bulk: true , runs:  100000000 },
+            { algo: bool, pgtype: bool  , bulk: false , runs:  100000000 },
             ]
 
     name: Fuzz decompression ${{ matrix.case.algo }} ${{ matrix.case.pgtype }} ${{ matrix.case.bulk && 'bulk' || 'rowbyrow' }}

--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -364,8 +364,7 @@ bool_compressed_from_parts(Simple8bRleSerialized *values, Simple8bRleSerialized 
 	uint32 num_values = values != NULL ? values->num_elements : 0;
 	uint32 values_size = values != NULL ? simple8brle_serialized_total_size(values) : 0;
 
-	if (num_values == 0)
-		return NULL;
+	CheckCompressedData(num_values != 0);
 
 	if (validity_bitmap != NULL)
 		validity_bitmap_size = simple8brle_serialized_total_size(validity_bitmap);


### PR DESCRIPTION
How I ran this locally:

```
export PGBUILD=build-pg-fuzz; rm -rf $PGBUILD; mkdir $PGBUILD; (cd $PGBUILD && ../pg/configure --prefix=$(pwd)/../install --enable-depend --enable-cassert --enable-debug --enable-tap-tests --with-openssl --without-llvm --with-lz4 CFLAGS="-fuse-ld=lld -ggdb3 -Og -fno-omit-frame-pointer -DTS_COMPRESSION_FUZZING=1" CC="clang-16" LD=lld-16 INSTALL="install -p" && make install -j8 && make check -j4)


export TSBUILD=build-ts-fuzz; rm -rf $TSBUILD; mkdir $TSBUILD; cmake -B $TSBUILD -S ts -DCMAKE_C_COMPILER=clang-16 -DASSERTIONS=ON -DLINTER=OFF -DCMAKE_VERBOSE_MAKEFILE=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_C_FLAGS="-fuse-ld=lld-16 -fsanitize=fuzzer-no-link -L/usr/lib/llvm-16/lib/clang/16/lib/linux/ -l:libclang_rt.fuzzer_no_main-x86_64.a -static-libsan" -DEXPERIMENTAL=ON -DPG_PATH=$(readlink -f install) && make -C $TSBUILD install -j12

create or replace function fuzz(algo cstring, pgtype regtype,
                bulk bool, runs int)
            returns int as 'timescaledb-tsl-2.20.0-dev.so', 'ts_fuzz_compression' language c;
            
select fuzz('bool'::cstring, 'bool'::regtype, false, 10000000);
```