### PR TITLE
Fix handling of unique expression indexes in constraint check

### DIFF
--- a/.unreleased/pr_8106
+++ b/.unreleased/pr_8106
@@ -1,0 +1,1 @@
+Fixes: #8106 Fix segfault when adding unique compression indexes to compressed chunks

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2542,6 +2542,7 @@ validate_index_constraints(Chunk *chunk, const IndexStmt *stmt)
 		StringInfoData command;
 		Oid nspcid = get_rel_namespace(chunk->table_id);
 		ListCell *lc;
+		List *dpcontext = deparse_context_for(get_rel_name(chunk->table_id), chunk->table_id);
 
 		initStringInfo(&command);
 		appendStringInfo(&command,
@@ -2561,7 +2562,13 @@ validate_index_constraints(Chunk *chunk, const IndexStmt *stmt)
 			{
 				i++;
 				IndexElem *elem = lfirst_node(IndexElem, lc);
-				appendStringInfo(&command, "%s IS NOT NULL", quote_identifier(elem->name));
+				appendStringInfo(&command,
+								 "%s IS NOT NULL",
+								 elem->name ? quote_identifier(elem->name) :
+											  deparse_expression((Node *) elem->expr,
+																 dpcontext,
+																 false,
+																 false));
 				if (i < list_length(stmt->indexParams))
 					appendStringInfo(&command, " AND ");
 			}
@@ -2574,7 +2581,11 @@ validate_index_constraints(Chunk *chunk, const IndexStmt *stmt)
 		{
 			j++;
 			IndexElem *elem = lfirst_node(IndexElem, lc);
-			appendStringInfo(&command, "%s", quote_identifier(elem->name));
+			appendStringInfo(&command,
+							 "%s",
+							 elem->name ?
+								 quote_identifier(elem->name) :
+								 deparse_expression((Node *) elem->expr, dpcontext, false, false));
 			if (j < list_length(stmt->indexParams))
 				appendStringInfo(&command, ",");
 		}

--- a/tsl/test/expected/compression_constraints.out
+++ b/tsl/test/expected/compression_constraints.out
@@ -421,3 +421,32 @@ INSERT INTO metrics SELECT '2025-01-01','d1',1,42;
 ERROR:  new row for relation "_hyper_9_32_chunk" violates check constraint "metrics_c1_check"
 \set ON_ERROR_STOP 1
 ROLLBACK;
+-- test unique expression indexes
+BEGIN;
+-- should succeed since no conflict
+CREATE UNIQUE INDEX metrics_unique ON metrics(time, device, md5(value::text));
+ROLLBACK;
+BEGIN;
+INSERT INTO metrics SELECT '2025-01-01','d1',1;
+-- partially compressed chunk
+-- should fail because there is conflict
+\set ON_ERROR_STOP 0
+CREATE UNIQUE INDEX metrics_unique ON metrics(time, device, md5(value::text));
+ERROR:  duplicate key value violates unique constraint
+\set ON_ERROR_STOP 1
+ROLLBACK;
+BEGIN;
+INSERT INTO metrics SELECT '2025-01-01','d1',1;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
+ count 
+-------
+     1
+(1 row)
+
+-- fully compressed chunk
+-- should fail because there is conflict
+\set ON_ERROR_STOP 0
+CREATE UNIQUE INDEX metrics_unique ON metrics(time, device, md5(value::text));
+ERROR:  duplicate key value violates unique constraint
+\set ON_ERROR_STOP 1
+ROLLBACK;


### PR DESCRIPTION
When trying to add a unique expression index to a compressed
chunk trying to do the constraint check would previously
lead to a segfault. This patch fixes the segfault and properly
checks the constraint.
