### PR TITLE
Post release actions

### DIFF
--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -1,0 +1,57 @@
+name: Release - Post Release Ceremony
+"on":
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# The workflow needs the permission to a PR
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  post-release-ceremony:
+    name: Post Release Ceremony
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest tag
+        run: |
+          git fetch --tags
+          VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Checkout TimescaleDB
+        uses: actions/checkout@v4
+
+      - name: Forward port changes to main
+        run: |
+          ./scripts/release/build_post_release_artefacts.sh ${{ env.CURRENT_VERSION }} ${{ env.NEXT_VERSION }}
+
+      - name: Create Pull Request for forward ported artefacts
+        id: cpr_fwdp
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          branch: "release/${{ env.NEXT_VERSION }}--forwardport"
+          base: "main"
+          delete-branch: true
+          title: "Forwardport ${{ env.NEXT_VERSION }}"
+          body: |
+              - CHANGELOG
+              - set previous_version in version.config
+              - adjust CMakeList.txt with up & down grade files
+              - TODO removed .unreleased files
+          labels: |
+            release
+          add-paths: |
+            .unreleased/*
+            CHANGELOG.md
+            version.config
+            sql/updates/*.sql
+            sql/CMakeLists.txt
+      
+      - name: "Validate next version PR"
+        if: ${{ steps.cpr_fwdp.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request: ${{ steps.cpr_fwdp.outputs.pull-request-url }}"

--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -2,7 +2,6 @@ name: Release - Post Release Ceremony
 "on":
   release:
     types: [published]
-  workflow_dispatch:
 
 # The workflow needs the permission to a PR
 permissions:
@@ -15,28 +14,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get latest tag
-        run: |
-          git fetch --tags
-          VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-
       - name: Checkout TimescaleDB
         uses: actions/checkout@v4
 
       - name: Forward port changes to main
         run: |
-          ./scripts/release/build_post_release_artefacts.sh ${{ env.CURRENT_VERSION }} ${{ env.NEXT_VERSION }}
+          ./scripts/release/build_post_release_artefacts.sh ${{ github.event.release.tag_name }}
 
       - name: Create Pull Request for forward ported artefacts
         id: cpr_fwdp
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
-          branch: "release/${{ env.NEXT_VERSION }}--forwardport"
+          branch: "release/${{ github.event.release.tag_name }}--forwardport"
           base: "main"
           delete-branch: true
-          title: "Forwardport ${{ env.NEXT_VERSION }}"
+          title: "Forwardport ${{ github.event.release.tag_name }}"
           body: |
               - CHANGELOG
               - set previous_version in version.config

--- a/scripts/release/build_post_release_artefacts.sh
+++ b/scripts/release/build_post_release_artefacts.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#
+# Build the necessary artefacts for the forwardporting the
+# the release to `main` (Minor & Patch)
+# - up & down files for the next version
+# - latest.sql & reverse.sql
+# - sets new version in version.config
+# - adjusts the CMakeLists.txt
+#
+# Param: <published_version>
+#
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "${0} <published_version>"
+    exit 2
+fi
+
+PUBLISHED_VERSION=$1
+PREVIOUS_VERSION=$(tail -1 version.config | cut -d ' ' -f 3 | cut -d '-' -f 1)
+
+echo "fetch the up & downgrade files"
+URL_UPGRADE="https://raw.githubusercontent.com/timescale/timescaledb/refs/tags/${PUBLISHED_VERSION}/sql/updates/${PREVIOUS_VERSION}--${PUBLISHED_VERSION}.sql"
+URL_DOWNGRADE="https://raw.githubusercontent.com/timescale/timescaledb/refs/tags/${PUBLISHED_VERSION}/sql/updates/${PUBLISHED_VERSION}--${PREVIOUS_VERSION}.sql"
+echo $URL_UPGRADE
+curl --fail -o sql/updates/${PREVIOUS_VERSION}--${PUBLISHED_VERSION}.sql $URL_UPGRADE
+curl --fail -o sql/updates/${PUBLISHED_VERSION}--${PREVIOUS_VERSION}.sql $URL_DOWNGRADE
+
+# find last up & down grade files
+LAST_UPDATE_FILE=$(find sql/updates/*--${PREVIOUS_VERSION}.sql | head -1 | cut -d '/' -f 3)
+LAST_DOWNGRADE_FILE=$(find sql/updates/${PREVIOUS_VERSION}--*.sql | head -1 | cut -d '/' -f 3)
+
+echo "register upgrade sql file"
+gawk -i inplace '/'${LAST_UPDATE_FILE}')/ { print; print "    updates/'${PREVIOUS_VERSION}'--'${PUBLISHED_VERSION}'.sql)"; next }1' ./sql/CMakeLists.txt
+sed -i.bak "s/${LAST_UPDATE_FILE})/${LAST_UPDATE_FILE}/g" ./sql/CMakeLists.txt
+
+echo "register downgrade sql file"
+gawk -i inplace '/'${LAST_DOWNGRADE_FILE}')/ { print; print "    '${PUBLISHED_VERSION}'--'${PREVIOUS_VERSION}'.sql)"; next }1' ./sql/CMakeLists.txt
+sed -i.bak "s/${LAST_DOWNGRADE_FILE})/${LAST_DOWNGRADE_FILE}/g" ./sql/CMakeLists.txt
+
+# CHANGELOG
+echo "fetching CHANGELOG"
+URL_CHANGELOG="https://raw.githubusercontent.com/timescale/timescaledb/refs/tags/${PUBLISHED_VERSION}/CHANGELOG.md"
+curl --silent --fail -o CHANGELOG.md $URL_CHANGELOG
+
+# .unreleased files
+echo "remove .unreleased files"
+echo "TODO"
+
+# Set new previous version
+echo "Set new previous version version.config to ${PUBLISHED_VERSION}"
+sed -i.bak "s/${PREVIOUS_VERSION}/${PUBLISHED_VERSION}/g" version.config
+rm version.config.bak
+tail -n 1 version.config


### PR DESCRIPTION
This PR adds an action that runs after a release is published to handle the bulk of the post-release tasks. Example: https://github.com/timescale/timescaledb/pull/8206

A script is executed, which:
* sets the new `previous_version` in version.config
* get the updated CHANGELOG.md
* get the up & down grade SQL files
* set the up & down grade files in CMakeList.txt

What is **not** covered:
* bumping the `version` to the next minor in version.config
* removing the delta of deleted .unreleased files

AND added a missing downgrade file

Disable-check: approval-count
Disable-check: force-changelog-file