### PR TITLE
Refactor compressor and decompressor

### DIFF
--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -128,6 +128,7 @@ typedef struct BulkWriter
 	EState *estate;
 	CommandId mycid;
 	BulkInsertState bistate;
+	int insert_options; /* heap insert options */
 } BulkWriter;
 
 typedef struct RowDecompressor
@@ -228,13 +229,8 @@ typedef struct RowCompressor
 	/* memory context reset per-row is stored */
 	MemoryContext per_row_ctx;
 
-	/* the table we're writing the compressed data to */
-	Relation compressed_table;
-	BulkInsertState bistate;
-	/* segment by index Oid if any */
-	Oid index_oid;
-	/* relation info necessary to update indexes on compressed table */
-	ResultRelInfo *resultRelInfo;
+	/* The descriptor of the compressed tuple we're generating */
+	TupleDesc out_desc;
 
 	/* in theory we could have more input columns than outputted ones, so we
 	   store the number of inputs/compressors separately */
@@ -265,8 +261,6 @@ typedef struct RowCompressor
 	int64 num_compressed_rows;
 	/* flag for checking if we are working on the first tuple */
 	bool first_iteration;
-	/* the heap insert options */
-	int insert_options;
 
 	/* Callback called on every flush. The ntuples argument is the number of
 	 * tuples flushed. Typically used for progress reporting. */
@@ -368,22 +362,22 @@ extern void compress_chunk_populate_sort_info_for_column(const CompressionSettin
 														 Oid *collation, bool *nulls_first);
 extern Tuplesortstate *compression_create_tuplesort_state(CompressionSettings *settings,
 														  Relation rel);
-extern void row_compressor_init(const CompressionSettings *settings, RowCompressor *row_compressor,
-								const TupleDesc noncompressed_tupdesc, Relation compressed_table,
-								bool need_bistate, int insert_options);
+extern void row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *settings,
+								const TupleDesc noncompressed_tupdesc,
+								const TupleDesc compressed_tupdesc);
 extern void row_compressor_reset(RowCompressor *row_compressor);
 extern void row_compressor_close(RowCompressor *row_compressor);
 extern HeapTuple row_compressor_build_tuple(RowCompressor *row_compressor);
 extern void row_compressor_clear_batch(RowCompressor *row_compressor, bool changed_groups);
 extern void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
 											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc,
-											  Relation in_rel);
+											  Relation in_rel, BulkWriter *writer);
 extern Oid get_compressed_chunk_index(ResultRelInfo *resultRelInfo,
 									  const CompressionSettings *settings);
 
 extern void segment_info_update(SegmentInfo *segment_info, Datum val, bool is_null);
 
-extern BulkWriter bulk_writer_build(Relation out_rel);
+extern BulkWriter bulk_writer_build(Relation out_rel, int insert_options);
 extern void bulk_writer_close(BulkWriter *writer);
 extern RowDecompressor build_decompressor(const TupleDesc in_desc, const TupleDesc out_desc);
 

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -523,7 +523,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 		{
 			decompressor = build_decompressor(RelationGetDescr(in_rel), RelationGetDescr(out_rel));
 			decompressor_initialized = true;
-			writer = bulk_writer_build(out_rel);
+			writer = bulk_writer_build(out_rel, 0);
 			meta_count_attno = TupleDescGetAttrNumber(decompressor.in_desc,
 													  COMPRESSION_COLUMN_METADATA_COUNT_NAME);
 			Assert(meta_count_attno != InvalidAttrNumber);

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -251,7 +251,9 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 
 	/******************** row decompressor **************/
 
-	RowDecompressor decompressor = build_decompressor(compressed_chunk_rel, uncompressed_chunk_rel);
+	RowDecompressor decompressor = build_decompressor(RelationGetDescr(compressed_chunk_rel),
+													  RelationGetDescr(uncompressed_chunk_rel));
+
 	/********** row compressor *******************/
 	RowCompressor row_compressor;
 	row_compressor_init(settings,

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -256,9 +256,8 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 	RowCompressor row_compressor;
 	row_compressor_init(settings,
 						&row_compressor,
-						uncompressed_chunk_rel,
+						RelationGetDescr(uncompressed_chunk_rel),
 						compressed_chunk_rel,
-						compressed_rel_tupdesc->natts,
 						true /*need_bistate*/,
 						0 /*insert options*/);
 


### PR DESCRIPTION
This is a multi-commit PR:

Clean up RowCompressor and RowDecompressor

Remove unnecessary fields in the RowCompressor and RowDecompressor
structs. Some of these fields were unused or duplicated information
that could be retrieved by other means.

Break out write state from RowDecompressor

The RowDecompressor expects two relations: one reading compressed data
and one where decompressed data is written. However, some
(de)compression don't follow this pattern; for example, in case of
splitting a chunk it is necessary to split compressed segments into
multiple new segments and write back compressed to the new compressed
relations. Another is memory decompression, which has no output
relation.

To better support such use cases, move the relations and write state
out of the RowDecompressor and introduce a BulkWriter that takes care
of writing the data to the desired output relation if needed. This
removes the dependency on specific relations and makes the write state
optional.

Break out the write state from RowCompressor

Similar to the RowDecompressor, the RowCompressor is constructed from
output and input relations. However, sometimes when compressing this
one-to-one relation mapping does not fit. For example, the input could
also be a compressed relation (e.g., when recompressing or splitting
chunks), so it makes sense to move the relations and write state out
of the RowCompressor.

A previous refactor did the similar thing for RowDecompressor and
introduced a BulkWriter. In line with that change, remove the write
state from the RowCompressor and use the BulkWriter instead.


Disable-check: force-changelog-file
Disable-check: commit-count