### PR TITLE
Fix vectorised check when inserting into compressed column

### DIFF
--- a/.unreleased/pr_8230
+++ b/.unreleased/pr_8230
@@ -1,0 +1,1 @@
+Fixes: #8230 Fixes inserting into compressed data when vectorised check is not available.

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.c
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.c
@@ -49,6 +49,9 @@ get_vector_const_predicate(Oid pg_predicate)
 		case F_TEXTNE:
 			return vector_const_textne;
 
+		case F_BOOLEQ:
+			return vector_booleq;
+
 		default:
 			/*
 			 * More checks below, this branch is to placate the static analyzers.
@@ -94,6 +97,20 @@ vector_nulltest(const ArrowArray *arrow, int test_type, uint64 *restrict result)
 		{
 			result[i] &= validity_word;
 		}
+	}
+}
+
+void
+vector_booleq(const ArrowArray *arrow, Datum arg, uint64 *restrict result)
+{
+	bool check_val = DatumGetBool(arg);
+	if (check_val)
+	{
+		vector_booleantest(arrow, IS_TRUE, result);
+	}
+	else
+	{
+		vector_booleantest(arrow, IS_FALSE, result);
 	}
 }
 

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.h
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.h
@@ -23,6 +23,7 @@ void vector_nulltest(const ArrowArray *arrow, int test_type, uint64 *restrict re
  * NULL test types, like IS_UNKNOWN and IS_NOT_UNKNOWN.
  */
 void vector_booleantest(const ArrowArray *arrow, int test_type, uint64 *restrict result);
