### PR TITLE
Improve default segmentby for hypertables

### DIFF
--- a/.unreleased/pr_7991
+++ b/.unreleased/pr_7991
@@ -1,0 +1,1 @@
+Implements: #7991 Improves default segmentby options

--- a/sql/compression_defaults.sql
+++ b/sql/compression_defaults.sql
@@ -26,30 +26,48 @@ BEGIN
 
     SELECT * INTO STRICT _hypertable_row FROM _timescaledb_catalog.hypertable h WHERE h.table_name = _table_name AND h.schema_name = _schema_name;
 
-    --STEP 1 if column stats exist use unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
+    --STEP 1 if column stats exist use unique indexes.
+    --Pick the column that comes first in any such indexes
+    --Select the column such that tuples are segmented evenly across distinct values.
     --Note: this will only pick a column that is NOT unique in a multi-column unique index.
     with index_attr as (
-        SELECT
+      SELECT
         a.attnum, min(a.pos) as pos
-        FROM
-            (select indkey, indnkeyatts from pg_catalog.pg_index where indisunique and indrelid = relation) i
-        INNER JOIN LATERAL
-            (select * from unnest(i.indkey) with ordinality) a(attnum, pos) ON (TRUE)
-        WHERE a.pos <= i.indnkeyatts
-        GROUP BY 1
-    )
-    SELECT
-      a.attname INTO _segmentby
-    FROM
-      index_attr i
-    INNER JOIN
-      pg_attribute a on (a.attnum = i.attnum AND a.attrelid = relation)
-    --right now stats are from the hypertable itself. Use chunks in the future.
-    INNER JOIN pg_stats s ON (s.attname = a.attname and s.schemaname = _schema_name and s.tablename = _table_name)
-    WHERE
-      a.attname NOT IN (SELECT column_name FROM _timescaledb_catalog.dimension d WHERE d.hypertable_id = _hypertable_row.id)
+      FROM (
+        SELECT indkey, indnkeyatts
+        FROM pg_catalog.pg_index
+        WHERE indisunique AND indrelid = relation
+      ) i
+      INNER JOIN LATERAL (
+        SELECT * FROM unnest(i.indkey) WITH ORDINALITY
+      ) a(attnum, pos) ON TRUE
+      WHERE a.pos <= i.indnkeyatts
+      GROUP BY a.attnum
+    ),
+    stats_with_stddev as (
+      SELECT
+        a.attname,
+        i.pos,
+        ROUND(stddev_pop(freqs)::numeric, 5) as freq_stddev
+      FROM index_attr i
+      INNER JOIN pg_attribute a ON a.attnum = i.attnum AND a.attrelid = relation
+      INNER JOIN pg_stats s ON s.attname = a.attname
+                            AND s.schemaname = _schema_name
+                            AND s.tablename = _table_name
+                            AND s.inherited = true
+      LEFT JOIN LATERAL unnest(s.most_common_freqs) as freqs ON TRUE
+      WHERE a.attname NOT IN (
+        SELECT column_name
+        FROM _timescaledb_catalog.dimension d
+        WHERE d.hypertable_id = _hypertable_row.id
+      )
       AND s.n_distinct > 1
-    ORDER BY i.pos
+      GROUP BY a.attname, i.pos
+    )
+    SELECT attname
+    INTO _segmentby
+    FROM stats_with_stddev
+    ORDER BY pos ASC, freq_stddev ASC NULLS LAST
     LIMIT 1;
 
     IF FOUND THEN
@@ -57,7 +75,9 @@ BEGIN
     END IF;
 
 
