### PR TITLE
Allow setting bgw_log_level to FATAL and ERROR

### DIFF
--- a/.unreleased/pr_8126
+++ b/.unreleased/pr_8126
@@ -1,0 +1,1 @@
+Fixes: #8126 Allow setting bgw_log_level to FATAL and ERROR

--- a/src/guc.c
+++ b/src/guc.c
@@ -80,7 +80,8 @@ static const struct config_enum_entry loglevel_options[] = {
 	{ "debug5", DEBUG5, false }, { "debug4", DEBUG4, false }, { "debug3", DEBUG3, false },
 	{ "debug2", DEBUG2, false }, { "debug1", DEBUG1, false }, { "debug", DEBUG2, true },
 	{ "info", INFO, false },	 { "notice", NOTICE, false }, { "warning", WARNING, false },
-	{ "log", LOG, false },		 { NULL, 0, false }
+	{ "log", LOG, false },		 { "error", ERROR, false },	  { "fatal", FATAL, false },
+	{ NULL, 0, false }
 };
 
 /*

--- a/tsl/test/expected/bgw_scheduler_control.out
+++ b/tsl/test/expected/bgw_scheduler_control.out
@@ -44,7 +44,6 @@ TRUNCATE _timescaledb_internal.bgw_job_stat;
 --
 -- We change user to make sure that granting SET and ALTER SYSTEM
 -- privileges to the default user actually works.
---
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 ALTER DATABASE :TEST_DBNAME SET timescaledb.bgw_log_level = 'DEBUG1';
 SELECT pg_reload_conf();
@@ -102,6 +101,63 @@ SELECT * FROM cleaned_bgw_log;
       5 | DB Scheduler     | scheduler for database (RANDOM) exiting with exit status 0
 (8 rows)
 
+-- We test that we can set it to FATAL, which removed LOG level
+-- entries from the log.
+ALTER DATABASE :TEST_DBNAME SET timescaledb.bgw_log_level = 'FATAL';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+SELECT ts_bgw_params_reset_time(0, false);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 0);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM cleaned_bgw_log;
+ msg_no | application_name | msg 
+--------+------------------+-----
+(0 rows)
+
+-- We test that we can set it to ERROR.
+ALTER DATABASE :TEST_DBNAME SET timescaledb.bgw_log_level = 'ERROR';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+SELECT ts_bgw_params_reset_time(0, false);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 0);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM cleaned_bgw_log;
+ msg_no | application_name | msg 
+--------+------------------+-----
+(0 rows)
+
+-- Reset the log level and check that normal entries are showing up
+-- again.
 ALTER DATABASE :TEST_DBNAME RESET timescaledb.bgw_log_level;
 SELECT pg_reload_conf();
  pg_reload_conf 
@@ -109,6 +165,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE bgw_log;
 SELECT ts_bgw_params_reset_time(0, false);
  ts_bgw_params_reset_time 


### PR DESCRIPTION
In order to exclude LOG level events, it is necessary to be able to set the `bgw_log_level` to `FATAL` as well.