### PR TITLE
Fix left over reference to time_column WITH option

### DIFF
--- a/.unreleased/pr_8106
+++ b/.unreleased/pr_8106
@@ -1,1 +1,2 @@
 Fixes: #8106 Fix segfault when adding unique compression indexes to compressed chunks
+Thanks: @thotokraa for reporting an issue with unique expression indexes on compressed chunks

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -5096,8 +5096,9 @@ process_create_stmt(ProcessUtilityArgs *args)
 				ereport(ERROR,
 						(errcode(ERRCODE_UNDEFINED_COLUMN),
 						 errmsg("hypertable option requires time_column"),
-						 errhint("Use \"timescaledb.time_column\" to specify the column to use as "
-								 "partitioning column.")));
+						 errhint(
+							 "Use \"timescaledb.partition_column\" to specify the column to use as "
+							 "partitioning column.")));
 		}
 	}
 


### PR DESCRIPTION
Change time_column to partition_column in hint to reflect rename
of the option.

Disable-check: force-changelog-file
Disable-check: commit-count