### PR TITLE
Switch to old git runner with latest docker image

### DIFF
--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -18,13 +18,13 @@ jobs:
 
   assign-pr:
     name: Assign PR to author
-    runs-on: timescaledb-runner-arm64
+    runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0
 
   ask-review:
     name: Run pull-review
-    runs-on: timescaledb-runner-arm64
+    runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Switch back to old git runner that has the docker image for ghcr.io/imsky/pull-review for the job "Assign PR to author and
reviewers" 

Disable-check: force-changelog-file