-    --STEP 2 if column stats exist and no unique indexes use non-unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
+    --STEP 2 if column stats exist and no unique indexes use non-unique indexes.
+    --Pick the column that comes first in any such indexes
+    --Select the column such that tuples are segmented evenly across distinct values.
     with index_attr as (
         SELECT
         a.attnum, min(a.pos) as pos
@@ -67,26 +87,69 @@ BEGIN
             (select * from unnest(i.indkey) with ordinality) a(attnum, pos) ON (TRUE)
         WHERE a.pos <= i.indnkeyatts
         GROUP BY 1
-    )
-    SELECT
-      a.attname INTO _segmentby
-    FROM
-      index_attr i
-    INNER JOIN
-      pg_attribute a on (a.attnum = i.attnum AND a.attrelid = relation)
-    --right now stats are from the hypertable itself. Use chunks in the future.
-    INNER JOIN pg_stats s ON (s.attname = a.attname and s.schemaname = _schema_name and s.tablename = _table_name)
-    WHERE
-      a.attname NOT IN (SELECT column_name FROM _timescaledb_catalog.dimension d WHERE d.hypertable_id = _hypertable_row.id)
+    ),
+    stats_with_stddev as (
+      SELECT
+        a.attname,
+        i.pos,
+        ROUND(stddev_pop(freqs)::numeric, 5) as freq_stddev
+      FROM index_attr i
+      INNER JOIN pg_attribute a ON a.attnum = i.attnum AND a.attrelid = relation
+      INNER JOIN pg_stats s ON s.attname = a.attname
+                            AND s.schemaname = _schema_name
+                            AND s.tablename = _table_name
+                            AND s.inherited = true
+      LEFT JOIN LATERAL unnest(s.most_common_freqs) as freqs ON TRUE
+      WHERE a.attname NOT IN (
+        SELECT column_name
+        FROM _timescaledb_catalog.dimension d
+        WHERE d.hypertable_id = _hypertable_row.id
+      )
       AND s.n_distinct > 1
-    ORDER BY i.pos
+      GROUP BY a.attname, i.pos
+    )
+    SELECT attname
+    INTO _segmentby
+    FROM stats_with_stddev
+    ORDER BY pos ASC, freq_stddev ASC NULLS LAST
     LIMIT 1;
 
     IF FOUND THEN
         return json_build_object('columns', json_build_array(_segmentby), 'confidence', 8);
     END IF;
 
-    --STEP 3 if column stats do not exist use non-unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
+    --STEP 3 if column stats exist but there are no indexes
+    --Select the column such that tuples are segmented evenly across distinct values.
+    with stats_with_stddev as (
+      SELECT
+        a.attname,
+        ROUND(stddev_pop(freqs)::numeric, 5) as freq_stddev
+      FROM pg_attribute a
+      INNER JOIN pg_stats s ON s.attname = a.attname
+                            AND s.schemaname = _schema_name
+                            AND s.tablename = _table_name
+                            AND s.inherited = true
+      LEFT JOIN LATERAL unnest(s.most_common_freqs) as freqs ON TRUE
+      WHERE a.attrelid = relation
+        AND a.attname NOT IN (
+          SELECT column_name
+          FROM _timescaledb_catalog.dimension d
+          WHERE d.hypertable_id = _hypertable_row.id
+        )
+      AND s.n_distinct > 1
+      GROUP BY a.attname
+    )
+    SELECT attname
+    INTO _segmentby
+    FROM stats_with_stddev
+    ORDER BY freq_stddev ASC NULLS LAST
+    LIMIT 1;
+
+    IF FOUND THEN
+        return json_build_object('columns', json_build_array(_segmentby), 'confidence', 7);
+    END IF;
+
+    --STEP 4 if column stats do not exist use non-unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
     with index_attr as (
         SELECT
         a.attnum, min(a.pos) as pos
@@ -105,8 +168,10 @@ BEGIN
       pg_attribute a on (a.attnum = i.attnum AND a.attrelid = relation)
     LEFT JOIN
       pg_catalog.pg_attrdef ad ON (ad.adrelid = relation AND ad.adnum = a.attnum)
-    LEFT JOIN
-      pg_stats s ON (s.attname = a.attname and s.schemaname = _schema_name and s.tablename = _table_name)
+    LEFT JOIN pg_stats s ON s.attname = a.attname
+                          AND s.schemaname = _schema_name
+                          AND s.tablename = _table_name
+                          AND s.inherited = true
     WHERE
       a.attname NOT IN (SELECT column_name FROM _timescaledb_catalog.dimension d WHERE d.hypertable_id = _hypertable_row.id)
       AND s.n_distinct is null
@@ -121,7 +186,7 @@ BEGIN
             'message',  'Please make sure '|| _segmentby||' is not a unique column and appropriate for a segment by');
     END IF;
 
