### PR TITLE
Add option to not process hypertable invalidations

### DIFF
--- a/.unreleased/pr_8191
+++ b/.unreleased/pr_8191
@@ -1,0 +1,1 @@
+Implements: #8191 Add option to not process hypertable invalidations

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -213,6 +213,7 @@ CREATE OR REPLACE PROCEDURE @extschema@.refresh_continuous_aggregate(
     continuous_aggregate     REGCLASS,
     window_start             "any",
     window_end               "any",
-    force                    BOOLEAN = FALSE
+    force                    BOOLEAN = FALSE,
+    options                  JSONB = NULL
 ) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh';
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -46,3 +46,17 @@ $$ LANGUAGE PLPGSQL;
 -- chunk_id.
 ALTER TABLE _timescaledb_catalog.chunk_column_stats ALTER COLUMN chunk_id DROP NOT NULL;
 UPDATE _timescaledb_catalog.chunk_column_stats SET chunk_id = NULL WHERE chunk_id = 0;
+DROP PROCEDURE @extschema@.refresh_continuous_aggregate(
+    continuous_aggregate REGCLASS,
+    window_start "any",
+    window_end "any",
+    force BOOLEAN
+);
+
+CREATE PROCEDURE @extschema@.refresh_continuous_aggregate(
+    continuous_aggregate     REGCLASS,
+    window_start             "any",
+    window_end               "any",
+    force                    BOOLEAN = FALSE,
+    options                  JSONB = NULL
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_update_placeholder';

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -48,3 +48,17 @@ END
 $$;
 DELETE FROM _timescaledb_catalog.chunk_column_stats WHERE chunk_id IS NULL;
 ALTER TABLE _timescaledb_catalog.chunk_column_stats ALTER COLUMN chunk_id SET NOT NULL;
+DROP PROCEDURE @extschema@.refresh_continuous_aggregate(
+    continuous_aggregate REGCLASS,
+    window_start "any",
+    window_end "any",
+    force BOOLEAN,
+    options JSONB
+);
+
+CREATE PROCEDURE @extschema@.refresh_continuous_aggregate(
+    continuous_aggregate     REGCLASS,
+    window_start             "any",
+    window_end               "any",
+    force                    BOOLEAN = FALSE
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_update_placeholder';

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -11,7 +11,6 @@
 #include <parser/parse_coerce.h>
 #include <utils/acl.h>
 
-#include <jsonb_utils.h>
 #include <utils/builtins.h>
 
 #include "bgw/job.h"
@@ -22,10 +21,9 @@
 #include "bgw_policy/job_api.h"
 #include "bgw_policy/policies_v2.h"
 #include "bgw_policy/policy_utils.h"
-#include "continuous_aggs/materialize.h"
 #include "dimension.h"
 #include "guc.h"
-#include "hypertable_cache.h"
+#include "jsonb_utils.h"
 #include "policy_config.h"
 #include "policy_utils.h"
 #include "time_utils.h"

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -47,6 +47,7 @@ typedef struct PolicyContinuousAggData
 	int32 buckets_per_batch;
 	int32 max_batches_per_execution;
 	bool refresh_newest_first;
+	bool process_hypertable_invalidations;
 } PolicyContinuousAggData;
 
 typedef struct PolicyCompressionData

--- a/tsl/src/bgw_policy/policies_v2.h
+++ b/tsl/src/bgw_policy/policies_v2.h
@@ -23,6 +23,7 @@
 #define POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH "buckets_per_batch"
 #define POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION "max_batches_per_execution"
 #define POL_REFRESH_CONF_KEY_REFRESH_NEWEST_FIRST "refresh_newest_first"
+#define POL_REFRESH_CONF_KEY_PROCESS_HYPERTABLE_INVALIDATIONS "process_hypertable_invalidations"
 
 #define POLICY_COMPRESSION_PROC_NAME "policy_compression"
 #define POLICY_COMPRESSION_CHECK_NAME "policy_compression_check"

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -951,7 +951,13 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 		refresh_window.end = ts_time_get_noend_or_max(refresh_window.type);
 
 		CaggRefreshContext context = { .callctx = CAGG_REFRESH_CREATION };
-		continuous_agg_refresh_internal(cagg, &refresh_window, context, true, true, false);
+		continuous_agg_refresh_internal(cagg,
+										&refresh_window,
+										context,
+										true,
+										true,
+										false,
+										true /* process_hypertable_invalidations */);
 	}
 
 	return DDL_DONE;

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -20,7 +20,7 @@ extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
 											const CaggRefreshContext context,
 											const bool start_isnull, const bool end_isnull,
-											bool force);
+											bool force, bool process_hypertable_invalidations);
 extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,
 												 InternalTimeRange *original_refresh_window,
 												 int32 buckets_per_batch,

--- a/tsl/test/expected/cagg_policy_move.out
+++ b/tsl/test/expected/cagg_policy_move.out
@@ -257,6 +257,56 @@ CALL _timescaledb_functions.policy_process_hypertable_invalidations(NULL, NULL);
 CALL _timescaledb_functions.policy_process_hypertable_invalidations(1, NULL);
 CALL _timescaledb_functions.policy_process_hypertable_invalidations(NULL, :'config');
 \set ON_ERROR_STOP 1
