### PR TITLE
Fix a minor error in test

### DIFF
--- a/tsl/test/expected/compress_bloom_sparse_debug.out
+++ b/tsl/test/expected/compress_bloom_sparse_debug.out
@@ -75,12 +75,12 @@ with col as (
 select
     round(
         sum(pg_column_size(cc))::numeric / (sum(pg_column_size(f))
-            + sum(pg_column_size(cc)) filter (where _timescaledb_functions.bloom1_contains(f, 'match'::text))),
+            + sum(pg_column_size(cc)) filter (where _timescaledb_functions.bloom1_contains(f, '0.4067781441845'::text))),
         2)
 from col;
  round 
 -------
-      
+  5.95
 (1 row)
 
 -- Compressed bytes-per-value vs bloom filter bytes-per-value.

--- a/tsl/test/sql/compress_bloom_sparse_debug.sql
+++ b/tsl/test/sql/compress_bloom_sparse_debug.sql
@@ -71,7 +71,7 @@ with col as (
 select
     round(
         sum(pg_column_size(cc))::numeric / (sum(pg_column_size(f))
-            + sum(pg_column_size(cc)) filter (where _timescaledb_functions.bloom1_contains(f, 'match'::text))),
+            + sum(pg_column_size(cc)) filter (where _timescaledb_functions.bloom1_contains(f, '0.4067781441845'::text))),
         2)
 from col;
 


### PR DESCRIPTION
The bloom filter test used an incorrect constant, so a query was returning null result.

Disable-check: approval-count