### PR TITLE
Optimize constraint check for COPY

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2110,6 +2110,19 @@ ts_is_partitioning_column(const Hypertable *ht, AttrNumber column_attno)
 	return false;
 }
 
+bool
+ts_is_partitioning_column_name(const Hypertable *ht, NameData column_name)
+{
+	uint16 i;
+
+	for (i = 0; i < ht->space->num_dimensions; i++)
+	{
+		if (namestrcmp(&ht->space->dimensions[i].fd.column_name, NameStr(column_name)) == 0)
+			return true;
+	}
+	return false;
+}
+
 static void
 integer_now_func_validate(Oid now_func_oid, Oid open_dim_type)
 {

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -136,6 +136,7 @@ extern Tablespace *ts_hypertable_get_tablespace_at_offset_from(int32 hypertable_
 extern TSDLLEXPORT bool ts_hypertable_has_chunks(Oid table_relid, LOCKMODE lockmode);
 extern void ts_hypertables_rename_schema_name(const char *old_name, const char *new_name);
 extern bool ts_is_partitioning_column(const Hypertable *ht, AttrNumber column_attno);
+extern bool ts_is_partitioning_column_name(const Hypertable *ht, NameData column_name);
 extern TSDLLEXPORT bool ts_hypertable_set_compressed(Hypertable *ht,
 													 int32 compressed_hypertable_id);
 extern TSDLLEXPORT bool ts_hypertable_unset_compressed(Hypertable *ht);

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -720,3 +720,18 @@ SELECT * FROM table_with_layout_change ORDER BY time, value7;
     6 |    725
 (27 rows)
 
+-- verify check constraints work
+CREATE TABLE test_check(a INT, b TIMESTAMPTZ);
+ALTER TABLE test_check ADD CONSTRAINT c1 CHECK (a > 7);
+SELECT table_name FROM create_hypertable('test_check', 'b');
+NOTICE:  adding not-null constraint to column "b"
+ table_name 
+------------
+ test_check
+(1 row)
+
+COPY test_check(a,b) FROM STDIN (delimiter ',', null 'N');
+\set ON_ERROR_STOP 0
+COPY test_check(a,b) FROM STDIN (delimiter ',', null 'N');
+ERROR:  new row for relation "_hyper_13_832_chunk" violates check constraint "c1"
+\set ON_ERROR_STOP 1

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -548,3 +548,17 @@ COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'n
 
 SELECT * FROM table_with_layout_change ORDER BY time, value7;
 
+-- verify check constraints work
+CREATE TABLE test_check(a INT, b TIMESTAMPTZ);
+ALTER TABLE test_check ADD CONSTRAINT c1 CHECK (a > 7);
+SELECT table_name FROM create_hypertable('test_check', 'b');
+COPY test_check(a,b) FROM STDIN (delimiter ',', null 'N');
+8,'2020-01-01'
+\.
+\set ON_ERROR_STOP 0
+COPY test_check(a,b) FROM STDIN (delimiter ',', null 'N');
+3,'2020-01-01'
+\.
+\set ON_ERROR_STOP 1
+
+


### PR DESCRIPTION
Only do the constraint check in COPY when non-partitioning constraints
are present since partitioning constraints are satisfied by tuple
routing selecting the right target chunk or creating it.
This was showing up as 5-10% cpu spent in flamegraph for compressed
COPY.

Disable-check: force-changelog-file
