### PR TITLE
Allow concurrent CAgg refreshes

### DIFF
--- a/.unreleased/pr_8187
+++ b/.unreleased/pr_8187
@@ -1,0 +1,1 @@
+Implements: #8187 Allow concurrent Continuous Aggregate refreshes

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -38,6 +38,7 @@
 
 #define DEFAULT_MATPARTCOLUMN_NAME "time_partition_col"
 #define CAGG_INVALIDATION_THRESHOLD_NAME "invalidation threshold watermark"
+#define CAGG_INVALIDATION_WRONG_GREATEST_VALUE ((int64) -210866803200000001)
 
 typedef struct FinalizeQueryInfo
 {

--- a/tsl/test/isolation/expected/cagg_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_refresh.out
@@ -1,4 +1,4 @@
-Parsed test spec with 9 sessions
+Parsed test spec with 11 sessions
 
 starting permutation: R1_refresh S1_select R3_refresh S1_select L2_read_unlock_threshold_table L3_unlock_cagg_table L1_unlock_threshold_table
 step R1_refresh: 
@@ -89,6 +89,11 @@ step L1_unlock_threshold_table:
 
 
 starting permutation: L2_read_lock_threshold_table R3_refresh L2_read_unlock_threshold_table S1_select L3_unlock_cagg_table L1_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step L2_read_lock_threshold_table: 
     LOCK _timescaledb_catalog.continuous_aggs_invalidation_threshold
     IN ACCESS SHARE MODE;
@@ -140,6 +145,11 @@ step L1_unlock_threshold_table:
 
 
 starting permutation: R1_refresh L2_read_lock_threshold_table R3_refresh L2_read_unlock_threshold_table S1_select L3_unlock_cagg_table L1_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
 
@@ -198,6 +208,11 @@ step L1_unlock_threshold_table:
 
 
 starting permutation: R3_refresh L2_read_lock_threshold_table R1_refresh L2_read_unlock_threshold_table S1_select L3_unlock_cagg_table L1_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step R3_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
 
@@ -256,6 +271,11 @@ step L1_unlock_threshold_table:
 
 
 starting permutation: L3_lock_cagg_table R1_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step L3_lock_cagg_table: 
     SELECT lock_cagg('cond_10');
 
@@ -266,11 +286,10 @@ lock_cagg
 
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
- <waiting ...>
+
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
-step R1_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -313,6 +332,11 @@ step L2_read_unlock_threshold_table:
 
 
 starting permutation: L3_lock_cagg_table R1_refresh R2_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step L3_lock_cagg_table: 
     SELECT lock_cagg('cond_10');
 
@@ -323,16 +347,14 @@ lock_cagg
 
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
- <waiting ...>
+
+R2: NOTICE:  continuous aggregate "cond_10" is already up-to-date
 step R2_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 35, 62);
- <waiting ...>
+
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
-step R1_refresh: <... completed>
-R2: NOTICE:  continuous aggregate "cond_10" is already up-to-date
-step R2_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -375,6 +397,11 @@ step L2_read_unlock_threshold_table:
 
 
 starting permutation: L3_lock_cagg_table R1_refresh R3_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step L3_lock_cagg_table: 
     SELECT lock_cagg('cond_10');
 
@@ -385,15 +412,13 @@ lock_cagg
 
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
- <waiting ...>
+
 step R3_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
- <waiting ...>
+
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
-step R1_refresh: <... completed>
-step R3_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -439,6 +464,11 @@ step L2_read_unlock_threshold_table:
 
 
 starting permutation: L3_lock_cagg_table R3_refresh R4_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step L3_lock_cagg_table: 
     SELECT lock_cagg('cond_10');
 
@@ -449,14 +479,13 @@ lock_cagg
 
 step R3_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
- <waiting ...>
+
 step R4_refresh: 
     CALL refresh_continuous_aggregate('cond_20', 39, 84);
 
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
-step R3_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -498,9 +527,129 @@ step L2_read_unlock_threshold_table:
 
 
 starting permutation: R1_refresh R12_refresh
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
 
 step R12_refresh: 
     CALL refresh_continuous_aggregate('cond2_10', 25, 70);
+
+
+starting permutation: WP_enable R1_refresh R5_refresh WP_release S1_select R3_refresh S1_select
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
+L1: WARNING:  there is already a transaction in progress
+L2: WARNING:  there is already a transaction in progress
+L3: WARNING:  there is already a transaction in progress
+step WP_enable: 
+    SELECT debug_waitpoint_enable('clear_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step R1_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 25, 70);
+ <waiting ...>
+R5: LOG:  statement: 
+    CALL refresh_continuous_aggregate('cond_10', 70, 107);
+
+step R5_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 70, 107);
+ <waiting ...>
+step WP_release: 
+    SELECT debug_waitpoint_release('clear_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step R1_refresh: <... completed>
+R5: DEBUG:  cannot lock "cond_10" materialization invalidation log [ 0, -1 ], skipping
+R5: DEBUG:  cannot lock "cond_10" materialization invalidation log [ 0, 49 ], skipping
+R5: DEBUG:  cannot lock "cond_10" materialization invalidation log [ 30, -1 ], skipping
+R5: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+step R5_refresh: <... completed>
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id
+    ORDER BY 1;
+
+bucket|        avg_temp
+------+----------------
+     0|15.8888888888889
+    10|            14.2
+    20|            13.4
+    30|            18.3
+    40|16.0909090909091
+    50|            26.9
+    60|            18.9
+(7 rows)
+
+cagg_bucket_count
+-----------------
+                7
+(1 row)
+
+hypertable |  threshold
+-----------+-----------
+conditions |        100
+conditions2|-2147483648
+(2 rows)
+
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 70, 107);
+
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id
+    ORDER BY 1;
+
+bucket|        avg_temp
+------+----------------
+     0|15.8888888888889
+    10|            14.2
+    20|            13.4
+    30|            18.3
+    40|16.0909090909091
+    50|            26.9
+    60|            18.9
+    70|            24.6
+    80|            23.6
+    90|            21.3
+(10 rows)
+
+cagg_bucket_count
+-----------------
+               10
+(1 row)
+
+hypertable |  threshold
+-----------+-----------
+conditions |        100
+conditions2|-2147483648
+(2 rows)
 

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -18,7 +18,6 @@ list(
   compression_conflicts_iso.spec
   cagg_insert.spec
   cagg_multi_iso.spec
-  cagg_concurrent_refresh.spec
   deadlock_drop_chunks_compress.spec
   deadlock_drop_index_vacuum.spec
   parallel_compression.spec
@@ -34,6 +33,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     TEST_FILES
     cagg_concurrent_move.spec
     cagg_concurrent_invalidation.spec
+    cagg_concurrent_refresh.spec
     compression_chunk_race.spec
     compression_freeze.spec
     compression_merge_race.spec


### PR DESCRIPTION
Historically we lock the materialization hypertable during the CAgg refresh to prevent concurrent executions. From tsl/src/continuous_aggs/refresh.c:

```C
/* Lock the continuous aggregate's materialized hypertable to protect
 * against concurrent refreshes. Only concurrent reads will be
 * allowed. This is a heavy lock that serializes all refreshes on the same
 * continuous aggregate. We might want to consider relaxing this in the
 * future, e.g., we'd like to at least allow concurrent refreshes on the
 * same continuous aggregate when they don't have overlapping refresh
 * windows.
*/
LockRelationOid(hyper_relid, ExclusiveLock);
```

This PR relax this strong lock on the materialization hypertable by locking the rows from the CAgg invalidation logs doing skip lock to allow concurrent refreshes.