### PR TITLE
Allow creating concurrent CAgg refresh policies

### DIFF
--- a/.unreleased/pr_8274
+++ b/.unreleased/pr_8274
@@ -1,0 +1,1 @@
+Implements: #8274 Allow creating concurrent continuous aggregate refresh policies

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -566,7 +566,7 @@ ts_get_mock_time_or_current_time(void)
 								  Int32GetDatum(-1));
 		return res;
 	}
-	res = TimestampTzGetDatum(GetCurrentTimestamp());
+	res = TimestampTzGetDatum(GetCurrentTransactionStartTimestamp());
 	return res;
 }
 #endif

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -6,9 +6,17 @@
 #pragma once
 
 #include <postgres.h>
+#include "bgw_policy/job.h"
 #include "dimension.h"
 #include <continuous_aggs/materialize.h>
 #include <utils/jsonb.h>
+
+typedef enum PolicyRefreshOffsetOverlapResult
+{
+	POLICY_REFRESH_OFFSET_OVERLAP,		 /* overlap but not exact */
+	POLICY_REFRESH_OFFSET_OVERLAP_EQUAL, /* exact match */
+	POLICY_REFRESH_OFFSET_OVERLAP_NONE,	 /* no overlap */
+} PolicyRefreshOffsetOverlapResult;
 
 extern Datum policy_refresh_cagg_add(PG_FUNCTION_ARGS);
 extern Datum policy_refresh_cagg_proc(PG_FUNCTION_ARGS);
@@ -33,3 +41,9 @@ Datum policy_refresh_cagg_add_internal(
 	NullableDatum buckets_per_batch, NullableDatum max_batches_per_execution,
 	NullableDatum refresh_newest_first);
 Datum policy_refresh_cagg_remove_internal(Oid cagg_oid, bool if_exists);
+
+PolicyRefreshOffsetOverlapResult policy_refresh_cagg_check_for_overlaps(ContinuousAgg *cagg,
+																		Jsonb *policy_config,
+																		int32 existing_job_id);
+
+bool policy_refresh_cagg_check_if_last_policy(PolicyContinuousAggData *policy_data);

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -382,6 +382,7 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 	JsonbToCStringIndent(str, &config->root, VARSIZE(config));
 
 	policy_refresh_cagg_read_and_validate_config(config, &policy_data);
+	bool extend_last_bucket = !policy_refresh_cagg_check_if_last_policy(&policy_data);
 
 	bool enable_osm_reads_old = ts_guc_enable_osm_reads;
 
@@ -427,7 +428,8 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 										refresh_window->end_isnull,
 										(context.callctx != CAGG_REFRESH_POLICY_BATCHED),
 										false, /* force */
-										policy_data.process_hypertable_invalidations);
+										policy_data.process_hypertable_invalidations,
+										extend_last_bucket);
 		if (processing_batch >= policy_data.max_batches_per_execution &&
 			processing_batch < context.number_of_batches &&
 			policy_data.max_batches_per_execution > 0)

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -958,7 +958,8 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 										true,  /* end_isnull */
 										true,  /* bucketing_refresh_window */
 										false, /* force */
-										true /* process_hypertable_invalidations */);
+										true,  /* process_hypertable_invalidations */
+										false /*extend_last_bucket*/);
 	}
 
 	return DDL_DONE;

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -16,12 +16,11 @@ extern void continuous_agg_calculate_merged_refresh_window(
 	const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
 	const InvalidationStore *invalidations, const ContinuousAggsBucketFunction *bucket_function,
 	InternalTimeRange *merged_refresh_window, const CaggRefreshContext context);
-extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
-											const InternalTimeRange *refresh_window,
-											const CaggRefreshContext context,
-											const bool start_isnull, const bool end_isnull,
-											bool bucketing_refresh_window, bool force,
-											bool process_hypertable_invalidations);
+extern void
+continuous_agg_refresh_internal(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
+								const CaggRefreshContext context, const bool start_isnull,
+								const bool end_isnull, bool bucketing_refresh_window, bool force,
+								bool process_hypertable_invalidations, bool extend_last_bucket);
 extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,
 												 InternalTimeRange *original_refresh_window,
 												 int32 buckets_per_batch,

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -510,7 +510,7 @@ NOTICE:  continuous aggregate "i2980_cagg" is already up-to-date
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
-ERROR:  configuration materialization hypertable id 1000 not found
+ERROR:  invalid materialized hypertable ID: 1000
 --test creating continuous aggregate with compression enabled --
 CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.compress)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -232,19 +232,13 @@ DETAIL:  The start and end offsets must cover at least two buckets in the valid 
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval) as job_id \gset
 --adding again should warn/error
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval, if_not_exists=>false);
-ERROR:  continuous aggregate policy already exists for "mat_m1"
-DETAIL:  Only one continuous aggregate policy can be created per continuous aggregate and a policy with job id 1009 already exists for "mat_m1".
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+DETAIL:  A refresh policy with the same start and end offset already exists for continuous aggregate "mat_m1".
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 15, '1h'::interval, if_not_exists=>true);
-WARNING:  continuous aggregate policy already exists for "mat_m1"
-DETAIL:  A policy already exists with different arguments.
-HINT:  Remove the existing policy before adding a new one.
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval, if_not_exists=>true);
-NOTICE:  continuous aggregate policy already exists for "mat_m1", skipping
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+DETAIL:  A refresh policy with the same start and end offset already exists for continuous aggregate "mat_m1".
  add_continuous_aggregate_policy 
 ---------------------------------
                               -1
