### PR TITLE
Fix crashes in batch sort merge over expressions

### DIFF
--- a/.unreleased/pr_7982
+++ b/.unreleased/pr_7982
@@ -1,0 +1,1 @@
+Fixes: #7982 Fix crash in batch sort merge over eligible expressions

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -965,36 +965,16 @@ ts_label_sort_with_costsize(PlannerInfo *root, Sort *plan, double limit_tuples)
 static Var *
 find_var_subexpression(void *expr, Index varno)
 {
-	if (IsA(expr, Var))
+	List *varlist = pull_var_clause((Node *) expr, 0);
+	if (list_length(varlist) == 1)
 	{
-		Var *var = castNode(Var, expr);
+		Var *var = (Var *) linitial(varlist);
 		if ((Index) var->varno == (Index) varno)
 		{
 			return var;
 		}
 
 		return NULL;
-	}
-
-	if (IsA(expr, List))
-	{
-		List *list = castNode(List, expr);
-		ListCell *lc;
-		foreach (lc, list)
-		{
-			Var *var = find_var_subexpression(lfirst(lc), varno);
-			if (var != NULL)
-			{
-				return var;
-			}
-		}
-
-		return NULL;
-	}
-
-	if (IsA(expr, FuncExpr))
-	{
-		return find_var_subexpression(castNode(FuncExpr, expr)->args, varno);
 	}
 
 	return NULL;

--- a/tsl/test/expected/compression_sorted_merge_columns.out
+++ b/tsl/test/expected/compression_sorted_merge_columns.out
@@ -38,6 +38,29 @@ select * from t order by time;
  4 | Wed Jan 01 00:00:00 2025 | Fri Jan 01 00:00:00 2021 PST |    -2 |    12 | e
 (6 rows)
 
+-- Test the fix for #7975: batch sort merge over eligible OpExpr and FuncExpr
+select time::timestamptz + interval '1 second' from t order by time::timestamptz + interval '1 second';
+           ?column?           
+------------------------------
+ Fri Jan 01 00:00:01 2021 PST
+ Fri Jan 01 00:00:01 2021 PST
+ Sat Jan 01 00:00:01 2022 PST
+ Sun Jan 01 00:00:01 2023 PST
+ Mon Jan 01 00:00:01 2024 PST
+ Wed Jan 01 00:00:01 2025 PST
+(6 rows)
+
+select time + interval '1 second' from t order by time + interval '1 second';
+         ?column?         
+--------------------------
+ Fri Jan 01 00:00:01 2021
+ Fri Jan 01 00:00:01 2021
+ Sat Jan 01 00:00:01 2022
+ Sun Jan 01 00:00:01 2023
+ Mon Jan 01 00:00:01 2024
+ Wed Jan 01 00:00:01 2025
+(6 rows)
+
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='timetz,time');
 select compress_chunk(show_chunks('t')) \gset
@@ -50,6 +73,28 @@ select * from t order by timetz, time;
  1 | Sat Jan 01 00:00:00 2022 | Sun Jan 01 00:00:00 2023 PST |     5 |   -13 | a
  2 | Sun Jan 01 00:00:00 2023 | Wed Jan 01 00:00:00 2025 PST |     1 |   -13 | b
  5 | Fri Jan 01 00:00:00 2021 | Thu Jan 01 00:00:00 2026 PST |    -2 |    14 | e
+(6 rows)
+
+select timetz::timestamp + interval '1 second' from t order by timetz::timestamp + interval '1 second';
+         ?column?         
+--------------------------
+ Fri Jan 01 00:00:01 2021
+ Fri Jan 01 00:00:01 2021
+ Sat Jan 01 00:00:01 2022
+ Sun Jan 01 00:00:01 2023
+ Wed Jan 01 00:00:01 2025
+ Thu Jan 01 00:00:01 2026
+(6 rows)
+
+select timetz + interval '1 second' from t order by timetz + interval '1 second';
+           ?column?           
+------------------------------
+ Fri Jan 01 00:00:01 2021 PST
+ Fri Jan 01 00:00:01 2021 PST
+ Sat Jan 01 00:00:01 2022 PST
+ Sun Jan 01 00:00:01 2023 PST
+ Wed Jan 01 00:00:01 2025 PST
+ Thu Jan 01 00:00:01 2026 PST
 (6 rows)
 
 select decompress_chunk(show_chunks('t')) \gset
@@ -66,6 +111,22 @@ select * from t order by int32, timetz, time;
  1 | Sat Jan 01 00:00:00 2022 | Sun Jan 01 00:00:00 2023 PST |     5 |   -13 | a
 (6 rows)
 
