### PR TITLE
Bump minimum compatible postgres version to 15.10, 16.6, 17.2

### DIFF
--- a/.github/ci_settings.py
+++ b/.github/ci_settings.py
@@ -11,15 +11,15 @@
 # ABI_MIN is the minimum postgres version required when the extension was build against LATEST
 #
 
-PG15_EARLIEST = "15.0"
+PG15_EARLIEST = "15.10"
 PG15_LATEST = "15.12"
 PG15_ABI_MIN = "15.0"
 
-PG16_EARLIEST = "16.0"
+PG16_EARLIEST = "16.6"
 PG16_LATEST = "16.8"
 PG16_ABI_MIN = "16.0"
 
-PG17_EARLIEST = "17.0"
+PG17_EARLIEST = "17.2"
 PG17_LATEST = "17.4"
 PG17_ABI_MIN = "17.0"
 

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -32,12 +32,9 @@
  * that was reverted in the following release.
  */
 
-#define is_supported_pg_version_15(version)                                                        \
-	((version >= 150000) && (version < 160000) && (version != 150009))
-#define is_supported_pg_version_16(version)                                                        \
-	((version >= 160000) && (version < 170000) && (version != 160005))
-#define is_supported_pg_version_17(version)                                                        \
-	((version >= 170000) && (version < 180000) && (version != 170001))
+#define is_supported_pg_version_15(version) ((version >= 150010) && (version < 160000))
+#define is_supported_pg_version_16(version) ((version >= 160006) && (version < 170000))
+#define is_supported_pg_version_17(version) ((version >= 170002) && (version < 180000))
 
 /*
  * PG16 support is a WIP and not complete yet.


### PR DESCRIPTION
Due to some backports in upstream timescaledb versions compiled against
15.10+, 16.6+ and 17.2+ will not be backwardscompatible with
previous PG versions.

Disable-check: force-changelog-file