-    --STEP 4 if column stats do not exist and no non-unique indexes, use unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
+    --STEP 5 if column stats do not exist and no non-unique indexes, use unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
     with index_attr as (
         SELECT
         a.attnum, min(a.pos) as pos
@@ -140,8 +205,10 @@ BEGIN
       pg_attribute a on (a.attnum = i.attnum AND a.attrelid = relation)
     LEFT JOIN
       pg_catalog.pg_attrdef ad ON (ad.adrelid = relation AND ad.adnum = a.attnum)
-    LEFT JOIN
-      pg_stats s ON (s.attname = a.attname and s.schemaname = _schema_name and s.tablename = _table_name)
+    LEFT JOIN pg_stats s ON s.attname = a.attname
+                          AND s.schemaname = _schema_name
+                          AND s.tablename = _table_name
+                          AND s.inherited = true
     WHERE
       a.attname NOT IN (SELECT column_name FROM _timescaledb_catalog.dimension d WHERE d.hypertable_id = _hypertable_row.id)
       AND s.n_distinct is null

--- a/tsl/src/compression/README.md
+++ b/tsl/src/compression/README.md
@@ -115,9 +115,10 @@ This function determines a segment-by column to use. It returns a JSONB with the
 
 The intuition is as follows:
 
-we use 2 criterias:
-- We want to pick an "important" column for querying. We measure "importance", in terms of how early the column comes in an index (i.e. leading columns are very important, others less so).
+we use 3 criterias:
+- We want to pick an "important" column for querying. We measure "importance", in terms of how early the column comes in an index (i.e. leading columns are very important, others less so). If there are no indexes, all columns will be considered if statistics are populated
 - The column has many rows for the same column value so that the segments will have many rows. We establish that a column will have many values if (i) it is not a dimension and (ii) either statistics tell us so (via `stadistinct` > 1) or, if statistics aren't populated, we check whether the column is a generated identity or serial column.
+- When we have multiple qualifying rows, we select the column where rows are spread most evenly across the distinct values. 
 
 Naturally, statistics give us more confidence that the column has enough rows per segment. In this case we break ties by preferring columns from unique indexes. Otherwise, we prefer columns from non-unique indexes (we are less likely to run into a unique column there).
 

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -111,9 +111,9 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY['devi
 drop index test_idx;
 CREATE UNIQUE INDEX test_idx ON metrics(val, time);
 SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
-                                                                                                        get_segmentby_defaults                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"columns": [], "message": "Several columns are potential segment by candidates and we do not have enough information to choose one. Please use the segment_by option to explicitly specify the segment_by column", "confidence": 0}
+           get_segmentby_defaults            
+---------------------------------------------
+ {"columns": ["device_id"], "confidence": 7}
 (1 row)
 
 SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY[]::text[]);
@@ -156,9 +156,9 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY['devi
 drop index test_idx;
 CREATE INDEX test_idx ON metrics(val, time);
 SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
-                                                                                                    get_segmentby_defaults                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"columns": [], "message": "You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes", "confidence": 5}
+           get_segmentby_defaults            
+---------------------------------------------
+ {"columns": ["device_id"], "confidence": 7}
 (1 row)
 
 SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY[]::text[]);
@@ -187,9 +187,9 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY['devi
 drop index test_idx1;
 drop index test_idx2;
 SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
-                                                                                                    get_segmentby_defaults                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"columns": [], "message": "You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes", "confidence": 5}
+           get_segmentby_defaults            
+---------------------------------------------
+ {"columns": ["device_id"], "confidence": 7}
 (1 row)
 
 SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY[]::text[]);
@@ -199,13 +199,12 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY[]::te
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
-WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
-NOTICE:  default segment by for hypertable "metrics" is set to ""
+NOTICE:  default segment by for hypertable "metrics" is set to "device_id"
 NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+----------------+-----------+---------+--------------+--------------------
