### PR TITLE
changelog 2.20.0

### DIFF
--- a/.unreleased/bloom1
+++ b/.unreleased/bloom1
@@ -1,1 +1,0 @@
-Implements: #7638 Bloom filter sparse indexes for compressed columns. Can be disabled with the GUC timescaledb.enable_sparse_index_bloom.

--- a/.unreleased/index-storage
+++ b/.unreleased/index-storage
@@ -1,1 +1,0 @@
-Implements: #7762 Speed up the queries that use minmax sparse indexes on compressed tables by changing the index TOAST storage type to MAIN. This applies to newly compressed chunks.

--- a/.unreleased/nonvolatile
+++ b/.unreleased/nonvolatile
@@ -1,1 +1,0 @@
-Implements: #8026 Allow WHERE conditions that use nonvolatile functions to be pushed down to the compressed scan level. For example, conditions like `time > now()`, where `time` is a columnstore orderby column, will evaluate `now()` and use the sparse index on `time` to filter out the entire compressed batches that cannot contain matching rows.

--- a/.unreleased/pg_7909
+++ b/.unreleased/pg_7909
@@ -1,1 +1,0 @@
-Fixes: #7909 Update compression stats when merging chunks

--- a/.unreleased/pr_7515
+++ b/.unreleased/pr_7515
@@ -1,1 +1,0 @@
-Fixes: #7515 Add missing lock to Constraint-aware append

--- a/.unreleased/pr_7756
+++ b/.unreleased/pr_7756
@@ -1,1 +1,0 @@
-Implements: #7756 Add warning for poor compression ratio

--- a/.unreleased/pr_7785
+++ b/.unreleased/pr_7785
@@ -1,1 +1,0 @@
-Implements: #7785 Do DELETE instead of TRUNCATE when locks aren't acquired

--- a/.unreleased/pr_7852
+++ b/.unreleased/pr_7852
@@ -1,1 +1,0 @@
-Implements: #7852 Allow creating foreign key constraints on compressed tables

--- a/.unreleased/pr_7854
+++ b/.unreleased/pr_7854
@@ -1,1 +1,0 @@
-Implements: #7854 Remove support for PG14

--- a/.unreleased/pr_7862
+++ b/.unreleased/pr_7862
@@ -1,1 +1,0 @@
-Fixes: #7862 Release cache pin when checking for NOT NULL

--- a/.unreleased/pr_7864
+++ b/.unreleased/pr_7864
@@ -1,1 +1,0 @@
-Implements: #7864 Allow adding CHECK constraints to compressed chunks

--- a/.unreleased/pr_7868
+++ b/.unreleased/pr_7868
@@ -1,1 +1,0 @@
-Implements: #7868 Allow adding columns with CHECK constraints to compressed chunks

--- a/.unreleased/pr_7874
+++ b/.unreleased/pr_7874
@@ -1,1 +1,0 @@
-Implements: #7874 Support for SkipScan for distinct aggregates over the same column

--- a/.unreleased/pr_7877
+++ b/.unreleased/pr_7877
@@ -1,1 +1,0 @@
-Implements: #7877 Remove blocker for unique constraints with ADD COLUMN

--- a/.unreleased/pr_7878
+++ b/.unreleased/pr_7878
@@ -1,1 +1,0 @@
-Implements: #7878 Don't block non-immutable functions in continuous aggregates

--- a/.unreleased/pr_7880
+++ b/.unreleased/pr_7880
@@ -1,1 +1,0 @@
-Implements: #7880 Add experimental support for window functions in caggs

--- a/.unreleased/pr_7899
+++ b/.unreleased/pr_7899
@@ -1,1 +1,0 @@
-Implements: #7899 Vectorized decompression and filtering for boolean columns

--- a/.unreleased/pr_7915
+++ b/.unreleased/pr_7915
@@ -1,1 +1,0 @@
-Implements: #7915 New option `refresh_newest_first` to CAgg refresh policy API

--- a/.unreleased/pr_7917
+++ b/.unreleased/pr_7917
@@ -1,1 +1,0 @@
-Implements: #7917 Remove _timescaledb_functions.create_chunk_table

--- a/.unreleased/pr_7928
+++ b/.unreleased/pr_7928
@@ -1,2 +1,0 @@
-Fixes: #7928 Don't create hypertable for implicitly published tables
-Thanks: @arajkumar for reporting that implicitly published tables were still able to create hypertables

