### PR TITLE
Use RowShareLock when reading CAgg threshold

### DIFF
--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -204,7 +204,7 @@ invalidation_threshold_get(int32 hypertable_id, Oid type)
 		.scankey = scankey,
 		.data = &data,
 		.tuple_found = invalidation_threshold_scan_get,
-		.lockmode = RowExclusiveLock,
+		.lockmode = RowShareLock,
 		.scandirection = ForwardScanDirection,
 		.result_mctx = CurrentMemoryContext,
 		.tuplock = &scantuplock,


### PR DESCRIPTION
It is not necessary to use a RowExclusiveLock when reading the continuous aggregate threshold and a RowShareLock is sufficient.

Disable-check: force-changelog-file