### PR TITLE
Adjust compressed_copy isolation test to work on Mac

### DIFF
--- a/tsl/test/isolation/expected/compressed_copy.out
+++ b/tsl/test/isolation/expected/compressed_copy.out
@@ -11,10 +11,10 @@ s1: WARNING:  there was some uncertainty picking the default segment by for the 
 s1: NOTICE:  default segment by for hypertable "metrics" is set to ""
 s1: NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 step s1_copy: 
-COPY metrics FROM PROGRAM 'seq 10 | xargs -II date -d "2025-01-01 + I hour" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
+COPY metrics FROM PROGRAM 'seq 10 | xargs -II echo 2025-01-01 0:00:00,d1,0.5' WITH (FORMAT CSV);
 
 step s2_copy: 
-COPY metrics FROM PROGRAM 'seq 10 | xargs -II date -d "2025-01-01 + I hour" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
+COPY metrics FROM PROGRAM 'seq 10 | xargs -II echo 2025-01-01 0:00:00,d1,0.5' WITH (FORMAT CSV);
  <waiting ...>
 step s1_commit: 
   COMMIT;

--- a/tsl/test/isolation/specs/compressed_copy.spec
+++ b/tsl/test/isolation/specs/compressed_copy.spec
@@ -22,7 +22,7 @@ step "s1_begin" {
 }
 
 step "s1_copy" {
-COPY metrics FROM PROGRAM 'seq 10 | xargs -II date -d "2025-01-01 + I hour" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
+COPY metrics FROM PROGRAM 'seq 10 | xargs -II echo 2025-01-01 0:00:00,d1,0.5' WITH (FORMAT CSV);
 }
 
 step "s1_commit" {
@@ -39,7 +39,7 @@ step "s2_begin" {
 }
 
 step "s2_copy" {
-COPY metrics FROM PROGRAM 'seq 10 | xargs -II date -d "2025-01-01 + I hour" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
+COPY metrics FROM PROGRAM 'seq 10 | xargs -II echo 2025-01-01 0:00:00,d1,0.5' WITH (FORMAT CSV);
 }
 
 step "s2_commit" {


### PR DESCRIPTION
MacOS date parameters are not compatible with linux date. Change
the isolation test to not use date since we dont need to generate
consecutive values for this test.

Disable-check: force-changelog-file
Disable-check: approval-count

