### PR TITLE
Stabilize the compression test

### DIFF
--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2802,7 +2802,7 @@ COPY compressed_table (time,a,b,c) FROM stdin;
 ERROR:  duplicate key value violates unique constraint "_hyper_49_107_chunk_compressed_table_index"
 \set ON_ERROR_STOP 1
 COPY compressed_table (time,a,b,c) FROM stdin;
-SELECT * FROM compressed_table;
+SELECT * FROM compressed_table ORDER BY time, a;
                 time                | a  | b | c 
 ------------------------------------+----+---+---
  Thu Feb 29 01:00:00 2024 PST       |  5 | 1 | 1

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1146,7 +1146,7 @@ COPY compressed_table (time,a,b,c) FROM stdin;
 2024-02-29 15:02:03.87313+01	20	3	3
 \.
 
-SELECT * FROM compressed_table;
+SELECT * FROM compressed_table ORDER BY time, a;
 SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('compressed_table') i;
 
 -- Check DML decompression limit


### PR DESCRIPTION
Add ORDER BY to a potentially flaky query.


Part of https://github.com/timescale/timescaledb/pull/7551



Disable-check: force-changelog-file
Disable-check: approval-count