+void vector_booleq(const ArrowArray *arrow, Datum arg, uint64 *restrict result);
 
 typedef enum VectorQualSummary
 {

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1380,3 +1380,109 @@ INSERT INTO unique_null VALUES ('2024-01-01 00:00', 1, NULL, '1', 1, 'default va
 ERROR:  duplicate key value violates unique constraint "_hyper_32_83_chunk_unique_nulls"
 \set ON_ERROR_STOP 1
 DROP TABLE unique_null;
+-- test NUMERIC data type
+CREATE TABLE unique_numeric(
+	time timestamptz NOT NULL,
+	device_id numeric(6,2) NOT NULL,
+	tag text,
+	tag2 text,
+	value float
+);
+CREATE UNIQUE INDEX unique_numeric_idx ON unique_numeric(time, device_id, tag, tag2);
+SELECT table_name FROM create_hypertable('unique_numeric', 'time');
+   table_name   
+----------------
+ unique_numeric
+(1 row)
+
+ALTER TABLE unique_numeric SET (tsdb.compress, tsdb.compress_segmentby = 'device_id', tsdb.compress_orderby = 'time');
+WARNING:  column "tag" should be used for segmenting or ordering
+WARNING:  column "tag2" should be used for segmenting or ordering
+INSERT INTO unique_numeric VALUES
+('2024-01-01 00:00', 1.1, NULL, '1', 1),
+('2024-01-01 00:00', 1.2, NULL, '2', 2),
+('2024-01-01 00:00', 1.3, NULL, '3', 3);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_numeric') c;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO unique_numeric VALUES ('2024-01-01 00:00', 1.4, NULL, '1', 1);
+DROP TABLE unique_numeric;
+-- test UUID data type
+CREATE TABLE unique_uuid(
+	time timestamptz NOT NULL,
+	device_id UUID NOT NULL,
+	tag text,
+	tag2 text,
+	value float
+);
+CREATE UNIQUE INDEX unique_uuid_idx ON unique_uuid(time, device_id, tag, tag2);
+SELECT table_name FROM create_hypertable('unique_uuid', 'time');
+ table_name  
+-------------
+ unique_uuid
+(1 row)
+
+ALTER TABLE unique_uuid SET (tsdb.compress, tsdb.compress_segmentby = 'device_id', tsdb.compress_orderby = 'time');
+WARNING:  column "tag" should be used for segmenting or ordering
+WARNING:  column "tag2" should be used for segmenting or ordering
+INSERT INTO unique_uuid VALUES
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000000', NULL, '1', 1),
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000000', NULL, '1', 2),
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000001', NULL, '1', 1),
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000001', NULL, '1', 2);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_uuid') c;
+ count 
+-------
+     1
+(1 row)
+
+INSERT INTO unique_uuid VALUES ('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000001', NULL, '1', 3);
+DROP TABLE unique_uuid;
+-- regression test for SDC 3006
+CREATE TABLE t_1sec(
+	"timestamp"                         timestamp with time zone NOT NULL,
+	device_id                           text,
+	speed                               double precision,
+	derived                             boolean
+);
+ALTER TABLE t_1sec ADD CONSTRAINT unique_device_timestamp_sensor_derived
+	UNIQUE (device_id, "timestamp", derived);
+CREATE INDEX t_1sec_timestamp_idx
+	ON t_1sec
+	USING btree ("timestamp" DESC);
+SELECT create_hypertable(
+	relation => 't_1sec',
+	time_column_name => 'timestamp',
+	chunk_time_interval => interval '06:00:00',
+	create_default_indexes => false
+);
+  create_hypertable   
+----------------------
+ (38,public,t_1sec,t)
+(1 row)
+
+ALTER TABLE t_1sec SET (
+	timescaledb.compress,
+	timescaledb.compress_segmentby = 'device_id',
+	timescaledb.compress_orderby='"timestamp"'
+);
+WARNING:  column "derived" should be used for segmenting or ordering
+insert into t_1sec ( "timestamp", device_id, speed, derived) values
+( '2025-06-06 10:00:00', 'device_id_1', 100, true),
+( '2025-06-06 10:01:00', 'device_id_2', 100, true),
+( '2025-06-06 10:02:00', 'device_id_3', 100, true);
+SELECT compress_chunk(show_chunks('t_1sec'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_38_89_chunk
+(1 row)
+
+insert into t_1sec ( "timestamp", device_id, speed, derived) values
+( '2025-06-06 10:03:00', 'device_id_1', 100, true),
+( '2025-06-06 10:00:00', 'device_id_1', 110, true),
+( '2025-06-06 10:00:00', 'device_id_1', 110, false)
+ON CONFLICT DO NOTHING;
+DROP TABLE t_1sec;

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -911,3 +911,91 @@ INSERT INTO unique_null VALUES ('2024-01-01 00:00', 1, NULL, '1', 1, 'default va
 \set ON_ERROR_STOP 1
 
 DROP TABLE unique_null;
+
+-- test NUMERIC data type
+
+CREATE TABLE unique_numeric(
+	time timestamptz NOT NULL,
+	device_id numeric(6,2) NOT NULL,
+	tag text,
+	tag2 text,
+	value float
+);
+CREATE UNIQUE INDEX unique_numeric_idx ON unique_numeric(time, device_id, tag, tag2);
+SELECT table_name FROM create_hypertable('unique_numeric', 'time');
+ALTER TABLE unique_numeric SET (tsdb.compress, tsdb.compress_segmentby = 'device_id', tsdb.compress_orderby = 'time');
+INSERT INTO unique_numeric VALUES
+('2024-01-01 00:00', 1.1, NULL, '1', 1),
+('2024-01-01 00:00', 1.2, NULL, '2', 2),
+('2024-01-01 00:00', 1.3, NULL, '3', 3);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_numeric') c;
+INSERT INTO unique_numeric VALUES ('2024-01-01 00:00', 1.4, NULL, '1', 1);
+
+DROP TABLE unique_numeric;
+
+-- test UUID data type
+
+CREATE TABLE unique_uuid(
+	time timestamptz NOT NULL,
+	device_id UUID NOT NULL,
+	tag text,
+	tag2 text,
+	value float
+);
+CREATE UNIQUE INDEX unique_uuid_idx ON unique_uuid(time, device_id, tag, tag2);
+SELECT table_name FROM create_hypertable('unique_uuid', 'time');
+ALTER TABLE unique_uuid SET (tsdb.compress, tsdb.compress_segmentby = 'device_id', tsdb.compress_orderby = 'time');
+INSERT INTO unique_uuid VALUES
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000000', NULL, '1', 1),
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000000', NULL, '1', 2),
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000001', NULL, '1', 1),
+('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000001', NULL, '1', 2);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_uuid') c;
+INSERT INTO unique_uuid VALUES ('2024-01-01 00:00', '018a0d1a-8e6a-7000-8000-000000000001', NULL, '1', 3);
+
+DROP TABLE unique_uuid;
+
+-- regression test for SDC 3006
+
+CREATE TABLE t_1sec(
+	"timestamp"                         timestamp with time zone NOT NULL,
+	device_id                           text,
+	speed                               double precision,
+	derived                             boolean
+);
+
+ALTER TABLE t_1sec ADD CONSTRAINT unique_device_timestamp_sensor_derived
+	UNIQUE (device_id, "timestamp", derived);
+
+CREATE INDEX t_1sec_timestamp_idx
+	ON t_1sec
+	USING btree ("timestamp" DESC);
+
+SELECT create_hypertable(
+	relation => 't_1sec',
+	time_column_name => 'timestamp',
+	chunk_time_interval => interval '06:00:00',
+	create_default_indexes => false
+);
+
+ALTER TABLE t_1sec SET (
+	timescaledb.compress,
+	timescaledb.compress_segmentby = 'device_id',
+	timescaledb.compress_orderby='"timestamp"'
+);
+
+insert into t_1sec ( "timestamp", device_id, speed, derived) values
+( '2025-06-06 10:00:00', 'device_id_1', 100, true),
+( '2025-06-06 10:01:00', 'device_id_2', 100, true),
+( '2025-06-06 10:02:00', 'device_id_3', 100, true);
+
+SELECT compress_chunk(show_chunks('t_1sec'));
+
+insert into t_1sec ( "timestamp", device_id, speed, derived) values
+( '2025-06-06 10:03:00', 'device_id_1', 100, true),
+( '2025-06-06 10:00:00', 'device_id_1', 110, true),
+( '2025-06-06 10:00:00', 'device_id_1', 110, false)
+ON CONFLICT DO NOTHING;
+
+DROP TABLE t_1sec;
+


### PR DESCRIPTION
The lack of vectorised 'booleq' function caused crashes when a composite unique key has a boolean column. This change adds vectorisation for 'booleq' and also makes the vectorisation check more robust, so the lack of a vectorised test doesn't cause a crash.

(cherry picked from commit 6c7619ce3041ae73d38c2a1444ae62e240e018fa)