### PR TITLE
Fix RPM and APT downgrade test

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -85,13 +85,12 @@ jobs:
         fi
 
     - name: Test Downgrade
-      if: matrix.pg != '17'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.
         prev_version=$(wget --quiet -O - \
         https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config \
-          | grep update_from_version | sed -e 's!update_from_version = !!')
+          | grep previous_version | sed -e 's!previous_version = !!')
         sudo -u postgres psql -X -c "ALTER EXTENSION timescaledb UPDATE TO '${prev_version}'" \
           -c "SELECT extname,extversion,version() FROM pg_extension WHERE extname='timescaledb'"
         installed_version=$(sudo -u postgres psql -X -t \

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -93,13 +93,12 @@ jobs:
         fi
 
     - name: Test Downgrade
-      if: matrix.pg != '17'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.
         prev_version=$(wget --quiet -O - \
           https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config \
-          | grep update_from_version | sed -e 's!update_from_version = !!')
+          | grep previous_version | sed -e 's!previous_version = !!')
         yum downgrade -y timescaledb-2${{ matrix.pkg_suffix }}-postgresql-${{ matrix.pg }}-${prev_version}
         sudo -u postgres psql -X -c "ALTER EXTENSION timescaledb UPDATE TO '${prev_version}'" \
           -c "SELECT extname,extversion,version() FROM pg_extension WHERE extname='timescaledb';"


### PR DESCRIPTION
version.config has been cleaned up and has `previous_version` entry
for the target of the downgrade, so use that instead.