--- a/.unreleased/pr_7929
+++ b/.unreleased/pr_7929
@@ -1,1 +1,0 @@
-Implements: #7929 Add CREATE TABLE ... WITH API for creating hypertables

--- a/.unreleased/pr_7946
+++ b/.unreleased/pr_7946
@@ -1,1 +1,0 @@
-Implements: #7946 Add support for splitting a chunk

--- a/.unreleased/pr_7958
+++ b/.unreleased/pr_7958
@@ -1,1 +1,0 @@
-Implements: #7958 Allow custom names for User-Defined Actions

--- a/.unreleased/pr_7972
+++ b/.unreleased/pr_7972
@@ -1,1 +1,0 @@
-Implements: #7972 Add vectorized filtering for constraint checking while backfilling into compressed chunks

--- a/.unreleased/pr_7976
+++ b/.unreleased/pr_7976
@@ -1,1 +1,0 @@
-Implements: #7976 Include Continuous Aggregate name in jobs informational view.

--- a/.unreleased/pr_7977
+++ b/.unreleased/pr_7977
@@ -1,1 +1,0 @@
-Implements: #7977 Replace references to compression with columnstore

--- a/.unreleased/pr_7981
+++ b/.unreleased/pr_7981
@@ -1,1 +1,0 @@
-Implements: #7981 Add columnstore as alias for enable_columnstore in ALTER TABLE

--- a/.unreleased/pr_7982
+++ b/.unreleased/pr_7982
@@ -1,1 +1,0 @@
-Fixes: #7982 Fix crash in batch sort merge over eligible expressions

--- a/.unreleased/pr_7983
+++ b/.unreleased/pr_7983
@@ -1,1 +1,0 @@
-Implements: #7983 Support for SkipScan over compressed data

--- a/.unreleased/pr_7991
+++ b/.unreleased/pr_7991
@@ -1,1 +1,0 @@
-Implements: #7991 Improves default segmentby options

--- a/.unreleased/pr_7992
+++ b/.unreleased/pr_7992
@@ -1,1 +1,0 @@
-Implements: #7992 Add API into hypertable invalidation log

--- a/.unreleased/pr_8000
+++ b/.unreleased/pr_8000
@@ -1,1 +1,0 @@
-Implements: #8000 Add primary dimension info to information schema

--- a/.unreleased/pr_8005
+++ b/.unreleased/pr_8005
@@ -1,1 +1,0 @@
-Implements: #8005 Support ALTER TABLE SET (timescaledb.chunk_time_interval='1 day')

--- a/.unreleased/pr_8008
+++ b/.unreleased/pr_8008
@@ -1,1 +1,0 @@
-Fixes: #8008 Fix compression policy error message that shows number of successes

--- a/.unreleased/pr_8012
+++ b/.unreleased/pr_8012
@@ -1,1 +1,0 @@
-Implements: #8012 Add event triggers support on chunk creation

--- a/.unreleased/pr_8014
+++ b/.unreleased/pr_8014
@@ -1,1 +1,0 @@
-Implements: #8014 enable bool compression by default by setting `timescaledb.enable_bool_compression=true`. Note: for downgrading to 2.18 or earlier version one needs to use the provided downgrade script in 'timescaledb-extras'.

--- a/.unreleased/pr_8018
+++ b/.unreleased/pr_8018
@@ -1,1 +1,0 @@
-Implements: #8018 Add spin-lock during recompression on unique constraints

--- a/.unreleased/pr_8027
+++ b/.unreleased/pr_8027
@@ -1,1 +1,0 @@
-Implements: #8027 Add materialization invalidations API

--- a/.unreleased/pr_8031
+++ b/.unreleased/pr_8031
@@ -1,1 +1,0 @@
-Fixes: #8031 Fix reporting of deleted tuples for direct batch delete

--- a/.unreleased/pr_8033
+++ b/.unreleased/pr_8033
@@ -1,1 +1,0 @@
-Fixes: #8033 Skip default segmentby if orderby is explicitly set

--- a/.unreleased/pr_8047
+++ b/.unreleased/pr_8047
@@ -1,1 +1,0 @@
-Implements: #8047 Support SkipScan for SELECT DISTINCT with multiple distincts when all but one distinct is pinned

--- a/.unreleased/pr_8061
+++ b/.unreleased/pr_8061
@@ -1,1 +1,0 @@
-Fixes: #8061 Ensure settings for a compressed relation are found

