### PR TITLE
Show deprecation warning when using hypercore access method

### DIFF
--- a/.unreleased/pr_8196
+++ b/.unreleased/pr_8196
@@ -1,0 +1,1 @@
+Implements: #8196 Show deprecation warning for TAM

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4136,6 +4136,9 @@ process_set_access_method(AlterTableCmd *cmd, ProcessUtilityArgs *args)
 											DEFELEM_UNSPEC,
 											-1);
 
+		elog(WARNING,
+			 "the hypercore access method is marked as deprecated with the 2.21.0 release and will "
+			 "be fully removed in the 2.22.0 release.");
 		AlterTableCmd *cmd = makeNode(AlterTableCmd);
 		cmd->type = T_AlterTableCmd;
 		cmd->subtype = AT_SetRelOptions;

--- a/tsl/test/expected/hypercore.out
+++ b/tsl/test/expected/hypercore.out
@@ -811,6 +811,7 @@ from generate_series('2022-06-01'::timestamptz, '2022-06-10'::timestamptz, '1h')
 alter table crossmodule_test
       set access method hypercore,
       set (timescaledb.compress_orderby = 'time');
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 \c :TEST_DBNAME :ROLE_SUPERUSER
 select count(*) from crossmodule_test;
  count 

--- a/tsl/test/expected/hypercore_copy.out
+++ b/tsl/test/expected/hypercore_copy.out
@@ -195,6 +195,7 @@ NOTICE:  adding not-null constraint to column "created_at"
 (1 row)
 
 alter table copy_test1 set access method hypercore;
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for converting to columnstore. Please make sure you are not missing any indexes
 NOTICE:  default segment by for hypertable "copy_test1" is set to ""
 NOTICE:  default order by for hypertable "copy_test1" is set to "created_at DESC"
@@ -252,6 +253,7 @@ select * from amrels where relparent = 'test1'::regclass;
 (1 row)
 
 alter table test1 set access method hypercore;
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 copy test1 from stdin delimiter ',';
 select count(*) from test1;
  count 

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -135,6 +135,7 @@ select create_hypertable('test2', 'created_at');
 alter table test2
 	  set access method hypercore,
 	  set (compress_segmentby = 'location_id');
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: Please make sure device_id is not a unique column and appropriate for a segment by
 NOTICE:  default segment by for hypertable "test2" is set to "device_id"
 NOTICE:  default order by for hypertable "test2" is set to "created_at DESC"
@@ -143,16 +144,19 @@ ERROR:  unrecognized parameter "compress_segmentby"
 alter table test2
 	  set access method hypercore,
 	  set (timescaledb.compress_segmentby = 'location_id');
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 NOTICE:  default order by for hypertable "test2" is set to "created_at DESC, device_id"
 -- Test altering hypertable to hypercore again. It should be allowed
 -- and be a no-op.
 alter table test2 set access method hypercore;
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 \set ON_ERROR_STOP 0
 -- This shows an error but the error is weird, we should probably get
 -- a better one.
 alter table test2
 	  set access method hypercore,
 	  set (compress_segmentby = 'location_id');
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 ERROR:  unrecognized parameter "compress_segmentby"
 \set ON_ERROR_STOP 1
 -- Create view for hypercore rels
@@ -336,6 +340,7 @@ select * from amrels where relparent='test3'::regclass;
 
 -- Set hypercore on hypertable
 alter table test3 set access method hypercore;
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 -- Create a third chunk
 insert into test3 values ('2022-10-01', 1, 1.0);
 -- The third chunk should be a hypercore chunk
@@ -1122,6 +1127,7 @@ alter table conditions set (
 -- Set hypercore access method on the hypertable
 -------------------------------------------------------------------------------
 alter table conditions set access method hypercore;
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 -----------------------
 -- Create a new user
 -----------------------

--- a/tsl/test/expected/hypercore_insert.out
+++ b/tsl/test/expected/hypercore_insert.out
@@ -330,6 +330,7 @@ insert into test2 select t, 'second'::text, 120, 1 from generate_series(11, 15) 
 alter table test2
       set access method hypercore,
       set (timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'c, itime desc');
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 select compress_chunk(show_chunks('test2'));
              compress_chunk              
 -----------------------------------------

--- a/tsl/test/expected/hypercore_trigger.out
+++ b/tsl/test/expected/hypercore_trigger.out
@@ -114,6 +114,7 @@ select format('%I.%I', chunk_schema, chunk_name)::regclass as chunk2
 -- Set the hypercore access method on the hypertable for transition
 -- tables to work properly.
 alter table :hypertable set access method hypercore;
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 create table saved_rows (like :chunk1, new_row bool not null, kind text);
 create table count_stmt (inserts int, updates int, deletes int);
 create function save_row() returns trigger as $$

--- a/tsl/test/expected/hypercore_vacuum.out
+++ b/tsl/test/expected/hypercore_vacuum.out
@@ -51,6 +51,7 @@ alter table hystable set access method hypercore, set (
       timescaledb.compress_orderby = 'time',
       timescaledb.compress_segmentby = 'location'
 );
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 select ch chunk, amname access_method
 from show_chunks('hystable') ch
 inner join pg_class cl on (cl.oid = ch)
@@ -391,6 +392,7 @@ NOTICE:  adding not-null constraint to column "time"
 alter table hystable set access method hypercore, set (
       timescaledb.compress_orderby = 'time'
 );
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 -- vacuum on empty table
 vacuum (index_cleanup on) hystable;
 insert into hystable select * from regtable;
@@ -443,6 +445,7 @@ alter table readings
       set access method hypercore,
       set (timescaledb.compress_orderby = 'time',
       	   timescaledb.compress_segmentby = 'device');
+WARNING:  the hypercore access method is marked as deprecated with the 2.21.0 release and will be fully removed in the 2.22.0 release.
 -- Save frozenxid to test that it advances on hypertable root when
 -- root is using Hypercore TAM.
 select relfrozenxid as old_relfrozenxid


### PR DESCRIPTION
The hypercore access method is being deprecated and will be removed
in a future release. This patch adds a warning when enabling the
access method.
