### PR TITLE
SkipScan over compressed chunks

### DIFF
--- a/.unreleased/pr_7983
+++ b/.unreleased/pr_7983
@@ -1,0 +1,1 @@
+Implements: #7983 Support for SkipScan over compressed data

--- a/src/guc.c
+++ b/src/guc.c
@@ -178,6 +178,8 @@ TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 #if PG16_GE
 TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates = true;
 #endif
+TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan = true;
+TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier = 1.0;
 static char *ts_guc_default_segmentby_fn = NULL;
 static char *ts_guc_default_orderby_fn = NULL;
 TSDLLEXPORT bool ts_guc_enable_job_execution_logging = false;
@@ -678,6 +680,33 @@ _guc_init(void)
 							 NULL,
 							 NULL);
 #endif
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compressed_skipscan"),
+							 "Enable SkipScan for compressed chunks",
+							 "Enable SkipScan for distinct inputs over compressed chunks",
+							 &ts_guc_enable_compressed_skip_scan,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomRealVariable(MAKE_EXTOPTION("skip_scan_run_cost_multiplier"),
+							 "Multiplier for SkipScan run cost as an option to make the cost "
+							 "smaller so that SkipScan can be chosen",
+							 "Default is 1.0 i.e. regularly estimated SkipScan run cost, 0.0 will "
+							 "make SkipScan to have run cost = 0",
+							 &ts_guc_skip_scan_run_cost_multiplier,
+							 1.0,
+							 0.0,
+							 1.0,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compression_wal_markers"),
 							 "Enable WAL markers for compression ops",
 							 "Enable the generation of markers in the WAL stream which mark the "
@@ -814,6 +843,7 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
 	DefineCustomIntVariable(MAKE_EXTOPTION("compression_batch_size_limit"),
 							"The max number of tuples that can be batched together during "
 							"compression",

--- a/src/guc.h
+++ b/src/guc.h
@@ -77,6 +77,8 @@ extern TSDLLEXPORT int ts_guc_compression_batch_size_limit;
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif
 extern bool ts_guc_enable_event_triggers;
+extern TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan;
+extern TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier;
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -61,5 +61,6 @@ void ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *rel, cons
 										const Chunk *chunk);
 
 extern bool ts_is_decompress_chunk_path(Path *path);
+extern bool ts_is_decompress_chunk_plan(Plan *plan);
 
 DecompressChunkPath *copy_decompress_chunk_path(DecompressChunkPath *src);

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -44,6 +44,14 @@ static CustomScanMethods decompress_chunk_plan_methods = {
 	.CreateCustomScanState = decompress_chunk_state_create,
 };
 
+/* Check if the provided plan is a DecompressChunkPlan */
+bool
+ts_is_decompress_chunk_plan(Plan *plan)
+{
+	return IsA(plan, CustomScan) &&
+		   castNode(CustomScan, plan)->methods == &decompress_chunk_plan_methods;
+}
+
 void
 _decompress_chunk_init(void)
 {

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -29,6 +29,7 @@
 #include "guc.h"
 #include "nodes/chunk_append/chunk_append.h"
 #include "nodes/constraint_aware_append/constraint_aware_append.h"
+#include "nodes/decompress_chunk/decompress_chunk.h"
 #include "nodes/skip_scan/skip_scan.h"
 #include <import/planner.h>
 
@@ -41,8 +42,20 @@ typedef struct SkipScanPath
 
 	/* Index clause which we'll use to skip past elements we've already seen */
 	RestrictInfo *skip_clause;
-	/* attribute number of the distinct column on the table/chunk */
+
+	/* attribute number of the distinct column on the table/chunk which provides comparison value
+	 * for Skip qual */
 	AttrNumber distinct_attno;
+
+	/* attribute number of the Skip qual comparison column on the indexed table/chunk
+	 * "indexed_column_attno = distinct_attno" for (SkipScan <- Index Scan) scenario,
+	 * it can be different for (SkipScan <- DecompressChunk <- compressed Index Scan) scenario,
+	 * in that case "indexed_column_attno" is the attribute number of the compressed chunk column
+	 * corresponding to the distinct column "distinct_attno" on the decompressed chunk consumed by
+	 * SkipScan
+	 */
+	AttrNumber indexed_column_attno;
+
 	/* The column offset on the index we are calling DISTINCT on */
 	AttrNumber scankey_attno;
 	int distinct_typ_len;
@@ -65,7 +78,7 @@ static bool build_skip_qual(PlannerInfo *root, SkipScanPath *skip_scan_path, Ind
 							Var *var);
 static List *build_subpath(PlannerInfo *root, List *subpaths, DistinctPathInfo *dpinfo,
 						   List *top_pathkeys);
-static Var *get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_path,
+static Var *get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, Path *child_path,
 							 SkipScanPath *skip_scan_path);
 static TargetEntry *tlist_member_match_var(Var *var, List *targetlist);
 
@@ -85,6 +98,32 @@ _skip_scan_init(void)
 }
 
 static Plan *