@@ -275,14 +269,7 @@ SELECT config FROM _timescaledb_config.bgw_job where id = :job_id;
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval, if_not_exists=>true);
-WARNING:  continuous aggregate policy already exists for "mat_m1"
-DETAIL:  A policy already exists with different arguments.
-HINT:  Remove the existing policy before adding a new one.
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
 SELECT remove_continuous_aggregate_policy('int_tab');
 ERROR:  "int_tab" is not a continuous aggregate
 SELECT remove_continuous_aggregate_policy('mat_m1');
@@ -299,21 +286,15 @@ SELECT add_continuous_aggregate_policy('mat_m1', 20, NULL, '1h'::interval, if_no
 (1 row)
 
 SELECT add_continuous_aggregate_policy('mat_m1', 20, NULL, '1h'::interval, if_not_exists=>true); -- same param values, so we get a NOTICE
-NOTICE:  continuous aggregate policy already exists for "mat_m1", skipping
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+DETAIL:  A refresh policy with the same start and end offset already exists for continuous aggregate "mat_m1".
  add_continuous_aggregate_policy 
 ---------------------------------
                               -1
 (1 row)
 
 SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '1h'::interval, if_not_exists=>true); -- different values, so we get a WARNING
-WARNING:  continuous aggregate policy already exists for "mat_m1"
-DETAIL:  A policy already exists with different arguments.
-HINT:  Remove the existing policy before adding a new one.
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
 SELECT remove_continuous_aggregate_policy('mat_m1');
  remove_continuous_aggregate_policy 
 ------------------------------------
@@ -327,21 +308,15 @@ SELECT add_continuous_aggregate_policy('mat_m1', NULL, 20, '1h'::interval, if_no
 (1 row)
 
 SELECT add_continuous_aggregate_policy('mat_m1', NULL, 20, '1h'::interval, if_not_exists=>true);
-NOTICE:  continuous aggregate policy already exists for "mat_m1", skipping
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+DETAIL:  A refresh policy with the same start and end offset already exists for continuous aggregate "mat_m1".
  add_continuous_aggregate_policy 
 ---------------------------------
                               -1
 (1 row)
 
 SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '1h'::interval, if_not_exists=>true);
-WARNING:  continuous aggregate policy already exists for "mat_m1"
-DETAIL:  A policy already exists with different arguments.
-HINT:  Remove the existing policy before adding a new one.
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
 SELECT remove_continuous_aggregate_policy('mat_m1');
  remove_continuous_aggregate_policy 
 ------------------------------------
@@ -835,12 +810,7 @@ SELECT config FROM _timescaledb_config.bgw_job where id = :job_id;
 
 \set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', '15 day', '1 day', '1h'::interval, if_not_exists=>true);
-WARNING:  continuous aggregate policy already exists for "max_mat_view_timestamp"
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "max_mat_view_timestamp"
 SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', 'xyz', '1 day', '1h'::interval, if_not_exists=>true);
 ERROR:  invalid input syntax for type interval: "xyz"
 \set ON_ERROR_STOP 1
@@ -1043,10 +1013,9 @@ ERROR:  invalid parameter value for start_offset
 SELECT add_continuous_aggregate_policy('mat_smallint', '15', 10, '1h'::interval, if_not_exists=>true);
 ERROR:  invalid parameter value for end_offset
 SELECT add_continuous_aggregate_policy('mat_smallint', '15', '10', '1h'::interval, if_not_exists=>true);
-WARNING:  continuous aggregate policy already exists for "mat_smallint"
  add_continuous_aggregate_policy 
 ---------------------------------
-                              -1
+                            1045
 (1 row)
 
 \set ON_ERROR_STOP 1
@@ -1152,7 +1121,7 @@ NOTICE:  defaulting compress_orderby to a
 SELECT add_compression_policy('mat_smallint', -4::smallint);
  add_compression_policy 
 ------------------------
-                   1053
+                   1054
 (1 row)
 
 SELECT remove_compression_policy('mat_smallint');
@@ -1164,7 +1133,7 @@ SELECT remove_compression_policy('mat_smallint');
 SELECT add_compression_policy('mat_bigint', 0::bigint);
  add_compression_policy 
 ------------------------
-                   1054
+                   1055
 (1 row)
 
 SELECT remove_compression_policy('mat_bigint');
@@ -1177,13 +1146,13 @@ SELECT remove_compression_policy('mat_bigint');
 SELECT add_compression_policy('mat_smallint', 5::smallint);
  add_compression_policy 
 ------------------------
-                   1055
+                   1056
 (1 row)
 
 SELECT add_compression_policy('mat_bigint', 20::bigint);
  add_compression_policy 
 ------------------------
-                   1056
+                   1057
 (1 row)
 
 -- end of coverage tests
@@ -1235,16 +1204,12 @@ WITH NO DATA;
 SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, NULL, '1 h'::interval, if_not_exists => true);
  add_continuous_aggregate_policy 
 ---------------------------------
-                            1057
+                            1058
 (1 row)
 
+\set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval, if_not_exists => true);
-WARNING:  continuous aggregate policy already exists for "metrics_cagg"
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "metrics_cagg"
 SELECT remove_continuous_aggregate_policy('metrics_cagg');
  remove_continuous_aggregate_policy 
 ------------------------------------
@@ -1254,23 +1219,18 @@ SELECT remove_continuous_aggregate_policy('metrics_cagg');
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, '1 day'::interval, '1h'::interval, if_not_exists=>true);
  add_continuous_aggregate_policy 
 ---------------------------------
