### PR TITLE
Rename compression_with_clause to alter_table_with_clause

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -84,7 +84,7 @@
 #include "ts_catalog/continuous_aggs_watermark.h"
 #include "tss_callbacks.h"
 #include "utils.h"
-#include "with_clause/compression_with_clause.h"
+#include "with_clause/alter_table_with_clause.h"
 #include "with_clause/create_table_with_clause.h"
 #include "with_clause/with_clause_parser.h"
 
@@ -4922,7 +4922,7 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 				 errmsg("only timescaledb.compress parameters allowed when specifying compression "
 						"parameters for hypertable")));
 
-	parse_results = ts_compress_hypertable_set_clause_parse(compress_options);
+	parse_results = ts_alter_table_with_clause_parse(compress_options);
 
 	ts_cm_functions->process_compress_table(ht, parse_results);
 	return DDL_DONE;

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -41,7 +41,7 @@
 #include "ts_catalog/continuous_agg.h"
 #include "ts_catalog/continuous_aggs_watermark.h"
 #include "utils.h"
-#include "with_clause/compression_with_clause.h"
+#include "with_clause/alter_table_with_clause.h"
 
 #define BUCKET_FUNCTION_SERIALIZE_VERSION 1
 #define CHECK_NAME_MATCH(name1, name2) (namestrcmp(name1, name2) == 0)
