### PR TITLE
Move check for INSERT into compressed internal hypertable

### DIFF
--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -69,16 +69,6 @@ ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *point,
 	bool cis_changed = true;
 	Chunk *chunk = NULL;
 
-	/* Direct inserts into internal compressed hypertable is not supported.
-	 * For compression chunks are created explicitly by compress_chunk and
-	 * inserted into directly so we should never end up in this code path
-	 * for a compressed hypertable.
-	 */
-	if (dispatch->hypertable->fd.compression_state == HypertableInternalCompressionTable)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("direct insert into internal compressed hypertable is not supported")));
-
 	cis = ts_subspace_store_get(dispatch->cache, point);
 
 	/*


### PR DESCRIPTION
Move the check for INSERT into compressed hypertable into planner
to error out earlier and not have to the check be part of tuple routing.

Disable-check: force-changelog-file