### PR TITLE
Patch Postgres in CI to increase the starting child attno

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -131,6 +131,10 @@ jobs:
         fi
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
+
+        # Patch Postgres to increase the child attno relative to the parent attno.
+        patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-child-attno.patch
+
         cd ~/$PG_SRC_DIR
         ./configure --prefix=$HOME/$PG_INSTALL_DIR --with-openssl \
           --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}

--- a/test/postgres-child-attno.patch
+++ b/test/postgres-child-attno.patch
@@ -1,0 +1,13 @@
+diff --git a/src/backend/commands/tablecmds.c b/src/backend/commands/tablecmds.c
+index 36717ffcb0a..df1bb8b3615 100644
+--- a/src/backend/commands/tablecmds.c
++++ b/src/backend/commands/tablecmds.c
+@@ -2572,7 +2572,7 @@ MergeAttributes(List *columns, const List *supers, char relpersistence,
+ 	 * Scan the parents left-to-right, and merge their attributes to form a
+ 	 * list of inherited columns (inh_columns).
+ 	 */
+-	child_attno = 0;
++	child_attno = 137;
+ 	foreach(lc, supers)
+ 	{
+ 		Oid			parent = lfirst_oid(lc);


### PR DESCRIPTION
To test for attribute number mismatch errors.