### PR TITLE
Update Windows runner to 2022

### DIFF
--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2019 ]
+        os: [ windows-2022 ]
         pg: [ "15", "16", "17" ]
         include:
           - pg: 15


### PR DESCRIPTION
This updates the runner to windows-2022 since windows-2019 will be fully unsupported June 30.

See https://github.com/actions/runner-images/issues/12045