### PR TITLE
Change signature of ts_chunk_tuple_routing_create

### DIFF
--- a/src/chunk_tuple_routing.h
+++ b/src/chunk_tuple_routing.h
@@ -29,6 +29,9 @@ typedef struct ChunkTupleRouting
 	SharedCounters *counters; /* shared counters for the current statement */
 } ChunkTupleRouting;
 
-ChunkTupleRouting *ts_chunk_tuple_routing_create(EState *estate, Relation rel);
+ChunkTupleRouting *ts_chunk_tuple_routing_create(EState *estate, ResultRelInfo *rri);
 void ts_chunk_tuple_routing_destroy(ChunkTupleRouting *ctr);
 ChunkInsertState *ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point);
+extern void ts_chunk_tuple_routing_decompress_for_insert(ChunkInsertState *cis,
+														 TupleTableSlot *slot, EState *estate,
+														 bool update_counter);

--- a/src/copy.c
+++ b/src/copy.c
@@ -161,7 +161,6 @@ copy_chunk_state_create(Hypertable *ht, Relation rel, CopyFromFunc from_func, Co
 	ccstate = palloc(sizeof(CopyChunkState));
 	ccstate->rel = rel;
 	ccstate->estate = estate;
-	ccstate->ctr = ts_chunk_tuple_routing_create(estate, rel);
 	ccstate->cstate = cstate;
 	ccstate->scandesc = scandesc;
 	ccstate->next_copy_from = from_func;
@@ -890,7 +889,7 @@ copyfrom(CopyChunkState *ccstate, ParseState *pstate, Hypertable *ht, MemoryCont
 
 	ExecOpenIndices(resultRelInfo, false);
 
-	ccstate->ctr->hypertable_rri = resultRelInfo;
+	ccstate->ctr = ts_chunk_tuple_routing_create(estate, resultRelInfo);
 
 	singleslot = table_slot_create(resultRelInfo->ri_RelationDesc, &estate->es_tupleTable);
 
@@ -1036,7 +1035,7 @@ copyfrom(CopyChunkState *ccstate, ParseState *pstate, Hypertable *ht, MemoryCont
 
 		Assert(cis != NULL);
 
-		ts_chunk_dispatch_decompress_batches_for_insert(cis, myslot, ccstate->ctr->estate, false);
+		ts_chunk_tuple_routing_decompress_for_insert(cis, myslot, ccstate->ctr->estate, false);
 
 		/* Triggers and stuff need to be invoked in query context. */
 		MemoryContextSwitchTo(oldcontext);


### PR DESCRIPTION
Change signature of ts_chunk_tuple_routing_create in preparation
for ChunkDispatch removal. This patch extracts the COPY specific
changes.

Disable-check: force-changelog-file
