### PR TITLE
Fixes for the new testgres 1.11.0

### DIFF
--- a/scripts/test_pg_upgrade.py
+++ b/scripts/test_pg_upgrade.py
@@ -47,8 +47,8 @@ pg_version_new = getenv_or_error("PGVERSIONNEW")
 pg_node_old = f"pg{pg_version_old}"
 pg_node_new = f"pg{pg_version_new}"
 
-pg_port_old = getenv_or_default("PGPORTOLD", "54321")
-pg_port_new = getenv_or_default("PGPORTNEW", "54322")
+pg_port_old = int(getenv_or_default("PGPORTOLD", "54321"))
+pg_port_new = int(getenv_or_default("PGPORTNEW", "54322"))
 
 test_version = getenv_or_default("TEST_VERSION", "v8")
 
@@ -94,12 +94,10 @@ node_old.safe_psql(
 node_old.safe_psql(dbname=pg_database_test, query="CHECKPOINT")
 node_old.safe_psql(dbname=pg_database_test, filename="test/sql/updates/setup.check.sql")
 
-# Run new psql over the old node to have the same psql output
-node_new.port = pg_port_old
-(code, old_out, old_err) = node_new.psql(
+# Run over the old node to check the output
+(code, old_out, old_err) = node_old.psql(
     dbname=pg_database_test, filename="test/sql/updates/post.pg_upgrade.sql"
 )
-node_new.port = pg_port_new
 
 # Save output to log
 write_bytes_to_file(f"{working_dir}/post.{pg_node_old}.log", old_out)

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -30,10 +30,43 @@ ORDER BY schema, name, initpriv;
 
 \di _timescaledb_catalog.*
 \ds+ _timescaledb_catalog.*
-\df _timescaledb_internal.*
-\df+ _timescaledb_internal.*
-\df public.*;
-\df+ public.*;
+
+-- Functions in schemas:
+--   * _timescaledb_internal
+--   * _timescaledb_functions
+--   * public
+SELECT n.nspname as "Schema",
+  p.proname as "Name",
+  pg_catalog.pg_get_function_result(p.oid) as "Result data type",
+  pg_catalog.pg_get_function_arguments(p.oid) as "Argument data types",
+ CASE p.prokind
+  WHEN 'a' THEN 'agg'
+  WHEN 'w' THEN 'window'
+  WHEN 'p' THEN 'proc'
+  ELSE 'func'
+ END as "Type",
+ CASE
+  WHEN p.provolatile = 'i' THEN 'immutable'
+  WHEN p.provolatile = 's' THEN 'stable'
+  WHEN p.provolatile = 'v' THEN 'volatile'
+ END as "Volatility",
+ CASE
+  WHEN p.proparallel = 'r' THEN 'restricted'
+  WHEN p.proparallel = 's' THEN 'safe'
+  WHEN p.proparallel = 'u' THEN 'unsafe'
+ END as "Parallel",
+ pg_catalog.pg_get_userbyid(p.proowner) as "Owner",
+ CASE WHEN prosecdef THEN 'definer' ELSE 'invoker' END AS "Security",
+ CASE WHEN pg_catalog.array_length(p.proacl, 1) = 0 THEN '(none)' ELSE pg_catalog.array_to_string(p.proacl, E'\n') END AS "Access privileges",
+ l.lanname as "Language",
+ p.prosrc as "Source code",
+ CASE WHEN l.lanname IN ('internal', 'c') THEN p.prosrc END as "Internal name",
+ pg_catalog.obj_description(p.oid, 'pg_proc') as "Description"
+FROM pg_catalog.pg_proc p
+     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+     LEFT JOIN pg_catalog.pg_language l ON l.oid = p.prolang
+WHERE n.nspname OPERATOR(pg_catalog.~) '^(_timescaledb_internal|_timescaledb_functions|public)$' COLLATE pg_catalog.default
+ORDER BY 1, 2, 4;
 
 \dy
 \d public.*


### PR DESCRIPTION
A new testgres framework was released that makes `PostgresNode::port` read-only. Fixed it by properly set the port when initializing a new node.

Failure due to the new testgres version: https://github.com/timescale/timescaledb/actions/runs/14589439220/job/40921093070?pr=7976

References:
https://github.com/postgrespro/testgres/releases/tag/1.11.0
https://github.com/postgrespro/testgres/pull/234

Disable-check: force-changelog-file
Disable-check: approval-count
