### PR TITLE
Update docker image in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install from a Docker container:
 1. Run the TimescaleDB container:
 
     ```bash
-    docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg17
+    docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg17
     ```
 
 1. Connect to a database:


### PR DESCRIPTION
It has been pointed out that installation steps in the readme and in the docs use different Docker images. The docs use `-ha` image as the recommended full experience, while the readme uses the non-ha one. We might want to align unless for some specific reason the installation procedure in the readme needs to be a more light-weight one. 

Disable-check: force-changelog-file