### PR TITLE
Don't inherit copy methods from postgres

### DIFF
--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -189,7 +189,7 @@ SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 2);
 \copy hyper_copy FROM data/copy_data.csv WITH csv header;
 SET client_min_messages TO DEBUG1;
 \copy hyper_copy FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 SELECT count(*) FROM hyper_copy;
  count 
 -------
@@ -199,7 +199,7 @@ SELECT count(*) FROM hyper_copy;
 -- Limit number of open chunks
 SET timescaledb.max_open_chunks_per_insert = 1;
 \copy hyper_copy FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 SELECT count(*) FROM hyper_copy;
  count 
 -------
@@ -222,7 +222,7 @@ CREATE TRIGGER hyper_copy_trigger_insert_before
     BEFORE INSERT ON hyper_copy
     FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
 \copy hyper_copy FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+DEBUG:  Using normal unbuffered copy operation (TS_CIM_SINGLE) because triggers are defined on the destination table.
 SELECT count(*) FROM hyper_copy;
  count 
 -------
@@ -238,7 +238,7 @@ CREATE TRIGGER hyper_copy_trigger_insert_after
     AFTER INSERT ON hyper_copy
     FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
 \copy hyper_copy FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 SELECT count(*) FROM hyper_copy;
  count 
 -------
@@ -247,7 +247,7 @@ SELECT count(*) FROM hyper_copy;
 
 -- Insert data into the chunks in random order
 COPY hyper_copy FROM STDIN DELIMITER ',' NULL AS 'null';
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 SELECT count(*) FROM hyper_copy;
  count 
 -------
@@ -274,7 +274,7 @@ SELECT create_hypertable('hyper_copy_noindex', 'time', chunk_time_interval => 10
 \copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
 SET client_min_messages TO DEBUG1;
 \copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 RESET client_min_messages;
 SELECT count(*) FROM hyper_copy_noindex;
  count 
@@ -289,7 +289,7 @@ CREATE TRIGGER hyper_copy_trigger_insert_before
 \copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
 SET client_min_messages TO DEBUG1;
 \copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+DEBUG:  Using normal unbuffered copy operation (TS_CIM_SINGLE) because triggers are defined on the destination table.
 RESET client_min_messages;
 SELECT count(*) FROM hyper_copy_noindex;
  count 
@@ -305,7 +305,7 @@ CREATE TRIGGER hyper_copy_trigger_insert_after
 \copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
 SET client_min_messages TO DEBUG1;
 \copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 RESET client_min_messages;
 SELECT count(*) FROM hyper_copy_noindex;
  count 
@@ -404,7 +404,7 @@ CREATE TRIGGER table_with_chunk_trigger_before_trigger
 -- are flushed before the trigger is executed.
 SET client_min_messages TO DEBUG1;
 \copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 WARNING:  Trigger counted 28 tuples in table table_with_chunk_trigger
 RESET client_min_messages;
 SELECT count(*) FROM table_with_chunk_trigger;
@@ -423,7 +423,7 @@ CREATE TRIGGER table_with_chunk_trigger_after_trigger
 -- tuples are imported. So, the trigger should report 50+25 = 75
 SET client_min_messages TO DEBUG1;
 \copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 WARNING:  Trigger counted 75 tuples in table table_with_chunk_trigger
 RESET client_min_messages;
 SELECT count(*) FROM table_with_chunk_trigger;
@@ -487,7 +487,7 @@ DROP TRIGGER ts_insert_blocker ON table_without_bf_trigger;
 \copy table_without_bf_trigger from data/copy_data.csv with csv header;
 SET client_min_messages TO DEBUG1;
 \copy table_without_bf_trigger from data/copy_data.csv with csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 RESET client_min_messages;
 SELECT count(*) FROM table_without_bf_trigger;
  count 
@@ -501,7 +501,7 @@ CREATE TRIGGER table_with_chunk_trigger_after_trigger
     FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
 SET client_min_messages TO DEBUG1;
 \copy table_without_bf_trigger from data/copy_data.csv with csv header;
-DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+DEBUG:  Using optimized multi-buffer copy operation (TS_CIM_MULTI_CONDITIONAL).
 RESET client_min_messages;
 SELECT count(*) FROM table_without_bf_trigger;
  count 


### PR DESCRIPTION
Define our own CopyInsertMethod instead of inheriting from postgres.
This patch does not add any new methods but is preparation for a
followup patch that will add a method for compressed insert during
copy.

Disable-check: force-changelog-file
