### PR TITLE
Fix gapfill crash with locf NULL values treated as missing

### DIFF
--- a/.unreleased/pr_8163
+++ b/.unreleased/pr_8163
@@ -1,0 +1,2 @@
+Fixes: #8163 Fix gapfill crash with locf NULL values treated as missing
+Thanks: @svanharmelen, @cmdjulian, @etaMS20 for reporting time_bucket_gapfill with locf crash when NULL values are treated as missing 

--- a/tsl/src/nodes/gapfill/gapfill_internal.h
+++ b/tsl/src/nodes/gapfill/gapfill_internal.h
@@ -123,5 +123,5 @@ typedef struct GapFillState
 
 Node *gapfill_state_create(CustomScan *);
 Expr *gapfill_adjust_varnos(GapFillState *state, Expr *expr);
-Datum gapfill_exec_expr(GapFillState *state, Expr *expr, bool *isnull);
+Datum gapfill_exec_expr(GapFillState *state, TupleTableSlot *, Expr *expr, bool *isnull);
 int64 gapfill_datum_get_internal(Datum, Oid);

--- a/tsl/src/nodes/gapfill/interpolate.c
+++ b/tsl/src/nodes/gapfill/interpolate.c
@@ -92,7 +92,7 @@ gapfill_fetch_sample(GapFillState *state, GapFillInterpolateColumnState *column,
 	TupleDesc tupdesc;
 	Datum value;
 	bool isnull;
-	Datum datum = gapfill_exec_expr(state, lookup, &isnull);
+	Datum datum = gapfill_exec_expr(state, state->scanslot, lookup, &isnull);
 
 	if (isnull)
 	{

--- a/tsl/src/nodes/gapfill/locf.c
+++ b/tsl/src/nodes/gapfill/locf.c
@@ -61,12 +61,12 @@ gapfill_locf_tuple_returned(GapFillLocfColumnState *locf, Datum value, bool isnu
  * gapfill_locf_calculate gets called for every gapfilled tuple to calculate values
  */
 void
-gapfill_locf_calculate(GapFillLocfColumnState *locf, GapFillState *state, int64 time, Datum *value,
-					   bool *isnull)
+gapfill_locf_calculate(GapFillLocfColumnState *locf, GapFillState *state, TupleTableSlot *ecxt_slot,
+					   int64 time, Datum *value, bool *isnull)
 {
 	/* only evaluate expr for first tuple */
 	if (locf->isnull && locf->lookup_last && time == state->gapfill_start)
-		locf->value = gapfill_exec_expr(state, locf->lookup_last, &locf->isnull);
+		locf->value = gapfill_exec_expr(state, ecxt_slot, locf->lookup_last, &locf->isnull);
 
 	*value = locf->value;
 	*isnull = locf->isnull;

--- a/tsl/src/nodes/gapfill/locf.h
+++ b/tsl/src/nodes/gapfill/locf.h
@@ -21,4 +21,5 @@ typedef struct GapFillLocfColumnState
 void gapfill_locf_initialize(GapFillLocfColumnState *, GapFillState *, FuncExpr *);
 void gapfill_locf_group_change(GapFillLocfColumnState *);
 void gapfill_locf_tuple_returned(GapFillLocfColumnState *, Datum, bool);
-void gapfill_locf_calculate(GapFillLocfColumnState *, GapFillState *, int64, Datum *, bool *);
+void gapfill_locf_calculate(GapFillLocfColumnState *, GapFillState *, TupleTableSlot *, int64,
+							Datum *, bool *);

--- a/tsl/test/shared/expected/gapfill_bug.out
+++ b/tsl/test/shared/expected/gapfill_bug.out
@@ -1,0 +1,110 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Fix for issue #6078: crash in "time_bucket_gapfil"
+-- with "locf" using NULL value and NULLs treated as missing.
+create table tw(id varchar, time timestamp, value float);
+insert into tw values ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400);
+SET timezone TO 'Europe/Berlin';
+-- Losf lookup query being a SubPlan as it has a predicate over correlated variable
+-- We call Locf calculation for a "gapfill_start" tuple retrived from the input to override its NULL value,
+-- rather than for a tuple generated to fill the gaps.
+-- We used to crash in this scenario due to pointing to a wrong tuple slot. Should work OK now.
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM tw AS p WHERE p.id = tw.id  ORDER BY 1 LIMIT 1), true) AS value
+FROM tw GROUP BY 1,2;
+  id  |          bucket          | value  
+------+--------------------------+--------
+ uuid | Fri Sep 15 12:00:00 2023 |       
+ uuid | Fri Sep 15 12:50:00 2023 | 147673
+(2 rows)
+
+-- Should return same result for simpler Losf lookup query
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM tw AS p  ORDER BY 1 LIMIT 1), true) AS value
+FROM tw GROUP BY 1,2;
+  id  |          bucket          | value  
+------+--------------------------+--------
+ uuid | Fri Sep 15 12:00:00 2023 |       
+ uuid | Fri Sep 15 12:50:00 2023 | 147673
+(2 rows)
+
+-- Should return same result when using CTE instead of input table
+WITH data (id, time, value) AS (
+  VALUES ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400)
+)
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM data AS p WHERE p.id = data.id ORDER BY 1 LIMIT 1), true) AS value
+FROM data GROUP BY 1,2;
+  id  |          bucket          | value  
+------+--------------------------+--------
+ uuid | Fri Sep 15 12:00:00 2023 |       
+ uuid | Fri Sep 15 12:50:00 2023 | 147673
+(2 rows)
+
+-- Pick an average value instead of min
+WITH data (id, time, value) AS (
+  VALUES ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400)
+)
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT avg(p.value) FROM data AS p WHERE p.id = data.id), true) AS value
+FROM data GROUP BY 1,2;
+  id  |          bucket          |  value   
+------+--------------------------+----------
+ uuid | Fri Sep 15 12:00:00 2023 |         
+ uuid | Fri Sep 15 12:50:00 2023 | 148536.5
+(2 rows)
+
+-- Call Locf both for filling gaps and setting the non-NULL value for "gapfill_start" tuple
+WITH data (id, time, value) AS (
+  VALUES ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400)
+)
+SELECT id,
+  time_bucket_gapfill('1min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT avg(p.value) FROM data AS p WHERE p.id = data.id), true) AS value
+FROM data GROUP BY 1,2;
+  id  |          bucket          |  value   
+------+--------------------------+----------
+ uuid | Fri Sep 15 12:00:00 2023 |         
+ uuid | Fri Sep 15 12:50:00 2023 | 148536.5
+ uuid | Fri Sep 15 12:51:00 2023 | 148536.5
+ uuid | Fri Sep 15 12:52:00 2023 | 148536.5
+(4 rows)
+
+-- Use Locf lookup for multiple groupby values, use 2nd groupby column as a correlation var in the lookup
+-- Make sure correlation var is obtained from correct tuple passed to Locf lookup expression
+WITH data (id, gr, time, value) AS (
+  VALUES ('uuid', 12, '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', 14, '2023-09-15 12:52', 149400)
+)
+SELECT id, gr,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM data AS p where p.gr = data.gr ORDER BY 1 desc LIMIT 1), true) AS value
+FROM data GROUP BY 1,2,3 ORDER BY 1,2,3;
+  id  | gr |          bucket          | value  
+------+----+--------------------------+--------
+ uuid | 12 | Fri Sep 15 12:00:00 2023 |       
+ uuid | 12 | Fri Sep 15 12:50:00 2023 | 147673
+ uuid | 14 | Fri Sep 15 12:50:00 2023 | 149400
+(3 rows)
+
+-- Same but use two correlation vars in Locf lookup
+WITH data (id, gr, time, value) AS (
+  VALUES ('uuid', 12, '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', 14, '2023-09-15 12:52', 149400)
+)
+SELECT id, gr,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM data AS p where p.gr = data.gr and p.id = data.id ORDER BY 1 desc LIMIT 1), true) AS value
+FROM data GROUP BY 1,2,3 ORDER BY 1,2,3;
+  id  | gr |          bucket          | value  
+------+----+--------------------------+--------
+ uuid | 12 | Fri Sep 15 12:00:00 2023 |       
+ uuid | 12 | Fri Sep 15 12:50:00 2023 | 147673
+ uuid | 14 | Fri Sep 15 12:50:00 2023 | 149400
+(3 rows)
+
+drop table tw cascade;
+RESET timezone;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_FILES_SHARED
     decompress_join.sql
     decompress_placeholdervar.sql
     decompress_tracking.sql
