### PR TITLE
Speed up bgw test runs

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -418,6 +418,12 @@ SELECT delete_job(:job_id_2);
 TRUNCATE custom_log;
 -- Forced Exception
 SELECT add_job('custom_proc4', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_3 \gset
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_3, 1);
 INFO:  wait_for_job_to_run: job execution failed
  wait_for_job_to_run 
@@ -472,6 +478,12 @@ SELECT * FROM _timescaledb_internal.compressed_chunk_stats ORDER BY chunk_name;
 
 -- Compression policy
 SELECT add_compression_policy('conditions', interval '1 day') AS job_id_4 \gset
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_4, 1);
  wait_for_job_to_run 
 ---------------------
@@ -506,6 +518,12 @@ select t.schedule_interval FROM alter_job(:job_id_4, next_start=> now() ) t;
  schedule_interval 
 -------------------
  @ 12 hours
+(1 row)
+
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
 (1 row)
 
 SELECT test.wait_for_job_to_run(:job_id_4, 2);
@@ -554,6 +572,12 @@ GROUP BY location, bucket
 WITH NO DATA;
 -- Refresh Continous Aggregate by Job
 SELECT add_job('custom_proc5', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_5 \gset
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_5, 1);
  wait_for_job_to_run 
 ---------------------
@@ -862,6 +886,12 @@ END
 $$;
 select add_job('add_scheduled_jobs_with_check', schedule_interval => '1 hour') as last_job_id \gset
 -- wait for enough time
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:last_job_id, 1);
  wait_for_job_to_run 
 ---------------------
@@ -1039,6 +1069,12 @@ $$;
 -- before the first one by adjusting the initial_start values
 SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz + interval '2s') AS job_id_1 \gset
 SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz - interval '2s') AS job_id_2 \gset
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 -- wait for the jobs to start running job_2 will start running first
 CALL wait_for_job_status(:job_id_2, 'Running');
 CALL wait_for_job_status(:job_id_1, 'Running');

--- a/tsl/test/expected/bgw_job_stat_history.out
+++ b/tsl/test/expected/bgw_job_stat_history.out
@@ -21,6 +21,8 @@ SHOW timescaledb.enable_job_execution_logging;
  off
 (1 row)
 
