### PR TITLE
Block chunk merging on multi-dimensional hypertables

### DIFF
--- a/.unreleased/pr_8099
+++ b/.unreleased/pr_8099
@@ -1,0 +1,1 @@
+Fixes: #8099 Block chunk merging on multi-dimensional hypertables

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -4,6 +4,11 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE ACCESS METHOD testam TYPE TABLE HANDLER heap_tableam_handler;
 set role :ROLE_DEFAULT_PERM_USER;
+-- A limitation in the tuple routing cache can lead to routing errors
+-- when multi-dimensional time partitions are not aligned. Therefore,
+-- multi-dimensional merges are disabled by default until the routing
+-- is fixed. However, allow it in this test.
+set timescaledb.enable_merge_multidim_chunks = true;
 ------------------
 -- Helper views --
 -------------------
@@ -688,6 +693,13 @@ select
     round(ccs.numrows_frozen_immediately::numeric / :total_numrows_frozen_immediately, 1) as numrows_frozen_immediately_fraction
 from _timescaledb_catalog.compression_chunk_size ccs
 order by chunk_id;
+\set ON_ERROR_STOP 0
+-- Test blocked multi-dimensional merges
+set timescaledb.enable_merge_multidim_chunks = false;
+call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_4_chunk','_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_12_chunk']);
+ERROR:  cannot merge chunk in multi-dimensional hypertable
+set timescaledb.enable_merge_multidim_chunks = true;
+\set ON_ERROR_STOP 1
 --
 -- Merge all chunks until only 1 remains.  Also check that metadata is
 -- merged.


### PR DESCRIPTION
A limitation in the tuple routing cache can lead to insert  routing errors  if multi-dimensional time partitions are non-aligned (i.e., two partitions have overlapping time ranges).

Such overlapping time partitions can be created when merging chunks in multi-dimensional tables. Therefore, this change blocks such merges by default. However, since merge_chunks() already supports multi-dimensional hypertables, including tests, we use an "anonymous" settings variable to allow multi-dimensional merges.

Related issue: https://github.com/timescale/timescaledb/issues/8025