### PR TITLE
Enable SkipScan for multi-distincts with all but one pinned

### DIFF
--- a/.unreleased/pr_8047
+++ b/.unreleased/pr_8047
@@ -1,0 +1,1 @@
+Implements: #8047 Support SkipScan for SELECT DISTINCT with multiple distincts when all but one distinct is pinned

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -216,25 +216,70 @@ get_upper_distinct_expr(PlannerInfo *root, UpperRelationKind stage)
 
 	if (stage == UPPERREL_DISTINCT && root->parse->distinctClause)
 	{
-		foreach (lc, root->parse->distinctClause)
+		/* Obtain Distinct key from the target list, we ruled out numkeys > 1 cases before.
+		 * Examples of queries with 1 Distinct key but multiple target entries:
+		 * SELECT dev, dev FROM t; SELECT 1, dev FROM t; SELECT dev, time FROM t WHERE time = 100;
+		 */
+		if (root->distinct_pathkeys)
 		{
-			SortGroupClause *clause = lfirst_node(SortGroupClause, lc);
-			Node *expr = get_sortgroupclause_expr(clause, root->parse->targetList);
+			SortGroupClause *distinct_clause = NULL;
+#if PG16_GE
+			distinct_clause = linitial(root->processed_distinctClause);
+#else
+			PathKey *pathkey = linitial(root->distinct_pathkeys);
+			foreach (lc, root->parse->distinctClause)
+			{
+				SortGroupClause *clause = lfirst_node(SortGroupClause, lc);
+				if (clause->tleSortGroupRef == pathkey->pk_eclass->ec_sortref)
+				{
+					distinct_clause = clause;
+					break;
+				}
+			}
+#endif
+			Assert(distinct_clause);
+			Node *expr = get_sortgroupclause_expr(distinct_clause, root->parse->targetList);
 
 			/* we ignore any columns that can be constified to allow for cases like DISTINCT 'abc',
 			 * column */
 			if (IsA(estimate_expression_value(root, expr), Const))
-				continue;
-
-			num_vars++;
-			if (num_vars > 1)
 				return NULL;
 
 			/* We ignore binary-compatible relabeling */
 			tlexpr = (Expr *) expr;
 			while (tlexpr && IsA(tlexpr, RelabelType))
 				tlexpr = ((RelabelType *) tlexpr)->arg;
+
+			num_vars = 1;
 		}
+#if PG16_LT
+		/* In PG16+ we use LIMIT instead of UpperUniquePath for (numkeys = 0),
+		 * but in PG15- we would still create UpperUniquePath for (numkeys = 0), so handle this case
+		 * here
+		 */
+		else
+		{
+			foreach (lc, root->parse->distinctClause)
+			{
+				SortGroupClause *clause = lfirst_node(SortGroupClause, lc);
+				Node *expr = get_sortgroupclause_expr(clause, root->parse->targetList);
+
+				/* we ignore any columns that can be constified to allow for cases like DISTINCT
+				 * 'abc', column */
+				if (IsA(estimate_expression_value(root, expr), Const))
+					continue;
+
+				num_vars++;
+				if (num_vars > 1)
+					return NULL;
+
+				/* We ignore binary-compatible relabeling */
+				tlexpr = (Expr *) expr;
+				while (tlexpr && IsA(tlexpr, RelabelType))
+					tlexpr = ((RelabelType *) tlexpr)->arg;
+			}
+		}
+#endif
 	}
 #if PG16_GE
 	else if (stage == UPPERREL_GROUP_AGG)
@@ -336,6 +381,12 @@ obtain_upper_distinct_path(PlannerInfo *root, RelOptInfo *output_rel, DistinctPa
 				if (unique->numkeys > 1)
 					return;
 
+#if PG16_GE
+				/* since PG16+ we no longer create UpperUniquePath with 0 numkeys,
+				 * we create LIMIT path instead, so shouldn't be here with 0 numkeys
+				 */
+				Assert(unique->numkeys == 1);
+#endif
 				dpinfo->unique_path = (Path *) unique;
 				break;
 			}
