### PR TITLE
Add columnstore as alias for enable_columnstore in ALTER TABLE

### DIFF
--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -18,8 +18,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get purge llvm-16 llvm-18 clang-16 clang-18
-        sudo apt-get install llvm-19 llvm-19-dev clang-19 libclang-19-dev clang-tidy-19 libcurl4-openssl-dev postgresql-server-dev-16
+        sudo apt-get purge llvm-16 llvm-17 llvm-18 clang-16 clang-17 clang-18
+        sudo apt-get install llvm-19 llvm-19-dev clang-19 libclang-19-dev clang-tidy-19 libcurl4-openssl-dev
         sudo ln -sf /usr/bin/clang-tidy-19 /usr/bin/clang-tidy
 
     - name: Checkout timescaledb
@@ -35,7 +35,7 @@ jobs:
     - name: build pg_ladybug
       run:  |
         cd pg_ladybug
-        cmake -S . -B build
+        cmake -S . -B build -DLLVM_ROOT=/usr/lib/llvm-19
         make -C build
         sudo make -C build install
 
@@ -45,6 +45,8 @@ jobs:
 
     - name: Configure timescaledb
       run: |
+        # installing postgres headers pulls in llvm-17 which confuses pg_ladybug build process so we install this here instead of at beginning
+        sudo apt-get install postgresql-server-dev-16
         ./bootstrap -DCMAKE_BUILD_TYPE=Debug -DLINTER=ON -DCLANG_TIDY_EXTRA_OPTS=",-*,postgres-*;--load=/usr/local/lib/libPostgresCheck.so"
 
     - name: Build timescaledb

--- a/.unreleased/pr_7981
+++ b/.unreleased/pr_7981
@@ -1,0 +1,1 @@
+Implements: #7981 Add columnstore as alias for enable_columnstore in ALTER TABLE

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -25,7 +25,7 @@
 
 static const WithClauseDefinition alter_table_with_clause_def[] = {
 		[AlterTableFlagCompressEnabled] = {
-			.arg_names = {"compress", "enable_columnstore", NULL},
+			.arg_names = {"compress", "columnstore", "enable_columnstore", NULL},
 			.type_id = BOOLOID,
 			.default_val = (Datum)false,
 		},

--- a/tsl/test/expected/columnstore_aliases.out
+++ b/tsl/test/expected/columnstore_aliases.out
@@ -85,3 +85,24 @@ SELECT * FROM hypertable_columnstore_stats('test1') where 1 = 2;
 --------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
 (0 rows)
 
+CREATE TABLE test2 (ts timestamptz, i integer, b bigint, t text);
+SELECT * FROM create_hypertable('test2', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | test2      | t
+(1 row)
+
+INSERT INTO test2 SELECT t,  random(), random(), random()::text
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
+ALTER TABLE test2 set (
+      timescaledb.columnstore,
+      timescaledb.segmentby = 'b',
+      timescaledb.orderby = 'ts desc'
+);
+SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = 'test2';
+ hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces 
+-------------------+-----------------+-------------------+----------------+------------+---------------------+-------------
+ public            | test2           | default_perm_user |              1 |          4 | t                   | 
+(1 row)
+

--- a/tsl/test/sql/columnstore_aliases.sql
+++ b/tsl/test/sql/columnstore_aliases.sql
@@ -67,3 +67,16 @@ VACUUM FULL test1;
 -- the same as for the original function.
 SELECT * FROM chunk_columnstore_stats('test1') where 1 = 2 order by chunk_name;
 SELECT * FROM hypertable_columnstore_stats('test1') where 1 = 2;
+
+CREATE TABLE test2 (ts timestamptz, i integer, b bigint, t text);
+SELECT * FROM create_hypertable('test2', 'ts');
+INSERT INTO test2 SELECT t,  random(), random(), random()::text
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
+ALTER TABLE test2 set (
+      timescaledb.columnstore,
+      timescaledb.segmentby = 'b',
+      timescaledb.orderby = 'ts desc'
+);
+SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = 'test2';
+
+


### PR DESCRIPTION
Since the option is a bool the enable in the option name is redundant
and having the option named columnstore seems more consistent with
similarly named options.

Disable-check: commit-count
