### PR TITLE
Fix snapshot handling in background worker

### DIFF
--- a/.unreleased/pr_8236
+++ b/.unreleased/pr_8236
@@ -1,0 +1,1 @@
+Fixes: #8236 Fix snapshot handling in background workers

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1244,6 +1244,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 			/* If there was an error, rollback what was done before the error */
 			AbortCurrentTransaction();
 		StartTransactionCommand();
+		PushActiveSnapshot(GetTransactionSnapshot());
 
 		/* Free the old job if it exists, it's no longer needed, and since it's
 		 * in the TopMemoryContext it won't be freed otherwise.
@@ -1293,6 +1294,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 		 */
 		elog(LOG, "job %d threw an error", params.job_id);
 
+		PopActiveSnapshot();
 		CommitTransactionCommand();
 		ReThrowError(edata);
 	}

--- a/test/src/bgw/log.c
+++ b/test/src/bgw/log.c
@@ -10,6 +10,7 @@
 #include <storage/proc.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
+#include <utils/snapmgr.h>
 
 #include "log.h"
 #include "params.h"
@@ -53,11 +54,14 @@ static void
 bgw_log_insert(char *msg)
 {
 	Relation rel;
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	Oid log_oid = ts_get_relation_relid("public", "bgw_log", false);
 
 	rel = table_open(log_oid, RowExclusiveLock);
 	bgw_log_insert_relation(rel, msg);
 	table_close(rel, RowExclusiveLock);
+	PopActiveSnapshot();
 }
 
 static emit_log_hook_type prev_emit_log_hook = NULL;

--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -214,6 +214,8 @@ lazy_build_hypercore_info_cache(Relation rel, bool create_chunk_constraints,
 {
 	Assert(OidIsValid(rel->rd_id) && (!ts_extension_is_loaded() || !ts_is_hypertable(rel->rd_id)));
 
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	const CompressionSettings *settings;
 	HypercoreInfo *hcinfo;
 	TupleDesc tupdesc = RelationGetDescr(rel);
@@ -325,6 +327,7 @@ lazy_build_hypercore_info_cache(Relation rel, bool create_chunk_constraints,
 			colsettings->cattnum_max = get_attnum(hcinfo->compressed_relid, max_attname);
 		}
 	}
+	PopActiveSnapshot();
 
 	return hcinfo;
 }


### PR DESCRIPTION
Upstream commit fe8ea7a2a introduced additional assertions to
ensure there is always a valid snapshot present when updating
catalog. These were triggered by our background worker code
leading to failing ci runs against postgres pre release branches.

https://github.com/postgres/postgres/commit/fe8ea7a2a89342ecc36a054b2f328c4d8e56f9ae