--- a/.unreleased/pr_8067
+++ b/.unreleased/pr_8067
@@ -1,1 +1,0 @@
-Fixes: #8067 Make sure Hypercore TAM parent is vacuumed

--- a/.unreleased/pr_8074
+++ b/.unreleased/pr_8074
@@ -1,1 +1,0 @@
-Fixes: #8074 Fix memory leak in row compressor flush

--- a/.unreleased/pr_8099
+++ b/.unreleased/pr_8099
@@ -1,1 +1,0 @@
-Fixes: #8099 Block chunk merging on multi-dimensional hypertables

--- a/.unreleased/pr_8106
+++ b/.unreleased/pr_8106
@@ -1,2 +1,0 @@
-Fixes: #8106 Fix segfault when adding unique compression indexes to compressed chunks
-Thanks: @thotokraa for reporting an issue with unique expression indexes on compressed chunks

--- a/.unreleased/pr_8115
+++ b/.unreleased/pr_8115
@@ -1,1 +1,0 @@
-Implements: #8115 Add batch size limiting during compression

--- a/.unreleased/pr_8127
+++ b/.unreleased/pr_8127
@@ -1,1 +1,0 @@
-Fixes: #8127 Read bit-packed version of booleans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This release contains performance improvements and bug fixes since the 2.19.3 re
 
 Following the deprecation announcement for PostgreSQL 14 in TimescaleDB v2.19.0, PostgreSQL 14 is no longer supported in TimescaleDB v2.20.0. The currently supported PostgreSQL major versions are 15, 16, and 17.
 
