### PR TITLE
Implement direct DELETE on non-segmentby cols

### DIFF
--- a/.unreleased/pr_8179
+++ b/.unreleased/pr_8179
@@ -1,0 +1,1 @@
+Implements: #8179 Implement direct DELETE on non-segmentby columns

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1308,7 +1308,11 @@ process_truncate(ProcessUtilityArgs *args)
 						 * Block direct TRUNCATE on frozen chunk.
 						 */
 						if (ts_chunk_is_frozen(chunk))
-							elog(ERROR, "cannot TRUNCATE frozen chunk \"%s\"", get_rel_name(relid));
+							ereport(ERROR,
+									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									 errmsg("cannot TRUNCATE frozen chunk \"%s\"",
+											get_rel_name(relid)),
+									 errhint("Unfreeze the chunk to TRUNCATE it.")));
 
 						Assert(ht != NULL);
 

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -34,6 +34,10 @@
 #include <nodes/modify_hypertable.h>
 #include <ts_catalog/array_utils.h>
 
+typedef BatchQualSummary(BatchMatcher)(RowDecompressor *decompressor, ScanKeyData *scankeys,
+									   int num_scankeys, tuple_filtering_constraints *constraints,
+									   bool check_full_match, bool *skip_current_tuple);
+
 static struct decompress_batches_stats
 decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
 						ScanKeyData *index_scankeys, int num_index_scankeys,
@@ -42,11 +46,13 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 						tuple_filtering_constraints *constraints, bool *skip_current_tuple,
 						bool delete_only, Bitmapset *null_columns, List *is_nulls);
 
-static bool batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scankeys,
-						  tuple_filtering_constraints *constraints, bool *skip_current_tuple);
-static bool batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys,
-									 int num_scankeys, tuple_filtering_constraints *constraints,
-									 bool *skip_current_tuple);
+static BatchQualSummary batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys,
+									  int num_scankeys, tuple_filtering_constraints *constraints,
+									  bool check_full_match, bool *skip_current_tuple);
+static BatchQualSummary batch_matches_vectorized(RowDecompressor *decompressor,
+												 ScanKeyData *scankeys, int num_scankeys,
+												 tuple_filtering_constraints *constraints,
+												 bool check_full_match, bool *skip_current_tuple);
 static void process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							   ScanKeyData **mem_scankeys, int *num_mem_scankeys,
 							   List **heap_filters, List **index_filters, List **is_null);
@@ -628,15 +634,24 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 						  decompressor.compressed_datums,
 						  decompressor.compressed_is_nulls);
 
-		if (num_mem_scankeys && !batch_matcher(&decompressor,
-											   mem_scankeys,
-											   num_mem_scankeys,
-											   constraints,
-											   skip_current_tuple))
+		/* If there are no in-memory quals, all rows pass */
+		BatchQualSummary summary = AllRowsPass;
+		if (num_mem_scankeys)
 		{
-			row_decompressor_reset(&decompressor);
-			stats.batches_filtered++;
-			continue;
+			summary = batch_matcher(&decompressor,
+									mem_scankeys,
+									num_mem_scankeys,
+									constraints,
+									delete_only, /* need to check full batch for direct DELETEs */
+									skip_current_tuple);
+
+			/* If no rows pass, complete batch gets filtered */
+			if (summary == NoRowsPass)
+			{
+				row_decompressor_reset(&decompressor);
+				stats.batches_filtered++;
+				continue;
+			}
 		}
 
 		row_decompressor_reset(&decompressor);
@@ -680,7 +695,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			report_error(result);
 			return stats;
 		}
-		if (delete_only)
+		/* If all rows pass, complete batch can be deleted */
+		if (delete_only && summary == AllRowsPass)
 		{
 			stats.batches_deleted++;
 			stats.tuples_deleted += DatumGetInt32(
@@ -716,9 +732,10 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 	return stats;
 }
 
-static bool
+static BatchQualSummary
 batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scankeys,
-			  tuple_filtering_constraints *constraints, bool *skip_current_tuple)
+			  tuple_filtering_constraints *constraints, bool check_full_match,
+			  bool *skip_current_tuple)
 {
 	AttrNumber *attnos = palloc0(sizeof(AttrNumber) * num_scankeys);
 	for (int i = 0; i < num_scankeys; i++)
@@ -729,6 +746,12 @@ batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scan
 	bool next_tuple = decompress_batch_next_row(decompressor, attnos, num_scankeys);
 	ScanKey key;
 	bool match;
+
+	/* Default values are set like this because of binary operations
+	 * used to calculate these flags.
+	 */
+	bool match_any = false;
+	bool match_all = true;
 
 	while (next_tuple)
 	{
@@ -764,8 +787,12 @@ batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scan
 			}
 		}
 
