### PR TITLE
Enable bool compression

### DIFF
--- a/.unreleased/pr_8014
+++ b/.unreleased/pr_8014
@@ -1,0 +1,1 @@
+Implements: #8014 enable bool compression by default by setting `timescaledb.enable_bool_compression=true`. Note: for downgrading to 2.18 or earlier version one needs to use the provided downgrade script in 'timescaledb-extras'.

--- a/src/guc.c
+++ b/src/guc.c
@@ -160,7 +160,7 @@ TSDLLEXPORT bool ts_guc_default_hypercore_use_access_method = false;
 bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
-TSDLLEXPORT bool ts_guc_enable_bool_compression = false;
+TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
 
@@ -802,10 +802,10 @@ _guc_init(void)
 							 NULL);
 
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_bool_compression"),
-							 "Enable experimental bool compression functionality",
+							 "Enable bool compression functionality",
 							 "Enable bool compression",
 							 &ts_guc_enable_bool_compression,
-							 false,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/tsl/src/compression/algorithms/array.c
+++ b/tsl/src/compression/algorithms/array.c
@@ -18,6 +18,7 @@
 #include "compression/compression.h"
 #include "datum_serialize.h"
 #include "simple8b_rle.h"
+#include "simple8b_rle_bitarray.h"
 #include "simple8b_rle_bitmap.h"
 
 #include "compression/arrow_c_data_interface.h"
@@ -467,6 +468,90 @@ tsl_array_decompression_iterator_from_datum_reverse(Datum compressed_array, Oid 
 	iterator->deserializer = create_datum_deserializer(iterator->base.element_type);
 
 	return &iterator->base;
+}
+
+/* Pass through to the specialized functions below for BOOL and TEXT */
+ArrowArray *
+tsl_array_decompress_all(Datum compressed_array, Oid element_type, MemoryContext dest_mctx)
+{
+	switch (element_type)
+	{
+		case BOOLOID:
+			return tsl_bool_array_decompress_all(compressed_array, element_type, dest_mctx);
+		case TEXTOID:
+			return tsl_text_array_decompress_all(compressed_array, element_type, dest_mctx);
+		default:
+			elog(ERROR, "unsupported array type %u", element_type);
+			break;
+	}
+	return NULL;
+}
+
+ArrowArray *
+tsl_bool_array_decompress_all(Datum compressed_array, Oid element_type, MemoryContext dest_mctx)
+{
+	Assert(element_type == BOOLOID);
+	void *compressed_data = PG_DETOAST_DATUM(compressed_array);
+	StringInfoData si = { .data = compressed_data, .len = VARSIZE(compressed_data) };
+	ArrayCompressed *header = consumeCompressedData(&si, sizeof(ArrayCompressed));
+
+	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_ARRAY);
+	CheckCompressedData(header->element_type == BOOLOID);
+
+	Simple8bRleSerialized *nulls_serialized = NULL;
+	if (header->has_nulls)
+	{
+		nulls_serialized = bytes_deserialize_simple8b_and_advance(&si);
+	}
+
+	Simple8bRleSerialized *sizes_serialized = bytes_deserialize_simple8b_and_advance(&si);
+
+	const uint32 n_notnull = sizes_serialized->num_elements;
+	const uint32 n_total = header->has_nulls ? nulls_serialized->num_elements : n_notnull;
+	const uint32 n_padded_bits = n_total + 63;
+	const uint32 n_padded_bytes = n_padded_bits / 8;
+
+	uint64 *validity_bitmap = NULL;
+	uint64 *values = MemoryContextAllocZero(dest_mctx, n_padded_bytes);
+
+	MemoryContext old_context = MemoryContextSwitchTo(dest_mctx);
+	/* Decompress the nulls */
+	Simple8bRleBitArray validity_bits =
+		simple8brle_bitarray_decompress(nulls_serialized, /* inverted*/ true);
+	validity_bitmap = validity_bits.data;
+	MemoryContextSwitchTo(old_context);
+
+	/* Decompress the values using the iterator based decompressor */
+	{
+		int position = 0;
+		DecompressionIterator *iter =
+			tsl_array_decompression_iterator_from_datum_forward(PointerGetDatum(compressed_data),
+																BOOLOID);
+		for (DecompressResult r = array_decompression_iterator_try_next_forward(iter); !r.is_done;
+			 r = array_decompression_iterator_try_next_forward(iter))
+		{
+			if (!r.is_null)
+			{
+				bool data = DatumGetBool(r.val) == true;
+				if (data)
+				{
+					arrow_set_row_validity(values, position, true);
+				}
+			}
+			++position;
+		}
+	}
+
+	ArrowArray *result =
+		MemoryContextAllocZero(dest_mctx, sizeof(ArrowArray) + (sizeof(void *) * 2));
+	const void **buffers = (const void **) &result[1];
+	buffers[0] = validity_bitmap;
+	buffers[1] = values;
+	result->n_buffers = 2;
+	result->buffers = buffers;
+	result->length = n_total;
+	result->null_count = n_total - n_notnull;
+	return result;
 }
 
 #define ELEMENT_TYPE uint32

