### PR TITLE
Run most prerelease tests on each commit in release branches (#8090)

### DIFF
--- a/.github/workflows/catalog-updates-check.yaml
+++ b/.github/workflows/catalog-updates-check.yaml
@@ -1,6 +1,10 @@
 name: Check for unsafe catalog updates
 "on":
   pull_request:
+  push:
+    branches:
+      - main
+      - ?.*.x
 jobs:
   check_catalog_correctly_updated:
     name: Check updates to latest-dev and reverse-dev are properly handled by PR

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -5,7 +5,7 @@ name: Coccinelle
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
 jobs:
   coccinelle:
     name: Coccinelle

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -3,7 +3,7 @@ name: Code style
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
   pull_request:
 
 jobs:

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -6,7 +6,7 @@ name: Libfuzzer
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
       - trigger/libfuzzer
   pull_request:
     paths:

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -10,7 +10,7 @@ name: Regression Linux i386
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
     paths-ignore:
       - '**.md'
       - 'LICENSE*'

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -10,7 +10,7 @@ name: Regression
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
     paths-ignore:
       - '**.md'
       - 'LICENSE*'

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -3,7 +3,7 @@ name: Memory tests
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
       - memory_test
       - trigger/memory_test
   pull_request:

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -4,7 +4,7 @@ name: pg_ladybug
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
 jobs:
   pg_ladybug:
     runs-on: ubuntu-latest

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -3,7 +3,7 @@ name: pg_upgrade test
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
   pull_request:
 
 jobs:

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -5,7 +5,7 @@ name: pgspot
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
 
 jobs:
   pgspot:

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -7,7 +7,7 @@ name: Sanitizer test
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
       - trigger/sanitizer
   pull_request:
     paths: .github/workflows/sanitizer-build-and-test.yaml

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -8,7 +8,7 @@ name: Shellcheck
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
     paths:
       - '**.sh'
       - .github/workflows/shellcheck.yaml

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -9,7 +9,7 @@ name: ABI Test Against Snapshot
     - cron: '0 20 * * *'
   push:
     branches:
-      - prerelease_test
+      - ?.*.x
       - trigger/snapshot-abi
   pull_request:
     paths: .github/workflows/snapshot-abi.yaml

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -8,7 +8,7 @@ name: SQLsmith
     branches:
       - sqlsmith
       - main
-      - prerelease_test
+      - ?.*.x
   pull_request:
     paths: .github/workflows/sqlsmith.yaml
 

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -3,7 +3,7 @@ name: Test Update and Downgrade
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -7,7 +7,7 @@ name: Regression Windows
   push:
     branches:
       - main
-      - prerelease_test
+      - ?.*.x
       - trigger/windows_tests
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
These branches are not very active, so this would give up-to-date results w/o too much CI load.

(cherry picked from commit 9b12dbbd5817030a1bb292e6975d93ceff3e6920)

(manual backport of #8090)