### PR TITLE
Add API into hypertable invalidation log

### DIFF
--- a/.unreleased/pr_7992
+++ b/.unreleased/pr_7992
@@ -1,0 +1,1 @@
+Implements: #7992 Add API into hypertable invalidation log

--- a/sql/cagg_api.sql
+++ b/sql/cagg_api.sql
@@ -24,6 +24,137 @@ BEGIN
 
     RETURN info;
 END
+$body$ LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp;
+
+-- Get hypertable id for a hypertable and execute common checks to
+-- avoid duplicating them in the overloaded functions below.
+--
+-- This function is part of the internal API and not intended for
+-- public consumption.
+CREATE OR REPLACE FUNCTION _timescaledb_functions.get_hypertable_id(
+       hypertable REGCLASS,
+       column_type REGTYPE
+) RETURNS integer AS
+$body$
+DECLARE
+   info RECORD;
+BEGIN
+   SELECT ht.id AS hypertable_id,
+          di.column_type::regtype,
+          EXISTS(SELECT FROM _timescaledb_catalog.continuous_agg where raw_hypertable_id = ht.id) AS has_cagg
+     INTO info
+     FROM _timescaledb_catalog.hypertable ht
+     JOIN _timescaledb_catalog.dimension di ON ht.id = di.hypertable_id
+    WHERE format('%I.%I', schema_name, table_name)::regclass = hypertable
+      AND di.interval_length IS NOT NULL;
+
+   IF info IS NULL THEN
+      RAISE EXCEPTION 'table "%" is not a hypertable', hypertable
+      USING ERRCODE = 'object_not_in_prerequisite_state';
+   END IF;
+
+   IF NOT info.has_cagg THEN
+      RAISE EXCEPTION 'hypertable "%" has no continuous aggregate', hypertable
+      USING HINT = 'Define a continuous aggregate for the hypertable to read invalidations.',
+            ERRCODE = 'object_not_in_prerequisite_state';
+   END IF;
+
+   IF info.column_type <> get_hypertable_id.column_type THEN
+      RAISE EXCEPTION 'wrong column type for hypertable %', hypertable
+      USING HINT = format('hypertable type was "%s", but caller expected "%s"',
+                          info.column_type, get_hypertable_id.column_type),
+	    ERRCODE = 'datatype_mismatch';
+   END IF;
+
+   RETURN info.hypertable_id;
+END
+$body$ LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp;
+
+-- Get hypertable invalidations ranges based on bucket size.
+--
+-- This will return a multirange for each bucket size passed in and a
+-- token that can be used to accept the multirange.
+--
+-- Note that the token returned is not unique for each bucket size and
+-- represents either the LSN or a Snapshot of what data was read to
+-- produce the bucket ranges.
+--
+-- Currently, we only have support for timestamp with and without
+-- timezone, but it is straightforward to add similar implementations
+-- for integer types.
+CREATE OR REPLACE FUNCTION _timescaledb_functions.get_hypertable_invalidations(
+   hypertable REGCLASS,
+   base TIMESTAMPTZ,
+   bucket_widths INTERVAL[]
+) RETURNS TABLE (bucket_width INTERVAL, token TEXT, invalidations TSTZMULTIRANGE) AS
+$body$
+DECLARE
+   l_hypertable_id INTEGER := _timescaledb_functions.get_hypertable_id(hypertable, 'timestamptz'::regtype);
+BEGIN
+   RETURN QUERY (
+      WITH
+         -- Collect ranges from the invalidation log and convert them
+         -- to correct type.
+         timestamps AS MATERIALIZED (
+            SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+                   _timescaledb_functions.to_timestamp(greatest_modified_value) AS finish
+              FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+             WHERE hypertable_id = l_hypertable_id
+         ),
+         -- Since a range can end at the end of a bucket and this
+         -- range should not include the next bucket, we need to
+         -- subtract one microsecond before computing the bucket and
+         -- then add the width again.
+         ranges AS MATERIALIZED (
+           SELECT width,
+                  tstzrange(@extschema@.time_bucket(width, start),
+                            @extschema@.time_bucket(width, finish - '1 microsecond'::interval) + width) AS bucket
+             FROM timestamps CROSS JOIN UNNEST(bucket_widths) w(width)
+         )
+      SELECT width, pg_current_snapshot()::text, range_agg(bucket) ranges
+        FROM ranges GROUP BY width
+   );
+END
+$body$
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp;
+
+CREATE OR REPLACE FUNCTION _timescaledb_functions.get_hypertable_invalidations(
+   hypertable REGCLASS,
+   base TIMESTAMP,
+   bucket_widths INTERVAL[]
+) RETURNS TABLE (bucket_width INTERVAL, token TEXT, invalidations TSMULTIRANGE) AS
+$body$
+DECLARE
+   l_hypertable_id INTEGER := _timescaledb_functions.get_hypertable_id(hypertable, 'timestamp'::regtype);
+BEGIN
+   RETURN QUERY (
+      WITH
+         -- Collect ranges from the invalidation log and convert them
+         -- to correct type.
+         timestamps AS MATERIALIZED (
+            SELECT _timescaledb_functions.to_timestamp_without_timezone(lowest_modified_value) AS start,
+                   _timescaledb_functions.to_timestamp_without_timezone(greatest_modified_value) AS finish
+              FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+             WHERE hypertable_id = l_hypertable_id
+         ),
+         -- Compute bucket-aligned ranges from the ranges above. Since
+         -- a range can end at the end of a bucket and this range
+         -- should not include the next bucket, we need to subtract
+         -- one microsecond before computing the bucket and then add
+         -- the width again.
+         ranges AS MATERIALIZED (
+           SELECT width,
+                  tsrange(@extschema@.time_bucket(width, start),
+                          @extschema@.time_bucket(width, finish - '1 microsecond'::interval) + width) AS bucket
+             FROM timestamps CROSS JOIN UNNEST(bucket_widths) w(width)
+         )
+      SELECT width, pg_current_snapshot()::text, range_agg(bucket)
+        FROM ranges GROUP BY width
+   );
+END
 $body$
 LANGUAGE plpgsql
 SET search_path TO pg_catalog, pg_temp;
