### PR TITLE
Add batch size limiting during compression

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -54,6 +54,7 @@ jobs:
           append-*
           bgw_db_scheduler*
           compress_bloom_sparse_debug
+          compression_allocation
           hypercore_parallel
           hypercore_vacuum
           hypercore_vectoragg

--- a/.unreleased/pr_8115
+++ b/.unreleased/pr_8115
@@ -1,0 +1,1 @@
+Implements: #8115 Add batch size limiting during compression

--- a/src/guc.c
+++ b/src/guc.c
@@ -164,6 +164,7 @@ TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
+TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
 bool ts_guc_enable_event_triggers = false;
 
@@ -863,6 +864,19 @@ _guc_init(void)
 							NULL,
 							NULL,
 							NULL);
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compressor_batch_limit"),
+							 "Enable compressor batch limit",
+							 "Enable compressor batch limit for compressors which "
+							 "can go over the allocation limit (1 GB). This feature will"
+							 "limit those compressors by reducing the size of the batch and thus "
+							 "avoid hitting the limit.",
+							 &ts_guc_compression_enable_compressor_batch_limit,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_event_triggers"),
 							 "Enable event triggers for chunks creation",
 							 "Enable event triggers for chunks creation",

--- a/src/guc.h
+++ b/src/guc.h
@@ -73,6 +73,7 @@ extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
 extern TSDLLEXPORT int ts_guc_compression_batch_size_limit;
+extern TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit;
 #if PG16_GE
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif

--- a/tsl/src/compression/algorithms/array.h
+++ b/tsl/src/compression/algorithms/array.h
@@ -14,8 +14,11 @@
 
 #include <postgres.h>
 #include <fmgr.h>
+#include <utils/memutils.h>
 
 #include "compression/compression.h"
+
+#define MAX_ARRAY_COMPRESSOR_SIZE_BYTES MaxAllocSize
 
 typedef struct StringInfoData StringInfoData;
 typedef StringInfoData *StringInfo;

--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -53,6 +53,7 @@ static void *bool_compressor_finish_and_reset(Compressor *compressor);
 const Compressor bool_compressor_initializer = {
 	.append_val = bool_compressor_append_bool,
 	.append_null = bool_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = bool_compressor_finish_and_reset,
 };
 