+-- Check that a refresh with hypertable invalidation processing
+-- disabled does not move the invalidations.
+INSERT INTO measurements VALUES (40, 12, 12.3);
+INSERT INTO measurements VALUES (50, 13, 34.5);
+SELECT hypertable, lowest_modified_value, greatest_modified_value
+  FROM hypertable_invalidations;
+  hypertable  | lowest_modified_value | greatest_modified_value 
+--------------+-----------------------+-------------------------
+ measurements |                    40 |                      40
+ measurements |                    50 |                      50
+(2 rows)
+
+CALL refresh_continuous_aggregate('measure_10', NULL, NULL,
+     options => '{"process_hypertable_invalidations": false}');
+SELECT hypertable, lowest_modified_value, greatest_modified_value
+  FROM hypertable_invalidations;
+  hypertable  | lowest_modified_value | greatest_modified_value 
+--------------+-----------------------+-------------------------
+ measurements |                    40 |                      40
+ measurements |                    50 |                      50
+(2 rows)
+
+-- Check that a refresh with hypertable invalidation processing
+-- enabled move the invalidations.
+CALL refresh_continuous_aggregate('measure_10', NULL, NULL,
+     options => '{"process_hypertable_invalidations": true}');
+SELECT hypertable, lowest_modified_value, greatest_modified_value
+  FROM hypertable_invalidations;
+ hypertable | lowest_modified_value | greatest_modified_value 
+------------+-----------------------+-------------------------
+(0 rows)
+
+-- Check that a refresh by default moves the invalidations.
+INSERT INTO measurements VALUES (60, 16, 12.3);
+INSERT INTO measurements VALUES (61, 17, 34.5);
+SELECT hypertable, lowest_modified_value, greatest_modified_value
+  FROM hypertable_invalidations;
+  hypertable  | lowest_modified_value | greatest_modified_value 
+--------------+-----------------------+-------------------------
+ measurements |                    60 |                      60
+ measurements |                    61 |                      61
+(2 rows)
+
+CALL refresh_continuous_aggregate('measure_10', NULL, NULL);
+SELECT hypertable, lowest_modified_value, greatest_modified_value
+  FROM hypertable_invalidations;
+ hypertable | lowest_modified_value | greatest_modified_value 
+------------+-----------------------+-------------------------
+(0 rows)
+
 -- Check permissions. Only owner should be able to remove policy.
 \set ON_ERROR_STOP 0
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
@@ -273,3 +323,53 @@ ERROR:  move invalidations policy for "conditions" not found
 CALL remove_process_hypertable_invalidations_policy('conditions', if_exists => true);
 NOTICE:  move invalidations policy for "conditions" not found, skipping
 \set ON_ERROR_STOP 1
+-- Add a policy that has hypertable invalidations processing disabled
+-- and check that it does not move invalidations.
+SELECT add_continuous_aggregate_policy('measure_10', 100::int, 10::int, '1h'::interval) as job_id \gset
+SELECT jsonb_set(config, '{process_hypertable_invalidations}', 'false') AS config
+  FROM _timescaledb_config.bgw_job WHERE id = :job_id \gset
+SELECT jsonb_pretty(config)
+  FROM alter_job(:job_id, config := :'config');
+                 jsonb_pretty                  
+-----------------------------------------------
+ {                                            +
+     "end_offset": 10,                        +
+     "start_offset": 100,                     +
+     "mat_hypertable_id": 4,                  +
+     "process_hypertable_invalidations": false+
+ }
+(1 row)
+
+INSERT INTO measurements VALUES (70, 19, 12.3), (71, 20, 34.5);
+SELECT hypertable, lowest_modified_value, greatest_modified_value FROM hypertable_invalidations;
+  hypertable  | lowest_modified_value | greatest_modified_value 
+--------------+-----------------------+-------------------------
+ measurements |                    70 |                      71
+(1 row)
+
+CALL run_job(:job_id);
+SELECT hypertable, lowest_modified_value, greatest_modified_value FROM hypertable_invalidations;
+  hypertable  | lowest_modified_value | greatest_modified_value 
+--------------+-----------------------+-------------------------
+ measurements |                    70 |                      71
+(1 row)
+
+-- Enable invalidations and check that it now moves invalidations
+SELECT jsonb_pretty(config)
+  FROM alter_job(:job_id, config := jsonb_set(:'config', '{process_hypertable_invalidations}', 'true'));
+                 jsonb_pretty                 
+----------------------------------------------
+ {                                           +
+     "end_offset": 10,                       +
+     "start_offset": 100,                    +
+     "mat_hypertable_id": 4,                 +
+     "process_hypertable_invalidations": true+
+ }
+(1 row)
+
+CALL run_job(:job_id);
+SELECT hypertable, lowest_modified_value, greatest_modified_value FROM hypertable_invalidations;
+ hypertable | lowest_modified_value | greatest_modified_value 
+------------+-----------------------+-------------------------
+(0 rows)
+

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -281,7 +281,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  merge_chunks(regclass[])
  move_chunk(regclass,name,name,regclass,boolean)
  recompress_chunk(regclass,boolean)
- refresh_continuous_aggregate(regclass,"any","any",boolean)
+ refresh_continuous_aggregate(regclass,"any","any",boolean,jsonb)
  remove_columnstore_policy(regclass,boolean)
  remove_compression_policy(regclass,boolean)
  remove_continuous_aggregate_policy(regclass,boolean,boolean)


### PR DESCRIPTION
Add option to `refresh_continuous_aggregate` and refresh policy to skip processing the hypertable invalidations when refreshing.

If option `process_hypertable_invalidations` is set to `false`, hypertable invalidations will not be processed as part of a refresh. If option is set to true or does not exist, hypertable invalidations will be processed.