+select int32 + 1 from t order by int32 + 1;
+ ?column? 
+----------
+       -3
+       -1
+       -1
+        2
+        4
+        6
+(6 rows)
+
+-- Sort Merge not used because only last Order By expression can be sort-transformed, not both of them
+\set ON_ERROR_STOP 0
+select int32 + 1, timetz  + interval '1 second' from t order by int32 + 1, timetz  + interval '1 second';
+ERROR:  debug: batch sorted merge is required but not used
+\set ON_ERROR_STOP 1
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='int64,int32,timetz,time');
 select compress_chunk(show_chunks('t')) \gset
@@ -80,6 +141,23 @@ select * from t order by int64, int32, timetz, time;
  6 | Fri Jan 01 00:00:00 2021 | Sat Jan 01 00:00:00 2022 PST |    -4 |    15 | c
 (6 rows)
 
+-- Both sides of OpExpr have to be of the same type for sort_transform to work
+select int64 + 1 from t order by int64 + 1::int8;
+ ?column? 
+----------
+      -15
+      -12
+      -12
+       13
+       15
+       16
+(6 rows)
+
+-- Batch sort merge won't be used as sides of OpExpr are of different types (int8 vs int4)
+\set ON_ERROR_STOP 0
+select int64 + 1 from t order by int64 + 1;
+ERROR:  debug: batch sorted merge is required but not used
+\set ON_ERROR_STOP 1
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='s,int32,time desc');
 select compress_chunk(show_chunks('t')) \gset
@@ -94,3 +172,8 @@ select * from t order by s, int32, time desc;
  5 | Fri Jan 01 00:00:00 2021 | Thu Jan 01 00:00:00 2026 PST |    -2 |    14 | e
 (6 rows)
 
+-- Batch sort merge won't be used as only Int and Date/Time types are allowed in OpExpr
+\set ON_ERROR_STOP 0
+select s||'1' from t order by s||'1';
+ERROR:  debug: batch sorted merge is required but not used
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -36,7 +36,6 @@ set(TEST_FILES
     compression_sequence_num_removal.sql
     compression_settings.sql
     compression_sorted_merge.sql
-    compression_sorted_merge_columns.sql
     compression_sorted_merge_distinct.sql
     compression.sql
     compression_trigger.sql
@@ -122,6 +121,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compression_merge.sql
     compression_indexscan.sql
     compression_segment_meta.sql
+    compression_sorted_merge_columns.sql
     compression_sorted_merge_filter.sql
     cagg_bgw_drop_chunks.sql
     cagg_drop_chunks.sql

--- a/tsl/test/sql/compression_sorted_merge_columns.sql
+++ b/tsl/test/sql/compression_sorted_merge_columns.sql
@@ -28,6 +28,9 @@ set timescaledb.debug_require_batch_sorted_merge to on;
 
 select * from t order by time;
 
+-- Test the fix for #7975: batch sort merge over eligible OpExpr and FuncExpr
+select time::timestamptz + interval '1 second' from t order by time::timestamptz + interval '1 second';
+select time + interval '1 second' from t order by time + interval '1 second';
 
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='timetz,time');
@@ -35,11 +38,20 @@ select compress_chunk(show_chunks('t')) \gset
 
 select * from t order by timetz, time;
 
+select timetz::timestamp + interval '1 second' from t order by timetz::timestamp + interval '1 second';
+select timetz + interval '1 second' from t order by timetz + interval '1 second';
+
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='int32,timetz,time');
 select compress_chunk(show_chunks('t')) \gset
 
 select * from t order by int32, timetz, time;
+
+select int32 + 1 from t order by int32 + 1;
+-- Sort Merge not used because only last Order By expression can be sort-transformed, not both of them
+\set ON_ERROR_STOP 0
+select int32 + 1, timetz  + interval '1 second' from t order by int32 + 1, timetz  + interval '1 second';
+\set ON_ERROR_STOP 1
 
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='int64,int32,timetz,time');
@@ -47,8 +59,20 @@ select compress_chunk(show_chunks('t')) \gset
 
 select * from t order by int64, int32, timetz, time;
 
+-- Both sides of OpExpr have to be of the same type for sort_transform to work
+select int64 + 1 from t order by int64 + 1::int8;
+-- Batch sort merge won't be used as sides of OpExpr are of different types (int8 vs int4)
+\set ON_ERROR_STOP 0
+select int64 + 1 from t order by int64 + 1;
+\set ON_ERROR_STOP 1
+
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='s,int32,time desc');
 select compress_chunk(show_chunks('t')) \gset
 
 select * from t order by s, int32, time desc;
+
+-- Batch sort merge won't be used as only Int and Date/Time types are allowed in OpExpr
+\set ON_ERROR_STOP 0
+select s||'1' from t order by s||'1';
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Fix crashes in batch sort merge over eligible OpExprs which were not recognized while setting up batch sort merge for decompression. 
Related to https://github.com/timescale/timescaledb/pull/7528.

Fixes #7975.