### PR TITLE
Special handling for dictionary-encoded text in vectorized grouping

### DIFF
--- a/tsl/src/nodes/vector_agg/grouping_policy_hash.h
+++ b/tsl/src/nodes/vector_agg/grouping_policy_hash.h
@@ -128,6 +128,19 @@ typedef struct GroupingPolicyHash
 	uint64 stat_input_valid_rows;
 	uint64 stat_bulk_filtered_rows;
 	uint64 stat_consecutive_keys;
+
+	/*
+	 * FIXME all the stuff below should be moved out.
+	 */
+
+	/*
+	 * For single text key that uses dictionary encoding, in some cases we first
+	 * calculate the key indexes for the dictionary entries, and then translate
+	 * it to the actual rows.
+	 */
+	uint32 *restrict key_index_for_dict;
+	uint64 num_key_index_for_dict;
+	bool use_key_index_for_dict;
 } GroupingPolicyHash;
 
 //#define DEBUG_PRINT(...) fprintf(stderr, __VA_ARGS__)

--- a/tsl/src/nodes/vector_agg/hashing/batch_hashing_params.h
+++ b/tsl/src/nodes/vector_agg/hashing/batch_hashing_params.h
@@ -21,7 +21,7 @@ typedef struct BatchHashingParams
 	int num_grouping_columns;
 	const CompressedColumnValues *grouping_column_values;
 
-	GroupingPolicyHash *policy;
+	GroupingPolicyHash *restrict policy;
 	HashingStrategy *restrict hashing;
 
 	uint32 *restrict result_key_indexes;

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_single_text.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_single_text.c
@@ -127,9 +127,259 @@ single_text_emit_key(GroupingPolicyHash *policy, uint32 current_key,
 	return hash_strategy_output_key_single_emit(policy, current_key, aggregated_slot);
 }
 
