### PR TITLE
Fix handling NULL compression in DML checks

### DIFF
--- a/.unreleased/pr_8200
+++ b/.unreleased/pr_8200
@@ -1,0 +1,1 @@
+Fixes: #8200 Fix NULL compression handling for vectorized constraint checking

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1866,7 +1866,7 @@ decompress_batch_next_row(RowDecompressor *decompressor, AttrNumber *attnos, int
 
 /* Decompress single column using vectorized decompression */
 ArrowArray *
-decompress_single_column(RowDecompressor *decompressor, AttrNumber attno, bool *default_value)
+decompress_single_column(RowDecompressor *decompressor, AttrNumber attno, bool *single_value)
 {
 	int16 target_col = -1;
 	PerCompressedColumn *column_info = NULL;
@@ -1892,14 +1892,14 @@ decompress_single_column(RowDecompressor *decompressor, AttrNumber attno, bool *
 		 * be handled specially because of the assumption that the whole row has
 		 * this default value.
 		 */
-		*default_value = true;
+		*single_value = true;
 		bool isnull;
 		Datum default_datum = getmissingattr(decompressor->out_desc, attno, &isnull);
 
 		return make_single_value_arrow(column_info->decompressed_type, default_datum, isnull);
 	}
 
-	*default_value = false;
+	*single_value = false;
 
 	Datum compressed_datum = PointerGetDatum(
 		detoaster_detoast_attr_copy((struct varlena *) DatumGetPointer(
@@ -1907,6 +1907,13 @@ decompress_single_column(RowDecompressor *decompressor, AttrNumber attno, bool *
 									&decompressor->detoaster,
 									CurrentMemoryContext));
 	CompressedDataHeader *header = get_compressed_data_header(compressed_datum);
+
+	/* Handle NULL compression algorithm */
+	if (header->compression_algorithm == COMPRESSION_ALGORITHM_NULL)
+	{
+		*single_value = true;
+		return make_single_value_arrow(column_info->decompressed_type, (Datum) NULL, true);
+	}
 
 	DecompressAllFunction decompress_all =
 		tsl_get_decompress_all_function(header->compression_algorithm,

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -389,7 +389,7 @@ extern int decompress_batch(RowDecompressor *decompressor);
 extern bool decompress_batch_next_row(RowDecompressor *decompressor, AttrNumber *attnos,
 									  int num_attnos);
 extern ArrowArray *decompress_single_column(RowDecompressor *decompressor, AttrNumber attno,
-											bool *default_value);
+											bool *single_value);
 /*
  * A convenience macro to throw an error about the corrupted compressed data, if
  * the argument is false. When fuzzing is enabled, we don't show the message not

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -813,7 +813,7 @@ apply_validity_bitmap(const ArrowArray *arrow, uint64 *restrict result)
  * If we fail this check, it means the whole batch passed so we can bail immediately.
  */
 static inline bool
-check_default_value_match(const uint64 *result)
+check_single_value_match(const uint64 *result)
 {
 	return result[0] & 1;
 }
@@ -829,19 +829,19 @@ batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys, i
 		MemoryContextAlloc(decompressor->per_compressed_row_ctx, bitmap_bytes);
 	uint64 dict_result[(GLOBAL_MAX_ROWS_PER_COMPRESSION + 63) / 64];
 	memset(result, 0xFF, bitmap_bytes);
-	bool default_value = false;
+	bool single_value = false;
 	bool batch_failed = false;
 
 	for (int sk = 0; sk < num_scankeys; sk++)
 	{
 		ArrowArray *arrow =
-			decompress_single_column(decompressor, scankeys[sk].sk_attno, &default_value);
+			decompress_single_column(decompressor, scankeys[sk].sk_attno, &single_value);
 
 		/* Handle null check */
 		if (scankeys[sk].sk_flags & SK_ISNULL)
 		{
 			vector_nulltest(arrow, IS_NULL, result);
-			if (default_value && !check_default_value_match(result))
+			if (single_value && !check_single_value_match(result))
 			{
 				batch_failed = true;
 				break;
@@ -869,7 +869,7 @@ batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys, i
 
 		apply_validity_bitmap(arrow, result);
 
-		if (default_value && !check_default_value_match(result))
+		if (single_value && !check_single_value_match(result))
 		{
 			batch_failed = true;
 			break;

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1354,3 +1354,43 @@ INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1,
 ERROR:  duplicate key value violates unique constraint "_hyper_30_79_chunk_ultimate_unique"
 \set ON_ERROR_STOP 1
 DROP TABLE unique_all;
+-- test NULL compression algorithm
+CREATE TABLE unique_null(
+	time timestamptz NOT NULL,
+	device_id int,
+	tag text,
+	tag2 text,
+	value float
+);
+CREATE UNIQUE INDEX unique_nulls ON unique_null(time, device_id, tag, tag2) NULLS NOT DISTINCT;
+SELECT table_name FROM create_hypertable('unique_null', 'time');
+ table_name  
+-------------
+ unique_null
+(1 row)
+
+ALTER TABLE unique_null SET (tsdb.compress, tsdb.compress_segmentby = 'device_id', tsdb.compress_orderby = 'time');
+WARNING:  column "tag" should be used for segmenting or ordering
+WARNING:  column "tag2" should be used for segmenting or ordering
+INSERT INTO unique_null VALUES
+('2024-01-01 00:00', 1, NULL, '1', 1),
+('2024-01-01 00:00', 1, NULL, '2', 2),
+('2024-01-01 00:00', 1, NULL, '3', 3);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_null') c;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 0
+INSERT INTO unique_null VALUES ('2024-01-01 00:00', 1, NULL, '1', 1);
+ERROR:  duplicate key value violates unique constraint "_hyper_32_83_chunk_unique_nulls"
+\set ON_ERROR_STOP 1
+ALTER TABLE unique_null ADD COLUMN tag3 text DEFAULT 'default value';
+DROP INDEX unique_nulls;
+CREATE UNIQUE INDEX unique_nulls ON unique_null(time, device_id, tag, tag2, tag3) NULLS NOT DISTINCT;
+\set ON_ERROR_STOP 0
+INSERT INTO unique_null VALUES ('2024-01-01 00:00', 1, NULL, '1', 1, 'default value');
+ERROR:  duplicate key value violates unique constraint "_hyper_32_83_chunk_unique_nulls"
+\set ON_ERROR_STOP 1
+DROP TABLE unique_null;

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -885,3 +885,34 @@ INSERT INTO unique_all VALUES('2024-01-01 00:00', 1, true, 1.0, 1.0, 'first', 1,
 \set ON_ERROR_STOP 1
 
 DROP TABLE unique_all;
+
+-- test NULL compression algorithm
+
+CREATE TABLE unique_null(
+	time timestamptz NOT NULL,
+	device_id int,
+	tag text,
+	tag2 text,
+	value float
+);
+CREATE UNIQUE INDEX unique_nulls ON unique_null(time, device_id, tag, tag2) NULLS NOT DISTINCT;
+SELECT table_name FROM create_hypertable('unique_null', 'time');
+ALTER TABLE unique_null SET (tsdb.compress, tsdb.compress_segmentby = 'device_id', tsdb.compress_orderby = 'time');
+INSERT INTO unique_null VALUES
+('2024-01-01 00:00', 1, NULL, '1', 1),
+('2024-01-01 00:00', 1, NULL, '2', 2),
+('2024-01-01 00:00', 1, NULL, '3', 3);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_null') c;
+\set ON_ERROR_STOP 0
+INSERT INTO unique_null VALUES ('2024-01-01 00:00', 1, NULL, '1', 1);
+\set ON_ERROR_STOP 1
+
+ALTER TABLE unique_null ADD COLUMN tag3 text DEFAULT 'default value';
+DROP INDEX unique_nulls;
+CREATE UNIQUE INDEX unique_nulls ON unique_null(time, device_id, tag, tag2, tag3) NULLS NOT DISTINCT;
+
+\set ON_ERROR_STOP 0
+INSERT INTO unique_null VALUES ('2024-01-01 00:00', 1, NULL, '1', 1, 'default value');
+\set ON_ERROR_STOP 1
+
+DROP TABLE unique_null;


### PR DESCRIPTION
NULL compression algorithm does not implement
vectorized decompression so we have to handle it
as a special case (similar to default values).