### PR TITLE
Memory test fix

### DIFF
--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -6,6 +6,8 @@ name: Memory tests
       - prerelease_test
       - memory_test
       - trigger/memory_test
+  pull_request:
+    paths: .github/workflows/memory-tests.yaml
 jobs:
   memory_leak:
     name: Memory leak on insert PG${{ matrix.pg }}
@@ -36,6 +38,7 @@ jobs:
 
     - name: Setup database
       run: |
+        sudo pg_createcluster ${{matrix.pg}} main
         sudo tee -a /etc/postgresql/${{ matrix.pg }}/main/postgresql.conf <<-CONF
           shared_preload_libraries = 'timescaledb'
           max_worker_processes = 0


### PR DESCRIPTION
Cluster initialization was not happening automatically after the `postgresql` package was installed. Performing it manually fixes the error.

Also added the `pull_request` trigger to this test so that it is run whenever a PR modifying it is raised.

Closes #7959.

Disable-check: force-changelog-file