+/*
+ * We use a special batch preparation function to sometimes hash the dictionary-
+ * encoded column using the dictionary.
+ */
+
+#define USE_DICT_HASHING
+
+static void single_text_fill_offsets_impl(BatchHashingParams params, int start_row, int end_row);
+
 static void
 single_text_key_hashing_prepare_for_batch(GroupingPolicyHash *policy, TupleTableSlot *vector_slot)
 {
+	/*
+	 * Determine whether we're going to use the dictionary for hashing.
+	 */
+	policy->use_key_index_for_dict = false;
+
+	BatchHashingParams params = build_batch_hashing_params(policy, vector_slot);
+	if (params.single_grouping_column.decompression_type != DT_ArrowTextDict)
+	{
+		return;
+	}
+
+	uint16 batch_rows;
+	const uint64 *row_filter = vector_slot_get_qual_result(vector_slot, &batch_rows);
+
+	const int dict_rows = params.single_grouping_column.arrow->dictionary->length;
+	if (dict_rows > arrow_num_valid(row_filter, batch_rows))
+	{
+		return;
+	}
+
+	/*
+	 * Remember which aggregation states have already existed, and which we have
+	 * to initialize. State index zero is invalid.
+	 */
+	const uint32 last_initialized_key_index = params.hashing->last_used_key_index;
+	Assert(last_initialized_key_index <= policy->num_allocated_per_key_agg_states);
+
+	/*
+	 * Initialize the array for storing the aggregate state offsets corresponding
+	 * to a given batch row. We don't need the offsets for the previous batch
+	 * that are currently stored there, so we don't need to use repalloc.
+	 */
+	if ((size_t) dict_rows > policy->num_key_index_for_dict)
+	{
+		if (policy->key_index_for_dict != NULL)
+		{
+			pfree(policy->key_index_for_dict);
+		}
+		policy->num_key_index_for_dict = dict_rows;
+		policy->key_index_for_dict =
+			palloc(sizeof(policy->key_index_for_dict[0]) * policy->num_key_index_for_dict);
+	}
+
+	/*
+	 * We shouldn't add the dictionary entries that are not used by any matching
+	 * rows. Translate the batch filter bitmap to dictionary rows.
+	 */
+	if (row_filter != NULL)
+	{
+		uint64 *restrict dict_filter = policy->tmp_filter;
+		const size_t dict_words = (dict_rows + 63) / 64;
+		memset(dict_filter, 0, sizeof(*dict_filter) * dict_words);
+
+		bool *restrict tmp = (bool *) policy->key_index_for_dict;
+		Assert(sizeof(*tmp) <= sizeof(*policy->key_index_for_dict));
+		memset(tmp, 0, sizeof(*tmp) * dict_rows);
+
+		int outer;
+		for (outer = 0; outer < batch_rows / 64; outer++)
+		{
+#define INNER_LOOP(INNER_MAX)                                                                      \
+	const uint64 word = row_filter[outer];                                                         \
+	for (int inner = 0; inner < INNER_MAX; inner++)                                                \
+	{                                                                                              \
+		const int16 index =                                                                        \
+			((int16 *) params.single_grouping_column.buffers[3])[outer * 64 + inner];              \
+		tmp[index] = tmp[index] || (word & (1ull << inner));                                       \
+	}
+
+			INNER_LOOP(64)
+		}
+
+		if (batch_rows % 64)
+		{
+			INNER_LOOP(batch_rows % 64)
+		}
+#undef INNER_LOOP
+
+		for (outer = 0; outer < dict_rows / 64; outer++)
+		{
+#define INNER_LOOP(INNER_MAX)                                                                      \
+	uint64 word = 0;                                                                               \
+	for (int inner = 0; inner < INNER_MAX; inner++)                                                \
+	{                                                                                              \
+		word |= (tmp[outer * 64 + inner] ? 1ull : 0ull) << inner;                                  \
+	}                                                                                              \
+	dict_filter[outer] = word;
+
+			INNER_LOOP(64)
+		}
+		if (dict_rows % 64)
+		{
+			INNER_LOOP(dict_rows % 64)
+		}
+#undef INNER_LOOP
+
+		params.batch_filter = dict_filter;
+	}
+	else
+	{
+		params.batch_filter = NULL;
+	}
+
+	/*
+	 * The dictionary contains no null entries, so we will be adding the null
+	 * key separately. Determine if we have any null key that also passes the
+	 * batch filter.
+	 */
+	bool have_null_key = false;
+	if (row_filter != NULL)
+	{
+		if (params.single_grouping_column.arrow->null_count > 0)
+		{
+			Assert(params.single_grouping_column.buffers[0] != NULL);
+			const size_t batch_words = (batch_rows + 63) / 64;
+			for (size_t i = 0; i < batch_words; i++)
+			{
+				have_null_key = have_null_key ||
+								(row_filter[i] &
+								 (~((uint64 *) params.single_grouping_column.buffers[0])[i])) != 0;
+			}
+		}
+	}
+	else
+	{
+		if (params.single_grouping_column.arrow->null_count > 0)
+		{
+			Assert(params.single_grouping_column.buffers[0] != NULL);
+			have_null_key = true;
+		}
+	}
+
+	/*
+	 * The dictionary doesn't store nulls, so add the null key separately if we
+	 * have one. Note that we have to respect NULLS FIRST/LAST. Here we add the
+	 * null key before all other keys in case of NULLS FIRST.
+	 */
+	const bool nulls_first = !arrow_row_is_valid(params.single_grouping_column.buffers[0], 0);
+	if (have_null_key && nulls_first && policy->hashing.null_key_index == 0)
+	{
+		policy->hashing.null_key_index = ++params.hashing->last_used_key_index;
+		policy->hashing.output_keys[policy->hashing.null_key_index] = PointerGetDatum(NULL);
+	}
+
+	/*
+	 * Build key indexes for the dictionary entries as for normal non-nullable
+	 * text values.
+	 */
+	Assert(params.single_grouping_column.decompression_type = DT_ArrowTextDict);
+	Assert((size_t) dict_rows <= policy->num_key_index_for_dict);
+	memset(policy->key_index_for_dict, 0, sizeof(*policy->key_index_for_dict) * dict_rows);
+
+	params.single_grouping_column.decompression_type = DT_ArrowText;
+	params.single_grouping_column.buffers[0] = NULL;
+	params.result_key_indexes = policy->key_index_for_dict;
+
+	single_text_fill_offsets_impl(params, 0, dict_rows);
+
+	/*
+	 * The dictionary doesn't store nulls, so add the null key separately if we
+	 * have one. Note that we have to respect NULLS FIRST/LAST. Here we add the
+	 * null key after all other keys in case of NULLS LAST.
+	 */
+	if (have_null_key && !nulls_first && policy->hashing.null_key_index == 0)
+	{
+		policy->hashing.null_key_index = ++params.hashing->last_used_key_index;
+		policy->hashing.output_keys[policy->hashing.null_key_index] = PointerGetDatum(NULL);
+	}
+
+	/*
+	 * Initialize the new keys if we added any.
+	 */
+	if (params.hashing->last_used_key_index > last_initialized_key_index)
+	{
+		const uint64 new_aggstate_rows = policy->num_allocated_per_key_agg_states * 2 + 1;
+		const int num_fns = policy->num_agg_defs;
+		for (int i = 0; i < num_fns; i++)
+		{
+			const VectorAggDef *agg_def = &policy->agg_defs[i];
+			if (params.hashing->last_used_key_index >= policy->num_allocated_per_key_agg_states)
+			{
+				policy->per_agg_per_key_states[i] =
+					repalloc(policy->per_agg_per_key_states[i],
+							 new_aggstate_rows * agg_def->func.state_bytes);
+			}
+
+			/*
+			 * Initialize the aggregate function states for the newly added keys.
+			 */
+			void *first_uninitialized_state =
+				agg_def->func.state_bytes * (last_initialized_key_index + 1) +
+				(char *) policy->per_agg_per_key_states[i];
+			agg_def->func.agg_init(first_uninitialized_state,
+								   params.hashing->last_used_key_index -
+									   last_initialized_key_index);
+		}
+
+		/*
+		 * Record the newly allocated number of rows in case we had to reallocate.
+		 */
+		if (params.hashing->last_used_key_index >= policy->num_allocated_per_key_agg_states)
+		{
+			Assert(new_aggstate_rows > policy->num_allocated_per_key_agg_states);
+			policy->num_allocated_per_key_agg_states = new_aggstate_rows;
+		}
+	}
+
+	policy->use_key_index_for_dict = true;
+
+	DEBUG_PRINT("computed the dict offsets\n");
 }
