### PR TITLE
Fire event triggers on chunk creation

### DIFF
--- a/.unreleased/pr_8012
+++ b/.unreleased/pr_8012
@@ -1,0 +1,1 @@
+Implements: #8012 Add event triggers support on chunk creation

--- a/src/guc.c
+++ b/src/guc.c
@@ -163,6 +163,7 @@ TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
+bool ts_guc_enable_event_triggers = false;
 
 /* Only settable in debug mode for testing */
 TSDLLEXPORT bool ts_guc_enable_null_compression = true;
@@ -829,6 +830,16 @@ _guc_init(void)
 							NULL,
 							NULL,
 							NULL);
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_event_triggers"),
+							 "Enable event triggers for chunks creation",
+							 "Enable event triggers for chunks creation",
+							 &ts_guc_enable_event_triggers,
+							 false,
+							 PGC_SUSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 
 #ifdef TS_DEBUG
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_null_compression"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -76,6 +76,7 @@ extern TSDLLEXPORT int ts_guc_compression_batch_size_limit;
 #if PG16_GE
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif
+extern bool ts_guc_enable_event_triggers;
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1814,6 +1814,50 @@ SELECT * FROM event ORDER BY ts;
 ----+------
 (0 rows)
 
--- clean up databases created
+-- event triggers on chunk creation
+CREATE TABLE ht_try(timec timestamptz NOT NULL, acq_id bigint, value bigint);
+SELECT create_hypertable('ht_try', 'timec', chunk_time_interval => interval '1 day');
+  create_hypertable   
+----------------------
+ (25,public,ht_try,t)
+(1 row)
+
+-- creating event triggers requires superuser permissions
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- event trigger on ddl_start
+CREATE OR REPLACE FUNCTION ddl_start_trigger_func() RETURNS EVENT_TRIGGER AS
+$$
+BEGIN
+    RAISE NOTICE 'ddl_start_trigger_func() is invoked';
+END;
+$$ LANGUAGE plpgsql;
+CREATE EVENT TRIGGER ddl_start_trigger
+ON ddl_command_start WHEN TAG IN ('CREATE TABLE') EXECUTE FUNCTION ddl_start_trigger_func();
+-- event trigger on ddl_end
+CREATE OR REPLACE FUNCTION ddl_end_trigger_func() RETURNS EVENT_TRIGGER AS
+$$
+DECLARE
+    cmd RECORD;
+BEGIN
+    RAISE NOTICE 'ddl_end_trigger_func() is invoked';
+    FOR cmd IN SELECT * FROM pg_event_trigger_ddl_commands()
+    LOOP
+        RAISE NOTICE 'tag: %, object: %', cmd.command_tag, cmd.object_identity::regclass;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+CREATE EVENT TRIGGER ddl_end_trigger
+ON ddl_command_end WHEN TAG IN ('CREATE TABLE') EXECUTE FUNCTION ddl_end_trigger_func();
+-- by default event triggers on chunk creation are disabled
+INSERT INTO ht_try VALUES ('2025-05-01 00:00', 1, 10);
+SET timescaledb.enable_event_triggers = on;
+INSERT INTO ht_try VALUES ('2025-05-02 00:00', 1, 10);
+NOTICE:  ddl_start_trigger_func() is invoked
+NOTICE:  ddl_end_trigger_func() is invoked
+NOTICE:  tag: CREATE TABLE, object: _timescaledb_internal._hyper_25_41_chunk
+RESET timescaledb.enable_event_triggers;
+DROP EVENT TRIGGER ddl_start_trigger;
+DROP EVENT TRIGGER ddl_end_trigger;
+DROP TABLE ht_try;
+-- clean up databases created
 DROP DATABASE postgres_fdw_db WITH (FORCE);


### PR DESCRIPTION
Add support for event triggers on chunk creation. Event triggers are disabled by default but can be enabled with `timescaledb.enable_event_triggers` GUC.