@@ -160,6 +291,50 @@ BEGIN
       FROM ranges
      WHERE invals && aligned
        AND materialization_id = info.materialization_id;
+END
+$body$ LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp;
+
+-- Accept a set of hypertable invalidations for a hypertable.
+--
+-- This procedure is used to accept all invalidations for a hypertable
+-- using the token returned by a previous call of
+-- get_hypertable_invalidations().
+CREATE OR REPLACE PROCEDURE _timescaledb_functions.accept_hypertable_invalidations(
+   hypertable REGCLASS,
+   token TEXT
+) AS
+$body$
+DECLARE
+   info RECORD;
+   errmsg TEXT;
+BEGIN
+   SELECT ht.id AS hypertable_id,
+          (cagg.raw_hypertable_id IS NOT NULL) AS has_cagg
+     INTO info
+     FROM _timescaledb_catalog.hypertable ht
+     LEFT JOIN _timescaledb_catalog.continuous_agg cagg ON cagg.raw_hypertable_id = ht.id
+    WHERE format('%I.%I', schema_name, table_name)::regclass = hypertable;
+
+   IF info IS NULL THEN
+      RAISE EXCEPTION 'table "%" is not a hypertable', hypertable
+      USING ERRCODE = 'object_not_in_prerequisite_state';
+   END IF;
+
+   IF NOT info.has_cagg THEN
+      RAISE EXCEPTION 'hypertable "%" has no continuous aggregate', hypertable
+      USING HINT = 'Define a continuous aggregate for the hypertable to handle invalidations.',
+            ERRCODE = 'object_not_in_prerequisite_state';
+   END IF;
+
+   DELETE FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+    WHERE hypertable_id = info.hypertable_id
+      AND pg_visible_in_snapshot(xmin::text::xid8, token::pg_snapshot);
+EXCEPTION
+    WHEN invalid_text_representation THEN
+       RAISE EXCEPTION '%', SQLERRM
+       USING HINT = 'Use the token from the get_hypertable_invalidations() call.',
+             ERRCODE = 'invalid_text_representation';
 END
 $body$
 LANGUAGE plpgsql

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,5 +1,9 @@
 CREATE FUNCTION _timescaledb_internal.create_chunk_table(hypertable REGCLASS, slices JSONB, schema_name NAME, table_name NAME) RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_update_placeholder' LANGUAGE C VOLATILE;
 CREATE FUNCTION _timescaledb_functions.create_chunk_table(hypertable REGCLASS, slices JSONB, schema_name NAME, table_name NAME) RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_update_placeholder' LANGUAGE C VOLATILE;