+    gapfill_bug.sql
     generated_columns.sql
     memoize.sql
     security_barrier.sql

--- a/tsl/test/shared/sql/gapfill_bug.sql
+++ b/tsl/test/shared/sql/gapfill_bug.sql
@@ -1,0 +1,75 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Fix for issue #6078: crash in "time_bucket_gapfil"
+-- with "locf" using NULL value and NULLs treated as missing.
+
+create table tw(id varchar, time timestamp, value float);
+insert into tw values ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400);
+
+SET timezone TO 'Europe/Berlin';
+
+-- Losf lookup query being a SubPlan as it has a predicate over correlated variable
+-- We call Locf calculation for a "gapfill_start" tuple retrived from the input to override its NULL value,
+-- rather than for a tuple generated to fill the gaps.
+-- We used to crash in this scenario due to pointing to a wrong tuple slot. Should work OK now.
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM tw AS p WHERE p.id = tw.id  ORDER BY 1 LIMIT 1), true) AS value
+FROM tw GROUP BY 1,2;
+
+-- Should return same result for simpler Losf lookup query
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM tw AS p  ORDER BY 1 LIMIT 1), true) AS value
+FROM tw GROUP BY 1,2;
+
+-- Should return same result when using CTE instead of input table
+WITH data (id, time, value) AS (
+  VALUES ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400)
+)
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM data AS p WHERE p.id = data.id ORDER BY 1 LIMIT 1), true) AS value
+FROM data GROUP BY 1,2;
+
+-- Pick an average value instead of min
+WITH data (id, time, value) AS (
+  VALUES ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400)
+)
+SELECT id,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT avg(p.value) FROM data AS p WHERE p.id = data.id), true) AS value
+FROM data GROUP BY 1,2;
+
+-- Call Locf both for filling gaps and setting the non-NULL value for "gapfill_start" tuple
+WITH data (id, time, value) AS (
+  VALUES ('uuid', '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', '2023-09-15 12:52', 149400)
+)
+SELECT id,
+  time_bucket_gapfill('1min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT avg(p.value) FROM data AS p WHERE p.id = data.id), true) AS value
+FROM data GROUP BY 1,2;
+
+-- Use Locf lookup for multiple groupby values, use 2nd groupby column as a correlation var in the lookup
+-- Make sure correlation var is obtained from correct tuple passed to Locf lookup expression
+WITH data (id, gr, time, value) AS (
+  VALUES ('uuid', 12, '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', 14, '2023-09-15 12:52', 149400)
+)
+SELECT id, gr,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM data AS p where p.gr = data.gr ORDER BY 1 desc LIMIT 1), true) AS value
+FROM data GROUP BY 1,2,3 ORDER BY 1,2,3;
+
+-- Same but use two correlation vars in Locf lookup
+WITH data (id, gr, time, value) AS (
+  VALUES ('uuid', 12, '2023-09-15 12:00'::timestamp, 147673::float), ('uuid', 14, '2023-09-15 12:52', 149400)
+)
+SELECT id, gr,
+  time_bucket_gapfill('10min'::interval, time, '2023-09-15 12:50', '2023-09-15 12:53') AS bucket,
+  locf(null::float, (SELECT p.value FROM data AS p where p.gr = data.gr and p.id = data.id ORDER BY 1 desc LIMIT 1), true) AS value
+FROM data GROUP BY 1,2,3 ORDER BY 1,2,3;
+
+drop table tw cascade;
+RESET timezone;


### PR DESCRIPTION
Fixes #6078
Calculate `locf` for missing NULLs on the correct tuple slot.