-                            1058
+                            1059
 (1 row)
 
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, '1 day'::interval, '1h'::interval, if_not_exists=>true); -- same param values, so we get a NOTICE
-NOTICE:  continuous aggregate policy already exists for "metrics_cagg", skipping
+NOTICE:  continuous aggregate refresh policy already exists for "metrics_cagg", skipping
  add_continuous_aggregate_policy 
 ---------------------------------
                               -1
 (1 row)
 
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, NULL, '1h'::interval, if_not_exists=>true); -- different values, so we get a WARNING
-WARNING:  continuous aggregate policy already exists for "metrics_cagg"
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
-(1 row)
-
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "metrics_cagg"
 SELECT remove_continuous_aggregate_policy('metrics_cagg');
  remove_continuous_aggregate_policy 
 ------------------------------------
@@ -1278,7 +1238,6 @@ SELECT remove_continuous_aggregate_policy('metrics_cagg');
 (1 row)
 
 --can set compression policy only after setting up refresh policy --
-\set ON_ERROR_STOP 0
 SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
 ERROR:  setup a refresh policy for "metrics_cagg" before setting up a columnstore policy
 --can set compression policy only after enabling compression --
@@ -1295,7 +1254,7 @@ ERROR:  cannot use "compress_created_before" with continuous aggregate "metrics_
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
  COMP_JOB 
 ----------
-     1060
+     1061
 (1 row)
 
 SELECT remove_compression_policy('metrics_cagg');
@@ -1436,7 +1395,7 @@ SELECT set_integer_now_func('t', 'unix_now');
 SELECT add_retention_policy('t', 20);
  add_retention_policy 
 ----------------------
-                 1062
+                 1063
 (1 row)
 
 CREATE MATERIALIZED VIEW cagg(a, sumb) WITH (timescaledb.continuous)

