### PR TITLE
Remove obsolete downgrade_to_version entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,20 +101,13 @@ if(VERSION_CONFIG
   endif()
 endif()
 
-# fallback for < 2.20 downgrade can be removed after we release 2.20
-if(VERSION_CONFIG
-   MATCHES
-   ".*downgrade_to_version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.[0-9]+(-[a-z]+[0-9]*)?).*"
-)
-  set(UPDATE_FROM_VERSION ${CMAKE_MATCH_1})
-  set(DOWNGRADE_TO_VERSION ${CMAKE_MATCH_1})
-  set(PREVIOUS_VERSION ${CMAKE_MATCH_1})
-endif()
-
 if(VERSION_CONFIG MATCHES
    ".*previous_version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.[0-9]+(-[a-z]+[0-9]*)?).*"
 )
   set(PREVIOUS_VERSION ${CMAKE_MATCH_1})
+else()
+  message(
+    FATAL_ERROR "Could not determine previous version from version.config")
 endif()
 
 # a hack to avoid change of SQL extschema variable

--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -177,9 +177,9 @@ function(generate_downgrade_script)
   # Save the current PROJECT_VERSION_MOD
   set(SAVED_PROJECT_VERSION_MOD ${PROJECT_VERSION_MOD})
   # To use PROJECT_VERSION_MOD variable as a target version in downgrade scripts
-  # we should set it as the DOWNGRADE_TO_VERSION because it means the target version
+  # we should set it as the PREVIOUS_VERSION because it means the target version
   # when executing the downgrade scripts
-  set(PROJECT_VERSION_MOD ${DOWNGRADE_TO_VERSION})
+  set(PROJECT_VERSION_MOD ${PREVIOUS_VERSION})
   generate_script(
     VERSION
     ${_downgrade_TARGET_VERSION}

--- a/version.config
+++ b/version.config
@@ -1,3 +1,2 @@
 version = 2.21.0-dev
 previous_version = 2.20.0
-downgrade_to_version = 2.20.0


### PR DESCRIPTION
Since we now have a released version with the new version.config
entries we can drop downgrade_to_version since it should always
match previous_version.

Disable-check: force-changelog-file