+**Windows: Postgres support**
+
+This TimescaleDB release supports the Postgres versions `15.12.0`, `16.8.0` and `17.4.0` on Windows.
+
 **Features**
 * [#7638](https://github.com/timescale/timescaledb/pull/7638) Bloom filter sparse indexes for compressed columns. Can be disabled with the GUC `timescaledb.enable_sparse_index_bloom`
 * [#7756](https://github.com/timescale/timescaledb/pull/7756) Add warning for poor compression ratio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Following the deprecation announcement for PostgreSQL 14 in TimescaleDB v2.19.0,
 
 **Windows: Postgres support**
 
-This TimescaleDB release supports the Postgres versions `15.12.0`, `16.8.0` and `17.4.0` on Windows.
+This TimescaleDB release supports Postgres versions `15.12`, `16.8` and `17.4` on Windows.
 
 **Features**
 * [#7638](https://github.com/timescale/timescaledb/pull/7638) Bloom filter sparse indexes for compressed columns. Can be disabled with the GUC `timescaledb.enable_sparse_index_bloom`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ This release contains performance improvements and bug fixes since the 2.19.3 re
 
 Following the deprecation announcement for PostgreSQL 14 in TimescaleDB v2.19.0, PostgreSQL 14 is no longer supported in TimescaleDB v2.20.0. The currently supported PostgreSQL major versions are 15, 16, and 17.
 
-**Windows: Postgres support**
-
-This TimescaleDB release supports Postgres versions `15.12`, `16.8` and `17.4` on Windows.
-
 **Features**
 * [#7638](https://github.com/timescale/timescaledb/pull/7638) Bloom filter sparse indexes for compressed columns. Can be disabled with the GUC `timescaledb.enable_sparse_index_bloom`
 * [#7756](https://github.com/timescale/timescaledb/pull/7756) Add warning for poor compression ratio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## 2.20.0 (2025-05-13)
+## 2.20.0 (2025-05-15)
 
 This release contains performance improvements and bug fixes since the 2.19.3 release. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ accidentally triggering the load of a previous DB version.**
 
 ## 2.20.0 (2025-05-15)
 
-This release contains performance improvements and bug fixes since the 2.18.2 release. We recommend that you upgrade at the next available opportunity.
+This release contains performance improvements and bug fixes since the 2.19.3 release. We recommend that you upgrade at the next available opportunity.
 
 **Highlighted features in TimescaleDB v2.20.0**
 * The columnstore now leverages *bloom filters* to deliver up to 6x faster point queries on columns with high cardinality values, such as UUIDs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Following the deprecation announcement for PostgreSQL 14 in TimescaleDB v2.19.0,
 * [#7874](https://github.com/timescale/timescaledb/pull/7874) Support for SkipScan for distinct aggregates over the same column
 * [#7877](https://github.com/timescale/timescaledb/pull/7877) Remove blocker for unique constraints with `ADD COLUMN`
 * [#7878](https://github.com/timescale/timescaledb/pull/7878) Don't block non-immutable functions in continuous aggregates
-* [#7880](https://github.com/timescale/timescaledb/pull/7880) Add experimental support for window functions in caggs
+* [#7880](https://github.com/timescale/timescaledb/pull/7880) Add experimental support for window functions in continuous aggregates
 * [#7899](https://github.com/timescale/timescaledb/pull/7899) Vectorized decompression and filtering for boolean columns
 * [#7915](https://github.com/timescale/timescaledb/pull/7915) New option `refresh_newest_first` to CAgg refresh policy API
 * [#7917](https://github.com/timescale/timescaledb/pull/7917) Remove `_timescaledb_functions.create_chunk_table` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ This TimescaleDB release supports the Postgres versions `15.12.0`, `16.8.0` and 
 * [#8033](https://github.com/timescale/timescaledb/pull/8033) Skip default `segmentby` if `orderby` is explicitly set
 * [#8061](https://github.com/timescale/timescaledb/pull/8061) Ensure settings for a compressed relation are found
 * [#7515](https://github.com/timescale/timescaledb/pull/7515) Add missing lock to Constraint-aware append
-* [#8067](https://github.com/timescale/timescaledb/pull/8067) Make sure Hypercore TAM parent is vacuumed
+* [#8067](https://github.com/timescale/timescaledb/pull/8067) Make sure hypercore TAM parent is vacuumed
 * [#8074](https://github.com/timescale/timescaledb/pull/8074) Fix memory leak in row compressor flush
 * [#8099](https://github.com/timescale/timescaledb/pull/8099) Block chunk merging on multi-dimensional hypertables
 * [#8106](https://github.com/timescale/timescaledb/pull/8106) Fix segfault when adding unique compression indexes to compressed chunks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This TimescaleDB release supports the Postgres versions `15.12.0`, `16.8.0` and 
 * [#7878](https://github.com/timescale/timescaledb/pull/7878) Don't block non-immutable functions in continuous aggregates
 * [#7880](https://github.com/timescale/timescaledb/pull/7880) Add experimental support for window functions in continuous aggregates
 * [#7899](https://github.com/timescale/timescaledb/pull/7899) Vectorized decompression and filtering for boolean columns
-* [#7915](https://github.com/timescale/timescaledb/pull/7915) New option `refresh_newest_first` to CAgg refresh policy API
+* [#7915](https://github.com/timescale/timescaledb/pull/7915) New option `refresh_newest_first` to continuous aggregate refresh policy API
 * [#7917](https://github.com/timescale/timescaledb/pull/7917) Remove `_timescaledb_functions.create_chunk_table` function
 * [#7929](https://github.com/timescale/timescaledb/pull/7929) Add `CREATE TABLE ... WITH` API for creating hypertables
 * [#7946](https://github.com/timescale/timescaledb/pull/7946) Add support for splitting a chunk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ accidentally triggering the load of a previous DB version.**
 
 ## 2.20.0 (2025-05-15)
 
-This release contains performance improvements and bug fixes since the 2.19.3 release. We recommend that you upgrade at the next available opportunity.
+This release contains performance improvements and bug fixes since the 2.18.2 release. We recommend that you upgrade at the next available opportunity.
 
 **Highlighted features in TimescaleDB v2.20.0**
 * The columnstore now leverages *bloom filters* to deliver up to 6x faster point queries on columns with high cardinality values, such as UUIDs.
@@ -72,6 +72,7 @@ Following the deprecation announcement for PostgreSQL 14 in TimescaleDB v2.19.0,
 * [#8074](https://github.com/timescale/timescaledb/pull/8074) Fix memory leak in row compressor flush
 * [#8099](https://github.com/timescale/timescaledb/pull/8099) Block chunk merging on multi-dimensional hypertables
 * [#8106](https://github.com/timescale/timescaledb/pull/8106) Fix segfault when adding unique compression indexes to compressed chunks
+* [#8127](https://github.com/timescale/timescaledb/pull/8127) Read bit-packed version of booleans
 
 **GUCs**
 * `timescaledb.enable_sparse_index_bloom`: Enable creation of the bloom1 sparse index on compressed chunks; Default: `ON`


### PR DESCRIPTION
## 2.20.0 (2025-05-15)

This release contains performance improvements and bug fixes since the 2.19.3 release. We recommend that you upgrade at the next available opportunity.

**Highlighted features in TimescaleDB v2.20.0**
* The columnstore now leverages *bloom filters* to deliver up to 6x faster point queries on columns with high cardinality values, such as UUIDs.
* Major *improvements to the columnstores' backfill process* enable `UPSERTS` with strict constraints to execute up to 10x faster.
* *SkipScan is now supported in the columnstore*, including for DISTINCT queries. This enhancement leads to dramatic query performance improvements of 2000x to 2500x, especially for selective queries.
* SIMD vectorization for the bool data type is now enabled by default. This change results in a 30–45% increase in performance for analytical queries with bool clauses on the columnstore.
* *Continuous aggregates*  now include experimental support for *window functions and non-immutable functions*, extending the analytics use cases they can solve.
* Several quality-of-life improvements have been introduced: job names for continuous aggregates are now more descriptive, you can assign custom names to them, and it is now possible to add unique constraints along with `ADD COLUMN` operations in the columnstore.
* Improved management and optimization of chunks with the ability to split large uncompressed chunks at a specified point in time using the `split_chunk` function. This new function complements the existing `merge_chunk` function that can be used to merge two small chunks into one larger chunk. 
* Enhancements to the default behavior of the columnstore now provide better *automatic assessments* of `segment by` and `order by` columns, reducing the need for manual configuration and simplifying initial setup.

**PostgreSQL 14 support removal announcement**

Following the deprecation announcement for PostgreSQL 14 in TimescaleDB v2.19.0, PostgreSQL 14 is no longer supported in TimescaleDB v2.20.0. The currently supported PostgreSQL major versions are 15, 16, and 17.

**Features**
* [#7638](https://github.com/timescale/timescaledb/pull/7638) Bloom filter sparse indexes for compressed columns. Can be disabled with the GUC `timescaledb.enable_sparse_index_bloom`
* [#7756](https://github.com/timescale/timescaledb/pull/7756) Add warning for poor compression ratio
* [#7762](https://github.com/timescale/timescaledb/pull/7762) Speed up the queries that use minmax sparse indexes on compressed tables by changing the index TOAST storage type to `MAIN`. This applies to newly compressed chunks
* [#7785](https://github.com/timescale/timescaledb/pull/7785) Do `DELETE` instead of `TRUNCATE` when locks aren't acquired
* [#7852](https://github.com/timescale/timescaledb/pull/7852) Allow creating foreign key constraints on compressed tables
* [#7854](https://github.com/timescale/timescaledb/pull/7854) Remove support for PG14
* [#7864](https://github.com/timescale/timescaledb/pull/7854) Allow adding CHECK constraints to compressed chunks
* [#7868](https://github.com/timescale/timescaledb/pull/7868) Allow adding columns with `CHECK` constraints to compressed chunks
* [#7874](https://github.com/timescale/timescaledb/pull/7874) Support for SkipScan for distinct aggregates over the same column
* [#7877](https://github.com/timescale/timescaledb/pull/7877) Remove blocker for unique constraints with `ADD COLUMN`
* [#7878](https://github.com/timescale/timescaledb/pull/7878) Don't block non-immutable functions in continuous aggregates
* [#7880](https://github.com/timescale/timescaledb/pull/7880) Add experimental support for window functions in continuous aggregates
* [#7899](https://github.com/timescale/timescaledb/pull/7899) Vectorized decompression and filtering for boolean columns
* [#7915](https://github.com/timescale/timescaledb/pull/7915) New option `refresh_newest_first` to continuous aggregate refresh policy API
* [#7917](https://github.com/timescale/timescaledb/pull/7917) Remove `_timescaledb_functions.create_chunk_table` function
* [#7929](https://github.com/timescale/timescaledb/pull/7929) Add `CREATE TABLE ... WITH` API for creating hypertables
* [#7946](https://github.com/timescale/timescaledb/pull/7946) Add support for splitting a chunk
* [#7958](https://github.com/timescale/timescaledb/pull/7958) Allow custom names for jobs
* [#7972](https://github.com/timescale/timescaledb/pull/7972) Add vectorized filtering for constraint checking while backfilling into compressed chunks
* [#7976](https://github.com/timescale/timescaledb/pull/7976) Include continuous aggregate name in jobs informational view
* [#7977](https://github.com/timescale/timescaledb/pull/7977) Replace references to compression with columnstore
* [#7981](https://github.com/timescale/timescaledb/pull/7981) Add columnstore as alias for `enable_columnstore `in `ALTER TABLE`
* [#7983](https://github.com/timescale/timescaledb/pull/7983) Support for SkipScan over compressed data
* [#7991](https://github.com/timescale/timescaledb/pull/7991) Improves default `segmentby` options
* [#7992](https://github.com/timescale/timescaledb/pull/7992) Add API into hypertable invalidation log
* [#8000](https://github.com/timescale/timescaledb/pull/8000) Add primary dimension info to information schema
* [#8005](https://github.com/timescale/timescaledb/pull/8005) Support `ALTER TABLE SET (timescaledb.chunk_time_interval='1 day')`
* [#8012](https://github.com/timescale/timescaledb/pull/8012) Add event triggers support on chunk creation
* [#8014](https://github.com/timescale/timescaledb/pull/8014) Enable bool compression by default by setting `timescaledb.enable_bool_compression=true`. Note: for downgrading to `2.18` or earlier version, use [this downgrade script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.19.0-downgrade_new_compression_algorithms.sql)
* [#8018](https://github.com/timescale/timescaledb/pull/8018) Add spin-lock during recompression on unique constraints
* [#8026](https://github.com/timescale/timescaledb/pull/8026) Allow `WHERE` conditions that use nonvolatile functions to be pushed down to the compressed scan level. For example, conditions like `time > now()`, where `time` is a columnstore `orderby` column, will evaluate `now()` and use the sparse index on `time` to filter out the entire compressed batches that cannot contain matching rows.
* [#8027](https://github.com/timescale/timescaledb/pull/8027) Add materialization invalidations API
* [#8047](https://github.com/timescale/timescaledb/pull/8027) Support SkipScan for `SELECT DISTINCT` with multiple distincts when all but one distinct is pinned
* [#8115](https://github.com/timescale/timescaledb/pull/8115) Add batch size limiting during compression

**Bugfixes**
* [#7862](https://github.com/timescale/timescaledb/pull/7862) Release cache pin when checking for `NOT NULL`
* [#7909](https://github.com/timescale/timescaledb/pull/7909) Update compression stats when merging chunks
* [#7928](https://github.com/timescale/timescaledb/pull/7928) Don't create a hypertable for implicitly published tables
* [#7982](https://github.com/timescale/timescaledb/pull/7982) Fix crash in batch sort merge over eligible expressions
* [#8008](https://github.com/timescale/timescaledb/pull/8008) Fix compression policy error message that shows number of successes
* [#8031](https://github.com/timescale/timescaledb/pull/8031) Fix reporting of deleted tuples for direct batch delete
* [#8033](https://github.com/timescale/timescaledb/pull/8033) Skip default `segmentby` if `orderby` is explicitly set
* [#8061](https://github.com/timescale/timescaledb/pull/8061) Ensure settings for a compressed relation are found
* [#7515](https://github.com/timescale/timescaledb/pull/7515) Add missing lock to Constraint-aware append
* [#8067](https://github.com/timescale/timescaledb/pull/8067) Make sure hypercore TAM parent is vacuumed
* [#8074](https://github.com/timescale/timescaledb/pull/8074) Fix memory leak in row compressor flush
* [#8099](https://github.com/timescale/timescaledb/pull/8099) Block chunk merging on multi-dimensional hypertables
* [#8106](https://github.com/timescale/timescaledb/pull/8106) Fix segfault when adding unique compression indexes to compressed chunks
* [#8127](https://github.com/timescale/timescaledb/pull/8127) Read bit-packed version of booleans

**GUCs**
* `timescaledb.enable_sparse_index_bloom`: Enable creation of the bloom1 sparse index on compressed chunks; Default: `ON`
* `timescaledb.compress_truncate_behaviour`: Defines how truncate behaves at the end of compression; Default: `truncate_only`
* `timescaledb.enable_compression_ratio_warnings`: Enable warnings for poor compression ratio; Default: `ON`
* `timescaledb.enable_event_triggers`: Enable event triggers for chunks creation; Default: `OFF`
* `timescaledb.enable_cagg_window_functions`: Enable window functions in continuous aggregates; Default: `OFF`

**Thanks**
* @arajkumar for reporting that implicitly published tables were still able to create hypertables
* @thotokraa for reporting an issue with unique expression indexes on compressed chunks