--- a/tsl/src/compression/algorithms/array.h
+++ b/tsl/src/compression/algorithms/array.h
@@ -65,6 +65,11 @@ extern void array_compressed_send(CompressedDataHeader *header, StringInfo buffe
 extern Datum tsl_array_compressor_append(PG_FUNCTION_ARGS);
 extern Datum tsl_array_compressor_finish(PG_FUNCTION_ARGS);
 
+/* Pass through to the specialized functions below for BOOL and TEXT */
+ArrowArray *tsl_array_decompress_all(Datum compressed_array, Oid element_type,
+									 MemoryContext dest_mctx);
+ArrowArray *tsl_bool_array_decompress_all(Datum compressed_array, Oid element_type,
+										  MemoryContext dest_mctx);
 ArrowArray *tsl_text_array_decompress_all(Datum compressed_array, Oid element_type,
 										  MemoryContext dest_mctx);
 
@@ -79,5 +84,5 @@ ArrowArray *text_array_decompress_all_serialized_no_header(StringInfo si, bool h
 		.compressed_data_recv = array_compressed_recv,                                             \
 		.compressor_for_type = array_compressor_for_type,                                          \
 		.compressed_data_storage = TOAST_STORAGE_EXTENDED,                                         \
-		.decompress_all = tsl_text_array_decompress_all,                                           \
+		.decompress_all = tsl_array_decompress_all,                                                \
 	}

--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -26,6 +26,7 @@
 #include "dictionary.h"
 #include "dictionary_hash.h"
 #include "simple8b_rle.h"
+#include "simple8b_rle_bitarray.h"
 #include "simple8b_rle_bitmap.h"
 
 /*
@@ -404,6 +405,91 @@ dictionary_decompression_iterator_init(DictionaryDecompressionIterator *iter, co
 		iter->values[i] = res.val;
 	}
 	Assert(array_decompression_iterator_try_next_forward(dictionary_iterator).is_done);
+}
+
+/* Pass through to the specialized functions below for BOOL and TEXT */
+ArrowArray *
+tsl_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
+{
+	switch (element_type)
+	{
+		case BOOLOID:
+			return tsl_bool_dictionary_decompress_all(compressed, element_type, dest_mctx);
+		case TEXTOID:
+			return tsl_text_dictionary_decompress_all(compressed, element_type, dest_mctx);
+		default:
+			elog(ERROR, "unsupported dictionary type %u", element_type);
+			break;
+	}
+	return NULL;
+}
+
+ArrowArray *
+tsl_bool_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
+{
+	Assert(element_type == BOOLOID);
+
+	compressed = PointerGetDatum(PG_DETOAST_DATUM(compressed));
+	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
+	const DictionaryCompressed *header = consumeCompressedData(&si, sizeof(DictionaryCompressed));
+
+	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_DICTIONARY);
+	CheckCompressedData(header->element_type == BOOLOID);
+
+	Simple8bRleSerialized *indices_serialized = bytes_deserialize_simple8b_and_advance(&si);
+
+	Simple8bRleSerialized *nulls_serialized = NULL;
+	if (header->has_nulls)
+	{
+		nulls_serialized = bytes_deserialize_simple8b_and_advance(&si);
+	}
+
+	const uint32 n_notnull = indices_serialized->num_elements;
+	const uint32 n_total = header->has_nulls ? nulls_serialized->num_elements : n_notnull;
+	const uint32 n_padded_bits = n_total + 63;
+	const uint32 n_padded_bytes = n_padded_bits / 8;
+
+	uint64 *validity_bitmap = NULL;
+	uint64 *values = MemoryContextAllocZero(dest_mctx, n_padded_bytes);
+
+	MemoryContext old_context = MemoryContextSwitchTo(dest_mctx);
+	/* Decompress the nulls */
+	Simple8bRleBitArray validity_bits =
+		simple8brle_bitarray_decompress(nulls_serialized, /* inverted*/ true);
+	validity_bitmap = validity_bits.data;
+	MemoryContextSwitchTo(old_context);
+
+	/* Decompress the values using the iterator based decompressor */
+	{
+		int position = 0;
+		DecompressionIterator *iter =
+			tsl_dictionary_decompression_iterator_from_datum_forward(compressed, BOOLOID);
+		for (DecompressResult r = dictionary_decompression_iterator_try_next_forward(iter);
+			 !r.is_done;
+			 r = dictionary_decompression_iterator_try_next_forward(iter))
+		{
+			if (!r.is_null)
+			{
+				bool data = DatumGetBool(r.val) == true;
+				if (data)
+				{
+					arrow_set_row_validity(values, position, true);
+				}
+			}
+			++position;
+		}
+	}
+
+	ArrowArray *result =
+		MemoryContextAllocZero(dest_mctx, sizeof(ArrowArray) + (sizeof(void *) * 2));
+	const void **buffers = (const void **) &result[1];
+	buffers[0] = validity_bitmap;
+	buffers[1] = values;
+	result->n_buffers = 2;
+	result->buffers = buffers;
+	result->length = n_total;
+	result->null_count = n_total - n_notnull;
+	return result;
 }
 
 #define ELEMENT_TYPE int16