- metrics |                |           | {time}  | {t}          | {t}
+  relid  | compress_relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-------------+---------+--------------+--------------------
+ metrics |                | {device_id} | {time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
@@ -359,12 +358,144 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY['devi
  {"clauses": ["\"time\" DESC"], "confidence": 8}
 (1 row)
 
+--test table with skewed statistics
+drop table metrics;
+CREATE TABLE "public"."metrics" (
+    "time" timestamp with time zone NOT NULL,
+    "device_id" "text",
+    "device_id2" "text",
+    "val" double precision
+) WITH (autovacuum_enabled=0);
+SELECT create_hypertable('public.metrics', 'time', create_default_indexes=>false);
+   create_hypertable   
+-----------------------
+ (11,public,metrics,t)
+(1 row)
+
+--skew device_id distribution compared to device_id2.
+--device_id2 will be the favourable default segmentby
+insert into metrics SELECT t, 1, 1, extract(epoch from t) from generate_series
+        ( '2007-02-01'::timestamp
+        , '2008-04-01'::timestamp
+        , '1 day'::interval) t;
+insert into metrics SELECT t, 1, 2, extract(epoch from t) from generate_series
+        ( '2010-02-01'::timestamp
+        , '2011-04-01'::timestamp
+        , '1 day'::interval) t;
+insert into metrics SELECT t, 1, 1, extract(epoch from t) from generate_series
+        ( '2012-02-01'::timestamp
+        , '2013-04-01'::timestamp
+        , '1 day'::interval) t;
+insert into metrics SELECT t, 2, 2, extract(epoch from t) from generate_series
+        ( '2016-02-01'::timestamp
+        , '2017-04-01'::timestamp
+        , '1 day'::interval) t;
+ANALYZE metrics;
+--use the best-scenario unique index (device_id2)
+CREATE UNIQUE INDEX test_idx ON metrics(device_id, time);
+CREATE UNIQUE INDEX test_idx2 ON metrics(device_id2, time);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+            get_segmentby_defaults             
+-----------------------------------------------
+ {"columns": ["device_id2"], "confidence": 10}
+(1 row)
+
+--opposite order of columns
+drop index test_idx;
+drop index test_idx2;
+CREATE UNIQUE INDEX test_idx ON metrics(time, device_id);
+CREATE UNIQUE INDEX test_idx2 ON metrics(time, device_id2);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+            get_segmentby_defaults             
+-----------------------------------------------
+ {"columns": ["device_id2"], "confidence": 10}
+(1 row)
+
+--use a high-cardinality column in the index (still choose device_id2)
+drop index test_idx;
+CREATE UNIQUE INDEX test_idx ON metrics(val, time);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+            get_segmentby_defaults             
+-----------------------------------------------
+ {"columns": ["device_id2"], "confidence": 10}
+(1 row)
+
+--use a non-unique index
+drop index test_idx;
+drop index test_idx2;
+CREATE INDEX test_idx ON metrics(device_id, time, val);
+CREATE INDEX test_idx2 ON metrics(device_id2, time, val);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+            get_segmentby_defaults            
+----------------------------------------------
+ {"columns": ["device_id2"], "confidence": 8}
+(1 row)
+
+--another non-unique index column order (choose device_id since it is in a lower index position)
+drop index test_idx;
+drop index test_idx2;
+CREATE INDEX test_idx ON metrics(device_id, time, val);
+CREATE INDEX test_idx2 ON metrics(val, device_id2, time);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+           get_segmentby_defaults            
+---------------------------------------------
+ {"columns": ["device_id"], "confidence": 8}
+(1 row)
+
+--use a high-cardinality column in the non-unque index (still choose device_id2)
+drop index test_idx;
+CREATE INDEX test_idx ON metrics(val, time);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+            get_segmentby_defaults            
+----------------------------------------------
+ {"columns": ["device_id2"], "confidence": 8}
+(1 row)
+
+--use 2 indexes (choose device_id since it is an indexed column)
+drop index test_idx;
+drop index test_idx2;
+CREATE INDEX test_idx ON metrics(val, time);
+CREATE INDEX test_idx2 ON metrics(device_id, time);
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+           get_segmentby_defaults            
+---------------------------------------------
+ {"columns": ["device_id"], "confidence": 8}
+(1 row)
+
+--no indexes (choose device_id2)
+drop index test_idx;
+drop index test_idx2;
+SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
+            get_segmentby_defaults            
+----------------------------------------------
+ {"columns": ["device_id2"], "confidence": 7}
+(1 row)
+
+ALTER TABLE metrics SET (timescaledb.compress = true);
+NOTICE:  default segment by for hypertable "metrics" is set to "device_id2"
+NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
+SELECT * FROM _timescaledb_catalog.compression_settings;
+  relid  | compress_relid |  segmentby   | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+--------------+---------+--------------+--------------------
+ metrics |                | {device_id2} | {time}  | {t}          | {t}
+(1 row)
+
+ALTER TABLE metrics SET (timescaledb.compress = false);
+ALTER TABLE metrics SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'device_id');
+NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
+SELECT * FROM _timescaledb_catalog.compression_settings;
+  relid  | compress_relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-------------+---------+--------------+--------------------
+ metrics |                | {device_id} | {time}  | {t}          | {t}
+(1 row)
+
+ALTER TABLE metrics SET (timescaledb.compress = false);
 --test on an empty order_by
 CREATE TABLE table1(col1 INT NOT NULL, col2 INT);
 SELECT create_hypertable('table1','col1', chunk_time_interval => 10);
   create_hypertable   
 ----------------------
- (11,public,table1,t)
+ (14,public,table1,t)
 (1 row)
 
 SELECT _timescaledb_functions.get_orderby_defaults('table1', ARRAY['col1']::text[]);
@@ -403,7 +534,7 @@ CREATE TABLE public.t1 (time timestamptz NOT NULL, segment_value text NOT NULL);
 SELECT public.create_hypertable('public.t1', 'time');
  create_hypertable 
 -------------------
- (13,public,t1,t)
+ (16,public,t1,t)
 (1 row)
 
 ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 'segment_value');
