### PR TITLE
Use generic license check from cross module instead of duplicated version

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -205,6 +205,13 @@ error_no_default_fn_pg_community(PG_FUNCTION_ARGS)
 	pg_unreachable();
 }
 
+static void
+error_no_default_fn_chunk_insert_state_community(ChunkInsertState *cis, TupleTableSlot *slot)
+{
+	error_no_default_fn_community();
+	pg_unreachable();
+}
+
 /*
  * TSL library is not loaded by the replication worker for some reason,
  * so a call to `compressed_data_in` and `compressed_data_out` functions would
@@ -440,6 +447,9 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.bool_compressor_append = error_no_default_fn_pg_community,
 	.bool_compressor_finish = error_no_default_fn_pg_community,
 	.bloom1_contains = error_no_default_fn_pg_community,
+
+	.decompress_batches_for_insert = error_no_default_fn_chunk_insert_state_community,
+	.init_decompress_state_for_insert = error_no_default_fn_chunk_insert_state_community,
 
 	.compression_enable = compression_enable_default,
 

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -134,7 +134,7 @@ typedef struct CrossModuleFunctions
 	PGFunction create_compressed_chunk;
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
-	void (*decompress_batches_for_insert)(const ChunkInsertState *state, TupleTableSlot *slot);
+	void (*decompress_batches_for_insert)(ChunkInsertState *state, TupleTableSlot *slot);
 	void (*init_decompress_state_for_insert)(ChunkInsertState *state, TupleTableSlot *slot);
 	bool (*decompress_target_segments)(ModifyHypertableState *ht_state);
 	int (*hypercore_decompress_update_segment)(Relation relation, const ItemPointer ctid,

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -339,7 +339,7 @@ extern DecompressAllFunction tsl_get_decompress_all_function(CompressionAlgorith
 
 typedef struct Chunk Chunk;
 typedef struct ChunkInsertState ChunkInsertState;
-extern void decompress_batches_for_insert(const ChunkInsertState *cis, TupleTableSlot *slot);
+extern void decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot);
 extern void init_decompress_state_for_insert(ChunkInsertState *cis, TupleTableSlot *slot);
 typedef struct ModifyHypertableState ModifyHypertableState;
 extern bool decompress_target_segments(ModifyHypertableState *ht_state);

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -211,7 +211,7 @@ get_updated_scankeys(const ScanKeyWithAttnos *scankeys, TupleTableSlot *slot, in
 }
 
 void
-decompress_batches_for_insert(const ChunkInsertState *cis, TupleTableSlot *slot)
+decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 {
 	/*
 	 * This is supposed to be called with the actual tuple that is being


### PR DESCRIPTION
Small refactor to ts_chunk_dispatch_decompress_batches_for_insert
to not have duplicated license check and to have early exit when
no unique constraints are present since we never have to decompress
when no unique constraints are present.

Disable-check: force-changelog-file
