### PR TITLE
Refactoring of compressed filter pushdown

### DIFF
--- a/tsl/test/expected/compress_qualpushdown_saop.out
+++ b/tsl/test/expected/compress_qualpushdown_saop.out
@@ -249,6 +249,68 @@ select * from saop where segmentby = all(array[with_bloom, with_minmax]);
          ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=69 loops=1)
 (9 rows)
 
+-- If the arguments of an operator can pushed down but require recheck, combining
+-- them is wrong.
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (with_bloom = '1') = (with_minmax = '1');
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Append (actual rows=96489 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=48245 loops=1)
+         Filter: ((with_bloom = '1'::text) = (with_minmax = '1'::text))
+         Rows Removed by Filter: 1755
+         ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=69 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=48244 loops=1)
+         Filter: ((with_bloom = '1'::text) = (with_minmax = '1'::text))
+         Rows Removed by Filter: 1756
+         ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=69 loops=1)
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (with_bloom = any(array['1', '10'])) = (with_minmax = any(array['1', '10']));
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Append (actual rows=92869 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=46434 loops=1)
+         Filter: ((with_bloom = ANY ('{1,10}'::text[])) = (with_minmax = ANY ('{1,10}'::text[])))
+         Rows Removed by Filter: 3566
+         ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=69 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=46435 loops=1)
+         Filter: ((with_bloom = ANY ('{1,10}'::text[])) = (with_minmax = ANY ('{1,10}'::text[])))
+         Rows Removed by Filter: 3565
+         ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=69 loops=1)
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (segmentby = '1') = (segmentby = '2');
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Append (actual rows=91304 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=45652 loops=1)
+         ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=63 loops=1)
+               Filter: ((segmentby = '1'::text) = (segmentby = '2'::text))
+               Rows Removed by Filter: 6
+   ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=45652 loops=1)
+         ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=63 loops=1)
+               Filter: ((segmentby = '1'::text) = (segmentby = '2'::text))
+               Rows Removed by Filter: 6
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (segmentby = any(array['1', '2'])) = (segmentby = any(array['3', '4']));
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Append (actual rows=82608 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=41304 loops=1)
+         ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=57 loops=1)
+               Filter: ((segmentby = ANY ('{1,2}'::text[])) = (segmentby = ANY ('{3,4}'::text[])))
+               Rows Removed by Filter: 12
+   ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=41304 loops=1)
+         ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=57 loops=1)
+               Filter: ((segmentby = ANY ('{1,2}'::text[])) = (segmentby = ANY ('{3,4}'::text[])))
+               Rows Removed by Filter: 12
+(9 rows)
+
 -- Partial pushdown of AND scalar array operation.
 explain (analyze, costs off, timing off, summary off)
 select * from saop where with_bloom = all(array[with_minmax, with_minmax]);

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -75,6 +75,12 @@ WHERE time = 3::bigint;
     3 |         3 |   1
 (1 row)
 
+SELECT * FROM hyper where time = val + 1;
+ time | device_id | val 
+------+-----------+-----
+    2 |         2 |   1
+(1 row)
+
 -- Test some volatile and stable functions
 SET timescaledb.enable_chunk_append TO OFF;
 SET timescaledb.enable_constraint_aware_append TO OFF;
@@ -637,3 +643,95 @@ LATERAL(
 (1 row)
 
 DROP TABLE svf_pushdown;
+-- Test bool segmentby column to cover bool-returning operator deeper in the
+-- expression tree.
+create table booltab(ts int, segmentby bool, flag bool, value int);
+select create_hypertable('booltab', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+   create_hypertable   
+-----------------------
+ (13,public,booltab,t)
+(1 row)
+
+alter table booltab set (timescaledb.compress, timescaledb.compress_segmentby = 'segmentby',
+    timescaledb.compress_orderby = 'ts, flag');
+insert into booltab values
+    (  1,  true,  true,   1),
+    ( 99, false, false,  99),
+    (100, false, false, 100),
+    (101, false, false, 101)
+;
+select count(compress_chunk(x)) from show_chunks('booltab') x;
+ count 
+-------
+     1
+(1 row)
+
+vacuum analyze booltab;
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where segmentby = (value = 1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=4 loops=1)
+   Filter: (segmentby = (value = 1))
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(3 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where segmentby = (ts = 1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=4 loops=1)
+   Filter: (segmentby = (ts = 1))
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(3 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where segmentby != (ts = 1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=0 loops=1)
+   Filter: (segmentby <> (ts = 1))
+   Rows Removed by Filter: 4
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(4 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where (value = 1) = (ts = 1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=4 loops=1)
+   Filter: ((value = 1) = (ts = 1))
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(3 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where flag = (ts = 1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=4 loops=1)
+   Filter: (flag = (ts = 1))
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(3 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where flag = (ts = 99);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=2 loops=1)
+   Filter: (flag = (ts = 99))
+   Rows Removed by Filter: 2
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(4 rows)
+
+explain (analyze, costs off, timing off, summary off)
+select * from booltab where flag = (ts = 99);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=2 loops=1)
+   Filter: (flag = (ts = 99))
+   Rows Removed by Filter: 2
+   ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2 loops=1)
+(4 rows)
+
+drop table booltab;

--- a/tsl/test/sql/compress_qualpushdown_saop.sql
+++ b/tsl/test/sql/compress_qualpushdown_saop.sql
@@ -87,6 +87,21 @@ explain (analyze, costs off, timing off, summary off)
 select * from saop where segmentby = all(array[with_bloom, with_minmax]);
 
 
+-- If the arguments of an operator can pushed down but require recheck, combining
+-- them is wrong.
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (with_bloom = '1') = (with_minmax = '1');
+
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (with_bloom = any(array['1', '10'])) = (with_minmax = any(array['1', '10']));
+
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (segmentby = '1') = (segmentby = '2');
+
+explain (analyze, costs off, timing off, summary off)
+select * from saop where (segmentby = any(array['1', '2'])) = (segmentby = any(array['3', '4']));
+
+
 -- Partial pushdown of AND scalar array operation.
 explain (analyze, costs off, timing off, summary off)
 select * from saop where with_bloom = all(array[with_minmax, with_minmax]);


### PR DESCRIPTION
Bring qual_pushdown_mutator() and the individual pushdown functions to the same interface as expression_tree_mutator() (no NULL returns + using context.can_pushdown) to avoid accidental errors.

Reorganize the code a little to make adding new pushdown optimizations easier.

Fix a couple of bugs where we apply the original operator to the pushed-down clause that needs rechecking. This is not correct because the operator can turn false positives into false negatives.

Disable-check: force-changelog-file