### PR TITLE
Use start transaction timestamp instead of clock

### DIFF
--- a/tsl/src/bgw_policy/policy_utils.c
+++ b/tsl/src/bgw_policy/policy_utils.c
@@ -22,7 +22,7 @@ subtract_interval_from_now(Interval *lag, Oid time_dim_type)
 #ifdef TS_DEBUG
 	Datum res = ts_get_mock_time_or_current_time();
 #else
-	Datum res = TimestampTzGetDatum(GetCurrentTimestamp());
+	Datum res = TimestampTzGetDatum(GetCurrentTransactionStartTimestamp());
 #endif
 
 	switch (time_dim_type)


### PR DESCRIPTION
Looks like an oversight from #2221 when CAgg refresh policies were introduced. The idea of the function `subtract_interval_from_now` is to calculate timestamp for offset intervals for policy checks and make no sense get the clock timestamp instead of the start transaction.

So changed the `GetCurrentTimestamp()` (aka `clock_timestamp()`) to `GetCurrentTransactionStartTimestamp` (aka `now()`).

Disable-check: force-changelog-file
