### PR TITLE
Clean up before style checks

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Run format on CMake files
         run: |
+          git reset --hard
           find  -name CMakeLists.txt  -exec cmake-format -i {} +
           find src test tsl -name '*.cmake' -exec cmake-format -i {} +
-      - name: Check for diff
-        run: git diff --exit-code
+          git diff --exit-code
 
   perl_checks:
     name: Check Perl code in tree
@@ -38,6 +38,7 @@ jobs:
       - name: Format Perl files, if needed
         if: always()
         run: |
+          git reset --hard
           find . -name '*.p[lm]' -exec perltidy -b -bext=/ {} +
           git diff --exit-code
 
@@ -79,6 +80,7 @@ jobs:
     - name: Check trailing whitespace
       if: always()
       run: |
+        git reset --hard
         find . -type f -regex '.*\.\(c\|h\|sql\|sql\.in\)$' -exec perl -pi -e 's/[ \t]+$//' {} +
         git diff --exit-code
 
@@ -88,6 +90,7 @@ jobs:
         sudo apt install clang-format-14
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
         sudo update-alternatives --set clang-format /usr/bin/clang-format-14
+        git reset --hard
         ./scripts/clang_format_all.sh
         git diff --exit-code
 
@@ -109,6 +112,7 @@ jobs:
 
       - name: Run prospector
         run: |
+          git reset --hard
           find . -type f -name "*.py" -print -exec prospector {} + -exec black {} +
           git diff --exit-code
 


### PR DESCRIPTION
Do git reset in actions that use git diff, otherwise the errors from the previous checks get mixed into the output of the subsequent checks.

Disable-check: force-changelog-file