### PR TITLE
Ignore result of bgw_launcher test in snapshot ABI workflow

### DIFF
--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -136,7 +136,7 @@ jobs:
       id: regresscheck
       run: |
           set -o pipefail
-          make -k -C build_snapshot installcheck | tee installcheck.log
+          make -k -C build_snapshot installcheck IGNORES=bgw_launcher | tee installcheck.log
 
     - name: Show regression diffs
       if: always()


### PR DESCRIPTION
- **Ignore result of bgw_launcher test in snapshot ABI workflow**


Disable-check: force-changelog-file