+SELECT add_job('custom_job_ok', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_1 \gset
+SELECT add_job('custom_job_error', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_2 \gset
 -- Start Background Workers
 SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
@@ -28,8 +30,6 @@ SELECT _timescaledb_functions.start_background_workers();
  t
 (1 row)
 
-SELECT add_job('custom_job_ok', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_1 \gset
-SELECT add_job('custom_job_error', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_2 \gset
 SELECT test.wait_for_job_to_run(:job_id_1, 1);
  wait_for_job_to_run 
 ---------------------
@@ -86,6 +86,12 @@ SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
 SELECT scheduled FROM alter_job(:job_id_2, next_start => now());
  scheduled 
 -----------
+ t
+(1 row)
+
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
  t
 (1 row)
 
@@ -146,6 +152,12 @@ SELECT scheduled FROM alter_job(:job_id_2, next_start => now());
  t
 (1 row)
 
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_1, 3);
  wait_for_job_to_run 
 ---------------------
@@ -186,6 +198,12 @@ SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
  t
 (1 row)
 
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_1, 4);
  wait_for_job_to_run 
 ---------------------
@@ -216,6 +234,12 @@ $$;
 SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
  scheduled 
 -----------
+ t
+(1 row)
+
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
  t
 (1 row)
 
@@ -256,6 +280,12 @@ SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
  t
 (1 row)
 
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_1, 6);
  wait_for_job_to_run 
 ---------------------
@@ -284,6 +314,12 @@ BEGIN
 END
 $$;
 SELECT add_job('custom_job_alter', schedule_interval => interval '1 hour', initial_start := now()) AS job_id_3 \gset
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(:job_id_3, 1);
  wait_for_job_to_run 
 ---------------------
@@ -295,6 +331,12 @@ FROM alter_job(:job_id_3, timezone => 'America/Sao_Paulo', fixed_schedule => fal
      timezone      | fixed_schedule |      config      | schedule_interval 
 -------------------+----------------+------------------+-------------------
  America/Sao_Paulo | f              | {"key": "value"} | @ 10 mins
+(1 row)
+
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
 (1 row)
 
 SELECT test.wait_for_job_to_run(:job_id_3, 2);

--- a/tsl/test/expected/bgw_job_stat_history_errors.out
+++ b/tsl/test/expected/bgw_job_stat_history_errors.out
@@ -132,7 +132,16 @@ WHERE succeeded IS FALSE;
 
 -- drop all job_stats for the retention job
 DELETE FROM _timescaledb_internal.bgw_job_stat WHERE job_id = 3;
-SELECT  next_start FROM alter_job(3, next_start => now() + interval '2 seconds') \gset
+SELECT FROM alter_job(3, next_start => now());
+--
+(1 row)
+
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 SELECT test.wait_for_job_to_run(3, 1);
  wait_for_job_to_run 
 ---------------------
@@ -215,6 +224,12 @@ END;
 $TEST$;
 INFO:  Creating 26 jobs
 INFO:  Scheduling 26 jobs
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 -- Wait for jobs to run
 DO
 $TEST$

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -215,6 +215,7 @@ TRUNCATE custom_log;
 
 -- Forced Exception
 SELECT add_job('custom_proc4', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_3 \gset
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT test.wait_for_job_to_run(:job_id_3, 1);
 
 -- Check results
@@ -247,6 +248,7 @@ SELECT * FROM _timescaledb_internal.compressed_chunk_stats ORDER BY chunk_name;
 
 -- Compression policy
 SELECT add_compression_policy('conditions', interval '1 day') AS job_id_4 \gset
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT test.wait_for_job_to_run(:job_id_4, 1);
 
 -- Chunk compress stats
@@ -263,6 +265,7 @@ order by id;
 
 --running job second time, wait for it to complete
 select t.schedule_interval FROM alter_job(:job_id_4, next_start=> now() ) t;
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT test.wait_for_job_to_run(:job_id_4, 2);
 
 SELECT id, table_name, status from _timescaledb_catalog.chunk
@@ -290,6 +293,7 @@ WITH NO DATA;
 
 -- Refresh Continous Aggregate by Job
 SELECT add_job('custom_proc5', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_5 \gset
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT test.wait_for_job_to_run(:job_id_5, 1);
 SELECT count(*) FROM conditions_summary_daily;
 
@@ -510,6 +514,7 @@ $$;
 
 select add_job('add_scheduled_jobs_with_check', schedule_interval => '1 hour') as last_job_id \gset
 -- wait for enough time
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT test.wait_for_job_to_run(:last_job_id, 1);
 select total_runs, total_successes, last_run_status from timescaledb_information.job_stats where job_id = :last_job_id;
 
@@ -660,6 +665,7 @@ $$;
 SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz + interval '2s') AS job_id_1 \gset
 SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz - interval '2s') AS job_id_2 \gset
 
+SELECT _timescaledb_functions.restart_background_workers();
 -- wait for the jobs to start running job_2 will start running first
 CALL wait_for_job_status(:job_id_2, 'Running');
 CALL wait_for_job_status(:job_id_1, 'Running');

--- a/tsl/test/sql/bgw_job_stat_history_errors.sql
+++ b/tsl/test/sql/bgw_job_stat_history_errors.sql
@@ -85,7 +85,8 @@ FROM _timescaledb_internal.bgw_job_stat_history
 WHERE succeeded IS FALSE;
 -- drop all job_stats for the retention job
 DELETE FROM _timescaledb_internal.bgw_job_stat WHERE job_id = 3;
-SELECT  next_start FROM alter_job(3, next_start => now() + interval '2 seconds') \gset
+SELECT FROM alter_job(3, next_start => now());
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT test.wait_for_job_to_run(3, 1);
 -- only the last row remains
 SELECT job_id, pid, succeeded, execution_start, execution_finish, data
@@ -138,6 +139,8 @@ BEGIN
   FROM generate_series(1, njobs) AS i;
 END;
 $TEST$;
+
+SELECT _timescaledb_functions.restart_background_workers();
 
 -- Wait for jobs to run
 DO


### PR DESCRIPTION
Restart bgw after schedule changes so changes get applied immediately
this leads to over a minute saved for every CI run.

Disable-check: approval-count