+setup_index_plan(CustomScan *skip_plan, Plan *child_plan)
+{
+	Plan *plan = child_plan;
+	if (IsA(child_plan, IndexScan))
+	{
+		skip_plan->scan = castNode(IndexScan, child_plan)->scan;
+	}
+	else if (IsA(child_plan, IndexOnlyScan))
+	{
+		skip_plan->scan = castNode(IndexOnlyScan, child_plan)->scan;
+	}
+	else if (ts_is_decompress_chunk_plan(child_plan))
+	{
+		CustomScan *csplan = castNode(CustomScan, plan);
+		skip_plan->scan = csplan->scan;
+		plan = linitial(csplan->custom_plans);
+	}
+	else
+		elog(ERROR,
+			 "unsupported subplan type for SkipScan: %s",
+			 ts_get_node_name((Node *) child_plan));
+
+	return plan;
+}
+
+static Plan *
 skip_scan_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *best_path, List *tlist,
 					  List *clauses, List *custom_plans)
 {
@@ -94,12 +133,12 @@ skip_scan_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *best_pa
 
 	OpExpr *op = fix_indexqual(index_path->indexinfo, path->skip_clause, path->scankey_attno);
 
-	Plan *plan = linitial(custom_plans);
+	Plan *child_plan = linitial(custom_plans);
+	Plan *plan = setup_index_plan(skip_plan, child_plan);
+
 	if (IsA(plan, IndexScan))
 	{
 		IndexScan *idx_plan = castNode(IndexScan, plan);
-		skip_plan->scan = idx_plan->scan;
-
 		/* we prepend skip qual here so sort_indexquals will put it as first qual for that column */
 		idx_plan->indexqual =
 			sort_indexquals(index_path->indexinfo, lcons(op, idx_plan->indexqual));
@@ -107,7 +146,6 @@ skip_scan_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *best_pa
 	else if (IsA(plan, IndexOnlyScan))
 	{
 		IndexOnlyScan *idx_plan = castNode(IndexOnlyScan, plan);
-		skip_plan->scan = idx_plan->scan;
 		/* we prepend skip qual here so sort_indexquals will put it as first qual for that column */
 		idx_plan->indexqual =
 			sort_indexquals(index_path->indexinfo, lcons(op, idx_plan->indexqual));
@@ -121,8 +159,8 @@ skip_scan_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *best_pa
 	skip_plan->scan.plan.type = T_CustomScan;
 	skip_plan->methods = &skip_scan_plan_methods;
 	skip_plan->custom_plans = custom_plans;
-	/* get position of skipped column in tuples produced by child scan */
-	TargetEntry *tle = tlist_member_match_var(path->distinct_var, plan->targetlist);
+	/* get position of distinct column in tuples produced by child scan */
+	TargetEntry *tle = tlist_member_match_var(path->distinct_var, child_plan->targetlist);
 
 	bool nulls_first = index_path->indexinfo->nulls_first[path->scankey_attno - 1];
 	if (index_path->indexscandir == BackwardScanDirection)
@@ -165,6 +203,7 @@ find_aggrefs_walker(Node *node, FindAggrefsContext *context)
 	return expression_tree_walker(node, find_aggrefs_walker, context);
 }
 #endif
+
 /* We can get upper path Distinct expression once for upper path,
  * rather than repeat this check for each child path of an upper path input
  */
@@ -201,7 +240,7 @@ get_upper_distinct_expr(PlannerInfo *root, UpperRelationKind stage)
 	else if (stage == UPPERREL_GROUP_AGG)
 	{
 		/* Find all non-nested Aggrefs in the query target list */
-		FindAggrefsContext agg_ctx = { NULL };
+		FindAggrefsContext agg_ctx = { .aggrefs = NULL };
 		find_aggrefs_walker((Node *) root->parse->targetList, &agg_ctx);
 
 		foreach (lc, agg_ctx.aggrefs)
@@ -369,7 +408,7 @@ obtain_upper_distinct_path(PlannerInfo *root, RelOptInfo *output_rel, DistinctPa
 	}
 }
 
-static SkipScanPath *skip_scan_path_create(PlannerInfo *root, IndexPath *index_path,
+static SkipScanPath *skip_scan_path_create(PlannerInfo *root, Path *child_path,
 										   DistinctPathInfo *dpinfo);
 
 /*
@@ -407,7 +446,12 @@ void
 tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output_rel,
 						UpperRelationKind stage)
 {
-	DistinctPathInfo dpinfo = { stage, NULL, NULL };
+	DistinctPathInfo dpinfo = {
+		.stage = stage,
+		.unique_path = NULL,
+		.distinct_expr = NULL,
+	};
+
 	obtain_upper_distinct_path(root, output_rel, &dpinfo);
 	if (!dpinfo.unique_path)
 		return;
@@ -463,11 +507,9 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 			has_caa = true;
 		}
 
-		if (IsA(subpath, IndexPath))
+		if (IsA(subpath, IndexPath) || ts_is_decompress_chunk_path(subpath))
 		{
-			IndexPath *index_path = castNode(IndexPath, subpath);
-
-			subpath = (Path *) skip_scan_path_create(root, index_path, &dpinfo);
+			subpath = (Path *) skip_scan_path_create(root, subpath, &dpinfo);
 			if (!subpath)
 				continue;
 		}
@@ -568,8 +610,6 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 				proj->subpath = subpath;
 				subpath = (Path *) proj;
 			}
-			/* Is there a better way to cost new AggPath w/o recreating AggClauseCosts from the new
-			 * input? */
 			AggClauseCosts agg_costs;
 			MemSet(&agg_costs, 0, sizeof(AggClauseCosts));
 			get_agg_clause_costs(root, dist_agg_path->aggsplit, &agg_costs);
@@ -589,12 +629,40 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 	}
 }
 
-static SkipScanPath *
-skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, DistinctPathInfo *dpinfo)
+static IndexPath *
+get_compressed_index_path(DecompressChunkPath *dcpath)
 {
-	double startup = index_path->path.startup_cost;
-	double total = index_path->path.total_cost;
-	double rows = index_path->path.rows;
+	Path *compressed_path = linitial(dcpath->custom_path.custom_paths);
+	if (IsA(compressed_path, IndexPath))
+	{
+		IndexPath *index_path = castNode(IndexPath, compressed_path);
+		if (!pathkeys_contained_in(dcpath->required_compressed_pathkeys, compressed_path->pathkeys))
+			return NULL;
+
+		return index_path;
+	}
+	return NULL;
+}
+
+static SkipScanPath *
+skip_scan_path_create(PlannerInfo *root, Path *child_path, DistinctPathInfo *dpinfo)
+{
+	IndexPath *index_path = NULL;
+
+	if (IsA(child_path, IndexPath))
+	{
+		index_path = castNode(IndexPath, child_path);
+	}
+	else if (ts_is_decompress_chunk_path(child_path))
+	{
+		if (!ts_guc_enable_compressed_skip_scan)
+			return NULL;
+
+		DecompressChunkPath *dcpath = (DecompressChunkPath *) child_path;
+		index_path = get_compressed_index_path(dcpath);
+	}
+	if (!index_path)
+		return NULL;
 
 	/* cannot use SkipScan with non-orderable index or IndexPath without pathkeys */
 	if (!index_path->path.pathkeys || !index_path->indexinfo->sortopfamily)
@@ -605,15 +673,54 @@ skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, DistinctPathInfo
 		return NULL;
 
 	SkipScanPath *skip_scan_path = (SkipScanPath *) newNode(sizeof(SkipScanPath), T_CustomPath);
-	int ndistinct = dpinfo->unique_path->rows;
 	skip_scan_path->cpath.path.pathtype = T_CustomScan;
-	skip_scan_path->cpath.path.pathkeys = index_path->path.pathkeys;
-	skip_scan_path->cpath.path.pathtarget = index_path->path.pathtarget;
-	skip_scan_path->cpath.path.param_info = index_path->path.param_info;
-	skip_scan_path->cpath.path.parent = index_path->path.parent;
-	skip_scan_path->cpath.path.rows = ndistinct;
-	skip_scan_path->cpath.custom_paths = list_make1(index_path);
+	skip_scan_path->cpath.path.pathkeys = child_path->pathkeys;
+	skip_scan_path->cpath.path.pathtarget = child_path->pathtarget;
+	skip_scan_path->cpath.path.param_info = child_path->param_info;
+	skip_scan_path->cpath.path.parent = child_path->parent;
+	skip_scan_path->cpath.custom_paths = list_make1(child_path);
 	skip_scan_path->cpath.methods = &skip_scan_path_methods;
+
+	/* While add_path may pfree paths with higher costs
+	 * it will never free IndexPaths and only ever do a shallow
+	 * free so reusing the IndexPath here is safe. */
+	skip_scan_path->index_path = index_path;
+
+	Var *dvar = get_distinct_var(root, dpinfo, child_path, skip_scan_path);
+
+	if (!dvar)
+		return NULL;
+
+	skip_scan_path->distinct_var = dvar;
+
+	/* build skip qual this may fail if we cannot look up the operator */
+	if (!build_skip_qual(root, skip_scan_path, index_path, dvar))
+		return NULL;
+
+	/* We have valid SkipScanPath: now we can cost it */
+	double startup = child_path->startup_cost;
+	double total = child_path->total_cost;
+	double rows = child_path->rows;
+	double indexscan_rows = index_path->path.rows;
+
+	/* Also true for SkipScan over compressed chunks as can't have more distinct segmentby values
+	 * than number of batches */
+	int ndistinct = Min(dpinfo->unique_path->rows, indexscan_rows);
+
+	/* If we are on a chunk rather than on a PG table, we want to get "ndistinct" for this chunk,
+	 * as Unique path rows may combine rows from each chunk and may not represent a true
+	 * "ndistinct". Consider a hypertable with 1000 chunks, each chunk has the same 1 distinct
+	 * value, Unique path will add them up and we will get "ndistinct" = 1000 instead of 1. If
+	 * Unique path has "ndistinct=1" we can't go any smaller so will just accept this number.
+	 */
+	if (ndistinct > 1)
+	{
+		List *dist_exprs = list_make1(dvar);
+		ndistinct =
+			Min(ndistinct,
+				Max(1, floor(estimate_num_groups(root, dist_exprs, child_path->rows, NULL, NULL))));
+	}
+	skip_scan_path->cpath.path.rows = ndistinct;
 
 	/* We calculate SkipScan cost as ndistinct * startup_cost + (ndistinct/rows) * total_cost
 	 * ndistinct * startup_cost is to account for the rescans we have to do and since startup
@@ -624,38 +731,64 @@ skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, DistinctPathInfo
 	 * by runtime exclusion. Otherwise the cost for this path would be highly inflated due
 	 * to (ndistinct / rows) * total leading to SkipScan not being chosen for queries on
 	 * hypertables with a lot of excluded chunks.
+	 *
+	 * This is the cost of (SkipScan <- IndexScan) scenario
 	 */
-	skip_scan_path->cpath.path.startup_cost = startup;
-	if (rows > 1)
-		skip_scan_path->cpath.path.total_cost = ndistinct * startup + (ndistinct / rows) * total;
+	if ((Path *) index_path == child_path)
+	{
+		skip_scan_path->cpath.path.startup_cost = startup;
+		if (indexscan_rows > 1)
+			skip_scan_path->cpath.path.total_cost =
+				ndistinct * startup + (ndistinct / rows) * total;
+		else
+			skip_scan_path->cpath.path.total_cost = startup;
+	}
+	/* For (SkipScan <- DecompressChunks <- compressed IndexScan) scenario
+	 * we will estimate cost as (ndistinct * costs( child_path LIMIT 1 OFFSET x))
+	 * i.e. as if we computed "ndistinct" LIMIT 1 queries on the "child_path" after initial setup.
+	 * If there is no qual above IndexScan, then OFFSET=0 (we don't need to scan tuples to pass qual
+	 * before returning the 1st tuple), otherwise OFFSET = (1 / qual_selectivity - 1), i.e. we have
+	 * to skip OFFSET tuples until we get the one which passes the qual.
+	 */
 	else
-		skip_scan_path->cpath.path.total_cost = startup;
+	{
+		int64 offset_until_qual_pass = 0;
+		if (child_path->parent->baserestrictinfo != NULL)
+		{
+			Selectivity qual_selectivity =
+				clauselist_selectivity(root,
+									   child_path->parent->baserestrictinfo,
+									   0,
+									   JOIN_INNER,
+									   NULL);
+			offset_until_qual_pass = Max(0, floor(1 / qual_selectivity - 1));
+		}
+		adjust_limit_rows_costs(&rows, &startup, &total, offset_until_qual_pass, 1);
 
-	/* While add_path may pfree paths with higher costs
-	 * it will never free IndexPaths and only ever do a shallow
-	 * free so reusing the IndexPath here is safe. */
-	skip_scan_path->index_path = index_path;
+		skip_scan_path->cpath.path.startup_cost = startup;
+		if (indexscan_rows > 1)
+			skip_scan_path->cpath.path.total_cost = startup + (total - startup) * ndistinct;
+		else
+			skip_scan_path->cpath.path.total_cost = startup;
+	}
 
-	Var *var = get_distinct_var(root, dpinfo, index_path, skip_scan_path);
-
-	if (!var)
-		return NULL;
-
-	skip_scan_path->distinct_var = var;
-
-	/* build skip qual this may fail if we cannot look up the operator */
-	if (!build_skip_qual(root, skip_scan_path, index_path, var))
-		return NULL;
+	/* Finally, adjust SkipScan run costs with GUC multiplier (1.0 by default), to give users more
+	 * control over choosing SkipScan */
+	skip_scan_path->cpath.path.total_cost =
+		startup +
+		(skip_scan_path->cpath.path.total_cost - startup) * ts_guc_skip_scan_run_cost_multiplier;
 
 	return skip_scan_path;
 }
 
 /* Extract the Var to use for the SkipScan and do attno mapping if required. */
 static Var *