--- a/tsl/src/compression/algorithms/deltadelta.c
+++ b/tsl/src/compression/algorithms/deltadelta.c
@@ -177,40 +177,47 @@ deltadelta_compressor_finish_and_reset(Compressor *compressor)
 const Compressor deltadelta_bool_compressor = {
 	.append_val = deltadelta_compressor_append_bool,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_uint16_compressor = {
 	.append_val = deltadelta_compressor_append_int16,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 const Compressor deltadelta_uint32_compressor = {
 	.append_val = deltadelta_compressor_append_int32,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 const Compressor deltadelta_uint64_compressor = {
 	.append_val = deltadelta_compressor_append_int64,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_date_compressor = {
 	.append_val = deltadelta_compressor_append_date,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_timestamp_compressor = {
 	.append_val = deltadelta_compressor_append_timestamp,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 
 const Compressor deltadelta_timestamptz_compressor = {
 	.append_val = deltadelta_compressor_append_timestamptz,
 	.append_null = deltadelta_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = deltadelta_compressor_finish_and_reset,
 };
 

--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -87,11 +87,13 @@ typedef struct DictionaryCompressor
 {
 	dictionary_hash *dictionary_items;
 	uint32 next_index;
+	uint32 dict_val_size;
 	Oid type;
 	int16 typlen;
 	bool typbyval;
 	char typalign;
 	bool has_nulls;
+	DatumSerializer *serializer;
 	Simple8bRleCompressor dictionary_indexes;
 	Simple8bRleCompressor nulls;
 } DictionaryCompressor;
@@ -123,6 +125,26 @@ dictionary_compressor_append_null_value(Compressor *compressor)
 	dictionary_compressor_append_null(extended->internal);
 }
 
+static bool
+dictionary_compressor_is_full(Compressor *compressor, Datum val)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = dictionary_compressor_alloc(extended->element_type);
+
+	Size datum_size_and_align;
+	DictionaryCompressor *dict_comp = (DictionaryCompressor *) extended->internal;
+	if (datum_serializer_value_may_be_toasted(dict_comp->serializer))
+		val = PointerGetDatum(PG_DETOAST_DATUM_PACKED(val));
+
+	datum_size_and_align =
+		datum_get_bytes_size(dict_comp->serializer, dict_comp->dict_val_size, val) -
+		dict_comp->dict_val_size;
+
+	/* If we can't fit new datum in the max size, we are full */
+	return (datum_size_and_align + dict_comp->dict_val_size) > MAX_ARRAY_COMPRESSOR_SIZE_BYTES;
+}
+
 static void *
 dictionary_compressor_finish_and_reset(Compressor *compressor)
 {
@@ -136,6 +158,7 @@ dictionary_compressor_finish_and_reset(Compressor *compressor)
 const Compressor dictionary_compressor = {
 	.append_val = dictionary_compressor_append_datum,
 	.append_null = dictionary_compressor_append_null_value,
+	.is_full = dictionary_compressor_is_full,
 	.finish = dictionary_compressor_finish_and_reset,
 };
 
@@ -158,6 +181,7 @@ dictionary_compressor_alloc(Oid type)
 		lookup_type_cache(type, TYPECACHE_EQ_OPR_FINFO | TYPECACHE_HASH_PROC_FINFO);
 
 	compressor->next_index = 0;
+	compressor->dict_val_size = 0;
 	compressor->has_nulls = false;
 	compressor->type = type;
 	compressor->typlen = tentry->typlen;
@@ -165,6 +189,7 @@ dictionary_compressor_alloc(Oid type)
 	compressor->typalign = tentry->typalign;
 
 	compressor->dictionary_items = dictionary_hash_alloc(tentry);
+	compressor->serializer = create_datum_serializer(type);
 
 	simple8brle_compressor_init(&compressor->dictionary_indexes);
 	simple8brle_compressor_init(&compressor->nulls);
@@ -186,6 +211,9 @@ dictionary_compressor_append(DictionaryCompressor *compressor, Datum val)
 
 	Assert(compressor != NULL);
 
+	if (datum_serializer_value_may_be_toasted(compressor->serializer))
+		val = PointerGetDatum(PG_DETOAST_DATUM_PACKED(val));
+
 	dict_item = dictionary_insert(compressor->dictionary_items, val, &found);
 
 	if (!found)
@@ -196,6 +224,12 @@ dictionary_compressor_append(DictionaryCompressor *compressor, Datum val)
 		Assert(compressor->next_index <= INT16_MAX - 1);
 		compressor->next_index += 1;
 	}
+
+	Size datum_size_and_align =
+		datum_get_bytes_size(compressor->serializer, compressor->dict_val_size, val) -
+		compressor->dict_val_size;
+
+	compressor->dict_val_size += datum_size_and_align;
 
 	simple8brle_compressor_append(&compressor->dictionary_indexes, dict_item->index);
 	simple8brle_compressor_append(&compressor->nulls, 0);

--- a/tsl/src/compression/algorithms/gorilla.c
+++ b/tsl/src/compression/algorithms/gorilla.c
@@ -202,27 +202,32 @@ gorilla_compressor_finish_and_reset(Compressor *compressor)
 const Compressor gorilla_float_compressor = {
 	.append_val = gorilla_compressor_append_float,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 
 const Compressor gorilla_double_compressor = {
 	.append_val = gorilla_compressor_append_double,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 const Compressor gorilla_uint16_compressor = {
 	.append_val = gorilla_compressor_append_int16,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 const Compressor gorilla_uint32_compressor = {
 	.append_val = gorilla_compressor_append_int32,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 const Compressor gorilla_uint64_compressor = {
 	.append_val = gorilla_compressor_append_int64,
 	.append_null = gorilla_compressor_append_null_value,
+	.is_full = NULL,
 	.finish = gorilla_compressor_finish_and_reset,
 };
 

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -67,6 +67,7 @@ struct Compressor
 {
 	void (*append_null)(Compressor *compressord);
 	void (*append_val)(Compressor *compressor, Datum val);
+	bool (*is_full)(Compressor *compressor, Datum val);
 	void *(*finish)(Compressor *data);
 };
 
@@ -243,6 +244,8 @@ typedef struct RowCompressor
 
 	/* info about each column */
 	struct PerColumn *per_column;
+	/* do we have to check if compressors can accept more data */
+	bool needs_fullness_check;
 
 	/* the order of columns in the compressed data need not match the order in the
 	 * uncompressed. This array maps each attribute offset in the uncompressed

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -3009,26 +3009,3 @@ HINT:  Changing compression settings for "badly_compressed_ht" can improve compr
 
 \set VERBOSITY terse
 RESET timescaledb.enable_compression_ratio_warnings;
--- Test vector overallocation error
-CREATE TABLE hyper_86 (time timestamptz, device int8, value text);
-SELECT create_hypertable('hyper_86', 'time', create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (59,public,hyper_86,t)
-(1 row)
-
--- This will try to create an array of chars over 1GB allocation limit
-INSERT INTO hyper_86
-VALUES
-	('2025-01-01 00:00:00', 1, repeat(md5(random()::text), 32*1024*200)), --200 MB value
-	('2025-01-01 00:00:01', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:02', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:03', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:04', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:05', 1, repeat(md5(random()::text), 32*1024*200));
-ALTER TABLE hyper_86 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
-\set ON_ERROR_STOP 0
-SELECT compress_chunk(ch) FROM show_chunks('hyper_86') ch;
-ERROR:  vector allocation overflow when trying to allocate 1258291224 bytes
-\set ON_ERROR_STOP 1

--- a/tsl/test/expected/compression_allocation.out
+++ b/tsl/test/expected/compression_allocation.out
@@ -1,0 +1,45 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test array compression overallocation protection
+CREATE TABLE vector_overalloc (time timestamptz, device int8, ord numeric, value text);
+SELECT create_hypertable('vector_overalloc', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
+       create_hypertable       
+-------------------------------
+ (1,public,vector_overalloc,t)
+(1 row)
+
+-- This will try to create an array of chars over 1GB allocation limit
+INSERT INTO vector_overalloc
+VALUES
+	('2025-01-01 00:00:00', 1, 1, repeat(md5(random()::text), 32*1024*200)), --200 MB value
+	('2025-01-01 00:00:01', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:02', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:03', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:04', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:05', 1, 1, repeat(md5(random()::text), 32*1024*200));
+ALTER TABLE vector_overalloc SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+SET timescaledb.enable_compressor_batch_limit to true;
+SELECT compress_chunk(ch) FROM show_chunks('vector_overalloc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT ch1.id "CHUNK_ID"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'vector_overalloc'
+ORDER BY ch1.id
+LIMIT 1 \gset
+select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
+where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+-- Confirm we have multiple batches
+SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 ASC;
+ _ts_meta_count 
+----------------
+              5
+              1
+(2 rows)
+
+DROP TABLE vector_overalloc;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_FILES
     compressed_collation.sql
     compressed_detoaster.sql
     compress_float8_corrupt.sql
+    compression_allocation.sql
     compression_conflicts.sql
     compression_constraints.sql
     compression_create_compressed_table.sql

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1260,20 +1260,3 @@ SELECT compress_chunk(show_chunks('badly_compressed_ht'));
 
 RESET timescaledb.enable_compression_ratio_warnings;
 
--- Test vector overallocation error
-CREATE TABLE hyper_86 (time timestamptz, device int8, value text);
-SELECT create_hypertable('hyper_86', 'time', create_default_indexes => false);
--- This will try to create an array of chars over 1GB allocation limit
-INSERT INTO hyper_86
-VALUES
-	('2025-01-01 00:00:00', 1, repeat(md5(random()::text), 32*1024*200)), --200 MB value
-	('2025-01-01 00:00:01', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:02', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:03', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:04', 1, repeat(md5(random()::text), 32*1024*200)),
-	('2025-01-01 00:00:05', 1, repeat(md5(random()::text), 32*1024*200));
-
-ALTER TABLE hyper_86 SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
-\set ON_ERROR_STOP 0
-SELECT compress_chunk(ch) FROM show_chunks('hyper_86') ch;
-\set ON_ERROR_STOP 1

--- a/tsl/test/sql/compression_allocation.sql
+++ b/tsl/test/sql/compression_allocation.sql
@@ -1,0 +1,34 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test array compression overallocation protection
+CREATE TABLE vector_overalloc (time timestamptz, device int8, ord numeric, value text);
+SELECT create_hypertable('vector_overalloc', 'time', create_default_indexes => false);
+-- This will try to create an array of chars over 1GB allocation limit
+INSERT INTO vector_overalloc
+VALUES
+	('2025-01-01 00:00:00', 1, 1, repeat(md5(random()::text), 32*1024*200)), --200 MB value
+	('2025-01-01 00:00:01', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:02', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:03', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:04', 1, 1, repeat(md5(random()::text), 32*1024*200)),
+	('2025-01-01 00:00:05', 1, 1, repeat(md5(random()::text), 32*1024*200));
+
+ALTER TABLE vector_overalloc SET (tsdb.compress, tsdb.compress_segmentby='device', tsdb.compress_orderby='time');
+SET timescaledb.enable_compressor_batch_limit to true;
+SELECT compress_chunk(ch) FROM show_chunks('vector_overalloc') ch;
+
+SELECT ch1.id "CHUNK_ID"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'vector_overalloc'
+ORDER BY ch1.id
+LIMIT 1 \gset
+
+select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
+where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+
+-- Confirm we have multiple batches
+SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 ASC;
+
+DROP TABLE vector_overalloc;


### PR DESCRIPTION
For dictionary and array compression algorithms, you could potentially hit allocation limits if you try to compress too much data in a single column. Usually we limit batches based on number of rows but with this feature, we can limit them based on the size as well.