### PR TITLE
Simplify the check for valid open dimension

### DIFF
--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -160,10 +160,7 @@ cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry, int32 hyperta
 	cache_entry->hypertable_relid = ht->main_table_relid;
 
 	const Dimension *open_dim = hyperspace_get_open_dimension(ht->space, 0);
-	if (!open_dim)
-		ereport(ERROR,
-				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("hypertable has no open partitioning dimension")));
+	Ensure(open_dim != NULL, "hypertable %d has no open partitioning dimension", hypertable_id);
 
 	cache_entry->hypertable_open_dimension = *open_dim;
 	if (cache_entry->hypertable_open_dimension.partitioning != NULL)

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -255,7 +255,6 @@ Select sum( b), min(c)
 from rowsec_tab
 group by time_bucket('1', a) WITH NO DATA;
 ERROR:  cannot create continuous aggregate on hypertable with row security
-DROP TABLE rowsec_tab CASCADE;
 drop table conditions cascade;
 --negative tests for WITH options
 CREATE TABLE conditions (
@@ -602,10 +601,6 @@ ERROR:  hypertable is an internal compressed hypertable
 --Check error handling for this case
 SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
 ERROR:  columnstore not enabled on "i2980"
-DROP TABLE i2980 CASCADE;
-NOTICE:  drop cascades to 6 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_3_chunk
-DROP TABLE comp_ht_test CASCADE;
 -- cagg on normal view should error out
 CREATE VIEW v1 AS SELECT now() AS time;
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
@@ -617,42 +612,3 @@ ERROR:  invalid continuous aggregate view
 -- No FROM clause in CAGG definition
 CREATE MATERIALIZED VIEW cagg1 with (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT 1 GROUP BY 1 WITH NO DATA;
 ERROR:  invalid continuous aggregate query
-CREATE TABLE "conditions"(
-  time         TIMESTAMP WITH TIME ZONE NOT NULL,
-  device_id    TEXT,
-  temperature  NUMERIC,
-  humidity     NUMERIC
-) WITH (
-  timescaledb.hypertable,
-  timescaledb.partition_column='time',
-  timescaledb.chunk_interval='1 day'
-);
-CREATE MATERIALIZED VIEW conditions_by_hour
-WITH (timescaledb.continuous) AS
-SELECT
-  time_bucket(INTERVAL '1 hour', time) AS bucket,
-  device_id,
-  MAX(temperature),
-  MIN(temperature),
-  COUNT(*)
-FROM conditions
-GROUP BY 1, 2
-WITH NO DATA;
--- Should work
-INSERT INTO conditions (time, device_id, temperature, humidity)
-VALUES
-  ('2023-10-01 00:00:00+00', 'device1', 20.5, 30.0);
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-\set ON_ERROR_STOP 0
-\set VERBOSITY default
--- Remove dimensions to test cagg trigger for invalid dimension
-TRUNCATE _timescaledb_catalog.dimension CASCADE;
-NOTICE:  truncate cascades to table "dimension_slice"
-NOTICE:  truncate cascades to table "chunk_constraint"
--- Should fail with no valid open dimension
-DELETE FROM conditions WHERE device_id = 'device1';
-ERROR:  hypertable has no open partitioning dimension
-DROP TABLE conditions cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to view _timescaledb_internal._partial_view_21
-drop cascades to view _timescaledb_internal._direct_view_21

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -224,7 +224,6 @@ set(SOLO_TESTS
     cagg_bgw
     cagg_ddl-${PG_VERSION_MAJOR}
     cagg_dump
-    cagg_errors
     cagg_invalidation
     cagg_policy_incremental
     hypercore

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -223,8 +223,6 @@ Select sum( b), min(c)
 from rowsec_tab
 group by time_bucket('1', a) WITH NO DATA;
 
-DROP TABLE rowsec_tab CASCADE;
-
 drop table conditions cascade;
 
 --negative tests for WITH options
@@ -496,9 +494,6 @@ CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.material
 --Check error handling for this case
 SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
 
-DROP TABLE i2980 CASCADE;
-DROP TABLE comp_ht_test CASCADE;
-
 -- cagg on normal view should error out
 CREATE VIEW v1 AS SELECT now() AS time;
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
@@ -509,43 +504,3 @@ CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materia
 
 -- No FROM clause in CAGG definition
 CREATE MATERIALIZED VIEW cagg1 with (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT 1 GROUP BY 1 WITH NO DATA;
-
-CREATE TABLE "conditions"(
-  time         TIMESTAMP WITH TIME ZONE NOT NULL,
-  device_id    TEXT,
-  temperature  NUMERIC,
-  humidity     NUMERIC
-) WITH (
-  timescaledb.hypertable,
-  timescaledb.partition_column='time',
-  timescaledb.chunk_interval='1 day'
-);
-
-CREATE MATERIALIZED VIEW conditions_by_hour
-WITH (timescaledb.continuous) AS
-SELECT
-  time_bucket(INTERVAL '1 hour', time) AS bucket,
-  device_id,
-  MAX(temperature),
-  MIN(temperature),
-  COUNT(*)
-FROM conditions
-GROUP BY 1, 2
-WITH NO DATA;
-
--- Should work
-INSERT INTO conditions (time, device_id, temperature, humidity)
-VALUES
-  ('2023-10-01 00:00:00+00', 'device1', 20.5, 30.0);
-
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-\set ON_ERROR_STOP 0
-\set VERBOSITY default
-
--- Remove dimensions to test cagg trigger for invalid dimension
-TRUNCATE _timescaledb_catalog.dimension CASCADE;
-
--- Should fail with no valid open dimension
-DELETE FROM conditions WHERE device_id = 'device1';
-
-DROP TABLE conditions cascade;


### PR DESCRIPTION
In #8244 we fixed a segfault in the CAgg invalidation trigger cache when trying to get an open dimension from a hypertable that don't have dimension. In a normal flow this will never happen so the tests added making a manual metadata corruption don't make sense and are hard to maintain. So removed the regression tests and used the Ensure instead of ereport to error out on release builds.

This partially reverts commit 6cb41f42f5663086196eaa85ab03bc231eb42668.

Disable-check: force-changelog-file
