### PR TITLE
Fix sorting transformation with joins

### DIFF
--- a/.unreleased/sort-transform-join
+++ b/.unreleased/sort-transform-join
@@ -1,0 +1,2 @@
+Fixes: #7292 Intermittent "could not find pathkey item to sort" error when grouping or ordering by a time_bucket of an equality join variable.
+Thanks: @bobozaur, @kvc0, @ChadMoran, @PaddyKe for reporting the pathkey error.

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -418,6 +418,33 @@ ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry
 	 * Using it for other ORDER BY clauses will result in wrong ordering.
 	 */
 	last_pk = llast(root->query_pathkeys);
+
+	/*
+	 * We can only transform the original pathkey if it references our hypertable.
+	 * If it references another one, we might be able to successfully transform
+	 * it to a join EC that references both hypertables, but when we replace it
+	 * back, we'll get into an incorrect state where the pathkey for the scan
+	 * references only a different hypertable and doesn't have an EC member for
+	 * ours.
+	 */
+	int desired_ec_relid = rel->relid;
+	if (rel->parent != NULL)
+	{
+		/*
+		 * The EC relids contain only inheritance parents, not individual
+		 * children.
+		 */
+		desired_ec_relid = rel->parent->relid;
+	}
+
+	if (!bms_is_member(desired_ec_relid, last_pk->pk_eclass->ec_relids))
+	{
+		return NIL;
+	}
+
+	/*
+	 * Try to apply the transformation.
+	 */
 	transformed = sort_transform_ec(root, last_pk->pk_eclass);
 
 	if (transformed == NULL)

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -428,13 +428,14 @@ ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry
 	 * ours.
 	 */
 	int desired_ec_relid = rel->relid;
-	if (rel->parent != NULL)
+	if (rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
 	{
 		/*
 		 * The EC relids contain only inheritance parents, not individual
 		 * children.
 		 */
-		desired_ec_relid = rel->parent->relid;
+		AppendRelInfo *appinfo = root->append_rel_array[rel->relid];
+		desired_ec_relid = appinfo->parent_relid;
 	}
 
 	if (!bms_is_member(desired_ec_relid, last_pk->pk_eclass->ec_relids))

--- a/tsl/test/expected/compress_sort_transform.out
+++ b/tsl/test/expected/compress_sort_transform.out
@@ -389,7 +389,38 @@ on a.time = b.time
 where b.time < '2020-01-07'
 group by 1
 ;
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-connection to server was lost
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Group (actual rows=480 loops=1)
+   Group Key: (time_bucket('@ 1 min'::interval, a_1."time"))
+   ->  Sort (actual rows=7560 loops=1)
+         Sort Key: (time_bucket('@ 1 min'::interval, a_1."time"))
+         Sort Method: quicksort 
+         ->  Hash Join (actual rows=7560 loops=1)
+               Hash Cond: (a_1."time" = b_1."time")
+               ->  Append (actual rows=1800 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk a_1 (actual rows=1080 loops=1)
+                           Filter: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 360
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
+                     ->  Index Only Scan Backward using _hyper_1_1_chunk_ht_metrics_partially_compressed_time_idx on _hyper_1_1_chunk a_1 (actual rows=720 loops=1)
+                           Index Cond: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
+               ->  Hash (actual rows=1800 loops=1)
+                     Buckets: 4096  Batches: 1 
+                     ->  Append (actual rows=1800 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk b_1 (actual rows=1080 loops=1)
+                                 Vectorized Filter: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
+                                 Rows Removed by Filter: 360
+                                 ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=3 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
+                           ->  Index Only Scan Backward using _hyper_1_1_chunk_ht_metrics_partially_compressed_time_idx on _hyper_1_1_chunk b_1 (actual rows=720 loops=1)
+                                 Index Cond: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
+(30 rows)
+
+reset work_mem;
+reset enable_hashagg;
+reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/compress_sort_transform.out
+++ b/tsl/test/expected/compress_sort_transform.out
@@ -381,6 +381,8 @@ order by device, time_bucket('1 minute', time) limit 1;
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=339 loops=1)
 (33 rows)
 
+-- Test incorrect transformation into a Pathkey on different relation through
+-- a join EquivalenceClass.
 set max_parallel_workers_per_gather = 0;
 :PREFIX
 select time_bucket('1 minute', a.time) from ht_metrics_partially_compressed a
@@ -421,6 +423,6 @@ group by 1
                                  Index Cond: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
 (30 rows)
 
+reset max_parallel_workers_per_gather;
 reset work_mem;
 reset enable_hashagg;
-reset max_parallel_workers_per_gather;

--- a/tsl/test/expected/compress_sort_transform.out
+++ b/tsl/test/expected/compress_sort_transform.out
@@ -381,5 +381,15 @@ order by device, time_bucket('1 minute', time) limit 1;
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=339 loops=1)
 (33 rows)
 
-reset work_mem;
-reset enable_hashagg;
+set max_parallel_workers_per_gather = 0;
+:PREFIX
+select time_bucket('1 minute', a.time) from ht_metrics_partially_compressed a
+join ht_metrics_partially_compressed b
+on a.time = b.time
+where b.time < '2020-01-07'
+group by 1
+;
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

--- a/tsl/test/sql/compress_sort_transform.sql
+++ b/tsl/test/sql/compress_sort_transform.sql
@@ -72,6 +72,8 @@ order by time_bucket('1 minute', time) limit 1;
 select * from ht_metrics_partially_compressed
 order by device, time_bucket('1 minute', time) limit 1;
 
+-- Test incorrect transformation into a Pathkey on different relation through
+-- a join EquivalenceClass.
 set max_parallel_workers_per_gather = 0;
 :PREFIX
 select time_bucket('1 minute', a.time) from ht_metrics_partially_compressed a
@@ -80,7 +82,7 @@ on a.time = b.time
 where b.time < '2020-01-07'
 group by 1
 ;
+reset max_parallel_workers_per_gather;
 
 reset work_mem;
 reset enable_hashagg;
-reset max_parallel_workers_per_gather;

--- a/tsl/test/sql/compress_sort_transform.sql
+++ b/tsl/test/sql/compress_sort_transform.sql
@@ -72,5 +72,15 @@ order by time_bucket('1 minute', time) limit 1;
 select * from ht_metrics_partially_compressed
 order by device, time_bucket('1 minute', time) limit 1;
 
+set max_parallel_workers_per_gather = 0;
+:PREFIX
+select time_bucket('1 minute', a.time) from ht_metrics_partially_compressed a
+join ht_metrics_partially_compressed b
+on a.time = b.time
+where b.time < '2020-01-07'
+group by 1
+;
+
 reset work_mem;
 reset enable_hashagg;
+reset max_parallel_workers_per_gather;


### PR DESCRIPTION
We ended up with the transformation applying the original pathkey from a different table, after successfully transforming to a join equivalence class that contains both tables. Add a check for that.


Fixes: https://github.com/timescale/timescaledb/issues/7292