-get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_path,
+get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, Path *child_path,
 				 SkipScanPath *skip_scan_path)
 {
-	RelOptInfo *rel = index_path->path.parent;
+	RelOptInfo *rel = child_path->parent;
+	IndexPath *index_path = skip_scan_path->index_path;
+	RelOptInfo *indexed_rel = index_path->path.parent;
 	Expr *tlexpr = dpinfo->distinct_expr;
 
 	if (!tlexpr || !IsA(tlexpr, Var))
@@ -665,12 +798,18 @@ get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_p
 
 	/* If we are dealing with a hypertable Var extracted from distinctClause will point to
 	 * the parent hypertable while the IndexPath will be on a Chunk.
-	 * For a normal table they point to the same relation and we are done here. */
+	 * For a normal PG table they point to the same relation and we are done here. */
 	if ((Index) var->varno == rel->relid)
+	{
+		/* Get attribute number for distinct column on a normal PG table */
+		skip_scan_path->indexed_column_attno = var->varattno;
 		return var;
+	}
 
 	RangeTblEntry *ht_rte = planner_rt_fetch(var->varno, root);
 	RangeTblEntry *chunk_rte = planner_rt_fetch(rel->relid, root);
+	RangeTblEntry *indexed_rte =
+		(indexed_rel == rel ? chunk_rte : planner_rt_fetch(indexed_rel->relid, root));
 
 	/* Check for hypertable */
 	if (!ts_is_hypertable(ht_rte->relid) || !bms_is_member(var->varno, rel->top_parent_relids))
@@ -678,9 +817,12 @@ get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_p
 
 	Relation ht_rel = table_open(ht_rte->relid, AccessShareLock);
 	Relation chunk_rel = table_open(chunk_rte->relid, AccessShareLock);
+
+	TupleDesc outdesc = RelationGetDescr(ht_rel);
+	TupleDesc indesc = RelationGetDescr(chunk_rel);
+
 	bool found_wholerow;
-	TupleConversionMap *map =
-		convert_tuples_by_name(RelationGetDescr(chunk_rel), RelationGetDescr(ht_rel));
+	TupleConversionMap *map = convert_tuples_by_name(indesc, outdesc);
 
 	/* attno mapping necessary */
 	if (map)
@@ -710,6 +852,29 @@ get_distinct_var(PlannerInfo *root, DistinctPathInfo *dpinfo, IndexPath *index_p
 		var = copyObject(var);
 	}
 
+	/* Get attribute number for distinct column on a compressed chunk */
+	if (ts_is_decompress_chunk_path(child_path))
+	{
+		/* distinct column has to be a segmentby column */
+		DecompressChunkPath *dcpath = (DecompressChunkPath *) child_path;
+		if (!bms_is_member(var->varattno, dcpath->info->chunk_segmentby_attnos))
+		{
+			table_close(ht_rel, NoLock);
+			table_close(chunk_rel, NoLock);
+
+			return NULL;
+		}
+
+		Form_pg_attribute att = TupleDescAttr(indesc, var->varattno - 1);
+		char *attname = NameStr(att->attname);
+		skip_scan_path->indexed_column_attno = get_attnum(indexed_rte->relid, attname);
+	}
+	/* Get attribute number for distinct column on an uncompressed chunk */
+	else
+	{
+		skip_scan_path->indexed_column_attno = var->varattno;
+	}
+
 	table_close(ht_rel, NoLock);
 	table_close(chunk_rel, NoLock);
 
@@ -733,14 +898,12 @@ build_subpath(PlannerInfo *root, List *subpaths, DistinctPathInfo *dpinfo, List 
 	foreach (lc, subpaths)
 	{
 		Path *child = lfirst(lc);
-		if (IsA(child, IndexPath))
+		if (IsA(child, IndexPath) || ts_is_decompress_chunk_path(child))
 		{
-			if (top_pathkeys &&
-				!pathkeys_contained_in(top_pathkeys, castNode(IndexPath, child)->path.pathkeys))
+			if (top_pathkeys && !pathkeys_contained_in(top_pathkeys, child->pathkeys))
 				continue;
 
-			SkipScanPath *skip_path =
-				skip_scan_path_create(root, castNode(IndexPath, child), dpinfo);
+			SkipScanPath *skip_path = skip_scan_path_create(root, child, dpinfo);
 
 			if (skip_path)
 			{
@@ -785,15 +948,16 @@ build_skip_qual(PlannerInfo *root, SkipScanPath *skip_scan_path, IndexPath *inde
 	 * Since a is always 2 due to the WHERE clause we can create the correct ordering for the
 	 * ORDER BY with an index that does not include the a column and only includes the time column.
 	 */
-	int idx_key = get_idx_key(info, var->varattno);
+	int idx_key = get_idx_key(index_path->indexinfo, skip_scan_path->indexed_column_attno);
 	if (idx_key < 0)
 		return false;
+
+	/* sk_attno of the skip qual */
+	skip_scan_path->scankey_attno = idx_key + 1;
 
 	skip_scan_path->distinct_attno = var->varattno;
 	skip_scan_path->distinct_by_val = tce->typbyval;
 	skip_scan_path->distinct_typ_len = tce->typlen;
-	/* sk_attno of the skip qual */
-	skip_scan_path->scankey_attno = idx_key + 1;
 
 	int16 strategy = info->reverse_sort[idx_key] ? BTLessStrategyNumber : BTGreaterStrategyNumber;
 	if (index_path->indexscandir == BackwardScanDirection)
@@ -824,7 +988,7 @@ build_skip_qual(PlannerInfo *root, SkipScanPath *skip_scan_path, IndexPath *inde
 
 	Const *prev_val = makeNullConst(need_coerce ? opcintype : column_type, -1, column_collation);
 	Expr *current_val = (Expr *) makeVar(info->rel->relid /*varno*/,
-										 var->varattno /*varattno*/,
+										 skip_scan_path->indexed_column_attno /*varattno*/,
 										 column_type /*vartype*/,
 										 -1 /*vartypmod*/,
 										 column_collation /*varcollid*/,

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -34,6 +34,24 @@ INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::tex
 INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
 CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
 CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
 CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
@@ -46,11 +64,55 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
 -- Turn off autovacuum to not trigger new vacuums that restores the
 -- adjusted statistics
 alter table skip_scan set (autovacuum_enabled = off);
 alter table skip_scan_nulls set (autovacuum_enabled = off);
 alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set TABLE skip_scan
@@ -3508,6 +3570,8 @@ TRUNCATE skip_scan_insert;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE INDEX ON :TABLE(dev);
 CREATE INDEX ON :TABLE(time);
+-- To test scenarios with SkipScan/no SkipScan over a mix of uncompressed and compressed chunks
+SET timescaledb.enable_compressed_skipscan TO false;
 -- SkipScan with ordered append
 :PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
                                                           QUERY PLAN                                                          
@@ -3554,13 +3618,13 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 (1 row)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
    ->  Merge Append (actual rows=2538 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
-               ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+               ->  Index Scan using compress_hyper_2_17_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_17_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
@@ -3618,6 +3682,4090 @@ EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
    ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
 (2 rows)
 
+RESET timescaledb.enable_compressed_skipscan;
+-- run tests on compressed hypertable with different compression settings
+\set TABLE skip_scan_htc
+\ir include/skip_scan_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev NULLS FIRST
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_18_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_19_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_20_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_21_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(27 rows)
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- multicolumn sort not matching compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev DESC, compress_hyper_4_18_chunk._ts_meta_min_1 DESC, compress_hyper_4_18_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev DESC, compress_hyper_4_19_chunk._ts_meta_min_1 DESC, compress_hyper_4_19_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev DESC, compress_hyper_4_20_chunk._ts_meta_min_1 DESC, compress_hyper_4_20_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev DESC, compress_hyper_4_21_chunk._ts_meta_min_1 DESC, compress_hyper_4_21_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- same result when we use compressed IndexPath with pathkeys not matching DecompressChunk path required path keys
+SET enable_seqscan TO false;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev DESC, compress_hyper_4_18_chunk._ts_meta_min_1 DESC, compress_hyper_4_18_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev DESC, compress_hyper_4_19_chunk._ts_meta_min_1 DESC, compress_hyper_4_19_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev DESC, compress_hyper_4_20_chunk._ts_meta_min_1 DESC, compress_hyper_4_20_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev DESC, compress_hyper_4_21_chunk._ts_meta_min_1 DESC, compress_hyper_4_21_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(23 rows)
+
+RESET enable_seqscan;
+-- Distinct column not a segmentby column: should be no SkipScan
+:PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Custom Scan (ChunkAppend) on skip_scan_htc (actual rows=1000 loops=1)
+         Order: skip_scan_htc."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- multicolumn sort with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         Vectorized Filter: ("time" = 100)
+         Rows Removed by Filter: 2494
+         ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(6 rows)
+
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- dev is leading column
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev DESC, dev_name DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk.dev_name DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- query sort doesn't match "segmentby" sort
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.dev_name DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_22_chunk.dev, compress_hyper_4_22_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_23_chunk.dev, compress_hyper_4_23_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_24_chunk.dev, compress_hyper_4_24_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_25_chunk.dev, compress_hyper_4_25_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- dev_name is not a leading column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_htc
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val, 'q1_9'::text
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", 'q1_10'::text
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_26_chunk.dev, compress_hyper_4_26_chunk._ts_meta_min_1, compress_hyper_4_26_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_27_chunk.dev, compress_hyper_4_27_chunk._ts_meta_min_1, compress_hyper_4_27_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_28_chunk.dev, compress_hyper_4_28_chunk._ts_meta_min_1, compress_hyper_4_28_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_29_chunk.dev, compress_hyper_4_29_chunk._ts_meta_min_1, compress_hyper_4_29_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(28 rows)
+
+-- use SkipScan as only one non-const distinct column
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=11 loops=1)
+   Group Key: (_hyper_3_5_chunk.dev + 1), 'q1_13'::text
+   Batches: 1 
+   ->  Result (actual rows=10020 loops=1)
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(13 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=10020 loops=1)
+   Group Key: ((skip_scan_htc.*)::skip_scan_htc)
+   Batches: 1 
+   ->  Append (actual rows=10020 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htc
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htc
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(14 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(6 rows)
+
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=11 loops=1)
+   Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
+   Batches: 1 
+   ->  Result (actual rows=10020 loops=1)
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(13 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+(19 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htc
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 Rows Removed by Filter: 61
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+(26 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=7 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 4
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(19 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+(20 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_htc
+               Chunks excluded during startup: 0
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(27 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1106
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 500
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(24 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+-- no SkipScan as distinct is over subquery
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_3_5_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(17 rows)
+
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+(26 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+(22 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Result (actual rows=2 loops=11)
+         ->  Unique (actual rows=2 loops=11)
+               ->  Merge Append (actual rows=7 loops=11)
+                     Sort Key: _hyper_3_5_chunk_1.val
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+(36 rows)
+
+:PREFIX SELECT val, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Unique (actual rows=2 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(35 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Unique (actual rows=2 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(35 rows)
+
+-- no SkipScan: 2 distinct columns
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Merge Append (actual rows=10000 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Sort (actual rows=40 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+         Sort Method: quicksort 
+         ->  Append (actual rows=40 loops=1)
+               ->  Unique (actual rows=20 loops=1)
+                     ->  Merge Append (actual rows=10000 loops=1)
+                           Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+               ->  Nested Loop (actual rows=20 loops=1)
+                     ->  Unique (actual rows=11 loops=1)
+                           ->  Merge Append (actual rows=44 loops=1)
+                                 Sort Key: _hyper_3_5_chunk_1.dev
+                                 ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=11 loops=1)
+                     ->  Unique (actual rows=2 loops=11)
+                           ->  Merge Append (actual rows=7 loops=11)
+                                 Sort Key: _hyper_3_5_chunk_2.val
+                                 ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+(55 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  Result (actual rows=11 loops=1)
+               ->  Unique (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=44 loops=1)
+                           Sort Key: _hyper_3_5_chunk.dev
+                           ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(18 rows)
+
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(15 rows)
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+(19 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE val IS NULL AND dev > 100;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+(19 rows)
+
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+\set TABLE skip_scan_htcl
+\ir include/skip_scan_load_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htcl
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htcl
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htcl
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(14 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(6 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htcl
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time DESC) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time) a;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+(25 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   Filter: (a."time" > 5)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(18 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+(20 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_htcl
+               Chunks excluded during startup: 0
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(27 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(23 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 745
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(23 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_5_9_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+(26 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+(22 rows)
+
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
                               QUERY PLAN                               
@@ -3658,19 +7806,19 @@ SELECT table_name FROM create_hypertable('i3629', 'time');
 
 INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Unique
    ->  Sort
-         Sort Key: _hyper_3_6_chunk."time" DESC
+         Sort Key: _hyper_7_42_chunk."time" DESC
          ->  Append
-               ->  Seq Scan on _hyper_3_6_chunk
+               ->  Seq Scan on _hyper_7_42_chunk
                      Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_7_chunk
+               ->  Seq Scan on _hyper_7_43_chunk
                      Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_8_chunk
+               ->  Seq Scan on _hyper_7_44_chunk
                      Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_9_chunk
+               ->  Seq Scan on _hyper_7_45_chunk
                      Filter: (a = 2)
 (12 rows)
 
@@ -3698,8 +7846,8 @@ ANALYZE i3720;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
-   ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
-         ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_8_46_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using _hyper_8_46_chunk_i3720_data_time_idx on _hyper_8_46_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
 (5 rows)
 

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -34,6 +34,24 @@ INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::tex
 INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
 CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
 CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
 CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
@@ -46,11 +64,55 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
 -- Turn off autovacuum to not trigger new vacuums that restores the
 -- adjusted statistics
 alter table skip_scan set (autovacuum_enabled = off);
 alter table skip_scan_nulls set (autovacuum_enabled = off);
 alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set TABLE skip_scan
@@ -3503,6 +3565,8 @@ TRUNCATE skip_scan_insert;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE INDEX ON :TABLE(dev);
 CREATE INDEX ON :TABLE(time);
+-- To test scenarios with SkipScan/no SkipScan over a mix of uncompressed and compressed chunks
+SET timescaledb.enable_compressed_skipscan TO false;
 -- SkipScan with ordered append
 :PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
                                                           QUERY PLAN                                                          
@@ -3549,13 +3613,13 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 (1 row)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
    ->  Merge Append (actual rows=2538 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
-               ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+               ->  Index Scan using compress_hyper_2_17_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_17_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
@@ -3613,6 +3677,4082 @@ EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
    ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
 (2 rows)
 
+RESET timescaledb.enable_compressed_skipscan;
+-- run tests on compressed hypertable with different compression settings
+\set TABLE skip_scan_htc
+\ir include/skip_scan_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev NULLS FIRST
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_18_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_19_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_20_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_21_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(27 rows)
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- multicolumn sort not matching compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev DESC, compress_hyper_4_18_chunk._ts_meta_min_1 DESC, compress_hyper_4_18_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev DESC, compress_hyper_4_19_chunk._ts_meta_min_1 DESC, compress_hyper_4_19_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev DESC, compress_hyper_4_20_chunk._ts_meta_min_1 DESC, compress_hyper_4_20_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev DESC, compress_hyper_4_21_chunk._ts_meta_min_1 DESC, compress_hyper_4_21_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- same result when we use compressed IndexPath with pathkeys not matching DecompressChunk path required path keys
+SET enable_seqscan TO false;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev DESC, compress_hyper_4_18_chunk._ts_meta_min_1 DESC, compress_hyper_4_18_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev DESC, compress_hyper_4_19_chunk._ts_meta_min_1 DESC, compress_hyper_4_19_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev DESC, compress_hyper_4_20_chunk._ts_meta_min_1 DESC, compress_hyper_4_20_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev DESC, compress_hyper_4_21_chunk._ts_meta_min_1 DESC, compress_hyper_4_21_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(23 rows)
+
+RESET enable_seqscan;
+-- Distinct column not a segmentby column: should be no SkipScan
+:PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Custom Scan (ChunkAppend) on skip_scan_htc (actual rows=1000 loops=1)
+         Order: skip_scan_htc."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- multicolumn sort with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         Vectorized Filter: ("time" = 100)
+         Rows Removed by Filter: 2494
+         ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(6 rows)
+
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- dev is leading column
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev DESC, dev_name DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk.dev_name DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- query sort doesn't match "segmentby" sort
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.dev_name DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_22_chunk.dev, compress_hyper_4_22_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_23_chunk.dev, compress_hyper_4_23_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_24_chunk.dev, compress_hyper_4_24_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_25_chunk.dev, compress_hyper_4_25_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- dev_name is not a leading column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_htc
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_26_chunk.dev, compress_hyper_4_26_chunk._ts_meta_min_1, compress_hyper_4_26_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_27_chunk.dev, compress_hyper_4_27_chunk._ts_meta_min_1, compress_hyper_4_27_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_28_chunk.dev, compress_hyper_4_28_chunk._ts_meta_min_1, compress_hyper_4_28_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_29_chunk.dev, compress_hyper_4_29_chunk._ts_meta_min_1, compress_hyper_4_29_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(28 rows)
+
+-- use SkipScan as only one non-const distinct column
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=11 loops=1)
+   Group Key: (_hyper_3_5_chunk.dev + 1)
+   Batches: 1 
+   ->  Result (actual rows=10020 loops=1)
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(13 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=10020 loops=1)
+   Group Key: ((skip_scan_htc.*)::skip_scan_htc)
+   Batches: 1 
+   ->  Append (actual rows=10020 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htc
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htc
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(14 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(6 rows)
+
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=11 loops=1)
+   Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
+   Batches: 1 
+   ->  Result (actual rows=10020 loops=1)
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(13 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+(19 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htc
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 Rows Removed by Filter: 61
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+(26 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=7 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 4
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(19 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+(20 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_htc
+               Chunks excluded during startup: 0
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(27 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1106
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 500
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(24 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+-- no SkipScan as distinct is over subquery
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_3_5_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(17 rows)
+
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+(26 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+(22 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Result (actual rows=2 loops=11)
+         ->  Unique (actual rows=2 loops=11)
+               ->  Merge Append (actual rows=7 loops=11)
+                     Sort Key: _hyper_3_5_chunk_1.val
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+(36 rows)
+
+:PREFIX SELECT val, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Unique (actual rows=2 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(35 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Unique (actual rows=2 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(35 rows)
+
+-- no SkipScan: 2 distinct columns
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Merge Append (actual rows=10000 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Sort (actual rows=40 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+         Sort Method: quicksort 
+         ->  Append (actual rows=40 loops=1)
+               ->  Unique (actual rows=20 loops=1)
+                     ->  Merge Append (actual rows=10000 loops=1)
+                           Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2500 loops=1)
+                                 ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=20 loops=1)
+                                       Index Cond: (dev IS NOT NULL)
+               ->  Nested Loop (actual rows=20 loops=1)
+                     ->  Unique (actual rows=11 loops=1)
+                           ->  Merge Append (actual rows=44 loops=1)
+                                 Sort Key: _hyper_3_5_chunk_1.dev
+                                 ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=11 loops=1)
+                     ->  Unique (actual rows=2 loops=11)
+                           ->  Merge Append (actual rows=7 loops=11)
+                                 Sort Key: _hyper_3_5_chunk_2.val
+                                 ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+(55 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  Result (actual rows=11 loops=1)
+               ->  Unique (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=44 loops=1)
+                           Sort Key: _hyper_3_5_chunk.dev
+                           ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(18 rows)
+
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(15 rows)
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+(19 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE val IS NULL AND dev > 100;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+(19 rows)
+
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+\set TABLE skip_scan_htcl
+\ir include/skip_scan_load_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htcl
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htcl
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htcl
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(14 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(6 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htcl
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time DESC) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time) a;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+(25 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   Filter: (a."time" > 5)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(18 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+(20 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_htcl
+               Chunks excluded during startup: 0
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(27 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(23 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 745
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(23 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: _hyper_5_9_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+(26 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+(22 rows)
+
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
                               QUERY PLAN                               
@@ -3653,18 +7793,18 @@ SELECT table_name FROM create_hypertable('i3629', 'time');
 
 INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  Merge Append
-         Sort Key: _hyper_3_6_chunk."time" DESC
-         ->  Index Scan using _hyper_3_6_chunk_i3629_time_idx on _hyper_3_6_chunk
+         Sort Key: _hyper_7_42_chunk."time" DESC
+         ->  Index Scan using _hyper_7_42_chunk_i3629_time_idx on _hyper_7_42_chunk
                Filter: (a = 2)
-         ->  Index Scan using _hyper_3_7_chunk_i3629_time_idx on _hyper_3_7_chunk
+         ->  Index Scan using _hyper_7_43_chunk_i3629_time_idx on _hyper_7_43_chunk
                Filter: (a = 2)
-         ->  Index Scan using _hyper_3_8_chunk_i3629_time_idx on _hyper_3_8_chunk
+         ->  Index Scan using _hyper_7_44_chunk_i3629_time_idx on _hyper_7_44_chunk
                Filter: (a = 2)
-         ->  Index Scan using _hyper_3_9_chunk_i3629_time_idx on _hyper_3_9_chunk
+         ->  Index Scan using _hyper_7_45_chunk_i3629_time_idx on _hyper_7_45_chunk
                Filter: (a = 2)
 (11 rows)
 
@@ -3692,8 +7832,8 @@ ANALYZE i3720;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
-   ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
-         ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_8_46_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using _hyper_8_46_chunk_i3720_data_time_idx on _hyper_8_46_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
 (5 rows)
 

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -34,6 +34,24 @@ INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::tex
 INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
 CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
 CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
 CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
@@ -46,11 +64,55 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
 -- Turn off autovacuum to not trigger new vacuums that restores the
 -- adjusted statistics
 alter table skip_scan set (autovacuum_enabled = off);
 alter table skip_scan_nulls set (autovacuum_enabled = off);
 alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set TABLE skip_scan
@@ -3505,6 +3567,8 @@ TRUNCATE skip_scan_insert;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE INDEX ON :TABLE(dev);
 CREATE INDEX ON :TABLE(time);
+-- To test scenarios with SkipScan/no SkipScan over a mix of uncompressed and compressed chunks
+SET timescaledb.enable_compressed_skipscan TO false;
 -- SkipScan with ordered append
 :PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
                                                           QUERY PLAN                                                          
@@ -3551,13 +3615,13 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 (1 row)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
    ->  Merge Append (actual rows=2538 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
-               ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+               ->  Index Scan using compress_hyper_2_17_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_17_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
@@ -3615,6 +3679,4083 @@ EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
    ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
 (2 rows)
 
+RESET timescaledb.enable_compressed_skipscan;
+-- run tests on compressed hypertable with different compression settings
+\set TABLE skip_scan_htc
+\ir include/skip_scan_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev NULLS FIRST
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_18_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_19_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_20_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Sort (actual rows=11 loops=1)
+                           Sort Key: compress_hyper_4_21_chunk.dev NULLS FIRST
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(27 rows)
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- multicolumn sort not matching compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev DESC, compress_hyper_4_18_chunk._ts_meta_min_1 DESC, compress_hyper_4_18_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev DESC, compress_hyper_4_19_chunk._ts_meta_min_1 DESC, compress_hyper_4_19_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev DESC, compress_hyper_4_20_chunk._ts_meta_min_1 DESC, compress_hyper_4_20_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev DESC, compress_hyper_4_21_chunk._ts_meta_min_1 DESC, compress_hyper_4_21_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- same result when we use compressed IndexPath with pathkeys not matching DecompressChunk path required path keys
+SET enable_seqscan TO false;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev DESC, compress_hyper_4_18_chunk._ts_meta_min_1 DESC, compress_hyper_4_18_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev DESC, compress_hyper_4_19_chunk._ts_meta_min_1 DESC, compress_hyper_4_19_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev DESC, compress_hyper_4_20_chunk._ts_meta_min_1 DESC, compress_hyper_4_20_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev DESC, compress_hyper_4_21_chunk._ts_meta_min_1 DESC, compress_hyper_4_21_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(23 rows)
+
+RESET enable_seqscan;
+-- Distinct column not a segmentby column: should be no SkipScan
+:PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Custom Scan (ChunkAppend) on skip_scan_htc (actual rows=1000 loops=1)
+         Order: skip_scan_htc."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- multicolumn sort with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         Vectorized Filter: ("time" = 100)
+         Rows Removed by Filter: 2494
+         ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(6 rows)
+
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- dev is leading column
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev DESC, dev_name DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk.dev_name DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- query sort doesn't match "segmentby" sort
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.dev_name DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_22_chunk.dev, compress_hyper_4_22_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_23_chunk.dev, compress_hyper_4_23_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_24_chunk.dev, compress_hyper_4_24_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_25_chunk.dev, compress_hyper_4_25_chunk.dev_name DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- dev_name is not a leading column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_htc
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_26_chunk.dev, compress_hyper_4_26_chunk._ts_meta_min_1, compress_hyper_4_26_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_27_chunk.dev, compress_hyper_4_27_chunk._ts_meta_min_1, compress_hyper_4_27_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_28_chunk.dev, compress_hyper_4_28_chunk._ts_meta_min_1, compress_hyper_4_28_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: compress_hyper_4_29_chunk.dev, compress_hyper_4_29_chunk._ts_meta_min_1, compress_hyper_4_29_chunk._ts_meta_max_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(28 rows)
+
+-- use SkipScan as only one non-const distinct column
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=11 loops=1)
+   Group Key: (_hyper_3_5_chunk.dev + 1)
+   Batches: 1 
+   ->  Result (actual rows=10020 loops=1)
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(13 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=10020 loops=1)
+   Group Key: ((skip_scan_htc.*)::skip_scan_htc)
+   Batches: 1 
+   ->  Append (actual rows=10020 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htc
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=3 loops=1)
+(16 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htc
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(14 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(6 rows)
+
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=11 loops=1)
+   Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
+   Batches: 1 
+   ->  Result (actual rows=10020 loops=1)
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(13 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+(19 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htc
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev DESC, _hyper_3_5_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 Rows Removed by Filter: 61
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+(26 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=7 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 4
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(19 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+(20 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_htc
+               Chunks excluded during startup: 0
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(27 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1106
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 500
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(24 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: _hyper_3_5_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+-- no SkipScan as distinct is over subquery
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_3_5_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(17 rows)
+
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+(26 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+(22 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Result (actual rows=2 loops=11)
+         ->  Unique (actual rows=2 loops=11)
+               ->  Merge Append (actual rows=7 loops=11)
+                     Sort Key: _hyper_3_5_chunk_1.val
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                                 ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                       Index Cond: (dev = _hyper_3_5_chunk.dev)
+(36 rows)
+
+:PREFIX SELECT val, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Unique (actual rows=2 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(35 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Unique (actual rows=2 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(35 rows)
+
+-- no SkipScan: 2 distinct columns
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Merge Append (actual rows=10000 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2500 loops=1)
+               ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=20 loops=1)
+                     Index Cond: (dev IS NOT NULL)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+         ->  Unique (actual rows=20 loops=1)
+               ->  Merge Append (actual rows=10000 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk.val
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2500 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=20 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2500 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=20 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2500 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=20 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2500 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=20 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+         ->  Sort (actual rows=20 loops=1)
+               Sort Key: _hyper_3_5_chunk_2.dev, _hyper_3_5_chunk_2.val
+               Sort Method: quicksort 
+               ->  Nested Loop (actual rows=20 loops=1)
+                     ->  Unique (actual rows=11 loops=1)
+                           ->  Merge Append (actual rows=44 loops=1)
+                                 Sort Key: _hyper_3_5_chunk_1.dev
+                                 ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=11 loops=1)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=11 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=11 loops=1)
+                                             ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=11 loops=1)
+                     ->  Unique (actual rows=2 loops=11)
+                           ->  Merge Append (actual rows=7 loops=11)
+                                 Sort Key: _hyper_3_5_chunk_2.val
+                                 ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+                                 ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_2 (actual rows=2 loops=11)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_2 (actual rows=2 loops=11)
+                                             ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_2 (actual rows=2 loops=11)
+                                                   Index Cond: (dev = _hyper_3_5_chunk_1.dev)
+(56 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  Result (actual rows=11 loops=1)
+               ->  Unique (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=44 loops=1)
+                           Sort Key: _hyper_3_5_chunk.dev
+                           ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                       ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(18 rows)
+
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(15 rows)
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+(19 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE val IS NULL AND dev > 100;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+(19 rows)
+
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+\set TABLE skip_scan_htcl
+\ir include/skip_scan_load_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htcl
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htcl
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+(16 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htcl
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(14 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(6 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htcl
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time DESC) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev, _hyper_5_9_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time) a;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev DESC, _hyper_5_9_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 Vectorized Filter: ("time" > 5)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                                       Index Cond: (_ts_meta_max_1 > 5)
+(25 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                       Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   Filter: (a."time" > 5)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(18 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=1)
+                                 Index Cond: (dev > 1)
+(20 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_htcl
+               Chunks excluded during startup: 0
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                                 Filter: (dev > int_func_stable())
+                                 Rows Removed by Filter: 505
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(27 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=6 loops=1)
+                     Filter: (ROW(dev, "time") > ROW(5, 100))
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(23 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 745
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(23 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: _hyper_5_9_chunk."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
+                                       Filter: (dev <> "*VALUES*".column1)
+                                       Rows Removed by Filter: 2
+(26 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=10 loops=2)
+                                       Index Cond: (dev >= "*VALUES*".column1)
+(22 rows)
+
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
                               QUERY PLAN                               
@@ -3655,18 +7796,18 @@ SELECT table_name FROM create_hypertable('i3629', 'time');
 
 INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  Merge Append
-         Sort Key: _hyper_3_6_chunk."time" DESC
-         ->  Index Scan using _hyper_3_6_chunk_i3629_time_idx on _hyper_3_6_chunk
+         Sort Key: _hyper_7_42_chunk."time" DESC
+         ->  Index Scan using _hyper_7_42_chunk_i3629_time_idx on _hyper_7_42_chunk
                Filter: (a = 2)
-         ->  Index Scan using _hyper_3_7_chunk_i3629_time_idx on _hyper_3_7_chunk
+         ->  Index Scan using _hyper_7_43_chunk_i3629_time_idx on _hyper_7_43_chunk
                Filter: (a = 2)
-         ->  Index Scan using _hyper_3_8_chunk_i3629_time_idx on _hyper_3_8_chunk
+         ->  Index Scan using _hyper_7_44_chunk_i3629_time_idx on _hyper_7_44_chunk
                Filter: (a = 2)
-         ->  Index Scan using _hyper_3_9_chunk_i3629_time_idx on _hyper_3_9_chunk
+         ->  Index Scan using _hyper_7_45_chunk_i3629_time_idx on _hyper_7_45_chunk
                Filter: (a = 2)
 (11 rows)
 
@@ -3694,8 +7835,8 @@ ANALYZE i3720;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
-   ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
-         ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_8_46_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using _hyper_8_46_chunk_i3720_data_time_idx on _hyper_8_46_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
 (5 rows)
 

--- a/tsl/test/expected/plan_skip_scan_dagg.out
+++ b/tsl/test/expected/plan_skip_scan_dagg.out
@@ -34,6 +34,24 @@ INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::tex
 INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
 CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
 CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
 CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
@@ -46,11 +64,55 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
 -- Turn off autovacuum to not trigger new vacuums that restores the
 -- adjusted statistics
 alter table skip_scan set (autovacuum_enabled = off);
 alter table skip_scan_nulls set (autovacuum_enabled = off);
 alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set TABLE skip_scan
@@ -59,9 +121,9 @@ alter table skip_scan_ht set (autovacuum_enabled = off);
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
- enable_skipscan 
------------------
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_dagg_skipscan;
+ enable_dagg_skipscan 
+----------------------
  on
 (1 row)
 
@@ -1090,9 +1152,9 @@ TRUNCATE skip_scan_insert;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
- enable_skipscan 
------------------
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_dagg_skipscan;
+ enable_dagg_skipscan 
+----------------------
  on
 (1 row)
 
@@ -2976,6 +3038,8 @@ TRUNCATE skip_scan_insert;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE INDEX ON :TABLE(dev);
 CREATE INDEX ON :TABLE(time);
+-- To test scenarios with SkipScan/no SkipScan over a mix of uncompressed and compressed chunks
+SET timescaledb.enable_compressed_skipscan TO false;
 -- IndexPath without pathkeys doesnt use SkipScan
 EXPLAIN (costs off, timing off, summary off) SELECT count(DISTINCT 1) FROM pg_rewrite;
                                QUERY PLAN                                
@@ -3050,13 +3114,13 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 (1 row)
 
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    ->  Merge Append (actual rows=2538 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
-               ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+               ->  Index Scan using compress_hyper_2_17_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_17_chunk (actual rows=11 loops=1)
          ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
@@ -3070,13 +3134,13 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 
 -- compression on one chunk will prevent skipscan if it's the only chunk remaining
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=11 loops=1)
          Vectorized Filter: ("time" = 100)
          Rows Removed by Filter: 2494
-         ->  Index Scan using compress_hyper_2_5_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+         ->  Index Scan using compress_hyper_2_17_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_2_17_chunk (actual rows=11 loops=1)
                Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
 (6 rows)
 
@@ -3162,3 +3226,3416 @@ DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_time_idx;
                      Index Cond: (dev > NULL::integer)
 (19 rows)
 
+RESET timescaledb.enable_compressed_skipscan;
+-- run tests on compressed hypertable with different compression settings
+\set TABLE skip_scan_htc
+\ir include/skip_scan_dagg_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev NULLS FIRST
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_18_chunk.dev NULLS FIRST
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_19_chunk.dev NULLS FIRST
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_20_chunk.dev NULLS FIRST
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Sort (actual rows=11 loops=1)
+                     Sort Key: compress_hyper_4_21_chunk.dev NULLS FIRST
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_4_21_chunk (actual rows=11 loops=1)
+(24 rows)
+
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- multicolumn compressed index with dev as leading column
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- multicolumn compressed index with dev as leading column and with extra distinct column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev_name = 'device_1';
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1000 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+(15 rows)
+
+-- multicolumn compressed index with dev as non-leading column
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev = 1;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev = 1)
+(20 rows)
+
+-- multicolumn compressed index with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev = 1;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1000 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
+
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_htc
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_3_5_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev, count(DISTINCT _hyper_3_5_chunk.dev)
+         Batches: 1 
+         ->  GroupAggregate (actual rows=11 loops=1)
+               Group Key: _hyper_3_5_chunk.dev
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(22 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.dev
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.dev
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_6_chunk.dev_name, _hyper_3_6_chunk.dev
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_7_chunk.dev_name, _hyper_3_7_chunk.dev
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_8_chunk.dev_name, _hyper_3_8_chunk.dev
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(24 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT dev + 1), 'q1_13' FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: ((_hyper_3_5_chunk.dev + 1))
+         ->  Result (actual rows=2505 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Result (actual rows=2505 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Result (actual rows=2505 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Result (actual rows=2505 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: ((_hyper_3_5_chunk.dev + 1))
+   Sort Method: quicksort 
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1000 loops=1)
+   Group Key: _hyper_3_5_chunk."time"
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=44 loops=1)
+   Group Key: _hyper_3_5_chunk.dev, skip_scan_htc.tableoid
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev, skip_scan_htc.tableoid
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(14 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htc
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=13 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=4 loops=1)
+(17 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=13 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=4 loops=1)
+(17 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htc
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(15 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(8 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_8_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(7 rows)
+
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htc
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev_name IS NULL)
+(19 rows)
+
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: (length(_hyper_3_5_chunk.dev_name))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=44 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name, skip_scan_htc.tableoid
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name, skip_scan_htc.tableoid
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.tableoid
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_6_chunk.dev_name, _hyper_3_6_chunk.tableoid
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_7_chunk.dev_name, _hyper_3_7_chunk.tableoid
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: _hyper_3_8_chunk.dev_name, _hyper_3_8_chunk.tableoid
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(24 rows)
+
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: _hyper_3_5_chunk.dev_name
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     Vectorized Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     Vectorized Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     Vectorized Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     Vectorized Filter: (dev = 1)
+                     Rows Removed by Filter: 2255
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
+(24 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htc
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev DESC
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=20 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         Filter: (sum(DISTINCT _hyper_3_5_chunk.dev) > 2)
+         Rows Removed by Filter: 3
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(19 rows)
+
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=20 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         Filter: (sum(DISTINCT _hyper_3_5_chunk.dev) > 2)
+         Rows Removed by Filter: 3
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(19 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+(19 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=32 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htc
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 500
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     Rows Removed by Filter: 1005
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(24 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=0 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(8 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=1000 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(14 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=1000 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=250 loops=1)
+               ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(14 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_3_5_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_3_5_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=11 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(17 rows)
+
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Merge Append (actual rows=36 loops=2)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+(25 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Merge Append (actual rows=38 loops=2)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+(21 rows)
+
+--  DISTINCT aggs on different columns in different subqueries
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT val) FROM :TABLE WHERE dev = 1;
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=8 loops=1)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=1)
+                                 Index Cond: (dev = 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=1)
+                                 Index Cond: (dev = 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=1)
+                                 Index Cond: (dev = 1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=1)
+                                 Index Cond: (dev = 1)
+(35 rows)
+
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT val) ct FROM :TABLE WHERE dev = a.dev) b;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_3_5_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_3_5_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+   ->  Aggregate (actual rows=1 loops=11)
+         ->  Merge Append (actual rows=7 loops=11)
+               Sort Key: _hyper_3_5_chunk_1.val
+               ->  Custom Scan (SkipScan) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk _hyper_3_5_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk compress_hyper_4_38_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk _hyper_3_6_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk compress_hyper_4_39_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk _hyper_3_7_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk compress_hyper_4_40_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+               ->  Custom Scan (SkipScan) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=2 loops=11)
+                           ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk compress_hyper_4_41_chunk_1 (actual rows=2 loops=11)
+                                 Index Cond: (dev = _hyper_3_5_chunk.dev)
+(36 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  GroupAggregate (actual rows=11 loops=1)
+               Group Key: _hyper_3_5_chunk.dev
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_3_5_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(18 rows)
+
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=11 loops=1)
+(15 rows)
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=1 loops=1)
+                           Index Cond: (val IS NULL)
+(19 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE val IS NULL AND dev > 100;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_3_5_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_38_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_38_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_39_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_39_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_40_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_40_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_4_41_chunk_dev_val__ts_meta_min_1__ts_meta_m_idx on compress_hyper_4_41_chunk (actual rows=0 loops=1)
+                           Index Cond: ((dev > 100) AND (val IS NULL))
+(19 rows)
+
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+\set TABLE skip_scan_htcl
+\ir include/skip_scan_dagg_load_comp_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+ enable_compressed_skipscan 
+----------------------------
+ on
+(1 row)
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_htcl
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_5_9_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_5_9_chunk.dev, count(DISTINCT _hyper_5_9_chunk.dev)
+         Batches: 1 
+         ->  GroupAggregate (actual rows=11 loops=1)
+               Group Key: _hyper_5_9_chunk.dev
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(22 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_htcl
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: ((_hyper_5_9_chunk.dev + 1))
+   Sort Method: quicksort 
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_htcl
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=13 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=4 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=4 loops=1)
+(17 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  GroupAggregate (actual rows=3 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=13 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=4 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=4 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=4 loops=1)
+(17 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_htcl
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     Vectorized Filter: (("time" >= 100) AND ("time" <= 300))
+                     Rows Removed by Filter: 1993
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                           Index Cond: ((_ts_meta_min_1 <= 300) AND (_ts_meta_max_1 >= 100))
+(15 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" < 200)
+               Rows Removed by Filter: 501
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_min_1 < 200)
+(8 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_13_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" > 800)
+               ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+                     Index Cond: (_ts_meta_max_1 > 800)
+(7 rows)
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_htcl
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  GroupAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev DESC
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(17 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=20 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         Filter: (sum(DISTINCT _hyper_5_9_chunk.dev) > 2)
+         Rows Removed by Filter: 3
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(19 rows)
+
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         ->  Merge Append (actual rows=20 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(21 rows)
+
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=8 loops=1)
+   ->  GroupAggregate (actual rows=8 loops=1)
+         Group Key: _hyper_5_9_chunk.dev
+         Filter: (sum(DISTINCT _hyper_5_9_chunk.dev) > 2)
+         Rows Removed by Filter: 3
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(19 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+(19 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=32 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=8 loops=1)
+                           Filter: (dev > int_func_stable())
+                           Rows Removed by Filter: 505
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_stable()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_htcl
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(26 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=0 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=0 loops=1)
+                           Index Cond: (dev > 20)
+(19 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 745
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > 5) AND (_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=5 loops=1)
+                     Vectorized Filter: ("time" > 200)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev > 5) AND (_ts_meta_max_1 > 200))
+(23 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=2 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=2 loops=1)
+                           Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(19 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=0 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (("time" > 100) AND ("time" < 200) AND (val > 10) AND (val < 10000))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=4 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND (_ts_meta_min_1 < 200) AND (_ts_meta_max_1 > 100))
+(8 rows)
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: _hyper_5_9_chunk.dev
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(16 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX EXECUTE prep;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_5_9_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+(15 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_5_9_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_5_9_chunk.dev
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=2505 loops=1)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=11 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(17 rows)
+
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Merge Append (actual rows=36 loops=2)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 2
+(25 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Aggregate (actual rows=1 loops=2)
+         ->  Merge Append (actual rows=38 loops=2)
+               Sort Key: _hyper_5_9_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+               ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+               ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+               ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_5_13_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+(21 rows)
+
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -40,6 +40,24 @@ INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::tex
 INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
 CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
 CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
 CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
@@ -52,11 +70,55 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
 -- Turn off autovacuum to not trigger new vacuums that restores the
 -- adjusted statistics
 alter table skip_scan set (autovacuum_enabled = off);
 alter table skip_scan_nulls set (autovacuum_enabled = off);
 alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- run tests on normal table and diff results
 \set TABLE skip_scan
 \set PREFIX ''
@@ -898,6 +960,724 @@ RESET timescaledb.enable_skipscan;
 @@ -1,6 +1,6 @@
   enable_skipscan 
  -----------------
+- off
++ on
+ (1 row)
+ 
+  dev 
+-- run tests on compressed hypertable with different compression settings and diff results
+SELECT format('include/%s_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+\set TABLE skip_scan_htc
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+-- multicolumn sort not matching compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+-- same result when we use compressed IndexPath with pathkeys not matching DecompressChunk path required path keys
+SET enable_seqscan TO false;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+RESET enable_seqscan;
+-- Distinct column not a segmentby column: should be no SkipScan
+:PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
+-- multicolumn sort with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- dev is leading column
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev DESC, dev_name DESC;
+-- query sort doesn't match "segmentby" sort
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
+-- dev_name is not a leading column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+-- use SkipScan as only one non-const distinct column
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time DESC;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+-- no SkipScan as distinct is over subquery
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) * FROM :TABLE WHERE dev = a.dev) b) c;
+:PREFIX SELECT val, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b) c;
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+-- no SkipScan: 2 distinct columns
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE val IS NULL AND dev > 100;
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\o
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+-- multicolumn sort not matching compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+-- same result when we use compressed IndexPath with pathkeys not matching DecompressChunk path required path keys
+SET enable_seqscan TO false;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+RESET enable_seqscan;
+-- Distinct column not a segmentby column: should be no SkipScan
+:PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
+-- multicolumn sort with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- dev is leading column
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev DESC, dev_name DESC;
+-- query sort doesn't match "segmentby" sort
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
+-- dev_name is not a leading column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+-- use SkipScan as only one non-const distinct column
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time DESC;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+-- no SkipScan as distinct is over subquery
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) * FROM :TABLE WHERE dev = a.dev) b) c;
+:PREFIX SELECT val, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b) c;
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+-- no SkipScan: 2 distinct columns
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE val IS NULL AND dev > 100;
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\o
+RESET timescaledb.enable_compressed_skipscan;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_compressed_skipscan 
+ ----------------------------
+- off
++ on
+ (1 row)
+ 
+              compress_chunk             
+-- run tests on compressed hypertable with different layouts of compressed chunks
+SELECT format('include/%s_load_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+\set TABLE skip_scan_htcl
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time DESC) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
+\o
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time DESC) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
+\o
+RESET timescaledb.enable_compressed_skipscan;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_compressed_skipscan 
+ ----------------------------
 - off
 + on
  (1 row)

--- a/tsl/test/expected/skip_scan_dagg.out
+++ b/tsl/test/expected/skip_scan_dagg.out
@@ -40,6 +40,24 @@ INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::tex
 INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
 CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
 CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
 CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
@@ -52,11 +70,55 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
 -- Turn off autovacuum to not trigger new vacuums that restores the
 -- adjusted statistics
 alter table skip_scan set (autovacuum_enabled = off);
 alter table skip_scan_nulls set (autovacuum_enabled = off);
 alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- run tests on normal table and diff results
 \set TABLE skip_scan
 \set PREFIX ''
@@ -66,7 +128,7 @@ alter table skip_scan_ht set (autovacuum_enabled = off);
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_dagg_skipscan;
 -- test different index configurations
 -- no index so we cant do SkipScan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -249,7 +311,7 @@ SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_dagg_skipscan;
 -- test different index configurations
 -- no index so we cant do SkipScan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -431,8 +493,8 @@ RESET timescaledb.enable_skipscan_for_distinct_aggregates;
 --- Unoptimized results
 +++ Optimized results
 @@ -1,6 +1,6 @@
-  enable_skipscan 
- -----------------
+  enable_dagg_skipscan 
+ ----------------------
 - off
 + on
  (1 row)
@@ -447,7 +509,7 @@ RESET timescaledb.enable_skipscan_for_distinct_aggregates;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_dagg_skipscan;
 -- test different index configurations
 -- no index so we cant do SkipScan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -630,7 +692,7 @@ SET timescaledb.enable_skipscan_for_distinct_aggregates TO false;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_skipscan;
+SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS enable_dagg_skipscan;
 -- test different index configurations
 -- no index so we cant do SkipScan
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -812,8 +874,654 @@ RESET timescaledb.enable_skipscan_for_distinct_aggregates;
 --- Unoptimized results
 +++ Optimized results
 @@ -1,6 +1,6 @@
-  enable_skipscan 
- -----------------
+  enable_dagg_skipscan 
+ ----------------------
+- off
++ on
+ (1 row)
+ 
+  count 
+-- run tests on compressed hypertable and diff results
+SELECT format('include/%s_dagg_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+\set TABLE skip_scan_htc
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- multicolumn compressed index with dev as leading column
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- multicolumn compressed index with dev as leading column and with extra distinct column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev_name = 'device_1';
+-- multicolumn compressed index with dev as non-leading column
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev_name;
+-- multicolumn compressed index with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev = 1;
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT dev + 1), 'q1_13' FROM :TABLE;
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+--  DISTINCT aggs on different columns in different subqueries
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT val) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT val) ct FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE val IS NULL AND dev > 100;
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\o
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- test different compression configurations
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+-- NULLS FIRST doesn't match segmentby NULL direction
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- multicolumn compressed index with dev as leading column
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- multicolumn compressed index with dev as leading column and with extra distinct column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev_name = 'device_1';
+-- multicolumn compressed index with dev as non-leading column
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev_name;
+-- multicolumn compressed index with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev = 1;
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+-- Mix of aggregates on different columns and distinct/not distinct
+-- currently not supported by skipscan
+:PREFIX SELECT count(DISTINCT dev), max(DISTINCT dev_name), 'q1_9' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), sum(dev), 'q1_10' FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev_name, 'q1_11' FROM :TABLE GROUP BY dev_name ORDER BY dev_name;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT dev + 1), 'q1_13' FROM :TABLE;
+-- But expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT time, count(DISTINCT dev), 'q2_10' FROM :TABLE GROUP BY time;
+-- Cannot do SkipScan if we group on 2+ columns
+:PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_6', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev_name), 'q1_8', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev_name) FROM :TABLE WHERE dev_name IS NULL;
+-- distinct on expressions not supported
+:PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
+-- DISTINCT aggs grouped on their TEXT args
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name::varchar), dev_name::varchar, 'q3_5' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_immutable(), 'q3_6' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_stable(), 'q3_7' FROM :TABLE GROUP BY dev_name;
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, int_func_volatile(), 'q3_8' FROM :TABLE GROUP BY dev_name;
+-- Cannot do SkipScan as we group on a column which is not the distinct agg argument
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, tableoid::regclass, 'q3_9' FROM :TABLE GROUP BY dev_name, tableoid ORDER BY dev_name, tableoid;
+-- Can do SkipScan if extra group column is eliminated by pinning to a Const
+-- and when it changes group by ordering
+:PREFIX SELECT count(DISTINCT dev_name), dev, dev_name FROM :TABLE WHERE dev = 1 GROUP BY dev, dev_name ORDER BY dev, dev_name;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+-- Distinct aggregate path with no pathkeys because of Const predicate.
+-- PG is smart to add LIMIT 1 to SELECT DISTINCT in this case,
+-- but not smart enough to add LIMIT 1 to distinct aggregate input.
+-- TODO: create an issue for this task, i.e. add LIMIT 1 to distinct aggregate input when input equals to a Const
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev = 1 GROUP BY dev ORDER BY dev DESC;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+--  DISTINCT aggs on different columns in different subqueries
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT val) FROM :TABLE WHERE dev = 1;
+:PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT val) ct FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
+-- parallel query
+RESET max_parallel_workers_per_gather;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;
+-- no tuples in resultset
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE val IS NULL AND dev > 100;
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+\o
+RESET timescaledb.enable_compressed_skipscan;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_compressed_skipscan 
+ ----------------------------
+- off
++ on
+ (1 row)
+ 
+              compress_chunk             
+-- run tests on compressed hypertable with different layouts of compressed chunks
+SELECT format('include/%s_dagg_load_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+\set TABLE skip_scan_htcl
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+-- expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
+\o
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+-- expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
+\o
+RESET timescaledb.enable_compressed_skipscan;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_compressed_skipscan 
+ ----------------------------
 - off
 + on
  (1 row)

--- a/tsl/test/sql/include/skip_scan_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_comp_query.sql
@@ -3,80 +3,87 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 -- canary for result diff
-SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
 
--- test different index configurations
--- no index so we cant do SkipScan
-:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
 
--- NULLS LAST index on dev
-CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+-- test different compression configurations
+
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
-DROP INDEX skip_scan_idx_dev_nulls_last;
 
--- NULLS FIRST index on dev
-CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+-- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
-DROP INDEX skip_scan_idx_dev_nulls_first;
 
--- multicolumn index with dev as leading column
-CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+
+-- multicolumn sort not matching compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+-- same result when we use compressed IndexPath with pathkeys not matching DecompressChunk path required path keys
+SET enable_seqscan TO false;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
+RESET enable_seqscan;
+-- Distinct column not a segmentby column: should be no SkipScan
+:PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
+
+-- multicolumn sort with dev as non-leading column and with leading column pinned
+-- TODO: should be able to apply SkipScan here, issue created: #7998
+:PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
+
+-- multicolumn "segmentby = 'dev, dev_name'"
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+
+-- dev is leading column
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
-DROP INDEX skip_scan_idx_dev_time_idx;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev DESC, dev_name DESC;
+-- query sort doesn't match "segmentby" sort
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
 
--- multicolumn index with dev as non-leading column
-CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
-:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
-DROP INDEX skip_scan_idx_time_dev_idx;
+-- dev_name is not a leading column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
 
--- hash index is not ordered so can't use skipscan
-CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
-:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
-DROP INDEX skip_scan_idx_hash;
-
--- expression indexes
--- currently not supported by skipscan
-CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
-:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
-:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
-DROP INDEX skip_scan_expr_idx;
-
-CREATE INDEX ON :TABLE(dev_name);
-CREATE INDEX ON :TABLE(dev);
-CREATE INDEX ON :TABLE(dev, time);
-CREATE INDEX ON :TABLE(time,dev);
-CREATE INDEX ON :TABLE(time,dev,val);
+-- Basic tests for "segmentby = 'dev'"
+-----------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 \qecho basic DISTINCT queries on :TABLE
 :PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
-:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
 :PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
 
 \qecho stable expression in targetlist on :TABLE
 :PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
-:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
 
--- volatile expression in targetlist
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
 :PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
-:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
 
 -- queries without skipscan because distinct is not limited to specific column
+
 :PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+
+-- use SkipScan as only one non-const distinct column
 :PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
 
 -- distinct on expressions not supported
-:PREFIX SELECT DISTINCT time_bucket(10,time), 'q1_12' FROM :TABLE;
-:PREFIX SELECT DISTINCT length(dev_name), 'q1_13' FROM :TABLE;
-:PREFIX SELECT DISTINCT 3*time, 'q1_14' FROM :TABLE;
-:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
 
 -- DISTINCT ON queries
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
@@ -88,11 +95,41 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
-:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+
+-- Basic tests for text index "segmentby = 'dev_name'"
+------------------------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist counts as extra distinct column, no SkipScan
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+
+-- distinct on expressions not supported
+:PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
 
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
@@ -104,31 +141,20 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
-:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time DESC;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
 
-\qecho DISTINCT with wholerow var
-:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
--- should not use SkipScan since we only support SkipScan on single-column distinct
-:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
 
-\qecho LIMIT queries on :TABLE
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
-
-\qecho range queries on :TABLE
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
-:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
-
-\qecho ordered append on :TABLE
-:PREFIX SELECT * FROM :TABLE ORDER BY time;
-:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 \qecho SUBSELECTS on :TABLE
 :PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
@@ -166,7 +192,6 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
-:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
 
 -- test constants in ORDER BY
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
@@ -183,17 +208,18 @@ SELECT * FROM devices;
 SELECT * FROM devices ORDER BY dev;
 
 -- prepared statements
-PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
 :PREFIX EXECUTE prep;
 :PREFIX EXECUTE prep;
 :PREFIX EXECUTE prep;
 DEALLOCATE prep;
 
 -- ReScan tests
+-- no SkipScan as distinct is over subquery
 :PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
     VALUES (1), (2)) a(v),
     LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
-
+-- have SkipScan as Distinct is over index
 :PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
     VALUES (1), (2)) a(v),
     LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
@@ -204,30 +230,40 @@ DEALLOCATE prep;
     LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 
 -- Emulate multi-column DISTINCT using multiple SkipSkans
+
+-- "segmentby = 'dev, val'"
+---------------------------------------
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+
 :PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
     (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
-    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+    LATERAL (SELECT DISTINCT ON (val) * FROM :TABLE WHERE dev = a.dev) b) c;
 
-:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+:PREFIX SELECT val, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
     (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
-    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+    LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b) c;
 
 -- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
 :PREFIX SELECT * FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
-   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+-- no SkipScan: 2 distinct columns
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL;
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, val) dev, val FROM :TABLE WHERE dev IS NOT NULL
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
-   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+   LATERAL (SELECT DISTINCT ON (val) dev, val FROM :TABLE WHERE dev = a.dev) b;
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 
 -- parallel query
+RESET max_parallel_workers_per_gather;
+
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
@@ -235,8 +271,9 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
 TRUNCATE skip_scan_insert;
 
 -- table with only nulls
-:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
 
 -- no tuples in resultset
-:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE val IS NULL AND dev > 100;
 
+SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;

--- a/tsl/test/sql/include/skip_scan_dagg_load_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_load_comp_query.sql
@@ -1,0 +1,131 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+
+\qecho basic DISTINCT queries on :TABLE
+-- Various distint aggs over same column is OK
+:PREFIX SELECT count(DISTINCT dev), sum(DISTINCT dev), 'q1_1' FROM :TABLE;
+-- Distinct agg over Const is OK
+:PREFIX SELECT count(DISTINCT dev), count(DISTINCT 2), 'q1_3', NULL FROM :TABLE;
+-- DISTINCT over distinct agg is OK
+:PREFIX SELECT DISTINCT count(DISTINCT dev), dev, 'q1_4' FROM :TABLE GROUP BY dev ORDER BY dev;
+
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q1_5', length(md5(now()::text)) FROM :TABLE;
+-- volatile expression in targetlist
+:PREFIX SELECT count(DISTINCT dev), 'q1_7', length(md5(random()::text)) FROM :TABLE;
+
+-- expressions over distinct aggregates are supported
+:PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;
+
+-- DISTINCT aggs grouped on their args
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_1' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_2', NULL FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, 'q2_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_immutable(), 'q2_5' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_stable(), 'q2_6' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev, int_func_volatile(), 'q2_7' FROM :TABLE GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev+1, 'q2_8' FROM :TABLE GROUP BY dev ORDER BY 2;
+:PREFIX SELECT count(DISTINCT dev), dev+1, dev+2, 'q2_9' FROM :TABLE GROUP BY dev, dev;
+
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev LIMIT 3;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC LIMIT 3;
+
+\qecho range queries on :TABLE
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time BETWEEN 100 AND 300 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time < 200 GROUP BY dev;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 800 GROUP BY dev;
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_2' FROM (SELECT count(DISTINCT dev) as dev FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, c1, 2, c3, 'q4_3' FROM (SELECT count(DISTINCT dev) as c1, dev, 1 as c3 FROM :TABLE GROUP BY dev) a;
+
+\qecho ORDER BY
+:PREFIX SELECT c, dev, 'q5_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev) a;
+:PREFIX SELECT c, dev, 'q5_2' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev ORDER BY dev DESC) a;
+
+\qecho WHERE CLAUSES
+:PREFIX SELECT c, dev, 'q6_1' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE WHERE dev > 5 GROUP BY dev) a;
+:PREFIX SELECT c, dev, 'q6_2' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev HAVING sum(DISTINCT dev)>2) a;
+:PREFIX SELECT c, dev, 'q6_3' FROM (SELECT count(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE dev > 5;
+:PREFIX SELECT c, dev, 'q6_4' FROM (SELECT sum(DISTINCT dev) as c, dev FROM :TABLE GROUP BY dev) a WHERE c > 2;
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT count(DISTINCT dev), 'q6_7' FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT count(DISTINCT dev), 'q6_8' FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_9' FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT count(DISTINCT dev), 'q6_10' FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 GROUP BY dev ORDER BY dev;
+
+:PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE dev IS NULL;
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT count(DISTINCT dev) FROM :TABLE
+)
+SELECT * FROM devices;
+
+:PREFIX WITH devices AS (
+	SELECT dev, count(DISTINCT dev) FROM :TABLE GROUP BY dev
+)
+SELECT * FROM devices ORDER BY dev;
+
+-- prepared statements
+PREPARE prep AS SELECT count(DISTINCT dev) FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+
+-- ReScan tests
+:PREFIX SELECT c, 'q7_1' FROM (SELECT count(DISTINCT dev) c FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+
+:PREFIX SELECT c, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev != a.v) b) a;
+
+-- RuntimeKeys
+:PREFIX SELECT c, 'q8_1' FROM (SELECT * FROM (VALUES (1), (2)) a(v), LATERAL (SELECT count(DISTINCT dev) c FROM :TABLE WHERE dev >= a.v) b) c;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;

--- a/tsl/test/sql/include/skip_scan_dagg_query_ht.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_query_ht.sql
@@ -5,6 +5,9 @@
 CREATE INDEX ON :TABLE(dev);
 CREATE INDEX ON :TABLE(time);
 
+-- To test scenarios with SkipScan/no SkipScan over a mix of uncompressed and compressed chunks
+SET timescaledb.enable_compressed_skipscan TO false;
+
 -- IndexPath without pathkeys doesnt use SkipScan
 EXPLAIN (costs off, timing off, summary off) SELECT count(DISTINCT 1) FROM pg_rewrite;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where dev=1;
@@ -36,3 +39,5 @@ DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx1;
 
 DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_time_idx;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
+
+RESET timescaledb.enable_compressed_skipscan;

--- a/tsl/test/sql/include/skip_scan_load_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_load_comp_query.sql
@@ -1,0 +1,134 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_compressed_skipscan') AS enable_compressed_skipscan;
+
+-- To avoid ambiguity in test EXPLAIN outputs due to mixing of chunk plans with no SkipScan
+SET max_parallel_workers_per_gather = 0;
+
+-- To avoid choosing SeqScan under DecompressChunks before SkipScan can evaluate it,
+-- as cost of scanning and sorting a small dataset can be less than scanning an index
+-- TODO: address an issue of not preserving IndexPaths under DecompressChunks in "add_path"
+SET enable_seqscan = false;
+
+-- Run SkipScan queries on the provided compression layout
+-- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
+
+-- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+
+-- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
+
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time DESC LIMIT 3;
+
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+
+-- Various tests for "segmentby = 'dev'"
+---------------------------------------
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time DESC) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time) a;
+
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time DESC;
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+
+-- ReScan tests
+-- have SkipScan as Distinct is over index
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;

--- a/tsl/test/sql/include/skip_scan_query_ht.sql
+++ b/tsl/test/sql/include/skip_scan_query_ht.sql
@@ -5,6 +5,9 @@
 CREATE INDEX ON :TABLE(dev);
 CREATE INDEX ON :TABLE(time);
 
+-- To test scenarios with SkipScan/no SkipScan over a mix of uncompressed and compressed chunks
+SET timescaledb.enable_compressed_skipscan TO false;
+
 -- SkipScan with ordered append
 :PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
 
@@ -25,3 +28,5 @@ DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
 
 -- IndexPath without pathkeys doesnt use SkipScan
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
+
+RESET timescaledb.enable_compressed_skipscan;

--- a/tsl/test/sql/plan_skip_scan.sql.in
+++ b/tsl/test/sql/plan_skip_scan.sql.in
@@ -15,6 +15,14 @@
 \ir include/skip_scan_query.sql
 \ir include/skip_scan_query_ht.sql
 
+-- run tests on compressed hypertable with different compression settings
+\set TABLE skip_scan_htc
+\ir include/skip_scan_comp_query.sql
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+\set TABLE skip_scan_htcl
+\ir include/skip_scan_load_comp_query.sql
+
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan_ht;
@@ -37,4 +45,3 @@ FROM generate_series('2000-01-01'::timestamptz,'2000-01-03'::timestamptz, '10 mi
 CREATE INDEX ON i3720(data, time);
 ANALYZE i3720;
 :PREFIX SELECT DISTINCT ON(data) * FROM i3720;
-

--- a/tsl/test/sql/plan_skip_scan_dagg.sql
+++ b/tsl/test/sql/plan_skip_scan_dagg.sql
@@ -15,4 +15,10 @@
 \ir include/skip_scan_dagg_query.sql
 \ir include/skip_scan_dagg_query_ht.sql
 
+-- run tests on compressed hypertable with different compression settings
+\set TABLE skip_scan_htc
+\ir include/skip_scan_dagg_comp_query.sql
 
+-- run tests on compressed hypertable with different layouts of compressed chunks
+\set TABLE skip_scan_htcl
+\ir include/skip_scan_dagg_load_comp_query.sql

--- a/tsl/test/sql/skip_scan.sql
+++ b/tsl/test/sql/skip_scan.sql
@@ -47,3 +47,39 @@ RESET timescaledb.enable_skipscan;
 -- compare SkipScan results on hypertable
 :DIFF_CMD
 
+-- run tests on compressed hypertable with different compression settings and diff results
+SELECT format('include/%s_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+
+\set TABLE skip_scan_htc
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+RESET timescaledb.enable_compressed_skipscan;
+
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+SELECT format('include/%s_load_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+
+\set TABLE skip_scan_htcl
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+RESET timescaledb.enable_compressed_skipscan;
+
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+

--- a/tsl/test/sql/skip_scan_dagg.sql
+++ b/tsl/test/sql/skip_scan_dagg.sql
@@ -47,3 +47,38 @@ RESET timescaledb.enable_skipscan_for_distinct_aggregates;
 -- compare SkipScan results on hypertable
 :DIFF_CMD
 
+-- run tests on compressed hypertable and diff results
+SELECT format('include/%s_dagg_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+
+\set TABLE skip_scan_htc
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+RESET timescaledb.enable_compressed_skipscan;
+
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+
+-- run tests on compressed hypertable with different layouts of compressed chunks
+SELECT format('include/%s_dagg_load_comp_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+
+\set TABLE skip_scan_htcl
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_compressed_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+RESET timescaledb.enable_compressed_skipscan;
+
+-- compare SkipScan results on hypertable
+:DIFF_CMD


### PR DESCRIPTION
PR implements https://github.com/timescale/eng-database/issues/693 via "SkipScan <- DecompressChunk <- Compressed Index" plan.

SkipScan consumes DecompressChunk data to get the next distinct value, then uses it to update SkipScan qual on the compressed index under DecompressChunk node. 
DecompressChunk plan has "UniqueSegBy" flag set when it is consumed by SkipScan. When this flag is set, it jumps to the end of the current batch after the 1st tuple from the batch is retrieved.

Current unit test setup: `skip_scan_load` creates an extra table `skip_scan_htc` with the same setup as `skip_scan_ht` but with compressed data. Then the same correctness and plan tests run on `skip_scan_ht` are also run on `skip_scan_htc`.  Correctness checks pass, plan tests only apply to scenarios with index on "dev".

TODO:

- [x] Create separate `skip_scan_compressed` unit test for tables with data compressed in various ways. 
- [x] Create separate unit tests for distinct aggregates over compressed data.
- [x] Address SkipScan scenarios with `DISTINCT on (dev), time ... ORDER BY dev, time` on compressed data with `segmentby=dev, orderby=time` with ASC/DESC and NULLS LAST/FIRST for `time`.
- [x] Enable SkipScan for indexes with NULL direction not matching `segmentby` NULL direction if distinct column is guaranteed to be NOT NULL, for example if it's a distinct aggregate input, or there is a NOT NULL constraint on this column or NOT NULL predicate is pushed down into the index. Address it as a separate issue: https://github.com/timescale/timescaledb/issues/7996
- [x] Improve cost model of SkipScan over compressed data



