### PR TITLE
Don't build timescaledb with WARNINGS_AS_ERRORS in sqlsmith workflow

### DIFF
--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -92,7 +92,7 @@ jobs:
       run: |
         ./bootstrap -DCMAKE_BUILD_TYPE=Debug \
           -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR \
-          -DWARNINGS_AS_ERRORS=ON -DREQUIRE_ALL_TESTS=ON \
+          -DWARNINGS_AS_ERRORS=OFF -DREQUIRE_ALL_TESTS=ON \
           -DTEST_PG_LOG_DIRECTORY="$(readlink -f .)"
         make -j $(nproc) -C build
         make -C build install

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWARNINGS_AS_ERRORS=OFF
         make -j$(nproc) -C build
         sudo make -C build install
 


### PR DESCRIPTION
- **Don't build timescaledb with WARNINGS_AS_ERRORS in sqlsmith workflow**

Disable-check: force-changelog-file