### PR TITLE
Small refactor for row_compressor_append_sorted_rows

### DIFF
--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -384,8 +384,8 @@ extern void row_compressor_close(RowCompressor *row_compressor);
 extern HeapTuple row_compressor_build_tuple(RowCompressor *row_compressor);
 extern void row_compressor_clear_batch(RowCompressor *row_compressor, bool changed_groups);
 extern void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
-											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc,
-											  Relation in_rel, BulkWriter *writer);
+											  Tuplesortstate *sorted_rel, Relation in_rel,
+											  BulkWriter *writer);
 extern Oid get_compressed_chunk_index(ResultRelInfo *resultRelInfo,
 									  const CompressionSettings *settings);
 

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -716,11 +716,7 @@ recompress_segment(Tuplesortstate *tuplesortstate, Relation compressed_chunk_rel
 {
 	tuplesort_performsort(tuplesortstate);
 	row_compressor_reset(row_compressor);
-	row_compressor_append_sorted_rows(row_compressor,
-									  tuplesortstate,
-									  RelationGetDescr(compressed_chunk_rel),
-									  compressed_chunk_rel,
-									  writer);
+	row_compressor_append_sorted_rows(row_compressor, tuplesortstate, compressed_chunk_rel, writer);
 	tuplesort_reset(tuplesortstate);
 	CommandCounterIncrement();
 }

--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -2172,7 +2172,6 @@ static Oid
 compress_and_swap_heap(Relation rel, Tuplesortstate *tuplesort, TransactionId *xid_cutoff,
 					   MultiXactId *multi_cutoff)
 {
-	TupleDesc tupdesc = RelationGetDescr(rel);
 	Oid old_compressed_relid = RelationGetHypercoreInfo(rel)->compressed_relid;
 	const CompressionSettings *settings = ts_compression_settings_get(RelationGetRelid(rel));
 	Relation old_compressed_rel = hypercore_open_compressed(rel, AccessExclusiveLock);
@@ -2199,11 +2198,7 @@ compress_and_swap_heap(Relation rel, Tuplesortstate *tuplesort, TransactionId *x
 
 	writer = bulk_writer_build(new_compressed_rel, HEAP_INSERT_FROZEN);
 	row_compressor.on_flush = on_compression_progress;
-	row_compressor_append_sorted_rows(&row_compressor,
-									  tuplesort,
-									  tupdesc,
-									  old_compressed_rel,
-									  &writer);
+	row_compressor_append_sorted_rows(&row_compressor, tuplesort, old_compressed_rel, &writer);
 	reltuples = row_compressor.num_compressed_rows;
 	relpages = RelationGetNumberOfBlocks(new_compressed_rel);
 	row_compressor_close(&row_compressor);
@@ -3772,7 +3767,6 @@ convert_to_hypercore_finish(Oid relid)
 
 	Chunk *chunk = ts_chunk_get_by_relid(conversionstate->relid, true);
 	Relation relation = table_open(conversionstate->relid, AccessShareLock);
-	TupleDesc tupdesc = RelationGetDescr(relation);
 
 	if (!chunk)
 		elog(ERROR, "could not find uncompressed chunk for relation %s", get_rel_name(relid));
@@ -3801,7 +3795,6 @@ convert_to_hypercore_finish(Oid relid)
 
 	row_compressor_append_sorted_rows(&row_compressor,
 									  conversionstate->tuplesortstate,
-									  tupdesc,
 									  compressed_rel,
 									  &writer);
 


### PR DESCRIPTION
Use a while loop instead of for loop so we don't have to repeat
tuplesort_gettupleslot call and remove redundant TupleDesc argument.

Disable-check: force-changelog-file
