### PR TITLE
Do not use ERRCODE_INTERNAL_ERROR for user errors

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2162,7 +2162,9 @@ get_chunks_in_time_range(Hypertable *ht, int64 older_than, int64 newer_than, Mem
 				 errhint("The start of the time range must be before the end.")));
 
 	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
-		elog(ERROR, "invalid operation on compressed hypertable");
+		ereport(ERROR,
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
+				 errmsg("invalid operation on compressed hypertable")));
 
 	start_strategy = (newer_than == PG_INT64_MIN) ? InvalidStrategy : BTGreaterEqualStrategyNumber;
 	end_strategy = (older_than == PG_INT64_MAX) ? InvalidStrategy : BTLessStrategyNumber;
@@ -3403,7 +3405,7 @@ ts_chunk_clear_status(Chunk *chunk, int32 status)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to clear status %d , current status %x ",
 						   chunk->fd.id,
@@ -3438,7 +3440,7 @@ ts_chunk_add_status(Chunk *chunk, int32 status)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to set status %d , current status %x ",
 						   chunk->fd.id,
@@ -3457,7 +3459,7 @@ ts_chunk_add_status(Chunk *chunk, int32 status)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to set status %d , current status %d ",
 						   chunk->fd.id,
@@ -3490,7 +3492,7 @@ ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to set status %d , current status %d ",
 						   chunk->fd.id,
@@ -3510,7 +3512,7 @@ ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to set status %d , current status %d ",
 						   chunk->fd.id,
@@ -3540,7 +3542,7 @@ ts_chunk_clear_compressed_chunk(Chunk *chunk)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to set status %d , current status %d ",
 						   chunk->fd.id,
@@ -3560,7 +3562,7 @@ ts_chunk_clear_compressed_chunk(Chunk *chunk)
 	{
 		/* chunk in frozen state cannot be modified */
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 				 errmsg("cannot modify frozen chunk status"),
 				 errdetail("chunk id = %d attempt to set status %d , current status %d ",
 						   chunk->fd.id,
@@ -4100,7 +4102,9 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 	time_dim = hyperspace_get_open_dimension(ht->space, 0);
 
 	if (!time_dim)
-		elog(ERROR, "hypertable has no open partitioning dimension");
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("hypertable has no open partitioning dimension")));
 
 	time_type = ts_dimension_get_partition_type(time_dim);
 
@@ -4371,10 +4375,11 @@ ts_chunk_validate_chunk_status_for_operation(const Chunk *chunk, ChunkOperation 
 
 			default:
 				if (throw_error)
-					elog(ERROR,
-						 "%s not permitted on tiered chunk \"%s\" ",
-						 get_chunk_operation_str(cmd),
-						 get_rel_name(chunk_relid));
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("%s not permitted on tiered chunk \"%s\" ",
+									get_chunk_operation_str(cmd),
+									get_rel_name(chunk_relid))));
 				return false;
 				break;
 		}
@@ -4394,10 +4399,11 @@ ts_chunk_validate_chunk_status_for_operation(const Chunk *chunk, ChunkOperation 
 			case CHUNK_DROP:
 			{
 				if (throw_error)
-					elog(ERROR,
-						 "%s not permitted on frozen chunk \"%s\" ",
-						 get_chunk_operation_str(cmd),
-						 get_rel_name(chunk_relid));
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("%s not permitted on frozen chunk \"%s\" ",
+									get_chunk_operation_str(cmd),
+									get_rel_name(chunk_relid))));
 				return false;
 				break;
 			}
@@ -4816,7 +4822,9 @@ ts_chunk_attach_osm_table_chunk(PG_FUNCTION_ARGS)
 		if (!name)
 			ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("invalid Oid")));
 		else
-			elog(ERROR, "\"%s\" is not a hypertable", name);
+			ereport(ERROR,
+					(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
+					 errmsg("\"%s\" is not a hypertable", name)));
 	}
 
 	if (get_rel_relkind(ftable_relid) == RELKIND_FOREIGN_TABLE)

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -254,7 +254,7 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 	compress_ht = ts_hypertable_get_by_id(srcht->fd.compressed_hypertable_id);
 	if (compress_ht == NULL)
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("missing columnstore-enabled hypertable")));
 	/* user has to be the owner of the compression table too */
 	ts_hypertable_permissions_check(compress_ht->main_table_relid, GetUserId());
@@ -611,7 +611,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 		ts_hypertable_get_by_id(uncompressed_hypertable->fd.compressed_hypertable_id);
 	if (compressed_hypertable == NULL)
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("missing columnstore-enabled hypertable")));
 
 	if (uncompressed_chunk->fd.hypertable_id != uncompressed_hypertable->fd.id)
@@ -1028,7 +1028,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 
 	if (!ht->fd.compressed_hypertable_id)
 		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("missing columnstore-enabled hypertable")));
 
 	if (ts_is_hypercore_am(uncompressed_chunk->amoid))


### PR DESCRIPTION
This code is reserved for internal program errors, i.e. bugs. This commit fixes only some of these existing files with incorrect codes, we have more files

Note: This PR has modified different files from #8188

Disable-check: force-changelog-file