### PR TITLE
Fix security notification

### DIFF
--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -7,6 +7,15 @@ name: Process issue workflows
     types: [created, edited]
 
 jobs:
+  show-event-info:
+    name: Show issue workflow event information
+    steps:
+      - name: Show github event
+        run: >-
+          cat <<END_OF_TEXT
+          ${{ toJSON(github.event) }}
+          END_OF_TEXT
+
   add-to-project:
     name: Add issue to projects
     # issue_comment is triggered when commenting on both issues and
@@ -33,10 +42,15 @@ jobs:
     name: Notify security channel
     runs-on: timescaledb-runner-arm64
     if: >-
-      github.event_name == 'issues' &&
-      github.event.action != 'closed' &&
-      ( contains(github.event.issue.labels.*.name, 'segfault') ||
-        contains(github.event.issue.labels.*.name, 'security') )
+      github.event_name == 'issues' && github.event.action == 'opened' && (
+          contains(github.event.issue.labels.*.name, 'segfault') ||
+          contains(github.event.issue.labels.*.name, 'security')
+      )
+      ||
+      github.event_name == 'issues' && github.event.action == 'labeled' && (
+          github.event.label.name == 'segfault' ||
+          github.event.label.name == 'security'
+      )
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:


### PR DESCRIPTION
If an issue was labeled, the workflow only checked if a security label was part of the labels of the issue and not what label was used. Instead, only check the labels if an issue is opened. Otherwise, check if the actual security label was used.

Disable-check: force-changelog-file