### PR TITLE
Change documentation link on license errors

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -118,7 +118,7 @@ error_no_default_fn_community(void)
 	ereport(ERROR,
 			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			 errmsg("functionality not supported under the current \"%s\" license. Learn more at "
-					"https://timescale.com/.",
+					"https://tsdb.co/pdbir1r3",
 					ts_guc_license),
 			 errhint("To access all features and the best time-series experience, try out "
 					 "Timescale Cloud.")));

--- a/test/expected/license.out
+++ b/test/expected/license.out
@@ -53,7 +53,7 @@ SELECT create_hypertable('metrics', 'time');
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress);
-ERROR:  functionality not supported under the current "apache" license. Learn more at https://timescale.com/.
+ERROR:  functionality not supported under the current "apache" license. Learn more at https://tsdb.co/pdbir1r3
 HINT:  To access all features and the best time-series experience, try out Timescale Cloud.
 INSERT INTO metrics
 VALUES ('2022-01-01 00:00:00', 1), ('2022-01-01 01:00:00', 2), ('2022-01-01 02:00:00', 3);
@@ -66,7 +66,7 @@ SELECT time_bucket(INTERVAL '1 hour', time) AS bucket,
 FROM metrics
 GROUP BY bucket
 WITH NO DATA;
-ERROR:  functionality not supported under the current "apache" license. Learn more at https://timescale.com/.
+ERROR:  functionality not supported under the current "apache" license. Learn more at https://tsdb.co/pdbir1r3
 HINT:  To access all features and the best time-series experience, try out Timescale Cloud.
 CREATE MATERIALIZED VIEW metrics_hourly
 AS


### PR DESCRIPTION
Swap the generic timescale.com link out with direct link to our
license comparison page.

Disable-check: force-changelog-file
Disable-check: approval-count