+		match_any |= match;
+		match_all &= match;
+
 		if (match)
 		{
+			match_any = true;
 			if (constraints)
 			{
 				if (constraints->on_conflict == ONCONFLICT_NONE)
@@ -782,13 +809,19 @@ batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scan
 					*skip_current_tuple = true;
 				}
 			}
-			return true;
+			if (!check_full_match)
+				return SomeRowsPass;
 		}
-
 		next_tuple = decompress_batch_next_row(decompressor, attnos, num_scankeys);
 	}
 
-	return false;
+	if (match_all)
+		return AllRowsPass;
+
+	if (match_any)
+		return SomeRowsPass;
+
+	return NoRowsPass;
 }
 
 static void
@@ -819,9 +852,10 @@ check_single_value_match(const uint64 *result)
 	return result[0] & 1;
 }
 
-static bool
+static BatchQualSummary
 batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scankeys,
-						 tuple_filtering_constraints *constraints, bool *skip_current_tuple)
+						 tuple_filtering_constraints *constraints, bool check_full_match,
+						 bool *skip_current_tuple)
 {
 	const int n_rows =
 		DatumGetInt32(decompressor->compressed_datums[decompressor->count_compressed_attindex]);
@@ -879,10 +913,10 @@ batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys, i
 
 	if (batch_failed)
 	{
-		return false;
+		return NoRowsPass;
 	}
 
-	VectorQualSummary summary = get_vector_qual_summary(result, n_rows);
+	BatchQualSummary summary = get_vector_qual_summary(result, n_rows);
 
 	if (summary != NoRowsPass)
 	{
@@ -902,10 +936,10 @@ batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys, i
 				*skip_current_tuple = true;
 			}
 		}
-		return true;
+		return summary;
 	}
 