--- a/tsl/test/expected/cagg_policy_concurrent.out
+++ b/tsl/test/expected/cagg_policy_concurrent.out
@@ -1,0 +1,1449 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test creation of multiple refresh policies
+SET timezone TO PST8PDT;
+SET timescaledb.current_timestamp_mock TO '2025-06-01 0:30:00+00';
+SELECT setseed(1);
+ setseed 
+---------
+ 
+(1 row)
+
+-- test interval checking with bigint
+CREATE TABLE overlap_test_bigint (
+    time BIGINT NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+SELECT create_hypertable('overlap_test_bigint', 'time', chunk_time_interval => 100);
+        create_hypertable         
+----------------------------------
+ (1,public,overlap_test_bigint,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_overlap_test_bigint()
+RETURNS BIGINT LANGUAGE SQL STABLE AS
+$$ SELECT COALESCE(MAX(time), 0) FROM overlap_test_bigint $$;
+SELECT set_integer_now_func('overlap_test_bigint', 'integer_now_overlap_test_bigint');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO overlap_test_bigint
+SELECT i, (i % 5), random() * 100
+FROM generate_series(1, 2000) i;
+CREATE MATERIALIZED VIEW mat_m1(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket(10, time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_bigint
+GROUP BY 1
+WITH NO DATA;
+/* Test interval checking when multiple policies are created on the same cagg */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1000
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 1000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1001
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Creating policies in either order should work */
+SELECT add_continuous_aggregate_policy('mat_m1', 1000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1002
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1003
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 3000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1004
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1005
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Test non-null offsets on both sides too */
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1006
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 3000::bigint,'12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1007
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 3000::bigint, 2000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1008
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Check overlap is detected correctly */
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1009
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1010
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 5000::bigint, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1011
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1012
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 5000::bigint, 1000::bigint, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 2000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1013
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1014
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 1000::bigint, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Check behaviour when exact policy is already defined */
+\set ON_ERROR_STOP 0
+/*if_not_exists=false*/
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1015
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1016
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1017
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval);
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/*if_not_exists => true*/
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1018
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1019
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval, if_not_exists => true);
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+ add_continuous_aggregate_policy 
+---------------------------------
+                              -1
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1020
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval, if_not_exists => true);
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+ add_continuous_aggregate_policy 
+---------------------------------
+                              -1
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Throw an error if there is an overlap even if if_not_exists => true */
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1021
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', 3000::bigint, 1000::bigint, '12 h'::interval, if_not_exists => true);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Test `alter_job` changing the config */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 3000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1022
+(1 row)
+
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1023
+(1 row)
+
+/* Alter end offset but don't overlap */
+SELECT jsonb_set(:'config', '{end_offset}', '2000') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                               config                               | next_start |                           check_config                           | fixed_schedule | initial_start | timezone |              application_name              
+--------+-------------------+-------------+-------------+--------------+-----------+--------------------------------------------------------------------+------------+------------------------------------------------------------------+----------------+---------------+----------+--------------------------------------------
+   1022 | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | t         | {"end_offset": 2000, "start_offset": null, "mat_hypertable_id": 2} | -infinity  | _timescaledb_functions.policy_refresh_continuous_aggregate_check | f              |               |          | Refresh Continuous Aggregate Policy [1022]
+(1 row)
+
+\set ON_ERROR_STOP 0
+/* Alter end offset to overlap with another job*/
+SELECT jsonb_set(:'config', '{end_offset}', '1000') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+/* Alter end offset to be null */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+/* Alter job to be identical to existing job */
+SELECT jsonb_set(:'config', '{start_offset}', '2000') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1024
+(1 row)
+
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 3000::bigint, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1025
+(1 row)
+
+/* Alter end offset to null but no overlap */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                               config                               | next_start |                           check_config                           | fixed_schedule | initial_start | timezone |              application_name              
+--------+-------------------+-------------+-------------+--------------+-----------+--------------------------------------------------------------------+------------+------------------------------------------------------------------+----------------+---------------+----------+--------------------------------------------
+   1024 | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | t         | {"end_offset": null, "start_offset": 2000, "mat_hypertable_id": 2} | -infinity  | _timescaledb_functions.policy_refresh_continuous_aggregate_check | f              |               |          | Refresh Continuous Aggregate Policy [1024]
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Test that refresh is done correctly even though multiple policies exist */
+/* We do this by creating two CAggs on the same hypertable */
+/* One will have a single policy while the other will have two policies with adjacent offsets */
+CREATE MATERIALIZED VIEW mat_m2(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket(10, time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_bigint
+GROUP BY 1
+WITH NO DATA;
+/* Create two policies on mat_m1 */
+SELECT add_continuous_aggregate_policy('mat_m1', 5000::bigint, 3000::bigint, '12 h'::interval) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', 3000::bigint, 1000::bigint, '12 h'::interval) AS agg_m1_job_2 \gset
+/* Create single policy on mat_m2 */
+SELECT add_continuous_aggregate_policy('mat_m2', 5000::bigint, 1000::bigint, '12 h'::interval) AS agg_m2_job \gset
+/* Cleanup any existing data */
+TRUNCATE mat_m1;
+TRUNCATE mat_m2;
+/* Refresh both continuous aggs immediately */
+CALL run_job(:agg_m1_job_1);
+CALL run_job(:agg_m1_job_2);
+CALL run_job(:agg_m2_job);
+/* Compare both outputs */
+SELECT count(*) AS exp_row_count from mat_m1 \gset
+SELECT count(*) AS actual_row_count from (
+SELECT * from mat_m1 UNION SELECT * from mat_m2) union_q \gset
+/* Row counts should be the same */
+SELECT :exp_row_count = :actual_row_count, :exp_row_count, :actual_row_count;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        |      100 |      100
+(1 row)
+
+SELECT * from mat_m2 EXCEPT SELECT * from mat_m1;
+ time | counta | sum 
+------+--------+-----
+(0 rows)
+
+SELECT * from mat_m1 EXCEPT SELECT * from mat_m2;
+ time | counta | sum 
+------+--------+-----
+(0 rows)
+
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_22_chunk
+DROP MATERIALIZED VIEW mat_m2;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_23_chunk
+CREATE TABLE overlap_test_timestamptz (
+    time timestamptz NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+SELECT create_hypertable('overlap_test_timestamptz', 'time', chunk_time_interval => '1 day'::interval);
+           create_hypertable           
+---------------------------------------
+ (4,public,overlap_test_timestamptz,t)
+(1 row)
+
+INSERT INTO overlap_test_timestamptz
+SELECT t, (i % 5), random() * 100
+FROM
+generate_series('2025-01-01T01:01:01+00', '2025-06-01T01:01:01+00', INTERVAL '1 days') t,
+generate_series(1, 10) i;
+CREATE MATERIALIZED VIEW mat_m1(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz
+GROUP BY 1
+WITH NO DATA;
+/* Test interval checking when multiple policies are created on the same cagg */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1029
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '29 days'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1030
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Creating policies in either order should work */
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1031
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1032
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1033
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '15 days'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1034
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Test non-null offsets on both sides too */
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '20 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1035
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '10 days'::interval, '5 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1036
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '19 days'::interval, '11 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1037
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Check overlap is detected correctly */
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1038
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1039
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '10 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1040
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, '15 days'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, '15 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1041
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '10 days'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1042
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '20 days'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1043
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Check behaviour when exact policy is already defined */
+\set ON_ERROR_STOP 0
+/*if_not_exists=false*/
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days'::interval, '30 days', '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1044
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '31 days'::interval, '15 days', '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT add_continuous_aggregate_policy('mat_m1', '31 days'::interval, '15 days', '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1045
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/*if_not_exists => true*/
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days', '30 days', '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1046
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '15 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1047
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '15 days'::interval, '12 h'::interval, if_not_exists => true);
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+ add_continuous_aggregate_policy 
+---------------------------------
+                              -1
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1048
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval, if_not_exists => true);
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+ add_continuous_aggregate_policy 
+---------------------------------
+                              -1
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Throw an error if there is an overlap even if if_not_exists => true */
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '10 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1049
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', '15 days'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Mixing different interval units should also work correctly*/
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1050
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1051
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1052
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '5 weeks'::interval, '-7 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1053
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1054
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1055
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1056
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Check overlap with negative offsets */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1057
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '-1 month'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1058
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '-2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1059
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Test `alter_job` changing the config */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1060
+(1 row)
+
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1061
+(1 row)
+
+/* Alter end offset but don't overlap */
+SELECT jsonb_set(:'config', '{end_offset}', '"30 days"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                                 config                                  | next_start |                           check_config                           | fixed_schedule | initial_start | timezone |              application_name              
+--------+-------------------+-------------+-------------+--------------+-----------+-------------------------------------------------------------------------+------------+------------------------------------------------------------------+----------------+---------------+----------+--------------------------------------------
+   1060 | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | t         | {"end_offset": "30 days", "start_offset": null, "mat_hypertable_id": 5} | -infinity  | _timescaledb_functions.policy_refresh_continuous_aggregate_check | f              |               |          | Refresh Continuous Aggregate Policy [1060]
+(1 row)
+
+\set ON_ERROR_STOP 0
+/* Alter end offset to overlap with another job*/
+SELECT jsonb_set(:'config', '{end_offset}', '"1 week"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+/* Alter end offset to be null */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+/* Alter job to be identical to existing job */
+SELECT jsonb_set(:'config', '{start_offset}', '"2 weeks"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1062
+(1 row)
+
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1063
+(1 row)
+
+/* Alter end offset to null but no overlap */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                                  config                                   | next_start |                           check_config                           | fixed_schedule | initial_start | timezone |              application_name              
+--------+-------------------+-------------+-------------+--------------+-----------+---------------------------------------------------------------------------+------------+------------------------------------------------------------------+----------------+---------------+----------+--------------------------------------------
+   1062 | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | t         | {"end_offset": null, "start_offset": "@ 14 days", "mat_hypertable_id": 5} | -infinity  | _timescaledb_functions.policy_refresh_continuous_aggregate_check | f              |               |          | Refresh Continuous Aggregate Policy [1062]
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW mat_m2(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz
+GROUP BY 1
+WITH NO DATA;
+/* Create two policies on mat_m1 */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval) AS agg_m1_job_2 \gset
+/* Create single policy on mat_m2 */
+SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval) AS agg_m2_job \gset
+/* Cleanup any existing data */
+TRUNCATE mat_m1;
+TRUNCATE mat_m2;
+/* Refresh both continuous aggs immediately */
+CALL run_job(:agg_m1_job_1);
+CALL run_job(:agg_m1_job_2);
+CALL run_job(:agg_m2_job);
+/* Compare both outputs */
+SELECT count(*) AS exp_row_count from mat_m1 \gset
+SELECT count(*) AS actual_row_count from (
+SELECT * from mat_m1 UNION SELECT * from mat_m2) AS union_q \gset
+/* Row counts should be the same */
+SELECT :exp_row_count = :actual_row_count, :exp_row_count, :actual_row_count;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        |      152 |      152
+(1 row)
+
+SELECT * from mat_m2 EXCEPT SELECT * from mat_m1;
+ time | counta | sum 
+------+--------+-----
+(0 rows)
+
+SELECT * from mat_m1 EXCEPT SELECT * from mat_m2;
+ time | counta | sum 
+------+--------+-----
+(0 rows)
+
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to 17 other objects
+DROP MATERIALIZED VIEW mat_m2;
+NOTICE:  drop cascades to 17 other objects
+/* Test with variable sized buckets */
+CREATE TABLE overlap_test_timestamptz_var (
+    time timestamptz NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+SELECT create_hypertable('overlap_test_timestamptz_var', 'time', chunk_time_interval => '1 month'::interval);
+             create_hypertable             
+-------------------------------------------
+ (7,public,overlap_test_timestamptz_var,t)
+(1 row)
+
+INSERT INTO overlap_test_timestamptz_var
+SELECT t, (i % 5), random() * 100
+FROM
+generate_series('2024-01-01T01:01:01+00', '2025-06-01T01:01:01+00', INTERVAL '1 day') t,
+generate_series(1, 10) i;
+CREATE MATERIALIZED VIEW mat_m1(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 month', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz_var
+GROUP BY 1
+WITH NO DATA;
+/* Test interval checking when multiple policies are created on the same cagg */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '3 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1067
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1068
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Creating policies in either order should work */
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1069
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '3 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1070
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '3 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1071
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 months'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1072
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Test non-null offsets on both sides too */
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '6 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1073
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '6 months'::interval, '12 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1074
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '12 weeks'::interval, '1 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1075
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+/* Check overlap is detected correctly */
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1076
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1077
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '6 months'::interval, '1 week'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1078
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '4 months'::interval, '2 weeks'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '4 months'::interval, '2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1079
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '6 months'::interval, '1 week'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1080
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '20 days'::interval, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1081
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Check behaviour when exact policy is already defined */
+\set ON_ERROR_STOP 0
+/*if_not_exists=false*/
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '8 months', '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1082
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1083
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval);
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1084
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/*if_not_exists => true*/
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '8 months', '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1085
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1086
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval, if_not_exists => true);
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+ add_continuous_aggregate_policy 
+---------------------------------
+                              -1
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1087
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval, if_not_exists => true);
+NOTICE:  continuous aggregate refresh policy already exists for "mat_m1", skipping
+ add_continuous_aggregate_policy 
+---------------------------------
+                              -1
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Mixing different interval units should also work correctly*/
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1088
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1089
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1090
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '8 weeks'::interval, '-7 days'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1091
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1092
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1093
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1094
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Check overlap with negative offsets */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1095
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '-1 month'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1096
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '-2 weeks'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1097
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 1
+/* Test `alter_job` changing the config */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1098
+(1 row)
+
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1099
+(1 row)
+
+/* Alter end offset but don't overlap */
+SELECT jsonb_set(:'config', '{end_offset}', '"30 days"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                                 config                                  | next_start |                           check_config                           | fixed_schedule | initial_start | timezone |              application_name              
+--------+-------------------+-------------+-------------+--------------+-----------+-------------------------------------------------------------------------+------------+------------------------------------------------------------------+----------------+---------------+----------+--------------------------------------------
+   1098 | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | t         | {"end_offset": "30 days", "start_offset": null, "mat_hypertable_id": 8} | -infinity  | _timescaledb_functions.policy_refresh_continuous_aggregate_check | f              |               |          | Refresh Continuous Aggregate Policy [1098]
+(1 row)
+
+\set ON_ERROR_STOP 0
+/* Alter end offset to overlap with another job*/
+SELECT jsonb_set(:'config', '{end_offset}', '"1 week"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+/* Alter end offset to be null */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  refresh interval overlaps with an existing continuous aggregate policy on "mat_m1"
+/* Alter job to be identical to existing job */
+SELECT jsonb_set(:'config', '{start_offset}', '"2 weeks"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ERROR:  continuous aggregate refresh policy already exists for "mat_m1"
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1100
+(1 row)
+
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1101
+(1 row)
+
+/* Alter end offset to null but no overlap */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                                  config                                   | next_start |                           check_config                           | fixed_schedule | initial_start | timezone |              application_name              
+--------+-------------------+-------------+-------------+--------------+-----------+---------------------------------------------------------------------------+------------+------------------------------------------------------------------+----------------+---------------+----------+--------------------------------------------
+   1100 | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | t         | {"end_offset": null, "start_offset": "@ 14 days", "mat_hypertable_id": 8} | -infinity  | _timescaledb_functions.policy_refresh_continuous_aggregate_check | f              |               |          | Refresh Continuous Aggregate Policy [1100]
+(1 row)
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW mat_m2(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 month', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz_var
+GROUP BY 1
+WITH NO DATA;
+/* Create two policies on mat_m1 */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval) AS agg_m1_job_2 \gset
+/* Create single policy on mat_m2 */
+SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval) AS agg_m2_job \gset
+/* Cleanup any existing data */
+TRUNCATE mat_m1;
+TRUNCATE mat_m2;
+/* Refresh both continuous aggs immediately */
+CALL run_job(:agg_m1_job_1);
+CALL run_job(:agg_m1_job_2);
+CALL run_job(:agg_m2_job);
+/* Compare both outputs */
+SELECT count(*) AS exp_row_count from mat_m1 \gset
+SELECT count(*) AS actual_row_count from (
+SELECT * from mat_m1 UNION SELECT * from mat_m2) AS union_q \gset
+/* Row counts should be the same */
+SELECT :exp_row_count = :actual_row_count, :exp_row_count, :actual_row_count;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        |       18 |       18
+(1 row)
+
+SELECT * from mat_m2 EXCEPT SELECT * from mat_m1;
+ time | counta | sum 
+------+--------+-----
+(0 rows)
+
+SELECT * from mat_m1 EXCEPT SELECT * from mat_m2;
+ time | counta | sum 
+------+--------+-----
+(0 rows)
+
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to 3 other objects
+DROP MATERIALIZED VIEW mat_m2;
+NOTICE:  drop cascades to 3 other objects

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_FILES
     cagg_invalidation.sql
     cagg_policy.sql
     cagg_policy_move.sql
+    cagg_policy_concurrent.sql
     cagg_refresh.sql
     cagg_refresh_using_merge.sql
     cagg_utils.sql

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -555,6 +555,7 @@ WITH NO DATA;
 
 -- this was previously crashing
 SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, NULL, '1 h'::interval, if_not_exists => true);
+\set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval, if_not_exists => true);
 SELECT remove_continuous_aggregate_policy('metrics_cagg');
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, '1 day'::interval, '1h'::interval, if_not_exists=>true);
@@ -562,7 +563,6 @@ SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, '1 day'::interval, 
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, NULL, '1h'::interval, if_not_exists=>true); -- different values, so we get a WARNING
 SELECT remove_continuous_aggregate_policy('metrics_cagg');
 --can set compression policy only after setting up refresh policy --
-\set ON_ERROR_STOP 0
 SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
 
 --can set compression policy only after enabling compression --

--- a/tsl/test/sql/cagg_policy_concurrent.sql
+++ b/tsl/test/sql/cagg_policy_concurrent.sql
@@ -1,0 +1,617 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test creation of multiple refresh policies
+SET timezone TO PST8PDT;
+
+SET timescaledb.current_timestamp_mock TO '2025-06-01 0:30:00+00';
+
+SELECT setseed(1);
+
+-- test interval checking with bigint
+CREATE TABLE overlap_test_bigint (
+    time BIGINT NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+
+SELECT create_hypertable('overlap_test_bigint', 'time', chunk_time_interval => 100);
+
+CREATE OR REPLACE FUNCTION integer_now_overlap_test_bigint()
+RETURNS BIGINT LANGUAGE SQL STABLE AS
+$$ SELECT COALESCE(MAX(time), 0) FROM overlap_test_bigint $$;
+
+SELECT set_integer_now_func('overlap_test_bigint', 'integer_now_overlap_test_bigint');
+
+INSERT INTO overlap_test_bigint
+SELECT i, (i % 5), random() * 100
+FROM generate_series(1, 2000) i;
+
+CREATE MATERIALIZED VIEW mat_m1(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket(10, time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_bigint
+GROUP BY 1
+WITH NO DATA;
+
+/* Test interval checking when multiple policies are created on the same cagg */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 1000::bigint, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Creating policies in either order should work */
+SELECT add_continuous_aggregate_policy('mat_m1', 1000::bigint, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 3000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Test non-null offsets on both sides too */
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 3000::bigint,'12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 3000::bigint, 2000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Check overlap is detected correctly */
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', 5000::bigint, 1000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 5000::bigint, 1000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 2000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 1000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 1000::bigint, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Check behaviour when exact policy is already defined */
+\set ON_ERROR_STOP 0
+/*if_not_exists=false*/
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 1
+
+/*if_not_exists => true*/
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, 1000::bigint, '12 h'::interval, if_not_exists => true);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, NULL, '12 h'::interval, if_not_exists => true);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Throw an error if there is an overlap even if if_not_exists => true */
+SELECT add_continuous_aggregate_policy('mat_m1', 4000::bigint, 2000::bigint, '12 h'::interval);
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', 3000::bigint, 1000::bigint, '12 h'::interval, if_not_exists => true);
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Test `alter_job` changing the config */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 3000::bigint, '12 h'::interval);
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+
+/* Alter end offset but don't overlap */
+SELECT jsonb_set(:'config', '{end_offset}', '2000') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+\set ON_ERROR_STOP 0
+
+/* Alter end offset to overlap with another job*/
+SELECT jsonb_set(:'config', '{end_offset}', '1000') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+/* Alter end offset to be null */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+/* Alter job to be identical to existing job */
+SELECT jsonb_set(:'config', '{start_offset}', '2000') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+\set ON_ERROR_STOP 1
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', 2000::bigint, NULL, '12 h'::interval);
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 3000::bigint, '12 h'::interval);
+
+/* Alter end offset to null but no overlap */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Test that refresh is done correctly even though multiple policies exist */
+/* We do this by creating two CAggs on the same hypertable */
+/* One will have a single policy while the other will have two policies with adjacent offsets */
+
+CREATE MATERIALIZED VIEW mat_m2(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket(10, time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_bigint
+GROUP BY 1
+WITH NO DATA;
+
+/* Create two policies on mat_m1 */
+SELECT add_continuous_aggregate_policy('mat_m1', 5000::bigint, 3000::bigint, '12 h'::interval) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', 3000::bigint, 1000::bigint, '12 h'::interval) AS agg_m1_job_2 \gset
+
+/* Create single policy on mat_m2 */
+SELECT add_continuous_aggregate_policy('mat_m2', 5000::bigint, 1000::bigint, '12 h'::interval) AS agg_m2_job \gset
+
+/* Cleanup any existing data */
+TRUNCATE mat_m1;
+TRUNCATE mat_m2;
+
+/* Refresh both continuous aggs immediately */
+CALL run_job(:agg_m1_job_1);
+CALL run_job(:agg_m1_job_2);
+CALL run_job(:agg_m2_job);
+
+/* Compare both outputs */
+SELECT count(*) AS exp_row_count from mat_m1 \gset
+SELECT count(*) AS actual_row_count from (
+SELECT * from mat_m1 UNION SELECT * from mat_m2) union_q \gset
+
+/* Row counts should be the same */
+SELECT :exp_row_count = :actual_row_count, :exp_row_count, :actual_row_count;
+
+SELECT * from mat_m2 EXCEPT SELECT * from mat_m1;
+SELECT * from mat_m1 EXCEPT SELECT * from mat_m2;
+
+DROP MATERIALIZED VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m2;
+
+CREATE TABLE overlap_test_timestamptz (
+    time timestamptz NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+
+SELECT create_hypertable('overlap_test_timestamptz', 'time', chunk_time_interval => '1 day'::interval);
+
+INSERT INTO overlap_test_timestamptz
+SELECT t, (i % 5), random() * 100
+FROM
+generate_series('2025-01-01T01:01:01+00', '2025-06-01T01:01:01+00', INTERVAL '1 days') t,
+generate_series(1, 10) i;
+
+CREATE MATERIALIZED VIEW mat_m1(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz
+GROUP BY 1
+WITH NO DATA;
+
+/* Test interval checking when multiple policies are created on the same cagg */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '29 days'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Creating policies in either order should work */
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '15 days'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Test non-null offsets on both sides too */
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '20 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '10 days'::interval, '5 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '19 days'::interval, '11 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Check overlap is detected correctly */
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '10 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, '15 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, '15 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '10 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '20 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Check behaviour when exact policy is already defined */
+\set ON_ERROR_STOP 0
+/*if_not_exists=false*/
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days'::interval, '30 days', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '31 days'::interval, '15 days', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '31 days'::interval, '15 days', '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 1
+
+/*if_not_exists => true*/
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', '45 days', '30 days', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '15 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '15 days'::interval, '12 h'::interval, if_not_exists => true);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval, if_not_exists => true);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Throw an error if there is an overlap even if if_not_exists => true */
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, '10 days'::interval, '12 h'::interval);
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', '15 days'::interval, NULL, '12 h'::interval);
+\set ON_ERROR_STOP 1
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Mixing different interval units should also work correctly*/
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '2 months'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '5 weeks'::interval, '-7 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Check overlap with negative offsets */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '-1 month'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '-2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Test `alter_job` changing the config */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+
+/* Alter end offset but don't overlap */
+SELECT jsonb_set(:'config', '{end_offset}', '"30 days"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+\set ON_ERROR_STOP 0
+
+/* Alter end offset to overlap with another job*/
+SELECT jsonb_set(:'config', '{end_offset}', '"1 week"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+/* Alter end offset to be null */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+/* Alter job to be identical to existing job */
+SELECT jsonb_set(:'config', '{start_offset}', '"2 weeks"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+\set ON_ERROR_STOP 1
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+
+/* Alter end offset to null but no overlap */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+CREATE MATERIALIZED VIEW mat_m2(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz
+GROUP BY 1
+WITH NO DATA;
+
+/* Create two policies on mat_m1 */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval) AS agg_m1_job_2 \gset
+
+/* Create single policy on mat_m2 */
+SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval) AS agg_m2_job \gset
+
+/* Cleanup any existing data */
+TRUNCATE mat_m1;
+TRUNCATE mat_m2;
+
+/* Refresh both continuous aggs immediately */
+CALL run_job(:agg_m1_job_1);
+CALL run_job(:agg_m1_job_2);
+CALL run_job(:agg_m2_job);
+
+/* Compare both outputs */
+SELECT count(*) AS exp_row_count from mat_m1 \gset
+SELECT count(*) AS actual_row_count from (
+SELECT * from mat_m1 UNION SELECT * from mat_m2) AS union_q \gset
+
+/* Row counts should be the same */
+SELECT :exp_row_count = :actual_row_count, :exp_row_count, :actual_row_count;
+
+SELECT * from mat_m2 EXCEPT SELECT * from mat_m1;
+SELECT * from mat_m1 EXCEPT SELECT * from mat_m2;
+
+DROP MATERIALIZED VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m2;
+
+
+/* Test with variable sized buckets */
+
+CREATE TABLE overlap_test_timestamptz_var (
+    time timestamptz NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+
+SELECT create_hypertable('overlap_test_timestamptz_var', 'time', chunk_time_interval => '1 month'::interval);
+
+INSERT INTO overlap_test_timestamptz_var
+SELECT t, (i % 5), random() * 100
+FROM
+generate_series('2024-01-01T01:01:01+00', '2025-06-01T01:01:01+00', INTERVAL '1 day') t,
+generate_series(1, 10) i;
+
+CREATE MATERIALIZED VIEW mat_m1(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 month', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz_var
+GROUP BY 1
+WITH NO DATA;
+
+/* Test interval checking when multiple policies are created on the same cagg */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '3 months'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Creating policies in either order should work */
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '3 months'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '3 months'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '2 months'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Test non-null offsets on both sides too */
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '6 months'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '6 months'::interval, '12 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '12 weeks'::interval, '1 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+/* Check overlap is detected correctly */
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '3 months'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '6 months'::interval, '1 week'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '4 months'::interval, '2 weeks'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '4 months'::interval, '2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '6 months'::interval, '1 week'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '20 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '20 days'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Check behaviour when exact policy is already defined */
+\set ON_ERROR_STOP 0
+/*if_not_exists=false*/
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '8 months', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 1
+
+/*if_not_exists => true*/
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '8 months', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '8 months'::interval, '2 weeks', '12 h'::interval, if_not_exists => true);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL::interval, NULL::interval, '12 h'::interval, if_not_exists => true);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 1
+
+/* Mixing different interval units should also work correctly*/
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '1 year'::interval, '2 months'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '8 weeks'::interval, '-7 days'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '1 month'::interval, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Check overlap with negative offsets */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '-1 month'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '-2 weeks'::interval, '12 h'::interval);
+SELECT add_continuous_aggregate_policy('mat_m1', '1 month'::interval, NULL, '12 h'::interval);
+SELECT remove_continuous_aggregate_policy('mat_m1');
+\set ON_ERROR_STOP 1
+
+/* Test `alter_job` changing the config */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+
+/* Alter end offset but don't overlap */
+SELECT jsonb_set(:'config', '{end_offset}', '"30 days"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+\set ON_ERROR_STOP 0
+
+/* Alter end offset to overlap with another job*/
+SELECT jsonb_set(:'config', '{end_offset}', '"1 week"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+/* Alter end offset to be null */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+
+/* Alter job to be identical to existing job */
+SELECT jsonb_set(:'config', '{start_offset}', '"2 weeks"') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+\set ON_ERROR_STOP 1
+
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+SELECT add_continuous_aggregate_policy('mat_m1', '2 weeks'::interval, NULL, '12 h'::interval);
+SELECT id AS job_id, config AS config FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_refresh_continuous_aggregate' \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '2 months'::interval, '12 h'::interval);
+
+/* Alter end offset to null but no overlap */
+SELECT jsonb_set(:'config', '{end_offset}', 'null') AS config \gset
+SELECT * FROM alter_job(:job_id, config := :'config');
+SELECT remove_continuous_aggregate_policy('mat_m1');
+
+CREATE MATERIALIZED VIEW mat_m2(time, counta)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT
+    time_bucket('1 month', time) AS bucket,
+    count(a),
+    sum(b)
+FROM overlap_test_timestamptz_var
+GROUP BY 1
+WITH NO DATA;
+
+/* Create two policies on mat_m1 */
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval) AS agg_m1_job_2 \gset
+
+/* Create single policy on mat_m2 */
+SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval) AS agg_m2_job \gset
+
+/* Cleanup any existing data */
+TRUNCATE mat_m1;
+TRUNCATE mat_m2;
+
+/* Refresh both continuous aggs immediately */
+CALL run_job(:agg_m1_job_1);
+CALL run_job(:agg_m1_job_2);
+CALL run_job(:agg_m2_job);
+
+/* Compare both outputs */
+SELECT count(*) AS exp_row_count from mat_m1 \gset
+SELECT count(*) AS actual_row_count from (
+SELECT * from mat_m1 UNION SELECT * from mat_m2) AS union_q \gset
+
+/* Row counts should be the same */
+SELECT :exp_row_count = :actual_row_count, :exp_row_count, :actual_row_count;
+
+SELECT * from mat_m2 EXCEPT SELECT * from mat_m1;
+SELECT * from mat_m1 EXCEPT SELECT * from mat_m2;
+
+DROP MATERIALIZED VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m2;


### PR DESCRIPTION
Historically, we only allow creating a single refresh policy on each continuous aggregate.

This PR removes this restriction. We now support creating concurrent CAgg refresh policies, with the restriction that there is no overlap between their refresh intervals.

Along with https://github.com/timescale/timescaledb/pull/8187, this allows refresh policies to run concurrently.