@@ -102,21 +102,21 @@ ts_continuous_agg_get_compression_defelems(const WithClauseResult *with_clauses)
 {
 	List *ret = NIL;
 
-	for (int i = 0; i < CompressOptionMax; i++)
+	for (int i = 0; i < AlterTableFlagsMax; i++)
 	{
 		int option_index = 0;
 		switch (i)
 		{
-			case CompressEnabled:
+			case AlterTableFlagCompressEnabled:
 				option_index = ContinuousViewOptionCompress;
 				break;
-			case CompressSegmentBy:
+			case AlterTableFlagCompressSegmentBy:
 				option_index = ContinuousViewOptionCompressSegmentBy;
 				break;
-			case CompressOrderBy:
+			case AlterTableFlagCompressOrderBy:
 				option_index = ContinuousViewOptionCompressOrderBy;
 				break;
-			case CompressChunkTimeInterval:
+			case AlterTableFlagCompressChunkTimeInterval:
 				option_index = ContinuousViewOptionCompressChunkTimeInterval;
 				break;
 			default:

--- a/src/with_clause/CMakeLists.txt
+++ b/src/with_clause/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/compression_with_clause.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/alter_table_with_clause.c
     ${CMAKE_CURRENT_SOURCE_DIR}/create_table_with_clause.c
     ${CMAKE_CURRENT_SOURCE_DIR}/with_clause_parser.c)
 

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -21,34 +21,34 @@
 #include "compat/compat.h"
 #include "ts_catalog/array_utils.h"
 
-#include "compression_with_clause.h"
+#include "alter_table_with_clause.h"
 
-static const WithClauseDefinition compress_hypertable_with_clause_def[] = {
-		[CompressEnabled] = {
+static const WithClauseDefinition alter_table_with_clause_def[] = {
+		[AlterTableFlagCompressEnabled] = {
 			.arg_names = {"compress", "enable_columnstore", NULL},
 			.type_id = BOOLOID,
 			.default_val = (Datum)false,
 		},
-		[CompressSegmentBy] = {
+		[AlterTableFlagCompressSegmentBy] = {
 			.arg_names = {"compress_segmentby", "segmentby", NULL},
 			 .type_id = TEXTOID,
 		},
-		[CompressOrderBy] = {
+		[AlterTableFlagCompressOrderBy] = {
 			.arg_names = {"compress_orderby", "orderby", NULL},
 			 .type_id = TEXTOID,
 		},
-		[CompressChunkTimeInterval] = {
+		[AlterTableFlagCompressChunkTimeInterval] = {
 			.arg_names = {"compress_chunk_time_interval", NULL},
 			 .type_id = INTERVALOID,
 		},
 };
 
 WithClauseResult *
-ts_compress_hypertable_set_clause_parse(const List *defelems)
+ts_alter_table_with_clause_parse(const List *defelems)
 {
 	return ts_with_clauses_parse(defelems,
-								 compress_hypertable_with_clause_def,
-								 TS_ARRAY_LEN(compress_hypertable_with_clause_def));
+								 alter_table_with_clause_def,
+								 TS_ARRAY_LEN(alter_table_with_clause_def));
 }
 
 static inline void
@@ -307,9 +307,9 @@ ts_compress_parse_order_collist(char *inpstr, Hypertable *hypertable)
 ArrayType *
 ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypertable *hypertable)
 {
-	if (parsed_options[CompressSegmentBy].is_default == false)
+	if (parsed_options[AlterTableFlagCompressSegmentBy].is_default == false)
 	{
-		Datum textarg = parsed_options[CompressSegmentBy].parsed;
+		Datum textarg = parsed_options[AlterTableFlagCompressSegmentBy].parsed;
 		return parse_segment_collist(TextDatumGetCString(textarg), hypertable);
 	}
 	else
@@ -322,8 +322,9 @@ ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypert
 OrderBySettings
 ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertable *hypertable)
 {
-	Ensure(parsed_options[CompressOrderBy].is_default == false, "with clause is not default");
-	Datum textarg = parsed_options[CompressOrderBy].parsed;
+	Ensure(parsed_options[AlterTableFlagCompressOrderBy].is_default == false,
+		   "with clause is not default");
+	Datum textarg = parsed_options[AlterTableFlagCompressOrderBy].parsed;
 	return ts_compress_parse_order_collist(TextDatumGetCString(textarg), hypertable);
 }
 
@@ -334,9 +335,9 @@ Interval *
 ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
 												 Hypertable *hypertable)
 {
-	if (parsed_options[CompressChunkTimeInterval].is_default == false)
+	if (parsed_options[AlterTableFlagCompressChunkTimeInterval].is_default == false)
 	{
-		Datum textarg = parsed_options[CompressChunkTimeInterval].parsed;
+		Datum textarg = parsed_options[AlterTableFlagCompressChunkTimeInterval].parsed;
 		return DatumGetIntervalP(textarg);
 	}
 	else

--- a/src/with_clause/alter_table_with_clause.h
+++ b/src/with_clause/alter_table_with_clause.h
@@ -13,14 +13,14 @@
 
 #include "with_clause_parser.h"
 
-typedef enum CompressHypertableOption
+typedef enum AlterTableFlags
 {
-	CompressEnabled = 0,
-	CompressSegmentBy,
-	CompressOrderBy,
-	CompressChunkTimeInterval,
-	CompressOptionMax
-} CompressHypertableOption;
+	AlterTableFlagCompressEnabled = 0,
+	AlterTableFlagCompressSegmentBy,
+	AlterTableFlagCompressOrderBy,
+	AlterTableFlagCompressChunkTimeInterval,
+	AlterTableFlagsMax
+} AlterTableFlags;
 
 typedef struct
 {
@@ -36,7 +36,7 @@ typedef struct
 	ArrayType *orderby_nullsfirst;
 } OrderBySettings;
 
-extern TSDLLEXPORT WithClauseResult *ts_compress_hypertable_set_clause_parse(const List *defelems);
+extern TSDLLEXPORT WithClauseResult *ts_alter_table_with_clause_parse(const List *defelems);
 extern TSDLLEXPORT ArrayType *
 ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypertable *hypertable);
 extern TSDLLEXPORT OrderBySettings

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -23,7 +23,7 @@
 #include "options.h"
 #include "scan_iterator.h"
 #include "ts_catalog/continuous_agg.h"
-#include "with_clause/compression_with_clause.h"
+#include "with_clause/alter_table_with_clause.h"
 
 static void cagg_update_materialized_only(ContinuousAgg *agg, bool materialized_only);
 static List *cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht);
@@ -126,16 +126,15 @@ static void
 cagg_alter_compression(ContinuousAgg *agg, Hypertable *mat_ht, List *compress_defelems)
 {
 	Assert(mat_ht != NULL);
-	WithClauseResult *with_clause_options =
-		ts_compress_hypertable_set_clause_parse(compress_defelems);
+	WithClauseResult *with_clause_options = ts_alter_table_with_clause_parse(compress_defelems);
 
-	if (with_clause_options[CompressEnabled].parsed)
+	if (with_clause_options[AlterTableFlagCompressEnabled].parsed)
 	{
 		List *default_compress_defelems = cagg_get_compression_params(agg, mat_ht);
 		WithClauseResult *default_with_clause_options =
-			ts_compress_hypertable_set_clause_parse(default_compress_defelems);
+			ts_alter_table_with_clause_parse(default_compress_defelems);
 		/* Merge defaults if there's any. */
-		for (int i = 0; i < CompressOptionMax; i++)
+		for (int i = 0; i < AlterTableFlagsMax; i++)
 		{
 			if (with_clause_options[i].is_default && !default_with_clause_options[i].is_default)
 			{


### PR DESCRIPTION
This change is to make the naming similar to create table since
the with clause options are determined by the command used
and not limited to a specific feature.

Disable-check: force-changelog-file