### PR TITLE
Fix typo when checking function result

### DIFF
--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -1313,7 +1313,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 																 var->varattno,
 																 settings->fd.compress_relid,
 																 "max");
-				if (min_attno == InvalidAttrNumber)
+				if (max_attno == InvalidAttrNumber)
 					continue;
 
 				/* Need both min and max metadata attributes to build heap filters */


### PR DESCRIPTION
This was found by coverity as dead code but is actually a copy/paste
error from code a couple lines above.

Disable-check: force-changelog-file