-	return false;
+	return summary;
 }
 
 /*
@@ -1272,89 +1306,93 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 																 var->varattno,
 																 settings->fd.compress_relid,
 																 "min");
+				if (min_attno == InvalidAttrNumber)
+					continue;
+
 				int max_attno = compressed_column_metadata_attno(settings,
 																 ch->table_id,
 																 var->varattno,
 																 settings->fd.compress_relid,
 																 "max");
+				if (min_attno == InvalidAttrNumber)
+					continue;
 
-				if (min_attno != InvalidAttrNumber && max_attno != InvalidAttrNumber)
+				/* Need both min and max metadata attributes to build heap filters */
+
+				switch (op_strategy)
 				{
-					switch (op_strategy)
+					case BTEqualStrategyNumber:
 					{
-						case BTEqualStrategyNumber:
-						{
-							/* orderby col = value implies min <= value and max >= value */
-							*heap_filters =
-								lappend(*heap_filters,
-										make_batchfilter(get_attname(settings->fd.compress_relid,
-																	 min_attno,
-																	 false),
-														 BTLessEqualStrategyNumber,
-														 collation,
-														 opcode,
-														 arg_value,
-														 false, /* is_null_check */
-														 false, /* is_null */
-														 false	/* is_array_op */
-														 ));
-							*heap_filters =
-								lappend(*heap_filters,
-										make_batchfilter(get_attname(settings->fd.compress_relid,
-																	 max_attno,
-																	 false),
-														 BTGreaterEqualStrategyNumber,
-														 collation,
-														 opcode,
-														 arg_value,
-														 false, /* is_null_check */
-														 false, /* is_null */
-														 false	/* is_array_op */
-														 ));
-						}
-						break;
-						case BTLessStrategyNumber:
-						case BTLessEqualStrategyNumber:
-						{
-							/* orderby col <[=] value implies min <[=] value */
-							*heap_filters =
-								lappend(*heap_filters,
-										make_batchfilter(get_attname(settings->fd.compress_relid,
-																	 min_attno,
-																	 false),
-														 op_strategy,
-														 collation,
-														 opcode,
-														 arg_value,
-														 false, /* is_null_check */
-														 false, /* is_null */
-														 false	/* is_array_op */
-														 ));
-						}
-						break;
-						case BTGreaterStrategyNumber:
-						case BTGreaterEqualStrategyNumber:
-						{
-							/* orderby col >[=] value implies max >[=] value */
-							*heap_filters =
-								lappend(*heap_filters,
-										make_batchfilter(get_attname(settings->fd.compress_relid,
-																	 max_attno,
-																	 false),
-														 op_strategy,
-														 collation,
-														 opcode,
-														 arg_value,
-														 false, /* is_null_check */
-														 false, /* is_null */
-														 false	/* is_array_op */
-														 ));
-						}
-						break;
-						default:
-							/* Do nothing for unknown operator strategies. */
-							break;
+						/* orderby col = value implies min <= value and max >= value */
+						*heap_filters =
+							lappend(*heap_filters,
+									make_batchfilter(get_attname(settings->fd.compress_relid,
+																 min_attno,
+																 false),
+													 BTLessEqualStrategyNumber,
+													 collation,
+													 opcode,
+													 arg_value,
+													 false, /* is_null_check */
+													 false, /* is_null */
+													 false	/* is_array_op */
+													 ));
+						*heap_filters =
+							lappend(*heap_filters,
+									make_batchfilter(get_attname(settings->fd.compress_relid,
+																 max_attno,
+																 false),
+													 BTGreaterEqualStrategyNumber,
+													 collation,
+													 opcode,
+													 arg_value,
+													 false, /* is_null_check */
+													 false, /* is_null */
+													 false	/* is_array_op */
+													 ));
 					}
+					break;
+					case BTLessStrategyNumber:
+					case BTLessEqualStrategyNumber:
+					{
+						/* orderby col <[=] value implies min <[=] value */
+						*heap_filters =
+							lappend(*heap_filters,
+									make_batchfilter(get_attname(settings->fd.compress_relid,
+																 min_attno,
+																 false),
+													 op_strategy,
+													 collation,
+													 opcode,
+													 arg_value,
+													 false, /* is_null_check */
+													 false, /* is_null */
+													 false	/* is_array_op */
+													 ));
+					}
+					break;
+					case BTGreaterStrategyNumber:
+					case BTGreaterEqualStrategyNumber:
+					{
+						/* orderby col >[=] value implies max >[=] value */
+						*heap_filters =
+							lappend(*heap_filters,
+									make_batchfilter(get_attname(settings->fd.compress_relid,
+																 max_attno,
+																 false),
+													 op_strategy,
+													 collation,
+													 opcode,
+													 arg_value,
+													 false, /* is_null_check */
+													 false, /* is_null */
+													 false	/* is_array_op */
+													 ));
+					}
+					break;
+					default:
+						/* Do nothing for unknown operator strategies. */
+						break;
 				}
 			}
 			break;
@@ -1721,9 +1759,23 @@ can_delete_without_decompression(ModifyHypertableState *ht_state, CompressionSet
 				return false;
 			}
 			char *column_name = get_attname(chunk->table_id, var->varattno, false);
+			/* Can do direct DELETE if we are dealing with segmentby columns */
 			if (ts_array_is_member(settings->fd.segmentby, column_name))
-			{
 				continue;
+
+			/* Can do direct DELETE if we are using in-memory filtering but
+			 * only if we can actually create scankeys for filtering
+			 */
+			if (ts_guc_enable_dml_decompression_tuple_filtering)
+			{
+				switch (nodeTag(node))
+				{
+					case T_ScalarArrayOpExpr:
+					case T_NullTest:
+						return false;
+					default:
+						continue;
+				}
 			}
 		}
 		return false;

--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -31,9 +31,6 @@ typedef struct tuple_filtering_constraints
 	bool vectorized_filtering;
 } tuple_filtering_constraints;
 
