### PR TITLE
Fix setting compress_chunk_interval on continuous aggregates

### DIFF
--- a/.unreleased/pr_8162
+++ b/.unreleased/pr_8162
@@ -1,0 +1,2 @@
+Fixes: #8162 Fix setting compress_chunk_interval on continuous aggregates
+Thanks: @jlordiales for reporting an issue with setting compress_chunk_interval for continuous aggregates

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -42,7 +42,7 @@ static const WithClauseDefinition alter_table_with_clause_def[] = {
 			 .type_id = TEXTOID,
 		},
 		[AlterTableFlagCompressChunkTimeInterval] = {
-			.arg_names = {"compress_chunk_time_interval", NULL},
+			.arg_names = {"compress_chunk_interval", "compress_chunk_time_interval", NULL},
 			 .type_id = INTERVALOID,
 		},
 };

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2220,3 +2220,32 @@ SELECT time_interval from timescaledb_information.continuous_aggregates cagg INN
  @ 110 days
 (1 row)
 
+-- test columnstore options
+CREATE MATERIALIZED VIEW columnstore_options WITH (tsdb.continuous, tsdb.chunk_interval='1 day') AS SELECT time_bucket('1 day', time) FROM conditions GROUP BY 1 WITH NO DATA;
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |                         
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.columnstore, tsdb.chunk_interval='1 day', tsdb.orderby='time_bucket DESC', tsdb.compress_chunk_interval='2 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             172800000000
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_interval='3 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             259200000000
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_time_interval='4 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             345600000000
+(1 row)
+

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2220,3 +2220,32 @@ SELECT time_interval from timescaledb_information.continuous_aggregates cagg INN
  @ 110 days
 (1 row)
 
+-- test columnstore options
+CREATE MATERIALIZED VIEW columnstore_options WITH (tsdb.continuous, tsdb.chunk_interval='1 day') AS SELECT time_bucket('1 day', time) FROM conditions GROUP BY 1 WITH NO DATA;
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |                         
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.columnstore, tsdb.chunk_interval='1 day', tsdb.orderby='time_bucket DESC', tsdb.compress_chunk_interval='2 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             172800000000
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_interval='3 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             259200000000
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_time_interval='4 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             345600000000
+(1 row)
+

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -2220,3 +2220,32 @@ SELECT time_interval from timescaledb_information.continuous_aggregates cagg INN
  @ 110 days
 (1 row)
 
+-- test columnstore options
+CREATE MATERIALIZED VIEW columnstore_options WITH (tsdb.continuous, tsdb.chunk_interval='1 day') AS SELECT time_bucket('1 day', time) FROM conditions GROUP BY 1 WITH NO DATA;
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |                         
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.columnstore, tsdb.chunk_interval='1 day', tsdb.orderby='time_bucket DESC', tsdb.compress_chunk_interval='2 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             172800000000
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_interval='3 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             259200000000
+(1 row)
+
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_time_interval='4 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ column_name | compress_interval_length 
+-------------+--------------------------
+ time_bucket |             345600000000
+(1 row)
+

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1427,3 +1427,13 @@ ALTER MATERIALIZED VIEW cagg_chunk_interval SET (tsdb.chunk_interval='110 day');
 
 SELECT time_interval from timescaledb_information.continuous_aggregates cagg INNER JOIN timescaledb_information.dimensions dim ON cagg.materialization_hypertable_name = dim.hypertable_name  WHERE view_name='cagg_chunk_interval';
 
+-- test columnstore options
+CREATE MATERIALIZED VIEW columnstore_options WITH (tsdb.continuous, tsdb.chunk_interval='1 day') AS SELECT time_bucket('1 day', time) FROM conditions GROUP BY 1 WITH NO DATA;
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.columnstore, tsdb.chunk_interval='1 day', tsdb.orderby='time_bucket DESC', tsdb.compress_chunk_interval='2 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_interval='3 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_time_interval='4 day');
+SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
+


### PR DESCRIPTION
This also syncs option names with other WITH clauses and adds some
test to verify it can be set.

Fixes #8158