### PR TITLE
Make sure Hypercore TAM parent is vacuumed

### DIFF
--- a/.unreleased/pr_8067
+++ b/.unreleased/pr_8067
@@ -1,0 +1,1 @@
+Fixes: #8067 Make sure Hypercore TAM parent is vacuumed

--- a/tsl/test/expected/hypercore_vacuum.out
+++ b/tsl/test/expected/hypercore_vacuum.out
@@ -443,4 +443,16 @@ alter table readings
       set access method hypercore,
       set (timescaledb.compress_orderby = 'time',
       	   timescaledb.compress_segmentby = 'device');
+-- Save frozenxid to test that it advances on hypertable root when
+-- root is using Hypercore TAM.
+select relfrozenxid as old_relfrozenxid
+from pg_class where oid = 'readings'::regclass \gset
 vacuum analyze readings;
+select relfrozenxid as new_relfrozenxid
+from pg_class where oid = 'readings'::regclass \gset
+select :new_relfrozenxid > :old_relfrozenxid as frozenxid_advanced_during_vacuum;
+ frozenxid_advanced_during_vacuum 
+----------------------------------
+ t
+(1 row)
+

--- a/tsl/test/sql/hypercore_vacuum.sql
+++ b/tsl/test/sql/hypercore_vacuum.sql
@@ -258,4 +258,14 @@ alter table readings
       set (timescaledb.compress_orderby = 'time',
       	   timescaledb.compress_segmentby = 'device');
 
+-- Save frozenxid to test that it advances on hypertable root when
+-- root is using Hypercore TAM.
+select relfrozenxid as old_relfrozenxid
+from pg_class where oid = 'readings'::regclass \gset
+
 vacuum analyze readings;
+
+select relfrozenxid as new_relfrozenxid
+from pg_class where oid = 'readings'::regclass \gset
+
+select :new_relfrozenxid > :old_relfrozenxid as frozenxid_advanced_during_vacuum;


### PR DESCRIPTION
If the Hypertable root/parent table is using Hypercore TAM, it needs to be vacuumed in order to advance relfrozenxid. Otherwise, it might lead to wrap-around issues.