+DROP FUNCTION _timescaledb_functions.get_hypertable_id(REGCLASS, REGTYPE);
+DROP FUNCTION _timescaledb_functions.get_hypertable_invalidations(REGCLASS, TIMESTAMPTZ, INTERVAL[]);
+DROP FUNCTION _timescaledb_functions.get_hypertable_invalidations(REGCLASS, TIMESTAMP, INTERVAL[]);
+DROP PROCEDURE _timescaledb_functions.accept_hypertable_invalidations(REGCLASS, TEXT);
 
 -- Revert new option `refresh_newest_first` from incremental cagg refresh policy
 DROP FUNCTION @extschema@.add_continuous_aggregate_policy(

--- a/tsl/test/expected/cagg_api.out
+++ b/tsl/test/expected/cagg_api.out
@@ -200,3 +200,205 @@ SELECT * FROM _timescaledb_functions.get_materialization_invalidations(
  {["2025-04-25 00:00:00+02","2025-04-25 10:59:59.999999+02")}
 (1 row)
 
+-- Generate some invalidations. These new values need to be before the
+-- invalidation threshold, which is set to end time of the insertion
+-- above.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-04 10:00:00'::timestamp,
+                         '2025-01-04 11:12:00', '9 minutes') time;
+INSERT INTO hyper_tstz
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-04 12:00:00'::timestamptz,
+                         '2025-01-04 13:12:00', '8 minutes') time;
+-- Check the invalidation threshold. If that is not after the
+-- insertions above, nothing will show up in the invalidation log.
+SELECT hypertable_id,
+       _timescaledb_functions.to_timestamp_without_timezone(watermark) AS watermark
+  FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+  ORDER BY 1;
+ hypertable_id |       watermark        
+---------------+------------------------
+             1 | 2025-04-26 00:00:00
+             2 | 2025-04-26 00:00:00
+             4 | 4714-11-24 00:00:00 BC
+(3 rows)
+
+-- Check that there indeed is something in the hypertable invalidation
+-- log. If not, this will fail anyway. We show the "raw" timestamps,
+-- which is in UTC if it was originally a timestamp with timezone.
+SELECT hypertable_id,
+       _timescaledb_functions.to_timestamp_without_timezone(lowest_modified_value) AS start,
+       _timescaledb_functions.to_timestamp_without_timezone(greatest_modified_value) AS finish
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+  ORDER BY 1;
+ hypertable_id |        start        |       finish        
+---------------+---------------------+---------------------
+             1 | 2025-01-04 10:00:00 | 2025-01-04 11:12:00
+             2 | 2025-01-04 11:00:00 | 2025-01-04 12:12:00
+(2 rows)
+
+\set VERBOSITY default
+-- Check that we can handle hypertables with single and multiple
+-- dimensions. This function is not part of the official API but we
+-- add tests for it here.
+SELECT _timescaledb_functions.get_hypertable_id('hyper_ts', 'timestamp');
+ get_hypertable_id 
+-------------------
+                 1
+(1 row)
+
+SELECT _timescaledb_functions.get_hypertable_id('hyper_tstz', 'timestamptz');
+ get_hypertable_id 
+-------------------
+                 2
+(1 row)
+
+SELECT _timescaledb_functions.get_hypertable_id('hyper_multi', 'timestamptz');
+ get_hypertable_id 
+-------------------
+                 4
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- Not a hypertable
+SELECT _timescaledb_functions.get_hypertable_id('normal_ts', 'timestamp');
+ERROR:  table "public.normal_ts" is not a hypertable
+CONTEXT:  PL/pgSQL function _timescaledb_functions.get_hypertable_id(regclass,regtype) line 15 at RAISE
+SELECT _timescaledb_functions.get_hypertable_invalidations('normal_ts', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+ERROR:  table "public.normal_ts" is not a hypertable
+CONTEXT:  PL/pgSQL function _timescaledb_functions.get_hypertable_id(regclass,regtype) line 15 at RAISE
+PL/pgSQL function _timescaledb_functions.get_hypertable_invalidations(regclass,timestamp without time zone,interval[]) line 3 during statement block local variable initialization
+-- No continuous aggregate connected
+SELECT _timescaledb_functions.get_hypertable_id('hyper_no_cagg', 'timestamp');
+ERROR:  hypertable "public.hyper_no_cagg" has no continuous aggregate
+HINT:  Define a continuous aggregate for the hypertable to read invalidations.
+CONTEXT:  PL/pgSQL function _timescaledb_functions.get_hypertable_id(regclass,regtype) line 20 at RAISE
+SELECT _timescaledb_functions.get_hypertable_invalidations('hyper_no_cagg', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+ERROR:  hypertable "public.hyper_no_cagg" has no continuous aggregate
+HINT:  Define a continuous aggregate for the hypertable to read invalidations.
+CONTEXT:  PL/pgSQL function _timescaledb_functions.get_hypertable_id(regclass,regtype) line 20 at RAISE
+PL/pgSQL function _timescaledb_functions.get_hypertable_invalidations(regclass,timestamp without time zone,interval[]) line 3 during statement block local variable initialization
+-- Wrong type used
+SELECT _timescaledb_functions.get_hypertable_id('hyper_ts', 'timestamptz');
+ERROR:  wrong column type for hypertable public.hyper_ts
+HINT:  hypertable type was "timestamp without time zone", but caller expected "timestamp with time zone"
+CONTEXT:  PL/pgSQL function _timescaledb_functions.get_hypertable_id(regclass,regtype) line 26 at RAISE
+SELECT _timescaledb_functions.get_hypertable_invalidations('hyper_ts', null::timestamptz, array['15 minutes', '1 hour']::interval[]);
+ERROR:  wrong column type for hypertable public.hyper_ts
+HINT:  hypertable type was "timestamp without time zone", but caller expected "timestamp with time zone"
+CONTEXT:  PL/pgSQL function _timescaledb_functions.get_hypertable_id(regclass,regtype) line 26 at RAISE
+PL/pgSQL function _timescaledb_functions.get_hypertable_invalidations(regclass,timestamp with time zone,interval[]) line 3 during statement block local variable initialization
+\set ON_ERROR_STOP 1
+SELECT * INTO saved_invalidations_1
+  FROM _timescaledb_functions.get_hypertable_invalidations('hyper_ts', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+SELECT bucket_width, invalidations FROM saved_invalidations_1;
+ bucket_width |                  invalidations                  
+--------------+-------------------------------------------------
+ @ 15 mins    | {["2025-01-04 10:00:00","2025-01-04 11:15:00")}
+ @ 1 hour     | {["2025-01-04 10:00:00","2025-01-04 12:00:00")}
+(2 rows)
+
+-- Calling it twice should return same invalidations since we haven't
+-- inserted anything between.
+SELECT * INTO saved_invalidations_2
+  FROM _timescaledb_functions.get_hypertable_invalidations('hyper_ts', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+SELECT * FROM saved_invalidations_2 s1
+    FULL JOIN saved_invalidations_2 s2 ON row(s1.*) = row(s2.*)
+        WHERE s1.token IS NULL OR s2.token IS NULL;
+ bucket_width | token | invalidations | bucket_width | token | invalidations 
+--------------+-------+---------------+--------------+-------+---------------
+(0 rows)
+
+SELECT token FROM saved_invalidations_1 LIMIT 1 \gset
+-- Test some error cases
+\set ON_ERROR_STOP 0
+CALL _timescaledb_functions.accept_hypertable_invalidations('normal_ts', :'token');
+ERROR:  table "public.normal_ts" is not a hypertable
+CONTEXT:  PL/pgSQL function _timescaledb_functions.accept_hypertable_invalidations(regclass,text) line 14 at RAISE
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_no_cagg', :'token');
+ERROR:  hypertable "public.hyper_no_cagg" has no continuous aggregate
+HINT:  Define a continuous aggregate for the hypertable to handle invalidations.
+CONTEXT:  PL/pgSQL function _timescaledb_functions.accept_hypertable_invalidations(regclass,text) line 19 at RAISE
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_ts', 'garbage');
+ERROR:  invalid input syntax for type pg_snapshot: "garbage"
+HINT:  Use the token from the get_hypertable_invalidations() call.
+CONTEXT:  PL/pgSQL function _timescaledb_functions.accept_hypertable_invalidations(regclass,text) line 29 at RAISE
+\set ON_ERROR_STOP 1
+-- Accept the invalidations as processed by passing in the token.
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_ts', :'token');
+-- This should now show no validations.
+SELECT bucket_width, invalidations
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+       'hyper_ts',
+       null::timestamp,
+       array['15 minutes', '1 hour']::interval[]
+  );
+ bucket_width | invalidations 
+--------------+---------------
+(0 rows)
+
+-- Check that the invalidations associated with the token are removed
+-- when there are inserts in between.
+-- First insert some rows. All invalidations were removed above, so we
+-- should only see these.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-03 10:00:00'::timestamp,
+                         '2025-01-03 11:12:00', '10 minutes') time;
+-- Get invalidations from the hypertable, with a token.
+SELECT * INTO saved_3
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+	'hyper_ts',
+	null::timestamp,
+	array['15 minutes', '1 hour']::interval[]
+  );
+SELECT token FROM saved_3 LIMIT 1 \gset
+-- Insert some more rows into the hypertable that are disjoint with
+-- the invalidations associated with the token above. These should be
+-- fully removed.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-02 10:00:00'::timestamp,
+                         '2025-01-02 11:12:00', '10 minutes') time;
+-- Insert some more rows into the hypertable that are inside the range
+-- associated with the token above. These should remain after
+-- accepting the token.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-03 10:30:00'::timestamp,
+                         '2025-01-03 10:50:00', '5 minutes') time;
+-- Check that we have them in the invalidation log
+SELECT bucket_width, unnest(invalidations) AS inval
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+	'hyper_ts',
+	null::timestamp,
+	array['15 minutes', '1 hour']::interval[]
+  )
+ORDER BY 1, 2;
+ bucket_width |                     inval                     
+--------------+-----------------------------------------------
+ @ 15 mins    | ["2025-01-02 10:00:00","2025-01-02 11:15:00")
+ @ 15 mins    | ["2025-01-03 10:00:00","2025-01-03 11:15:00")
+ @ 1 hour     | ["2025-01-02 10:00:00","2025-01-02 12:00:00")
+ @ 1 hour     | ["2025-01-03 10:00:00","2025-01-03 12:00:00")
+(4 rows)
+
+-- Accept the original invalidations
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_ts', :'token');
+-- Check that we only removed the ones associated with the token.
+SELECT bucket_width, unnest(invalidations) AS inval
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+	'hyper_ts',
+	null::timestamp,
+	array['15 minutes', '1 hour']::interval[]
+  )
+ORDER BY 1, 2;
+ bucket_width |                     inval                     
+--------------+-----------------------------------------------
+ @ 15 mins    | ["2025-01-02 10:00:00","2025-01-02 11:15:00")
+ @ 15 mins    | ["2025-01-03 10:30:00","2025-01-03 11:00:00")
+ @ 1 hour     | ["2025-01-02 10:00:00","2025-01-02 12:00:00")
+ @ 1 hour     | ["2025-01-03 10:00:00","2025-01-03 11:00:00")
+(4 rows)
+

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -21,6 +21,7 @@ WHERE proname <> 'get_telemetry_report'
 ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text COLLATE "C";
  _timescaledb_debug.extension_state()
  _timescaledb_debug.is_compressed_tid(tid)
