### PR TITLE
Move small actions to different runner

### DIFF
--- a/.github/workflows/backport-trigger.yaml
+++ b/.github/workflows/backport-trigger.yaml
@@ -11,7 +11,7 @@ name: Trigger the Backport Workflow
 
 jobs:
   backport_trigger:
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Checkout TimescaleDB
         uses: actions/checkout@v4

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   backport:
     name: Backport Bug Fixes
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
 
     steps:
       - name: Install Python Dependencies

--- a/.github/workflows/catalog-updates-check.yaml
+++ b/.github/workflows/catalog-updates-check.yaml
@@ -4,7 +4,7 @@ name: Check for unsafe catalog updates
 jobs:
   check_catalog_correctly_updated:
     name: Check updates to latest-dev and reverse-dev are properly handled by PR
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -20,7 +20,7 @@ jobs:
   # Implements: #NNNN <feature description> (mandatory in case of new features)
   check_changelog_file:
     name: Check for file with CHANGELOG entry
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Install Linux Dependencies
         run: |

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -13,7 +13,7 @@ jobs:
     # pull requests. To avoid adding pull requests to the bug board,
     # filter out pull requests
     if: ${{ !github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Add to bugs board
         uses: actions/add-to-project@v0.5.0
@@ -31,7 +31,7 @@ jobs:
 
   notify-sec:
     name: Notify security channel
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     if: >-
       github.event_name == 'issues' &&
       github.event.action != 'closed' &&
@@ -60,7 +60,7 @@ jobs:
 
   close-issue:
     name: Issue is closed
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     if: github.event_name == 'issues' && github.event.action == 'closed' && contains(github.event.issues.issue.labels.*.name, 'bug')
     steps:
       - uses: leonsteinhaeuser/project-beta-automations@v2.0.0
@@ -78,7 +78,7 @@ jobs:
 
   waiting-for-author:
     name: Waiting for Author
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     if: github.event_name == 'issues' && github.event.action == 'labeled'
       && github.event.label.name == 'waiting-for-author'
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   waiting-for-engineering:
     name: Waiting for Engineering
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     steps:
       - name: Install dependencies

--- a/.github/workflows/pr-approvals.yaml
+++ b/.github/workflows/pr-approvals.yaml
@@ -13,7 +13,7 @@ jobs:
 
   check_approvals:
     name: Check for sufficient approvals
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -18,13 +18,13 @@ jobs:
 
   assign-pr:
     name: Assign PR to author
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0
 
   ask-review:
     name: Run pull-review
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -18,7 +18,7 @@ jobs:
   # but this is currently not enforced.
   count_commits:
     name: Enforce single commit pull request
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     name: Check for loader changes
     # Ignore loader changes if acknowledged already
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'upgrade-requires-restart') }}
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
Move the smaller actions to a different runner to free up resources for other more involved actions.

Disable-check: force-changelog-file
Disable-check: approval-count