### PR TITLE
Use correct memory context during flush

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -109,6 +109,9 @@ jobs:
           pip install black prospector pylint dodgy \
             mccabe pycodestyle pyflakes \
             psutil pygithub pglast testgres
+          # pinning snowballstemmer to version 2.2.0 due to:
+          # https://github.com/prospector-dev/prospector/issues/763
+          pip install --force-reinstall --no-deps snowballstemmer==2.2.0
           pip list
           pip list --user
 

--- a/.unreleased/pr_8074
+++ b/.unreleased/pr_8074
@@ -1,0 +1,1 @@
+Fixes: #8074 Fix memory leak in row compressor flush

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1079,6 +1079,9 @@ row_compressor_append_row(RowCompressor *row_compressor, TupleTableSlot *row)
 static void
 row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool changed_groups)
 {
+	MemoryContext old_ctx;
+	old_ctx = MemoryContextSwitchTo(row_compressor->per_row_ctx);
+
 	HeapTuple compressed_tuple;
 
 	for (int col = 0; col < row_compressor->n_input_columns; col++)
@@ -1184,6 +1187,7 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 	row_compressor->rows_compressed_into_current_value = 0;
 
 	MemoryContextReset(row_compressor->per_row_ctx);
+	MemoryContextSwitchTo(old_ctx);
 }
 
 void

--- a/tsl/test/expected/decompress_memory.out
+++ b/tsl/test/expected/decompress_memory.out
@@ -67,3 +67,42 @@ select * from log
 ---+---+----------------
 (0 rows)
 
+-- Test recompression with small batches.
+select count(decompress_chunk(c, true)) from show_chunks('ht_metrics_compressed') c;
+ count 
+-------
+    52
+(1 row)
+
+alter table ht_metrics_compressed set (timescaledb.compress,
+    timescaledb.compress_segmentby='time', timescaledb.compress_orderby='value');
+select count(compress_chunk(c, true)) from show_chunks('ht_metrics_compressed') c;
+ count 
+-------
+    52
+(1 row)
+
+update ht_metrics_compressed set value = 0 where value < 1 and value > -1;
+with
+to_recompress as (
+  select tableoid::oid::regclass c, count(*) r
+  from ht_metrics_compressed
+  where value = 0
+  group by 1
+),
+log as materialized (
+        select rank() over (order by r) n,
+            ts_debug_allocated_bytes(case
+                when _timescaledb_functions.recompress_chunk_segmentwise(c)::text != ''
+                then 'PortalContext' else '' end) b
+        from show_chunks('ht_metrics_compressed') c
+        join to_recompress using (c)
+        order by r),
+regression as (select regr_slope(b, n) slope, regr_intercept(b, n) intercept from log)
+select * from log
+    where (select slope / intercept::float > 0.01 from regression)
+;
+ n | b 
+---+---
+(0 rows)
+


### PR DESCRIPTION
row_compressor_flush was called without switching to per-row memory context causing memory leaks in the ExprContext memory context. This in turn would cause problems with recompression when there were a lot of small batches.

Disable-check: commit-count