### PR TITLE
Adjust coverity schedule

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -2,10 +2,13 @@ name: Coverity
 "on":
   schedule:
     # run at 22:00 on every saturday
-    - cron: '0 22 * * SAT'
+    - cron: '0 22 * * TUE,SAT'
   push:
     branches:
       - coverity_scan
+      - trigger/coverity
+  pull_request:
+    paths: .github/workflows/coverity.yaml
   workflow_dispatch:
 jobs:
 


### PR DESCRIPTION
Make coverity run on tuesday and saturday instead of only saturday.
Have coverity be trigger by trigger/coverity similar to other
workflows and have it be triggered by changes to the workflow file.
