### PR TITLE
Fix allocation overflow error on vec type

### DIFF
--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -3009,3 +3009,26 @@ HINT:  Changing compression settings for "badly_compressed_ht" can improve compr
 
 \set VERBOSITY terse
 RESET timescaledb.enable_compression_ratio_warnings;
+-- Test vector overallocation error
+CREATE TABLE hyper_86 (time timestamptz, device int8, value text);
+SELECT create_hypertable('hyper_86', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable    
+------------------------
+ (59,public,hyper_86,t)
+(1 row)
+
+-- This will try to create an array of chars over 1GB allocation limit
+INSERT INTO hyper_86
+VALUES
+	('2025-01-01 00:00:00', 1, repeat(md5(random()::text), 32*1024*200)), --200 MB value
+	('2025-01-01 00:00:01', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:02', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:03', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:04', 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:05', 1, repeat(md5(random()::text), 32*1024*200));
+ALTER TABLE hyper_86 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+\set ON_ERROR_STOP 0
+SELECT compress_chunk(ch) FROM show_chunks('hyper_86') ch;
+ERROR:  vector allocation overflow when trying to allocate 1258291224 bytes
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Our custom vector type had an issue with detecting allocation overflowing by using the wrong limit.
This change uses MaxAllocSize to limit the allocation and tries to resize to it if the realloc size can
fit into it.

Disable-check: force-changelog-file