@@ -705,7 +756,12 @@ skip_scan_path_create(PlannerInfo *root, Path *child_path, DistinctPathInfo *dpi
 
 	/* Also true for SkipScan over compressed chunks as can't have more distinct segmentby values
 	 * than number of batches */
-	int ndistinct = Min(dpinfo->unique_path->rows, indexscan_rows);
+	int ndistinct = indexscan_rows;
+	/* For SELECT DISTINCT path, #rows can cap "ndistinct",
+	 * but for Distinct aggregates #rows = 1 usually, i.e. we can't cap "ndistinct" in this case.
+	 */
+	if (dpinfo->stage == UPPERREL_DISTINCT)
+		ndistinct = Min(ndistinct, dpinfo->unique_path->rows);
 
 	/* If we are on a chunk rather than on a PG table, we want to get "ndistinct" for this chunk,
 	 * as Unique path rows may combine rows from each chunk and may not represent a true

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -1085,6 +1085,70 @@ WHERE CLAUSES
                Index Cond: (dev = 1)
 (4 rows)
 
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   ->  Unique (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (("time" = 100) AND (dev = 1))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1000 loops=1)
+         Index Cond: (dev_name = 'device_1'::text)
+(4 rows)
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (val = 100))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=19 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=19 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=19 loops=1)
+               Index Cond: ((dev = 1) AND ("time" > NULL::integer) AND ("time" < 20))
+(5 rows)
+
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -3116,6 +3180,88 @@ WHERE CLAUSES
                      Index Cond: (dev = 1)
 (15 rows)
 
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         Index Cond: (("time" = 100) AND (dev = 1))
+(4 rows)
+
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Result (actual rows=1000 loops=1)
+         ->  Append (actual rows=1000 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+(15 rows)
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (val = 100))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=20 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=20 loops=1)
+               Index Cond: ((dev = 1) AND ("time" > NULL::integer) AND ("time" < 20))
+(5 rows)
+
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -3947,17 +4093,18 @@ RESET enable_seqscan;
 (15 rows)
 
 -- multicolumn sort with dev as non-leading column and with leading column pinned
--- TODO: should be able to apply SkipScan here, issue created: #7998
+-- we are able to apply SkipScan here after resolving #7998
 :PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
-         Vectorized Filter: ("time" = 100)
-         Rows Removed by Filter: 2494
-         ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
-               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
-(6 rows)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 1492
+               ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+                     Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
 
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -1084,6 +1084,70 @@ WHERE CLAUSES
          Index Cond: (dev = 1)
 (3 rows)
 
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   ->  Limit (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (("time" = 100) AND (dev = 1))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+         Index Cond: (dev_name = 'device_1'::text)
+(4 rows)
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (val = 100))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=19 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=19 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=19 loops=1)
+               Index Cond: ((dev = 1) AND ("time" > NULL::integer) AND ("time" < 20))
+(5 rows)
+
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -3111,6 +3175,88 @@ WHERE CLAUSES
                Index Cond: (dev = 1)
 (11 rows)
 
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         Index Cond: (("time" = 100) AND (dev = 1))
+(4 rows)
+
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (never executed)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (never executed)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (never executed)
+                     Index Cond: (dev_name = 'device_1'::text)
+(15 rows)
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (val = 100))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=20 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=20 loops=1)
+               Index Cond: ((dev = 1) AND ("time" > NULL::integer) AND ("time" < 20))
+(5 rows)
+
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -3942,17 +4088,18 @@ RESET enable_seqscan;
 (15 rows)
 
 -- multicolumn sort with dev as non-leading column and with leading column pinned
--- TODO: should be able to apply SkipScan here, issue created: #7998
+-- we are able to apply SkipScan here after resolving #7998
 :PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
-         Vectorized Filter: ("time" = 100)
-         Rows Removed by Filter: 2494
-         ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
-               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
-(6 rows)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 1492
+               ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+                     Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
 
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -1084,6 +1084,70 @@ WHERE CLAUSES
          Index Cond: (dev = 1)
 (3 rows)
 
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   ->  Limit (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (("time" = 100) AND (dev = 1))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+         Index Cond: (dev_name = 'device_1'::text)
+(4 rows)
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (val = 100))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=19 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=19 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=19 loops=1)
+               Index Cond: ((dev = 1) AND ("time" > NULL::integer) AND ("time" < 20))
+(5 rows)
+
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -3112,6 +3176,88 @@ WHERE CLAUSES
                Index Cond: (dev = 1)
 (11 rows)
 
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         Index Cond: (("time" = 100) AND (dev = 1))
+(4 rows)
+
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (never executed)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (never executed)
+                     Index Cond: (dev_name = 'device_1'::text)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (never executed)
+                     Index Cond: (dev_name = 'device_1'::text)
+(15 rows)
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (val = 100))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: ("time" = 100)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=20 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=20 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=20 loops=1)
+               Index Cond: ((dev = 1) AND ("time" > NULL::integer) AND ("time" < 20))
+(5 rows)
+
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -3944,17 +4090,18 @@ RESET enable_seqscan;
 (15 rows)
 
 -- multicolumn sort with dev as non-leading column and with leading column pinned
--- TODO: should be able to apply SkipScan here, issue created: #7998
+-- we are able to apply SkipScan here after resolving #7998
 :PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
-         Vectorized Filter: ("time" = 100)
-         Rows Removed by Filter: 2494
-         ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
-               Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
-(6 rows)
+   ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               Vectorized Filter: ("time" = 100)
+               Rows Removed by Filter: 1492
+               ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+                     Index Cond: ((_ts_meta_min_1 <= 100) AND (_ts_meta_max_1 >= 100))
+(7 rows)
 
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -271,6 +271,14 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
 -- test constants in ORDER BY
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -475,6 +483,14 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
 -- test constants in ORDER BY
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -694,6 +710,14 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
 -- test constants in ORDER BY
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -898,6 +922,14 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
 -- test constants in ORDER BY
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -1001,7 +1033,7 @@ RESET enable_seqscan;
 -- Distinct column not a segmentby column: should be no SkipScan
 :PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
 -- multicolumn sort with dev as non-leading column and with leading column pinned
--- TODO: should be able to apply SkipScan here, issue created: #7998
+-- we are able to apply SkipScan here after resolving #7998
 :PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
@@ -1230,7 +1262,7 @@ RESET enable_seqscan;
 -- Distinct column not a segmentby column: should be no SkipScan
 :PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
 -- multicolumn sort with dev as non-leading column and with leading column pinned
--- TODO: should be able to apply SkipScan here, issue created: #7998
+-- we are able to apply SkipScan here after resolving #7998
 :PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;

--- a/tsl/test/sql/include/skip_scan_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_comp_query.sql
@@ -37,7 +37,7 @@ RESET enable_seqscan;
 :PREFIX SELECT DISTINCT time FROM :TABLE WHERE dev = 1 ORDER BY time DESC;
 
 -- multicolumn sort with dev as non-leading column and with leading column pinned
--- TODO: should be able to apply SkipScan here, issue created: #7998
+-- we are able to apply SkipScan here after resolving #7998
 :PREFIX SELECT DISTINCT time, dev FROM :TABLE WHERE time = 100 ORDER BY time, dev;
 
 -- multicolumn "segmentby = 'dev, dev_name'"

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -170,6 +170,15 @@ CREATE INDEX ON :TABLE(time,dev,val);
 
 -- test constants in ORDER BY
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE dev = 1 and time = 100 ORDER BY dev, time DESC;
+:PREFIX SELECT DISTINCT dev_name::varchar FROM :TABLE  WHERE dev_name::varchar = 'device_1' ORDER BY 1;
+
+-- test multiple distincts with all but one pinned: #7998
+:PREFIX SELECT DISTINCT dev, dev FROM :TABLE ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100 ORDER BY 1;
+:PREFIX SELECT DISTINCT ON (dev, time) * FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev = 1 AND time < 20 ORDER BY dev, time;
 
 -- CTE
 :PREFIX WITH devices AS (


### PR DESCRIPTION
Fixes #7998
We should be able to use SkipScan for queries like this if we have index on dev as only dev is a proper distinct column in below queries:

    SELECT DISTINCT dev, time FROM :TABLE WHERE time = 100;
    SELECT DISTINCT dev, time, val FROM :TABLE WHERE time = 100 and val = 100;
    SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE time = 100 ORDER BY dev, time;

There is no PG support to reliably recognize that only 1 distinct aggregate is actually aggregating here, so this scenario is out of scope:

    SELECT count(DISTINCT dev), count(DISTINCT val) from :TABLE WHERE val = 100;