-typedef bool(BatchMatcher)(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scankeys,
-						   tuple_filtering_constraints *constraints, bool *skip_current_tuple);
-
 bool slot_key_test(TupleTableSlot *slot, ScanKey skey);
 
 ScanKeyData *build_mem_scankeys_from_slot(Oid ht_relid, CompressionSettings *settings,

--- a/tsl/src/hypercore/vector_quals.c
+++ b/tsl/src/hypercore/vector_quals.c
@@ -98,9 +98,9 @@ ExecVectorQual(VectorQualState *vqstate, ExprContext *econtext)
 		(direction == BackwardScanDirection && arrow_slot_is_last(slot)))
 	{
 		vector_qual_state_reset(vqstate);
-		VectorQualSummary vector_qual_summary = vqstate->vectorized_quals_constified != NIL ?
-													vector_qual_compute(vqstate) :
-													AllRowsPass;
+		BatchQualSummary vector_qual_summary = vqstate->vectorized_quals_constified != NIL ?
+												   vector_qual_compute(vqstate) :
+												   AllRowsPass;
 
 		switch (vector_qual_summary)
 		{

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -759,7 +759,7 @@ compute_one_qual(VectorQualState *vqstate, TupleTableSlot *compressed_slot, Node
  * it means the entire batch is filtered out, and we use this for further
  * optimizations.
  */
-VectorQualSummary
+BatchQualSummary
 vector_qual_compute(VectorQualState *vqstate)
 {
 	/*
@@ -1014,7 +1014,7 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 	};
 	VectorQualState *vqstate = &cbvqstate.vqstate;
 
-	VectorQualSummary vector_qual_summary =
+	BatchQualSummary vector_qual_summary =
 		vqstate->vectorized_quals_constified != NIL ? vector_qual_compute(vqstate) : AllRowsPass;
 
 	batch_state->vector_qual_result = vqstate->vector_qual_result;

--- a/tsl/src/nodes/decompress_chunk/pred_vector_array.c
+++ b/tsl/src/nodes/decompress_chunk/pred_vector_array.c
@@ -117,7 +117,7 @@ vector_array_predicate(VectorPredicate *vector_const_predicate, bool is_or,
 		 * compressed batch size of 1000 rows, so we can check for early exit
 		 * after every row.
 		 */
-		VectorQualSummary summary = get_vector_qual_summary(array_result, n_rows);
+		BatchQualSummary summary = get_vector_qual_summary(array_result, n_rows);
 		if (summary == (is_or ? AllRowsPass : NoRowsPass))
 		{
 			return;

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.h
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.h
@@ -25,14 +25,14 @@ void vector_nulltest(const ArrowArray *arrow, int test_type, uint64 *restrict re
 void vector_booleantest(const ArrowArray *arrow, int test_type, uint64 *restrict result);
 void vector_booleq(const ArrowArray *arrow, Datum arg, uint64 *restrict result);
 
-typedef enum VectorQualSummary
+typedef enum BatchQualSummary
 {
 	AllRowsPass,
 	NoRowsPass,
 	SomeRowsPass
-} VectorQualSummary;
+} BatchQualSummary;
 
-static pg_attribute_always_inline VectorQualSummary
+static pg_attribute_always_inline BatchQualSummary
 get_vector_qual_summary(const uint64 *qual_result, size_t n_rows)
 {
 	bool any_rows_pass = false;

--- a/tsl/src/nodes/decompress_chunk/vector_quals.h
+++ b/tsl/src/nodes/decompress_chunk/vector_quals.h
@@ -65,5 +65,5 @@ typedef struct VectorQualState
 } VectorQualState;
 
 extern Node *vector_qual_make(Node *qual, const VectorQualInfo *vqinfo);
-extern VectorQualSummary vector_qual_compute(VectorQualState *vqstate);
+extern BatchQualSummary vector_qual_compute(VectorQualState *vqstate);
 extern ArrowArray *make_single_value_arrow(Oid pgtype, Datum datum, bool isnull);

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -300,7 +300,7 @@ UPDATE public.table_to_compress SET value = 3;
 ERROR:  cannot modify frozen chunk status
 --touches only frozen chunk
 DELETE FROM public.table_to_compress WHERE time < '2020-01-02';
-ERROR:  cannot modify frozen chunk status
+ERROR:  cannot update/delete rows from chunk "_hyper_2_3_chunk" as it is frozen
 \set ON_ERROR_STOP 1
 --try to refreeze
 SELECT  _timescaledb_functions.freeze_chunk( :'CHNAME');

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -2733,14 +2733,14 @@ UPDATE test_limit SET id = 0;
 ERROR:  tuple decompression limit exceeded by operation
 DETAIL:  current limit: 5000, tuples decompressed: 30000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 ERROR:  tuple decompression limit exceeded by operation
 DETAIL:  current limit: 5000, tuples decompressed: 30000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
 UPDATE test_limit SET id = 0;
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 \set ON_ERROR_STOP 1
 DROP TABLE test_limit;
 -- check partial compression with DML
@@ -3091,13 +3091,12 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
+   Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
-         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
                Filter: ("time" = 'Wed Jan 01 05:00:00 2020 PST'::timestamp with time zone)
-(7 rows)
+(6 rows)
 
 -- test sqlvaluefunction
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
@@ -3338,6 +3337,61 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
                      Rows Removed by Filter: 2
 (10 rows)
 
+-- test DELETE optimization without predicates
+-- should delete 3 complete batches without decompression
+BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
+(5 rows)
+
+-- test DELETE optimization on non-segmentby columns
+-- this shows optimization can be applied if in-memory filtering is enabled
+\set QUIET off
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
+               Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+(6 rows)
+
+ROLLBACK
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+DELETE 3
+ROLLBACK
+SET timescaledb.enable_dml_decompression_tuple_filtering TO OFF;
+SET
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=3 loops=1)
+               Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+(7 rows)
+
+ROLLBACK
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+DELETE 3
+ROLLBACK
+RESET timescaledb.enable_dml_decompression_tuple_filtering;
+RESET
+\set QUIET on
 -- github issue #6858
 -- check update triggers work correctly both on uncompressed and compressed chunks
 CREATE TABLE update_trigger_test (

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -2733,14 +2733,14 @@ UPDATE test_limit SET id = 0;
 ERROR:  tuple decompression limit exceeded by operation
 DETAIL:  current limit: 5000, tuples decompressed: 30000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 ERROR:  tuple decompression limit exceeded by operation
 DETAIL:  current limit: 5000, tuples decompressed: 30000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
 UPDATE test_limit SET id = 0;
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 \set ON_ERROR_STOP 1
 DROP TABLE test_limit;
 -- check partial compression with DML
@@ -3091,13 +3091,12 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
+   Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
-         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
                Filter: ("time" = 'Wed Jan 01 05:00:00 2020 PST'::timestamp with time zone)
-(7 rows)
+(6 rows)
 
 -- test sqlvaluefunction
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
@@ -3338,6 +3337,61 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
                      Rows Removed by Filter: 2
 (10 rows)
 
+-- test DELETE optimization without predicates
+-- should delete 3 complete batches without decompression
+BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
+(5 rows)
+
+-- test DELETE optimization on non-segmentby columns
+-- this shows optimization can be applied if in-memory filtering is enabled
+\set QUIET off
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
+               Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+(6 rows)
+
+ROLLBACK
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+DELETE 3
+ROLLBACK
+SET timescaledb.enable_dml_decompression_tuple_filtering TO OFF;
+SET
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=3 loops=1)
+               Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+(7 rows)
+
+ROLLBACK
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+DELETE 3
+ROLLBACK
+RESET timescaledb.enable_dml_decompression_tuple_filtering;
+RESET
+\set QUIET on
 -- github issue #6858
 -- check update triggers work correctly both on uncompressed and compressed chunks
 CREATE TABLE update_trigger_test (

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -2733,14 +2733,14 @@ UPDATE test_limit SET id = 0;
 ERROR:  tuple decompression limit exceeded by operation
 DETAIL:  current limit: 5000, tuples decompressed: 30000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 ERROR:  tuple decompression limit exceeded by operation
 DETAIL:  current limit: 5000, tuples decompressed: 30000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
 UPDATE test_limit SET id = 0;
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 \set ON_ERROR_STOP 1
 DROP TABLE test_limit;
 -- check partial compression with DML
@@ -3091,13 +3091,12 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
+   Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
-         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
                Filter: ("time" = 'Wed Jan 01 05:00:00 2020 PST'::timestamp with time zone)
-(7 rows)
+(6 rows)
 
 -- test sqlvaluefunction
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
@@ -3338,6 +3337,61 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
                      Rows Removed by Filter: 2
 (10 rows)
 
+-- test DELETE optimization without predicates
+-- should delete 3 complete batches without decompression
+BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
+(5 rows)
+
+-- test DELETE optimization on non-segmentby columns
+-- this shows optimization can be applied if in-memory filtering is enabled
+\set QUIET off
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=0 loops=1)
+               Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+(6 rows)
+
+ROLLBACK
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+DELETE 3
+ROLLBACK
+SET timescaledb.enable_dml_decompression_tuple_filtering TO OFF;
+SET
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_76_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_76_chunk test_pushdown_1 (actual rows=3 loops=1)
+               Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+(7 rows)
+
+ROLLBACK
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN
+DELETE 3
+ROLLBACK
+RESET timescaledb.enable_dml_decompression_tuple_filtering;
+RESET
+\set QUIET on
 -- github issue #6858
 -- check update triggers work correctly both on uncompressed and compressed chunks
 CREATE TABLE update_trigger_test (

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -605,46 +605,42 @@ ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE value = '1.0'; ROLLBACK;
 QUERY PLAN
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 8
-   Tuples decompressed: 8
+   Batches deleted: 8
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=8 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
                Filter: (value = '1'::double precision)
-(7 rows)
+(6 rows)
 
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1' AND value = '1.0'; ROLLBACK;
 QUERY PLAN
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 4
-   Tuples decompressed: 4
+   Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
                Filter: ((device = 'd1'::text) AND (value = '1'::double precision))
-(7 rows)
+(6 rows)
 
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE reading = 'r1' AND value = '1.0'; ROLLBACK;
 QUERY PLAN
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 2
-   Tuples decompressed: 2
+   Batches deleted: 2
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
                Filter: ((reading = 'r1'::text) AND (value = '1'::double precision))
-(7 rows)
+(6 rows)
 
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd2' AND reading = 'r3' AND value = '1.0'; ROLLBACK;
 QUERY PLAN
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
+   Batches deleted: 1
    ->  Delete on direct_delete (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
                Filter: ((device = 'd2'::text) AND (reading = 'r3'::text) AND (value = '1'::double precision))
-(7 rows)
+(6 rows)
 
 -- presence of trigger should prevent direct delete
 CREATE TRIGGER direct_delete_trigger BEFORE DELETE ON direct_delete FOR EACH ROW EXECUTE FUNCTION trigger_function();
@@ -713,14 +709,15 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading = 'r1';
 QUERY PLAN
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
-   Batches decompressed: 4
-   Tuples decompressed: 8
+   Batches decompressed: 3
+   Tuples decompressed: 7
+   Batches deleted: 1
    ->  Delete on compress_dml (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk compress_dml_1
-         ->  Seq Scan on _hyper_X_X_chunk compress_dml_1 (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk compress_dml_1 (actual rows=3 loops=1)
                Filter: (reading = 'r1'::text)
                Rows Removed by Filter: 4
-(8 rows)
+(9 rows)
 
 SELECT * FROM compress_dml t ORDER BY t;
              time             | device | reading | value 
@@ -740,14 +737,15 @@ BEGIN;
 QUERY PLAN
  Custom Scan (ModifyHypertable) (actual rows=0 loops=1)
    Batches filtered: 2
-   Batches decompressed: 4
-   Tuples decompressed: 8
+   Batches decompressed: 3
+   Tuples decompressed: 7
+   Batches deleted: 1
    ->  Delete on compress_dml (actual rows=0 loops=1)
          Delete on _hyper_X_X_chunk compress_dml_1
-         ->  Seq Scan on _hyper_X_X_chunk compress_dml_1 (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk compress_dml_1 (actual rows=3 loops=1)
                Filter: (reading <> 'r1'::text)
                Rows Removed by Filter: 4
-(9 rows)
+(10 rows)
 
 SELECT * FROM compress_dml t ORDER BY t;
              time             | device | reading | value 

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1440,11 +1440,11 @@ SET timescaledb.max_tuples_decompressed_per_dml_transaction = 5000;
 \set ON_ERROR_STOP 0
 -- Updating or deleting everything will break the set limit.
 UPDATE test_limit SET id = 0;
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
 UPDATE test_limit SET id = 0;
-DELETE FROM test_limit WHERE id > 0;
+DELETE FROM test_limit WHERE id = 1;
 \set ON_ERROR_STOP 1
 
 DROP TABLE test_limit;
@@ -1565,6 +1565,21 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-0
 -- no pushdown for volatile functions
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query()); ROLLBACK;
+
+-- test DELETE optimization without predicates
+-- should delete 3 complete batches without decompression
+BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
+
+-- test DELETE optimization on non-segmentby columns
+-- this shows optimization can be applied if in-memory filtering is enabled
+\set QUIET off
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+SET timescaledb.enable_dml_decompression_tuple_filtering TO OFF;
+BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+BEGIN; DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
+RESET timescaledb.enable_dml_decompression_tuple_filtering;
+\set QUIET on
 
 -- github issue #6858
 -- check update triggers work correctly both on uncompressed and compressed chunks


### PR DESCRIPTION
This change uses in-memory tuple filtering in order to determine if a batch can be directly deleted instead of materializing decompressed tuples based on the quals and if all rows match the quals used in the query.