### PR TITLE
Add function to process hypertable invalidations

### DIFF
--- a/.unreleased/pr_8141
+++ b/.unreleased/pr_8141
@@ -1,0 +1,1 @@
+Implements: #8141 Add function to process hypertable invalidations

--- a/sql/cagg_api.sql
+++ b/sql/cagg_api.sql
@@ -339,3 +339,7 @@ END
 $body$
 LANGUAGE plpgsql
 SET search_path TO pg_catalog, pg_temp;
+
+CREATE OR REPLACE PROCEDURE _timescaledb_functions.process_hypertable_invalidations(
+    hypertable REGCLASS
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_continuous_agg_process_hypertable_invalidations';

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,3 @@
+CREATE PROCEDURE _timescaledb_functions.process_hypertable_invalidations(
+    hypertable REGCLASS
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_update_placeholder';

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,1 @@
+DROP PROCEDURE _timescaledb_functions.process_hypertable_invalidations(REGCLASS);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -87,6 +87,7 @@ CROSSMODULE_WRAPPER(bloom1_contains);
 /* continuous aggregate */
 CROSSMODULE_WRAPPER(continuous_agg_invalidation_trigger);
 CROSSMODULE_WRAPPER(continuous_agg_refresh);
+CROSSMODULE_WRAPPER(continuous_agg_process_hypertable_invalidations);
 CROSSMODULE_WRAPPER(continuous_agg_validate_query);
 CROSSMODULE_WRAPPER(continuous_agg_get_bucket_function);
 CROSSMODULE_WRAPPER(continuous_agg_get_bucket_function_info);
@@ -392,6 +393,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.continuous_agg_invalidation_trigger = error_no_default_fn_pg_community,
 	.continuous_agg_call_invalidation_trigger = continuous_agg_call_invalidation_trigger_default,
 	.continuous_agg_refresh = error_no_default_fn_pg_community,
+	.continuous_agg_process_hypertable_invalidations = error_no_default_fn_pg_community,
 	.continuous_agg_invalidate_raw_ht = continuous_agg_invalidate_raw_ht_all_default,
 	.continuous_agg_invalidate_mat_ht = continuous_agg_invalidate_mat_ht_all_default,
 	.continuous_agg_update_options = continuous_agg_update_options_default,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -106,6 +106,7 @@ typedef struct CrossModuleFunctions
 													 HeapTuple chunk_tuple,
 													 HeapTuple chunk_newtuple, bool update);
 	PGFunction continuous_agg_refresh;
+	PGFunction continuous_agg_process_hypertable_invalidations;
 	void (*continuous_agg_invalidate_raw_ht)(const Hypertable *raw_ht, int64 start, int64 end);
 	void (*continuous_agg_invalidate_mat_ht)(const Hypertable *raw_ht, const Hypertable *mat_ht,
 											 int64 start, int64 end);

--- a/src/init.c
+++ b/src/init.c
@@ -32,9 +32,6 @@ extern void _hypertable_cache_fini(void);
 extern void _cache_invalidate_init(void);
 extern void _cache_invalidate_fini(void);
 
-extern void _cache_init(void);
-extern void _cache_fini(void);
-
 extern void _planner_init(void);
 extern void _planner_fini(void);
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -5573,6 +5573,12 @@ ts_process_utility_set_expect_chunk_modification(bool expect)
 }
 
 bool