+ _timescaledb_functions.accept_hypertable_invalidations(regclass,text)
  _timescaledb_functions.add_materialization_invalidations(regclass,tsrange)
  _timescaledb_functions.add_materialization_invalidations(regclass,tstzrange)
  _timescaledb_functions.align_to_bucket(interval,anyrange)
@@ -80,6 +81,9 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.get_compressed_chunk_index_for_recompression(regclass)
  _timescaledb_functions.get_create_command(name)
  _timescaledb_functions.get_git_commit()
+ _timescaledb_functions.get_hypertable_id(regclass,regtype)
+ _timescaledb_functions.get_hypertable_invalidations(regclass,timestamp with time zone,interval[])
+ _timescaledb_functions.get_hypertable_invalidations(regclass,timestamp without time zone,interval[])
  _timescaledb_functions.get_internal_time_max(regtype)
  _timescaledb_functions.get_internal_time_min(regtype)
  _timescaledb_functions.get_materialization_info(regclass)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -7,13 +7,13 @@ set(TEST_FILES
     bgw_job_ddl.sql
     bgw_policy.sql
     bgw_security.sql
+    cagg_api.sql
     cagg_deprecated_bucket_ng.sql
     cagg_errors.sql
     cagg_invalidation.sql
     cagg_policy.sql
     cagg_refresh.sql
     cagg_refresh_using_merge.sql
-    cagg_api.sql
     cagg_utils.sql
     cagg_watermark.sql
     chunk_column_stats.sql

--- a/tsl/test/sql/cagg_api.sql
+++ b/tsl/test/sql/cagg_api.sql
@@ -157,3 +157,145 @@ SELECT * FROM _timescaledb_functions.get_materialization_invalidations(
        'tstz_temperature_15m'::regclass,
        '["2025-04-25","2025-04-26"]'::tstzrange
 );
+-- Generate some invalidations. These new values need to be before the
+-- invalidation threshold, which is set to end time of the insertion
+-- above.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-04 10:00:00'::timestamp,
+                         '2025-01-04 11:12:00', '9 minutes') time;
+
+INSERT INTO hyper_tstz
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-04 12:00:00'::timestamptz,
+                         '2025-01-04 13:12:00', '8 minutes') time;
+
+-- Check the invalidation threshold. If that is not after the
+-- insertions above, nothing will show up in the invalidation log.
+SELECT hypertable_id,
+       _timescaledb_functions.to_timestamp_without_timezone(watermark) AS watermark
+  FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+  ORDER BY 1;
+
+-- Check that there indeed is something in the hypertable invalidation
+-- log. If not, this will fail anyway. We show the "raw" timestamps,
+-- which is in UTC if it was originally a timestamp with timezone.
+SELECT hypertable_id,
+       _timescaledb_functions.to_timestamp_without_timezone(lowest_modified_value) AS start,
+       _timescaledb_functions.to_timestamp_without_timezone(greatest_modified_value) AS finish
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+  ORDER BY 1;
+
+\set VERBOSITY default
+
+-- Check that we can handle hypertables with single and multiple
+-- dimensions. This function is not part of the official API but we
+-- add tests for it here.
+SELECT _timescaledb_functions.get_hypertable_id('hyper_ts', 'timestamp');
+SELECT _timescaledb_functions.get_hypertable_id('hyper_tstz', 'timestamptz');
+SELECT _timescaledb_functions.get_hypertable_id('hyper_multi', 'timestamptz');
+
+\set ON_ERROR_STOP 0
+-- Not a hypertable
+SELECT _timescaledb_functions.get_hypertable_id('normal_ts', 'timestamp');
+SELECT _timescaledb_functions.get_hypertable_invalidations('normal_ts', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+-- No continuous aggregate connected
+SELECT _timescaledb_functions.get_hypertable_id('hyper_no_cagg', 'timestamp');
+SELECT _timescaledb_functions.get_hypertable_invalidations('hyper_no_cagg', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+-- Wrong type used
+SELECT _timescaledb_functions.get_hypertable_id('hyper_ts', 'timestamptz');
+SELECT _timescaledb_functions.get_hypertable_invalidations('hyper_ts', null::timestamptz, array['15 minutes', '1 hour']::interval[]);
+\set ON_ERROR_STOP 1
+
+SELECT * INTO saved_invalidations_1
+  FROM _timescaledb_functions.get_hypertable_invalidations('hyper_ts', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+
+SELECT bucket_width, invalidations FROM saved_invalidations_1;
+
+-- Calling it twice should return same invalidations since we haven't
+-- inserted anything between.
+SELECT * INTO saved_invalidations_2
+  FROM _timescaledb_functions.get_hypertable_invalidations('hyper_ts', null::timestamp, array['15 minutes', '1 hour']::interval[]);
+
+SELECT * FROM saved_invalidations_2 s1
+    FULL JOIN saved_invalidations_2 s2 ON row(s1.*) = row(s2.*)
+        WHERE s1.token IS NULL OR s2.token IS NULL;
+
+SELECT token FROM saved_invalidations_1 LIMIT 1 \gset
+
+-- Test some error cases
+\set ON_ERROR_STOP 0
+CALL _timescaledb_functions.accept_hypertable_invalidations('normal_ts', :'token');
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_no_cagg', :'token');
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_ts', 'garbage');
+\set ON_ERROR_STOP 1
+
+-- Accept the invalidations as processed by passing in the token.
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_ts', :'token');
+
+-- This should now show no validations.
+SELECT bucket_width, invalidations
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+       'hyper_ts',
+       null::timestamp,
+       array['15 minutes', '1 hour']::interval[]
+  );
+
+-- Check that the invalidations associated with the token are removed
+-- when there are inserts in between.
+
+-- First insert some rows. All invalidations were removed above, so we
+-- should only see these.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-03 10:00:00'::timestamp,
+                         '2025-01-03 11:12:00', '10 minutes') time;
+
+-- Get invalidations from the hypertable, with a token.
+SELECT * INTO saved_3
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+	'hyper_ts',
+	null::timestamp,
+	array['15 minutes', '1 hour']::interval[]
+  );
+
+SELECT token FROM saved_3 LIMIT 1 \gset
+
+-- Insert some more rows into the hypertable that are disjoint with
+-- the invalidations associated with the token above. These should be
+-- fully removed.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-02 10:00:00'::timestamp,
+                         '2025-01-02 11:12:00', '10 minutes') time;
+
+-- Insert some more rows into the hypertable that are inside the range
+-- associated with the token above. These should remain after
+-- accepting the token.
+INSERT INTO hyper_ts
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2025-01-03 10:30:00'::timestamp,
+                         '2025-01-03 10:50:00', '5 minutes') time;
+
+-- Check that we have them in the invalidation log
+SELECT bucket_width, unnest(invalidations) AS inval
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+	'hyper_ts',
+	null::timestamp,
+	array['15 minutes', '1 hour']::interval[]
+  )
+ORDER BY 1, 2;
+
+-- Accept the original invalidations
+CALL _timescaledb_functions.accept_hypertable_invalidations('hyper_ts', :'token');
+
+-- Check that we only removed the ones associated with the token.
+SELECT bucket_width, unnest(invalidations) AS inval
+  FROM _timescaledb_functions.get_hypertable_invalidations(
+	'hyper_ts',
+	null::timestamp,
+	array['15 minutes', '1 hour']::interval[]
+  )
+ORDER BY 1, 2;
+
+


### PR DESCRIPTION
The API is intended to be used to read hypertable invalidations for a hypertable that has continuous aggregates. This commit adds two functions: `get_hypertable_invalidations` and
`accept_hypertable_invalidations`.

The function `get_hypertable_invalidations` will get the current invalidations for buckets of a suitable size. It will also return a token that can be used when accepting the invalidations.

The function `accept_hypertable_invalidations` will take a token and remove all invalidations that are associated with that token.