@@ -424,7 +555,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (15,schema1,page_events2,t)
+ (18,schema1,page_events2,t)
 (1 row)
 
 ALTER TABLE schema1.page_events2 SET (
@@ -439,7 +570,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (17,schema2,page_events2,t)
+ (20,schema2,page_events2,t)
 (1 row)
 
 ALTER TABLE schema2.page_events2 SET (
@@ -458,7 +589,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (19,schema1,page_events2,t)
+ (22,schema1,page_events2,t)
 (1 row)
 
 ALTER TABLE schema1.page_events2 SET (
@@ -475,7 +606,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (21,schema2,page_events2,t)
+ (24,schema2,page_events2,t)
 (1 row)
 
 ALTER TABLE schema2.page_events2 SET (

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -271,8 +271,7 @@ SELECT (SELECT count(*) FROM normal) num_inserted_rows,
 
 -- Add compression
 ALTER TABLE hyper SET (timescaledb.compress);
-WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
-NOTICE:  default segment by for hypertable "hyper" is set to ""
+NOTICE:  default segment by for hypertable "hyper" is set to "device"
 NOTICE:  default order by for hypertable "hyper" is set to ""time" DESC"
 SELECT compress_chunk(c)
 FROM show_chunks('hyper') c ORDER BY c LIMIT 4;
@@ -323,7 +322,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "toast_size": 40960,                             +
          "compression": {                                 +
              "compressed_heap_size": 114688,              +
-             "compressed_row_count": 14,                  +
+             "compressed_row_count": 49,                  +
              "compressed_toast_size": 40960,              +
              "num_compressed_chunks": 5,                  +
              "uncompressed_heap_size": 221184,            +
@@ -332,7 +331,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
              "uncompressed_toast_size": 0,                +
              "uncompressed_indexes_size": 131072,         +
              "num_compressed_hypertables": 2,             +
-             "compressed_row_count_frozen_immediately": 14+
+             "compressed_row_count_frozen_immediately": 49+
          },                                               +
          "indexes_size": 270336,                          +
          "num_children": 11,                              +


### PR DESCRIPTION
Previously, the default segmentby logic only used indexed columns with distinct values. It now includes non-indexed columns as candidates. When multiple columns are eligible, it selects the one with the most even value distribution based on pg_stats.

## Considerations
1. Low cardinality:
    - Must have +ve n_distinct values (may not be optimal in some scenarios)
 2. Index position:
    - column in a lower index key is considered. Assumption made is indexes are appropriately designed for performance reasons (might not always be the case)
 3. Even distribution of rows among the distinct values
    - It is still possible for chunks to have skewed distribution causing sub-optimal segmentation