### PR TITLE
Disable compression ratio warnings in update and downgrade scripts

### DIFF
--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -59,7 +59,7 @@ UNIX_SOCKET_DIR=$(readlink -f "${OUTPUT_DIR}")
 initdb > "${OUTPUT_DIR}/initdb.log" 2>&1
 
 # Don't try to wrap the settings, pg_ctl can't handle newlines there.
-pg_ctl -l "${OUTPUT_DIR}/postgres.log" start -o "-c unix_socket_directories=${UNIX_SOCKET_DIR} -c timezone=GMT -c client_min_messages=warning -c port=${PGPORT} -c max_prepared_transactions=100 -c shared_preload_libraries=timescaledb -c timescaledb.telemetry_level=off -c max_worker_processes=0 -c log_statement=all"
+pg_ctl -l "${OUTPUT_DIR}/postgres.log" start -o "-c unix_socket_directories=${UNIX_SOCKET_DIR} -c timezone=GMT -c client_min_messages=warning -c port=${PGPORT} -c max_prepared_transactions=100 -c shared_preload_libraries=timescaledb -c timescaledb.telemetry_level=off -c timescaledb.enable_compression_ratio_warnings=off -c max_worker_processes=0 -c log_statement=all"
 
 pg_isready -t 30 > /dev/null
 


### PR DESCRIPTION
Compression ratio warnings produce a lot of output making it harder
to follow what is happening in update/downgrade scripts.

Disable-check: approval-count