### PR TITLE
Ensure settings for a compressed rel are found

### DIFF
--- a/.unreleased/pr_8061
+++ b/.unreleased/pr_8061
@@ -1,0 +1,1 @@
+Fixes: #8061 Ensure settings for a compressed relation are found

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -194,7 +194,9 @@ ts_compression_settings_get(Oid relid)
 TSDLLEXPORT CompressionSettings *
 ts_compression_settings_get_by_compress_relid(Oid relid)
 {
-	return compression_settings_get(relid, true);
+	CompressionSettings *settings = compression_settings_get(relid, true);
+	Ensure(settings, "compression settings not found for %s", get_rel_name(relid));
+	return settings;
 }
 
 /*

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -273,8 +273,6 @@ compress_chunk(Oid in_table, Oid out_table, int insert_options)
 	HeapTuple in_table_tp = NULL, index_tp = NULL;
 	Form_pg_attribute in_table_attr_tp, index_attr_tp;
 	CompressionStats cstat;
-	/* Might be merging into an existing chunk, so get compression settings
-	 * from that chunk */
 	CompressionSettings *settings = ts_compression_settings_get_by_compress_relid(out_table);
 
 	int64 report_reltuples;


### PR DESCRIPTION
This is just a sanity check, a compressed chunk must always have
corresponding chunk settings. Settings not being present points
to catalog corruption but erroring out in those cases is preferred
over segfault.

Fixes: #8034 

Disable-check: force-changelog-file