+ts_process_utility_is_top_level(void)
+{
+	return last_process_utility_context == PROCESS_UTILITY_TOPLEVEL;
+}
+
+bool
 ts_process_utility_is_context_nonatomic(void)
 {
 	ProcessUtilityContext context = last_process_utility_context;

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -5,11 +5,13 @@
  */
 #pragma once
 
-#include "compat/compat.h"
 #include <postgres.h>
-#include "hypertable_cache.h"
+
 #include <nodes/plannodes.h>
+#include <parser/parse_node.h>
 #include <tcop/utility.h>
+
+#include "cache.h"
 
 typedef struct ProcessUtilityArgs
 {
@@ -80,6 +82,11 @@ extern void ts_process_utility_set_expect_chunk_modification(bool expect);
  * in that function.
  */
 extern TSDLLEXPORT bool ts_process_utility_is_context_nonatomic(void);
+
+/*
+ * Check if we are at top level.
+ */
+extern TSDLLEXPORT bool ts_process_utility_is_top_level(void);
 
 /*
  * Currently in TS ProcessUtility hook the saved ProcessUtilityContext

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -41,7 +41,7 @@ extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 
 extern void continuous_agg_invalidate_raw_ht(const Hypertable *raw_ht, int64 start, int64 end);
 extern void continuous_agg_invalidate_mat_ht(const Hypertable *raw_ht, const Hypertable *mat_ht,
 											 int64 start, int64 end);
-
+extern Datum continuous_agg_process_hypertable_invalidations(PG_FUNCTION_ARGS);
 extern void invalidation_process_hypertable_log(int32 hypertable_id, Oid dimtype);
 
 extern InvalidationStore *

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -143,6 +143,8 @@ CrossModuleFunctions tsl_cm_functions = {
 	.continuous_agg_invalidation_trigger = continuous_agg_trigfn,
 	.continuous_agg_call_invalidation_trigger = execute_cagg_trigger,
 	.continuous_agg_refresh = continuous_agg_refresh,
+	.continuous_agg_process_hypertable_invalidations =
+		continuous_agg_process_hypertable_invalidations,
 	.continuous_agg_invalidate_raw_ht = continuous_agg_invalidate_raw_ht,
 	.continuous_agg_invalidate_mat_ht = continuous_agg_invalidate_mat_ht,
 	.continuous_agg_update_options = continuous_agg_update_options,

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -12,6 +12,13 @@ SELECT _timescaledb_functions.stop_background_workers();
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET datestyle TO 'ISO, YMD';
 SET timezone TO 'UTC';
+CREATE VIEW hypertable_invalidation_thresholds AS
+SELECT format('%I.%I', ht.schema_name, ht.table_name)::regclass AS hypertable,
+       watermark AS threshold
+  FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+  JOIN _timescaledb_catalog.hypertable ht
+    ON hypertable_id = ht.id
+ORDER BY 1;
 CREATE TABLE conditions (time bigint NOT NULL, device int, temp float);
 SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
     create_hypertable    
@@ -1315,3 +1322,120 @@ CALL refresh_continuous_aggregate('i5474_summary_daily', NULL, '2023-01-01 01:00
 -- CAgg should be up-to-date now
 CALL refresh_continuous_aggregate('i5474_summary_daily', NULL, '2023-01-01 01:00:00+00');
 NOTICE:  continuous aggregate "i5474_summary_daily" is already up-to-date
+--
+-- Test the invalidation move function
+--
+-- Make sure to move the threshold for the insertions we are going to
+-- do.
+CALL refresh_continuous_aggregate('measure_10', 0, 200);
+SELECT * FROM hypertable_invalidation_thresholds
+ WHERE hypertable IN ('conditions'::regclass, 'measurements'::regclass);
+  hypertable  | threshold 
+--------------+-----------
+ conditions   |       200
+ measurements |       200
+(2 rows)
+
+SELECT * FROM hyper_invals;
+ hyper_id | start | end 
+----------+-------+-----
+(0 rows)
+
+-- Save away the contents of some materialized views so that we can
+-- check that they are not updated when we move invalidations.
+SELECT * INTO saved_measure_10 FROM measure_10;
+SELECT * INTO saved_cond_10 FROM cond_10;
+-- Generate some invalidations for the hypertables
+INSERT INTO conditions VALUES (110, 14, 23.7);
+INSERT INTO conditions VALUES (110, 15, 23.8), (119, 3, 23.6);
+INSERT INTO conditions VALUES (160, 13, 23.7), (170, 4, 23.7);
+INSERT INTO measurements VALUES (120, 14, 23.7);
+INSERT INTO measurements VALUES (130, 15, 23.8), (180, 3, 23.6);
+-- Move hypertable invalidations one hypertable at a time and see that
+-- they are moved and that attached continuous aggregates are not
+-- updated.
+SELECT * FROM hyper_invals;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |   110 | 110
+        1 |   110 | 119
+        1 |   160 | 170
+        2 |   120 | 120
+        2 |   130 | 180
+(5 rows)
+
+CALL _timescaledb_functions.process_hypertable_invalidations('measurements');
+SELECT * FROM measure_10
+    FULL JOIN saved_measure_10
+           ON row(measure_10.*) = row(saved_measure_10.*)
+        WHERE measure_10.bucket IS NULL OR saved_measure_10.bucket IS NULL
+     ORDER BY 1, 2;
+ bucket | device | avg_temp | bucket | device | avg_temp 
+--------+--------+----------+--------+--------+----------
+(0 rows)
+
+SELECT * FROM hyper_invals;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |   110 | 110
+        1 |   110 | 119
+        1 |   160 | 170
+(3 rows)
+
+CALL _timescaledb_functions.process_hypertable_invalidations('conditions');
+SELECT * FROM cond_10
+    FULL JOIN saved_cond_10
+           ON row(cond_10.*) = row(saved_cond_10.*)
+        WHERE cond_10.bucket IS NULL OR saved_cond_10.bucket IS NULL
+     ORDER BY 1, 2;
+ bucket | device | avg_temp | bucket | device | avg_temp 
+--------+--------+----------+--------+--------+----------
+(0 rows)
+
+SELECT * FROM hyper_invals;
+ hyper_id | start | end 
+----------+-------+-----
+(0 rows)
+
+-- Check that once we refresh the continuous aggregates, the changes
+-- are there.
+CALL refresh_continuous_aggregate('measure_10', NULL, NULL);
+SELECT * FROM measure_10
+    FULL JOIN saved_measure_10
+           ON row(measure_10.*) = row(saved_measure_10.*)
+        WHERE measure_10.bucket IS NULL OR saved_measure_10.bucket IS NULL
+     ORDER BY 1, 2;
+ bucket | device | avg_temp | bucket | device | avg_temp 
+--------+--------+----------+--------+--------+----------
+    120 |     14 |     23.7 |        |        |         
+    130 |     15 |     23.8 |        |        |         
+    180 |      3 |     23.6 |        |        |         
+(3 rows)
+
+CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
+SELECT * FROM cond_10
+    FULL JOIN saved_cond_10
+           ON row(cond_10.*) = row(saved_cond_10.*)
+        WHERE cond_10.bucket IS NULL OR saved_cond_10.bucket IS NULL
+     ORDER BY 1, 2;
+ bucket | device | avg_temp | bucket | device | avg_temp 
+--------+--------+----------+--------+--------+----------
+    110 |      3 |     23.6 |        |        |         
+    110 |     14 |     23.7 |        |        |         
+    110 |     15 |     23.8 |        |        |         
+    160 |     13 |     23.7 |        |        |         
+    170 |      4 |     23.7 |        |        |         
+(5 rows)
+
+-- These should fail for different reasons
+\set ON_ERROR_STOP 0
+CALL _timescaledb_functions.process_hypertable_invalidations(NULL);
+ERROR:  invalid relation
+CALL _timescaledb_functions.process_hypertable_invalidations(0);
+ERROR:  invalid relation
+CALL _timescaledb_functions.process_hypertable_invalidations('measure_10');
+ERROR:  relation "measure_10" is not a hypertable
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+CALL _timescaledb_functions.process_hypertable_invalidations('measurements');
+ERROR:  must be owner of hypertable "measurements"
+\set ON_ERROR_STOP 1

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -129,6 +129,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.policy_retention(integer,jsonb)
  _timescaledb_functions.policy_retention_check(jsonb)
  _timescaledb_functions.process_ddl_event()
+ _timescaledb_functions.process_hypertable_invalidations(regclass)
  _timescaledb_functions.range_value_to_pretty(bigint,regtype)
  _timescaledb_functions.recompress_chunk_segmentwise(regclass,boolean)
  _timescaledb_functions.relation_approximate_size(regclass)


### PR DESCRIPTION
Continuous aggregate invalidation moves hypertable invalidations to
materialization invalidations as part of refreshing a continuous
aggregate, but it is not possible to move hypertable invalidations
without refreshing a continuous aggregate.

This commit adds a function to process hypertable invalidations by
moving them from the hypertable invalidation log to the materialization
invalidation logs for all attached continuous aggregates.