+
+static void
+single_text_offsets_translate(BatchHashingParams params, int start_row, int end_row)
+{
+	GroupingPolicyHash *policy = params.policy;
+	Assert(policy->use_key_index_for_dict);
+
+	uint32 *restrict indexes_for_rows = params.result_key_indexes;
+	uint32 *restrict indexes_for_dict = policy->key_index_for_dict;
+
+	for (int row = start_row; row < end_row; row++)
+	{
+		const bool row_valid = arrow_row_is_valid(params.single_grouping_column.buffers[0], row);
+		const int16 dict_index = ((int16 *) params.single_grouping_column.buffers[3])[row];
+
+		if (row_valid)
+		{
+			indexes_for_rows[row] = indexes_for_dict[dict_index];
+		}
+		else
+		{
+			indexes_for_rows[row] = policy->hashing.null_key_index;
+		}
+
+		Assert(indexes_for_rows[row] != 0 || !arrow_row_is_valid(params.batch_filter, row));
+	}
+}
+
+#undef APPLY_FOR_SPECIALIZATIONS
+#undef APPLY_FOR_VALIDITY
+#undef APPLY_FOR_BATCH_FILTER
 
 #include "hash_strategy_impl.c"

--- a/tsl/test/expected/vector_agg_text.out
+++ b/tsl/test/expected/vector_agg_text.out
@@ -368,3 +368,100 @@ select count(*) from long group by a order by 1 limit 10;
 (5 rows)
 
 reset timescaledb.debug_require_vector_agg;
+-- Dictionary encoding with null values, used to test NULLS FIRST/LAST in the
+-- group aggregate mode.
+create table dictnulls(t int, x text);
+select create_hypertable('dictnulls', 't');
+NOTICE:  adding not-null constraint to column "t"
+   create_hypertable    
+------------------------
+ (5,public,dictnulls,t)
+(1 row)
+
+insert into dictnulls select x * 10,
+        (case when x % 11 != 0
+            then to_char(x % 11, '00')
+            else null end)::text
+from generate_series(1, 10000) x
+;
+alter table dictnulls set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'x');
+select count(compress_chunk(x)) from show_chunks('dictnulls') x;
+ count 
+-------
+     2
+(1 row)
+
+-- Test NULLS FIRST/LAST in GroupAgg mode.
+set enable_hashagg to off;
+explain (costs off) select x, count(*) from dictnulls group by x order by x nulls last;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: _hyper_5_9_chunk.x
+   ->  Merge Append
+         Sort Key: _hyper_5_9_chunk.x
+         ->  Custom Scan (VectorAgg)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk
+                     ->  Index Scan using compress_hyper_6_11_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on compress_hyper_6_11_chunk
+         ->  Custom Scan (VectorAgg)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk
+                     ->  Index Scan using compress_hyper_6_12_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on compress_hyper_6_12_chunk
+(10 rows)
+
+select x, count(*) from dictnulls group by x order by x nulls last;
+  x  | count 
+-----+-------
+  01 |   910
+  02 |   909
+  03 |   909
+  04 |   909
+  05 |   909
+  06 |   909
+  07 |   909
+  08 |   909
+  09 |   909
+  10 |   909
+     |   909
+(11 rows)
+
+alter table dictnulls set (timescaledb.compress, timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'x nulls first');
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('dictnulls') x;
+ count 
+-------
+     2
+(1 row)
+
+explain (costs off) select x, count(*) from dictnulls group by x order by x nulls first;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: _hyper_5_9_chunk.x
+   ->  Merge Append
+         Sort Key: _hyper_5_9_chunk.x NULLS FIRST
+         ->  Custom Scan (VectorAgg)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk
+                     ->  Index Scan using compress_hyper_6_13_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on compress_hyper_6_13_chunk
+         ->  Custom Scan (VectorAgg)
+               ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk
+                     ->  Index Scan using compress_hyper_6_14_chunk__ts_meta_min_1__ts_meta_max_1__ts_idx on compress_hyper_6_14_chunk
+(10 rows)
+
+select x, count(*) from dictnulls group by x order by x nulls first;
+  x  | count 
+-----+-------
+     |   909
+  01 |   910
+  02 |   909
+  03 |   909
+  04 |   909
+  05 |   909
+  06 |   909
+  07 |   909
+  08 |   909
+  09 |   909
+  10 |   909
+(11 rows)
+
+reset enable_hashagg;


### PR DESCRIPTION
If we have a small dictionary, hashing its entries and then translating the key indexes to the actual rows will be faster.