### PR TITLE
Fix CREATE WITH (timescaledb.hypertable) error

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -5028,7 +5028,7 @@ process_create_stmt(ProcessUtilityArgs *args)
 			if (!create_table_info.with_clauses[CreateTableFlagTimeColumn].parsed)
 				ereport(ERROR,
 						(errcode(ERRCODE_UNDEFINED_COLUMN),
-						 errmsg("hypertable option requires time_column"),
+						 errmsg("hypertable option requires partition_column"),
 						 errhint(
 							 "Use \"timescaledb.partition_column\" to specify the column to use as "
 							 "partitioning column.")));

--- a/test/expected/create_table_with.out
+++ b/test/expected/create_table_with.out
@@ -12,10 +12,10 @@ DROP TABLE t1;
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
-ERROR:  hypertable option requires time_column
+ERROR:  hypertable option requires partition_column
 HINT:  Use "timescaledb.partition_column" to specify the column to use as partitioning column.
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
-ERROR:  hypertable option requires time_column
+ERROR:  hypertable option requires partition_column
 HINT:  Use "timescaledb.partition_column" to specify the column to use as partitioning column.
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column=NULL);
 ERROR:  column "null" does not exist

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -11,9 +11,9 @@ DROP TABLE t1;
 -- test error cases
 \set ON_ERROR_STOP 0
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
-ERROR:  hypertable option requires time_column
+ERROR:  hypertable option requires partition_column
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
-ERROR:  hypertable option requires time_column
+ERROR:  hypertable option requires partition_column
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column=NULL);
 ERROR:  column "null" does not exist
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='');


### PR DESCRIPTION
The error message when you omitted `tsdb.partition_column` used to mention `time_column`, which makes it seem like the name of the option.

Changed to:

ERROR: hypertable option requires a timestamp or integer partitioning column",
HINT: Use "timescaledb.partition_column" to specify the column to use as partitioning column.

Disable-check: approval-count
Disable-check: force-changelog-file