--- a/tsl/src/compression/algorithms/dictionary.h
+++ b/tsl/src/compression/algorithms/dictionary.h
@@ -48,9 +48,11 @@ extern Datum dictionary_compressed_recv(StringInfo buf);
 extern Datum tsl_dictionary_compressor_append(PG_FUNCTION_ARGS);
 extern Datum tsl_dictionary_compressor_finish(PG_FUNCTION_ARGS);
 
-ArrowArray *tsl_text_array_decompress_all(Datum compressed_array, Oid element_type,
+/* Pass through to the specialized functions below for BOOL and TEXT */
+ArrowArray *tsl_dictionary_decompress_all(Datum compressed, Oid element_type,
 										  MemoryContext dest_mctx);
-
+ArrowArray *tsl_bool_dictionary_decompress_all(Datum compressed, Oid element_type,
+											   MemoryContext dest_mctx);
 ArrowArray *tsl_text_dictionary_decompress_all(Datum compressed, Oid element_type,
 											   MemoryContext dest_mctx);
 
@@ -62,5 +64,5 @@ ArrowArray *tsl_text_dictionary_decompress_all(Datum compressed, Oid element_typ
 		.compressed_data_recv = dictionary_compressed_recv,                                        \
 		.compressor_for_type = dictionary_compressor_for_type,                                     \
 		.compressed_data_storage = TOAST_STORAGE_EXTENDED,                                         \
-		.decompress_all = tsl_text_dictionary_decompress_all,                                      \
+		.decompress_all = tsl_dictionary_decompress_all,                                           \
 	}

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -106,7 +106,7 @@ tsl_get_decompress_all_function(CompressionAlgorithm algorithm, Oid type)
 	if (algorithm >= _END_COMPRESSION_ALGORITHMS)
 		elog(ERROR, "invalid compression algorithm %d", algorithm);
 
-	if (type != TEXTOID &&
+	if (type != TEXTOID && type != BOOLOID &&
 		(algorithm == COMPRESSION_ALGORITHM_DICTIONARY || algorithm == COMPRESSION_ALGORITHM_ARRAY))
 	{
 		/* Bulk decompression of array and dictionary is only supported for text. */

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -3512,4 +3512,143 @@ select * from bool_table where b is not null order by 1;
  101 | f
 (2 rows)
 
+-- At this point the bool data is generated as 'bool compression disabed'
+-- meaning, it is compressed with array compression. I try to confuse the
+-- executor by creating a vectorized plan and still hoping to get the right
+-- results.
+set timescaledb.debug_require_vector_qual to 'require';
+set timescaledb.enable_bool_compression = on;
+select * from bool_table where b is true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not true order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is not false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b is unknown order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not unknown order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b = false order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b = false order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true or b is null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = true or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = true and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = true and b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+(1 row)
+
+select * from bool_table where b = false order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b = false or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b = false and b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b = false and b is not null order by 1;
+ ts  | b 
+-----+---
+ 101 | f
+(1 row)
+
+select * from bool_table where b is null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is null or b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+select * from bool_table where b is null and b is not null order by 1;
+ ts | b 
+----+---
+(0 rows)
+
+select * from bool_table where b is not null order by 1;
+ ts  | b 
+-----+---
+ 100 | t
+ 101 | f
+(2 rows)
+
+reset timescaledb.debug_require_vector_qual;
 reset timescaledb.enable_bool_compression;

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -667,4 +667,35 @@ select * from bool_table where b is null or b is not null order by 1;
 select * from bool_table where b is null and b is not null order by 1;
 select * from bool_table where b is not null order by 1;
 
+-- At this point the bool data is generated as 'bool compression disabed'
+-- meaning, it is compressed with array compression. I try to confuse the
+-- executor by creating a vectorized plan and still hoping to get the right
+-- results.
+set timescaledb.debug_require_vector_qual to 'require';
+set timescaledb.enable_bool_compression = on;
+select * from bool_table where b is true order by 1;
+select * from bool_table where b is false order by 1;
+select * from bool_table where b is not true order by 1;
+select * from bool_table where b is not false order by 1;
+select * from bool_table where b is unknown order by 1;
+select * from bool_table where b is not unknown order by 1;
+select * from bool_table where b = true order by 1;
+select * from bool_table where b = true or b = false order by 1;
+select * from bool_table where b = true and b = false order by 1;
+select * from bool_table where b = true or b is null order by 1;
+select * from bool_table where b = true or b is not null order by 1;
+select * from bool_table where b = true and b is null order by 1;
+select * from bool_table where b = true and b is not null order by 1;
+select * from bool_table where b = false order by 1;
+select * from bool_table where b = false or b is null order by 1;
+select * from bool_table where b = false or b is not null order by 1;
+select * from bool_table where b = false and b is null order by 1;
+select * from bool_table where b = false and b is not null order by 1;
+select * from bool_table where b is null order by 1;
+select * from bool_table where b is null or b is not null order by 1;
+select * from bool_table where b is null and b is not null order by 1;
+select * from bool_table where b is not null order by 1;
+
+reset timescaledb.debug_require_vector_qual;
 reset timescaledb.enable_bool_compression;
+

--- a/tsl/test/src/compression_unit_test.c
+++ b/tsl/test/src/compression_unit_test.c
@@ -735,6 +735,9 @@ test_bool_array(bool nulls, int run_length, int expected_size)
 	DecompressionIterator *iter =
 		tsl_array_decompression_iterator_from_datum_forward(compressed, BOOLOID);
 
+	ArrowArray *bulk_result = tsl_array_decompress_all(compressed, BOOLOID, CurrentMemoryContext);
+	const uint64 *bulk_data = bulk_result->buffers[1];
+
 	for (int i = 0; i < TEST_ELEMENTS; ++i)
 	{
 		DecompressResult r = array_decompression_iterator_try_next_forward(iter);
@@ -742,9 +745,17 @@ test_bool_array(bool nulls, int run_length, int expected_size)
 		if (rlen == 0)
 		{
 			if (nulls)
+			{
+				TestAssertTrue(!arrow_row_is_valid(bulk_result->buffers[0], i));
 				TestAssertTrue(r.is_null);
+			}
 			else
+			{
 				TestAssertTrue(DatumGetBool(r.val) == val);
+				const int16 block = i / 64;
+				const int16 offset = i % 64;
+				TestAssertTrue(((bulk_data[block] >> offset) & 1UL) == (int) val);
+			}
 			rlen = run_length;
 			val = !val;
 		}
@@ -752,11 +763,87 @@ test_bool_array(bool nulls, int run_length, int expected_size)
 		{
 			TestAssertTrue(r.is_null == false);
 			TestAssertTrue(DatumGetBool(r.val) == val);
+			const int16 block = i / 64;
+			const int16 offset = i % 64;
+			TestAssertTrue(((bulk_data[block] >> offset) & 1UL) == (int) val);
 			--rlen;
 		}
 	}
 
 	DecompressResult r = array_decompression_iterator_try_next_forward(iter);
+	TestAssertTrue(r.is_done);
+}
+
+static void
+test_bool_dictionary(bool nulls, int run_length, int expected_size)
+{
+	Compressor *compressor = dictionary_compressor_for_type(BOOLOID);
+	int rlen = run_length;
+	bool val = true;
+	for (int i = 0; i < TEST_ELEMENTS; ++i)
+	{
+		if (rlen == 0)
+		{
+			if (nulls)
+				compressor->append_null(compressor);
+			else
+				compressor->append_val(compressor, BoolGetDatum(val));
+			rlen = run_length;
+			val = !val;
+		}
+		else
+		{
+			compressor->append_val(compressor, BoolGetDatum(val));
+			--rlen;
+		}
+	}
+
+	Datum compressed = (Datum) compressor->finish(compressor);
+	TestAssertTrue(DatumGetPointer(compressed) != NULL);
+	TestAssertInt64Eq(VARSIZE(DatumGetPointer(compressed)), expected_size);
+
+	rlen = run_length;
+	val = true;
+	DecompressionIterator *iter =
+		tsl_dictionary_decompression_iterator_from_datum_forward(compressed, BOOLOID);
+
+	ArrowArray *bulk_result =
+		tsl_dictionary_decompress_all(compressed, BOOLOID, CurrentMemoryContext);
+	const uint64 *bulk_data = bulk_result->buffers[1];
+
+	for (int i = 0; i < TEST_ELEMENTS; ++i)
+	{
+		DecompressResult r = dictionary_decompression_iterator_try_next_forward(iter);
+		TestAssertTrue(!r.is_done);
+		if (rlen == 0)
+		{
+			if (nulls)
+			{
+				TestAssertTrue(!arrow_row_is_valid(bulk_result->buffers[0], i));
+				TestAssertTrue(r.is_null);
+			}
+			else
+			{
+				TestAssertTrue(DatumGetBool(r.val) == val);
+				const int16 block = i / 64;
+				const int16 offset = i % 64;
+				TestAssertTrue(((bulk_data[block] >> offset) & 1UL) == (int) val);
+			}
+			rlen = run_length;
+			val = !val;
+		}
+		else
+		{
+			TestAssertTrue(r.is_null == false);
+			TestAssertTrue(DatumGetBool(r.val) == val);
+			const int16 block = i / 64;
+			const int16 offset = i % 64;
+			TestAssertTrue(((bulk_data[block] >> offset) & 1UL) == (int) val);
+			--rlen;
+		}
+	}
+
+	DecompressResult r = dictionary_decompression_iterator_try_next_forward(iter);
 	TestAssertTrue(r.is_done);
 }
 
@@ -860,6 +947,15 @@ test_bool()
 	test_bool_array(/* nulls = */ false,
 					/* run_length = */ TEST_ELEMENTS + 1,
 					/* expected_size = */ 1055);
+
+	/* few select cases for comparison against bool compression: */
+	test_bool_dictionary(/* nulls = */ false, /* run_length = */ 1, /* expected_size = */ 186);
+	test_bool_dictionary(/* nulls = */ true, /* run_length = */ 19, /* expected_size = */ 330);
+	test_bool_dictionary(/* nulls = */ false, /* run_length = */ 600, /* expected_size = */ 74);
+	test_bool_dictionary(/* nulls = */ true, /* run_length = */ 720, /* expected_size = */ 114);
+	test_bool_dictionary(/* nulls = */ false,
+						 /* run_length = */ TEST_ELEMENTS + 1,
+						 /* expected_size = */ 65);
 
 	int baseline = bool_compressed_size(1, 1);
 	int no_rle = bool_compressed_size(64, 2);


### PR DESCRIPTION
This change sets the default for the GUC value:

`timescaledb.enable_bool_compression=true`

It enables bulk decompression for array and dictionary compression
for BOOLs because this is mandatory to support upgrades to 2.20.