### PR TITLE
Fix chunk skipping cleanup in smoke test

### DIFF
--- a/test/sql/updates/cleanup.chunk_skipping.sql
+++ b/test/sql/updates/cleanup.chunk_skipping.sql
@@ -2,4 +2,4 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-DROP TABLE skip;
+DROP TABLE IF EXISTS chunkskip;


### PR DESCRIPTION
The update test for chunk skipping which is run during smoke test had a table renamed, but the cleanup script still has the old table name.