### PR TITLE
Add invalidate_using to continuous aggregates

### DIFF
--- a/.unreleased/pr_8306
+++ b/.unreleased/pr_8306
@@ -1,0 +1,1 @@
+Implements: #8306 Add option for invalidation collection using WAL for continuous aggregates

--- a/sql/pre_install/types.functions.sql
+++ b/sql/pre_install/types.functions.sql
@@ -58,3 +58,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.dimension_info_out(_timescaled
 -- Type for bloom filters used by the sparse indexes on compressed hypertables.
 CREATE OR REPLACE FUNCTION _timescaledb_functions.bloom1in(cstring) RETURNS _timescaledb_internal.bloom1 AS 'byteain' LANGUAGE INTERNAL STRICT IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_functions.bloom1out(_timescaledb_internal.bloom1) RETURNS cstring AS 'byteaout' LANGUAGE INTERNAL STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_functions.has_invalidation_trigger(regclass)
+   RETURNS bool
+   LANGUAGE C STRICT PARALLEL SAFE
+   AS '@MODULE_PATHNAME@', 'ts_has_invalidation_trigger';

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,4 +1,9 @@
+ALTER EXTENSION timescaledb DROP VIEW timescaledb_information.continuous_aggregates;
+
+DROP VIEW timescaledb_information.continuous_aggregates;
+
 DROP FUNCTION _timescaledb_functions.cagg_parse_invalidation_record(BYTEA);
+DROP FUNCTION _timescaledb_functions.has_invalidation_trigger(regclass);
 
 CREATE FUNCTION ts_hypercore_handler(internal) RETURNS table_am_handler
 AS '@MODULE_PATHNAME@', 'ts_hypercore_handler' LANGUAGE C;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -122,7 +122,11 @@ SELECT ht.schema_name AS hypertable_schema,
   mat_ht.schema_name AS materialization_hypertable_schema,
   mat_ht.table_name AS materialization_hypertable_name,
   directview.viewdefinition AS view_definition,
-  cagg.finalized
+  cagg.finalized,
+  CASE WHEN _timescaledb_functions.has_invalidation_trigger(format('%I.%I', ht.schema_name, ht.table_name)::regclass)
+       THEN 'trigger'
+       ELSE 'wal'
+  END AS invalidate_using
 FROM _timescaledb_catalog.continuous_agg cagg,
   _timescaledb_catalog.hypertable ht,
   LATERAL (

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -607,6 +607,17 @@ ts_hypertable_create_trigger(const Hypertable *ht, CreateTrigStmt *stmt, const c
 	return root_trigger_addr;
 }
 
+TSDLLEXPORT void
+ts_hypertable_drop_invalidation_replication_slot(const char *slot_name)
+{
+	CatalogSecurityContext sec_ctx;
+	NameData slot;
+	namestrcpy(&slot, slot_name);
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	DirectFunctionCall1(pg_drop_replication_slot, NameGetDatum(&slot));
+	ts_catalog_restore_user(&sec_ctx);
+}
+
 /* based on RemoveObjects */
 TSDLLEXPORT void
 ts_hypertable_drop_trigger(Oid relid, const char *trigger_name)

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -116,6 +116,7 @@ extern int ts_hypertable_delete_by_id(int32 hypertable_id);
 extern TSDLLEXPORT ObjectAddress ts_hypertable_create_trigger(const Hypertable *ht,
 															  CreateTrigStmt *stmt,
 															  const char *query);
+extern TSDLLEXPORT void ts_hypertable_drop_invalidation_replication_slot(const char *slot_name);
 extern TSDLLEXPORT void ts_hypertable_drop_trigger(Oid relid, const char *trigger_name);
 extern TSDLLEXPORT void ts_hypertable_drop(Hypertable *hypertable, DropBehavior behavior);
 

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1012,7 +1012,6 @@ typedef enum Anum_continuous_aggs_bucket_function_pkey
  */
 #define CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG_TABLE_NAME                                     \
 	"continuous_aggs_hypertable_invalidation_log"
-#define CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_SLOT_NAME "continuous_aggs_hypertable_invalidations"
 
 typedef enum Anum_continuous_aggs_hypertable_invalidation_log
 {

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -10,13 +10,17 @@
  */
 
 #include <postgres.h>
+
 #include <access/htup_details.h>
 #include <catalog/dependency.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_trigger.h>
 #include <commands/trigger.h>
+#include <executor/spi.h>
 #include <fmgr.h>
+#include <lib/stringinfo.h>
 #include <nodes/makefuncs.h>
+#include <replication/slot.h>
 #include <storage/lmgr.h>
 #include <utils/acl.h>
 #include <utils/builtins.h>
@@ -45,6 +49,14 @@
 
 #define BUCKET_FUNCTION_SERIALIZE_VERSION 1
 #define CHECK_NAME_MATCH(name1, name2) (namestrcmp(name1, name2) == 0)
+
+TS_FUNCTION_INFO_V1(ts_has_invalidation_trigger);
+
+Datum
+ts_has_invalidation_trigger(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(has_invalidation_trigger(PG_GETARG_OID(0)));
+}
 
 static void
 init_scan_by_mat_hypertable_id(ScanIterator *iterator, const int32 mat_hypertable_id)
@@ -191,6 +203,12 @@ hypertable_invalidation_log_delete(int32 raw_hypertable_id)
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
 	}
+}
+
+void
+ts_get_invalidation_replication_slot_name(char *slotname, Size szslot)
+{
+	snprintf(slotname, szslot, "ts_%u_cagg", MyDatabaseId);
 }
 
 void
@@ -500,6 +518,37 @@ ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id)
 			lappend_int(all_caggs_info.mat_hypertable_ids, cagg->data.mat_hypertable_id);
 	}
 	return all_caggs_info;
+}
+
+/*
+ * Return true if there is any continuous aggregate that is using WAL-based
+ * invalidation collection.
+ *
+ * A hypertable is using the WAL-based invalidation collection if it has a
+ * attached continuous aggregate but does not have an invalidation trigger.
+ */
+static bool
+hypertable_invalidation_slot_used(void)
+{
+	ScanIterator iterator =
+		ts_scan_iterator_create(CONTINUOUS_AGG, AccessShareLock, CurrentMemoryContext);
+	ts_scanner_foreach(&iterator)
+	{
+		bool isnull;
+		Datum datum = slot_getattr(ts_scan_iterator_slot(&iterator),
+								   Anum_continuous_agg_raw_hypertable_id,
+								   &isnull);
+
+		Assert(!isnull);
+		Oid relid = ts_hypertable_id_to_relid(DatumGetInt32(datum), true);
+		if (!has_invalidation_trigger(relid))
+		{
+			ts_scan_iterator_close(&iterator);
+			return true;
+		}
+	}
+	ts_scan_iterator_close(&iterator);
+	return false;
 }
 
 TSDLLEXPORT ContinuousAggHypertableStatus
@@ -829,6 +878,10 @@ drop_continuous_agg(FormData_continuous_agg *cadata, bool drop_user_view)
 	 *
 	 * AccessExclusiveLock is needed to drop triggers and also prevent
 	 * concurrent DML commands.
+	 *
+	 * It is needed also in the case that we are using WAL-based invalidation
+	 * collection since we want to serialize create and drop of continuous
+	 * aggregates.
 	 */
 	if (drop_user_view)
 		user_view = get_and_lock_rel_by_name(&cadata->user_view_schema,
@@ -856,17 +909,13 @@ drop_continuous_agg(FormData_continuous_agg *cadata, bool drop_user_view)
 		LockRelationOid(catalog_get_table_id(catalog, CONTINUOUS_AGGS_INVALIDATION_THRESHOLD),
 						RowExclusiveLock);
 
-		/* The trigger will be dropped if the hypertable still exists and no other
+		/* The trigger will be dropped if it exists (it does not for WAL-based
+		 * invalidation collection), the hypertable still exists and no other
 		 * caggs attached. */
-		if (OidIsValid(raw_hypertable.objectId))
+		Oid tgoid = get_trigger_oid(raw_hypertable.objectId, CAGGINVAL_TRIGGER_NAME, true);
+		if (OidIsValid(raw_hypertable.objectId) && OidIsValid(tgoid))
 		{
-			ObjectAddressSet(raw_hypertable_trig,
-							 TriggerRelationId,
-							 get_trigger_oid(raw_hypertable.objectId,
-											 CAGGINVAL_TRIGGER_NAME,
-											 false));
-
-			/* Raw hypertable is locked above */
+			ObjectAddressSet(raw_hypertable_trig, TriggerRelationId, tgoid);
 			LockRelationOid(raw_hypertable_trig.objectId, AccessExclusiveLock);
 		}
 	}
@@ -923,6 +972,18 @@ drop_continuous_agg(FormData_continuous_agg *cadata, bool drop_user_view)
 	{
 		ts_hypertable_drop_trigger(raw_hypertable.objectId, CAGGINVAL_TRIGGER_NAME);
 	}
+
+	/*
+	 * Drop invalidation slot if there are no hypertables using WAL-based
+	 * invalidation collection.
+	 *
+	 * This is important since there is no actor that reads the slot, which
+	 * means that the WAL cannot be pruned.
+	 */
+	char slot_name[TS_INVALIDATION_SLOT_NAME_MAX];
+	ts_get_invalidation_replication_slot_name(slot_name, sizeof(slot_name));
+	if (!hypertable_invalidation_slot_used() && SearchNamedReplicationSlot(slot_name, true) != NULL)
+		ts_hypertable_drop_invalidation_replication_slot(slot_name);
 
 	if (OidIsValid(mat_hypertable.objectId))
 	{

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -16,6 +16,7 @@
 #include "with_clause/with_clause_parser.h"
 
 #define CAGGINVAL_TRIGGER_NAME "ts_cagg_invalidation_trigger"
+#define TS_INVALIDATION_SLOT_NAME_MAX (32)
 
 /*switch to ts user for _timescaledb_internal access */
 #define SWITCH_TO_TS_USER(schemaname, newuid, saved_uid, saved_secctx)                             \
@@ -53,6 +54,13 @@ typedef enum ContinuousAggViewType
 	ContinuousAggDirectView,
 	ContinuousAggAnyView
 } ContinuousAggViewType;
+
+typedef enum ContinuousAggInvalidateUsing
+{
+	ContinuousAggInvalidateUsingDefault = 0,
+	ContinuousAggInvalidateUsingTrigger,
+	ContinuousAggInvalidateUsingWal,
+} ContinuousAggInvalidateUsing;
 
 /*
  * Information about the bucketing function.
@@ -146,6 +154,12 @@ typedef struct CaggPolicyOffset
 	const char *name;
 } CaggPolicyOffset;
 
+static inline bool
+has_invalidation_trigger(Oid relid)
+{
+	return OidIsValid(get_trigger_oid(relid, CAGGINVAL_TRIGGER_NAME, true));
+}
+
 extern TSDLLEXPORT Oid ts_cagg_permissions_check(Oid cagg_oid, Oid userid);
 
 extern TSDLLEXPORT CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
@@ -199,3 +213,4 @@ extern TSDLLEXPORT int64
 ts_continuous_agg_fixed_bucket_width(const ContinuousAggsBucketFunction *bucket_function);
 extern TSDLLEXPORT int64
 ts_continuous_agg_bucket_width(const ContinuousAggsBucketFunction *bucket_function);
+extern TSDLLEXPORT void ts_get_invalidation_replication_slot_name(char *slotname, Size szslot);

--- a/src/with_clause/create_materialized_view_with_clause.c
+++ b/src/with_clause/create_materialized_view_with_clause.c
@@ -59,6 +59,11 @@ static const WithClauseDefinition continuous_aggregate_with_clause_def[] = {
         .arg_names = {"compress_chunk_interval", "compress_chunk_time_interval", NULL},
          .type_id = INTERVALOID,
     },
+	[CreateMaterializedViewFlagInvalidateUsing] = {
+        .arg_names = {"invalidate_using", NULL},
+		.type_id = TEXTOID,
+		.default_val = (Datum) 0,
+	},
 };
 
 WithClauseResult *

--- a/src/with_clause/create_materialized_view_with_clause.h
+++ b/src/with_clause/create_materialized_view_with_clause.h
@@ -19,7 +19,8 @@ typedef enum CreateMaterializedViewFlags
 	CreateMaterializedViewFlagChunkTimeInterval,
 	CreateMaterializedViewFlagSegmentBy,
 	CreateMaterializedViewFlagOrderBy,
-	CreateMaterializedViewFlagCompressChunkTimeInterval
+	CreateMaterializedViewFlagCompressChunkTimeInterval,
+	CreateMaterializedViewFlagInvalidateUsing,
 } CreateMaterializedViewFlags;
 
 extern TSDLLEXPORT WithClauseResult *

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -6,6 +6,8 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+CREATE VIEW invalidation_slots AS
+SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -88,6 +90,7 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, de
                                   |    FROM device_readings                                                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, device_readings.observation_time)), device_readings.device_id;
 finalized                         | t
+invalidate_using                  | trigger
 
 \x
 -- Refresh interval
@@ -601,4 +604,206 @@ ORDER BY 1;
  _hyper_12_19_chunk |            0 | t       |        
  _hyper_12_21_chunk |            0 | f       |        
 (2 rows)
+
+\set ON_ERROR_STOP 1
+SELECT count(*) FROM invalidation_slots;
+ count 
+-------
+     0
+(1 row)
+
+CREATE TABLE magic1(time timestamptz not null, device int, value float);
+CREATE TABLE magic2(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('magic1','time');
+ table_name 
+------------
+ magic1
+(1 row)
+
+SELECT table_name FROM create_hypertable('magic2','time');
+ table_name 
+------------
+ magic2
+(1 row)
+
+INSERT INTO magic1
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+-- Creating a materialized view with a failure between adding the slot
+-- and finishing adding the slot should not leave a slot around.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE bad(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('bad','time');
+ table_name 
+------------
+ bad
+(1 row)
+
+-- We create such an error by setting the hypertable id sequence
+-- number to an already existing one, which will generate an error
+-- when adding the new hypertable data to the catalog.
+select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
+select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
+ setval 
+--------
+     18
+(1 row)
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW bad_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM bad
+     GROUP BY 1,2;
+ERROR:  duplicate key value violates unique constraint "hypertable_pkey"
+\set ON_ERROR_STOP 1
+-- There should be no replication slot around.
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+-- Advance the sequence again to consume the value we set before.
+SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
+--
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Test the option "invalidate_using". This should create the continuous
+-- aggregate and there should be a replication slot.
+CREATE MATERIALIZED VIEW magic1_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary1_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+-- Create another continuous aggregate on the same hypertable to be
+-- able to check that the slot remains after one continuous aggregate
+-- has been dropped.
+CREATE MATERIALIZED VIEW magic1_summary2_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary2_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+-- Create another continuous aggregate on a different hypertable that
+-- uses WAL-based invalidation collection. This is used to check that
+-- the slot stays when we remove all continuous aggregates for a
+-- hypertable.
+CREATE MATERIALIZED VIEW magic2_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic2
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
+\set ON_ERROR_STOP 0
+-- This should error out since we are using trigger-based collection
+-- for "metrics".
+CREATE MATERIALIZED VIEW metrics_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM metrics
+     GROUP BY 1,2;
+ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
+-- This should error out since we are using WAL-based collection for
+-- "magic".
+CREATE MATERIALIZED VIEW magic1_summary1_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+ERROR:  cannot use trigger-based invalidation collection with hypertable that is using wal-based invalidation collection
+-- This should error out because there is no such collection method.
+CREATE MATERIALIZED VIEW magic_summary1_magic
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+ERROR:  unrecognized value "magic" for invalidate_using
+\set ON_ERROR_STOP 1
+-- Check that it was actually written to the catalog
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+ hypertable_name |      view_name      | invalidate_using 
+-----------------+---------------------+------------------
+ magic1          | magic1_summary1_wal | wal
+ magic1          | magic1_summary2_wal | wal
+ magic2          | magic2_summary1_wal | wal
+(3 rows)
+
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic2_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
+-- Slot should be there. We have another hypertable using WAL-based
+-- invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic1_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
+-- Slot should be there. We have yet another continuous aggregate for
+-- the hypertable using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic1_summary2_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
+-- Now slot should be gone and we should not have any continuous
+-- aggregates using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+ hypertable_name | view_name | invalidate_using 
+-----------------+-----------+------------------
+(0 rows)
 

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -6,6 +6,8 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+CREATE VIEW invalidation_slots AS
+SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -88,6 +90,7 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, ob
                                   |    FROM device_readings                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, observation_time)), device_id;
 finalized                         | t
+invalidate_using                  | trigger
 
 \x
 -- Refresh interval
@@ -601,4 +604,206 @@ ORDER BY 1;
  _hyper_12_19_chunk |            0 | t       |        
  _hyper_12_21_chunk |            0 | f       |        
 (2 rows)
+
+\set ON_ERROR_STOP 1
+SELECT count(*) FROM invalidation_slots;
+ count 
+-------
+     0
+(1 row)
+
+CREATE TABLE magic1(time timestamptz not null, device int, value float);
+CREATE TABLE magic2(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('magic1','time');
+ table_name 
+------------
+ magic1
+(1 row)
+
+SELECT table_name FROM create_hypertable('magic2','time');
+ table_name 
+------------
+ magic2
+(1 row)
+
+INSERT INTO magic1
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+-- Creating a materialized view with a failure between adding the slot
+-- and finishing adding the slot should not leave a slot around.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE bad(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('bad','time');
+ table_name 
+------------
+ bad
+(1 row)
+
+-- We create such an error by setting the hypertable id sequence
+-- number to an already existing one, which will generate an error
+-- when adding the new hypertable data to the catalog.
+select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
+select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
+ setval 
+--------
+     18
+(1 row)
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW bad_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM bad
+     GROUP BY 1,2;
+ERROR:  duplicate key value violates unique constraint "hypertable_pkey"
+\set ON_ERROR_STOP 1
+-- There should be no replication slot around.
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+-- Advance the sequence again to consume the value we set before.
+SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
+--
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Test the option "invalidate_using". This should create the continuous
+-- aggregate and there should be a replication slot.
+CREATE MATERIALIZED VIEW magic1_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary1_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+-- Create another continuous aggregate on the same hypertable to be
+-- able to check that the slot remains after one continuous aggregate
+-- has been dropped.
+CREATE MATERIALIZED VIEW magic1_summary2_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary2_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+-- Create another continuous aggregate on a different hypertable that
+-- uses WAL-based invalidation collection. This is used to check that
+-- the slot stays when we remove all continuous aggregates for a
+-- hypertable.
+CREATE MATERIALIZED VIEW magic2_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic2
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
+\set ON_ERROR_STOP 0
+-- This should error out since we are using trigger-based collection
+-- for "metrics".
+CREATE MATERIALIZED VIEW metrics_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM metrics
+     GROUP BY 1,2;
+ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
+-- This should error out since we are using WAL-based collection for
+-- "magic".
+CREATE MATERIALIZED VIEW magic1_summary1_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+ERROR:  cannot use trigger-based invalidation collection with hypertable that is using wal-based invalidation collection
+-- This should error out because there is no such collection method.
+CREATE MATERIALIZED VIEW magic_summary1_magic
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+ERROR:  unrecognized value "magic" for invalidate_using
+\set ON_ERROR_STOP 1
+-- Check that it was actually written to the catalog
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+ hypertable_name |      view_name      | invalidate_using 
+-----------------+---------------------+------------------
+ magic1          | magic1_summary1_wal | wal
+ magic1          | magic1_summary2_wal | wal
+ magic2          | magic2_summary1_wal | wal
+(3 rows)
+
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic2_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
+-- Slot should be there. We have another hypertable using WAL-based
+-- invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic1_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
+-- Slot should be there. We have yet another continuous aggregate for
+-- the hypertable using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic1_summary2_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
+-- Now slot should be gone and we should not have any continuous
+-- aggregates using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+ hypertable_name | view_name | invalidate_using 
+-----------------+-----------+------------------
+(0 rows)
 

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -6,6 +6,8 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+CREATE VIEW invalidation_slots AS
+SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -88,6 +90,7 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, ob
                                   |    FROM device_readings                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, observation_time)), device_id;
 finalized                         | t
+invalidate_using                  | trigger
 
 \x
 -- Refresh interval
@@ -601,4 +604,206 @@ ORDER BY 1;
  _hyper_12_19_chunk |            0 | t       |        
  _hyper_12_21_chunk |            0 | f       |        
 (2 rows)
+
+\set ON_ERROR_STOP 1
+SELECT count(*) FROM invalidation_slots;
+ count 
+-------
+     0
+(1 row)
+
+CREATE TABLE magic1(time timestamptz not null, device int, value float);
+CREATE TABLE magic2(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('magic1','time');
+ table_name 
+------------
+ magic1
+(1 row)
+
+SELECT table_name FROM create_hypertable('magic2','time');
+ table_name 
+------------
+ magic2
+(1 row)
+
+INSERT INTO magic1
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+-- Creating a materialized view with a failure between adding the slot
+-- and finishing adding the slot should not leave a slot around.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE bad(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('bad','time');
+ table_name 
+------------
+ bad
+(1 row)
+
+-- We create such an error by setting the hypertable id sequence
+-- number to an already existing one, which will generate an error
+-- when adding the new hypertable data to the catalog.
+select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
+select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
+ setval 
+--------
+     18
+(1 row)
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW bad_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM bad
+     GROUP BY 1,2;
+ERROR:  duplicate key value violates unique constraint "hypertable_pkey"
+\set ON_ERROR_STOP 1
+-- There should be no replication slot around.
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+-- Advance the sequence again to consume the value we set before.
+SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
+--
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Test the option "invalidate_using". This should create the continuous
+-- aggregate and there should be a replication slot.
+CREATE MATERIALIZED VIEW magic1_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary1_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+-- Create another continuous aggregate on the same hypertable to be
+-- able to check that the slot remains after one continuous aggregate
+-- has been dropped.
+CREATE MATERIALIZED VIEW magic1_summary2_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary2_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+-- Create another continuous aggregate on a different hypertable that
+-- uses WAL-based invalidation collection. This is used to check that
+-- the slot stays when we remove all continuous aggregates for a
+-- hypertable.
+CREATE MATERIALIZED VIEW magic2_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic2
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
+\set ON_ERROR_STOP 0
+-- This should error out since we are using trigger-based collection
+-- for "metrics".
+CREATE MATERIALIZED VIEW metrics_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM metrics
+     GROUP BY 1,2;
+ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
+-- This should error out since we are using WAL-based collection for
+-- "magic".
+CREATE MATERIALIZED VIEW magic1_summary1_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+ERROR:  cannot use trigger-based invalidation collection with hypertable that is using wal-based invalidation collection
+-- This should error out because there is no such collection method.
+CREATE MATERIALIZED VIEW magic_summary1_magic
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+ERROR:  unrecognized value "magic" for invalidate_using
+\set ON_ERROR_STOP 1
+-- Check that it was actually written to the catalog
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+ hypertable_name |      view_name      | invalidate_using 
+-----------------+---------------------+------------------
+ magic1          | magic1_summary1_wal | wal
+ magic1          | magic1_summary2_wal | wal
+ magic2          | magic2_summary1_wal | wal
+(3 rows)
+
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic2_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
+-- Slot should be there. We have another hypertable using WAL-based
+-- invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic1_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
+-- Slot should be there. We have yet another continuous aggregate for
+-- the hypertable using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     1
+(1 row)
+
+DROP MATERIALIZED VIEW magic1_summary2_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
+-- Now slot should be gone and we should not have any continuous
+-- aggregates using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+ count 
+-------
+     0
+(1 row)
+
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+ hypertable_name | view_name | invalidate_using 
+-----------------+-----------+------------------
+(0 rows)
 

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -2235,6 +2235,7 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, con
                                   |    FROM conditions                                                  +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, conditions.timec));
 finalized                         | t
+invalidate_using                  | trigger
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -2235,6 +2235,7 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, tim
                                   |    FROM conditions                                       +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, timec));
 finalized                         | t
+invalidate_using                  | trigger
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -2235,6 +2235,7 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, tim
                                   |    FROM conditions                                       +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, timec));
 finalized                         | t
+invalidate_using                  | trigger
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/exp_cagg_monthly.out
+++ b/tsl/test/expected/exp_cagg_monthly.out
@@ -321,17 +321,19 @@ WHERE hypertable_id = :ht_id;
 -- Make sure the catalog is cleaned up when the cagg is dropped
 DROP MATERIALIZED VIEW conditions_summary;
 NOTICE:  drop cascades to 3 other objects
-SELECT * FROM _timescaledb_catalog.continuous_agg
+SELECT count(*) FROM _timescaledb_catalog.continuous_agg
 WHERE mat_hypertable_id = :cagg_id;
- mat_hypertable_id | raw_hypertable_id | parent_mat_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name | materialized_only | finalized 
--------------------+-------------------+--------------------------+------------------+----------------+---------------------+-------------------+--------------------+------------------+-------------------+-----------
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function
+SELECT count(*) FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
- mat_hypertable_id | bucket_func | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------+--------------+---------------+---------------+-----------------+--------------------
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 -- Re-create cagg, this time WITH DATA
 SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -98,6 +98,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.get_partition_hash(anyelement)
  _timescaledb_functions.get_raw_materialization_ranges(regtype)
  _timescaledb_functions.get_segmentby_defaults(regclass)
+ _timescaledb_functions.has_invalidation_trigger(regclass)
  _timescaledb_functions.hist_combinefunc(internal,internal)
  _timescaledb_functions.hist_deserializefunc(bytea,internal)
  _timescaledb_functions.hist_finalfunc(internal,double precision,double precision,double precision,integer)

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -8,6 +8,9 @@ SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
 
+CREATE VIEW invalidation_slots AS
+SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
+
 -- START OF USAGE TEST --
 
 --First create your hypertable
@@ -377,3 +380,145 @@ SELECT
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
+\set ON_ERROR_STOP 1
+
+SELECT count(*) FROM invalidation_slots;
+
+CREATE TABLE magic1(time timestamptz not null, device int, value float);
+CREATE TABLE magic2(time timestamptz not null, device int, value float);
+
+SELECT table_name FROM create_hypertable('magic1','time');
+SELECT table_name FROM create_hypertable('magic2','time');
+
+INSERT INTO magic1
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+
+INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+
+-- Creating a materialized view with a failure between adding the slot
+-- and finishing adding the slot should not leave a slot around.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE bad(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('bad','time');
+
+-- We create such an error by setting the hypertable id sequence
+-- number to an already existing one, which will generate an error
+-- when adding the new hypertable data to the catalog.
+select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
+select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW bad_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM bad
+     GROUP BY 1,2;
+\set ON_ERROR_STOP 1
+
+-- There should be no replication slot around.
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+
+-- Advance the sequence again to consume the value we set before.
+SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- Test the option "invalidate_using". This should create the continuous
+-- aggregate and there should be a replication slot.
+CREATE MATERIALIZED VIEW magic1_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+
+-- Create another continuous aggregate on the same hypertable to be
+-- able to check that the slot remains after one continuous aggregate
+-- has been dropped.
+CREATE MATERIALIZED VIEW magic1_summary2_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+
+-- Create another continuous aggregate on a different hypertable that
+-- uses WAL-based invalidation collection. This is used to check that
+-- the slot stays when we remove all continuous aggregates for a
+-- hypertable.
+CREATE MATERIALIZED VIEW magic2_summary1_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic2
+     GROUP BY 1,2;
+
+\set ON_ERROR_STOP 0
+-- This should error out since we are using trigger-based collection
+-- for "metrics".
+CREATE MATERIALIZED VIEW metrics_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM metrics
+     GROUP BY 1,2;
+
+-- This should error out since we are using WAL-based collection for
+-- "magic".
+CREATE MATERIALIZED VIEW magic1_summary1_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+
+-- This should error out because there is no such collection method.
+CREATE MATERIALIZED VIEW magic_summary1_magic
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+
+\set ON_ERROR_STOP 1
+
+-- Check that it was actually written to the catalog
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';
+
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+
+DROP MATERIALIZED VIEW magic2_summary1_wal;
+
+-- Slot should be there. We have another hypertable using WAL-based
+-- invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+
+DROP MATERIALIZED VIEW magic1_summary1_wal;
+
+-- Slot should be there. We have yet another continuous aggregate for
+-- the hypertable using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+
+DROP MATERIALIZED VIEW magic1_summary2_wal;
+
+-- Now slot should be gone and we should not have any continuous
+-- aggregates using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = 'timescaledb-invalidations'
+   AND database = current_database();
+
+SELECT hypertable_name, view_name, invalidate_using
+  FROM timescaledb_information.continuous_aggregates
+ WHERE view_name like 'magic_\_summary%';

--- a/tsl/test/sql/exp_cagg_monthly.sql
+++ b/tsl/test/sql/exp_cagg_monthly.sql
@@ -163,10 +163,10 @@ WHERE hypertable_id = :ht_id;
 -- Make sure the catalog is cleaned up when the cagg is dropped
 DROP MATERIALIZED VIEW conditions_summary;
 
-SELECT * FROM _timescaledb_catalog.continuous_agg
+SELECT count(*) FROM _timescaledb_catalog.continuous_agg
 WHERE mat_hypertable_id = :cagg_id;
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function
+SELECT count(*) FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
 
 -- Re-create cagg, this time WITH DATA


### PR DESCRIPTION
Add new storage option `timescaledb.invalidate_using` to continuous aggregates for source of invalidations: either use `trigger` to read invalidations from hypertable using a trigger, or use `wal` to read invalidations for hypertables from WAL using logical decoding.

It is not possible to attach continuous aggregates to hypertables using mixed collection method and an error will be thrown if you try to attach a continuous aggregate to a hypertable that is already using a different collection method.

If no `invalidate_using` option is given to the continuous aggregate, it will use whatever collection method is already used for the hypertable.

Part of the feature issue #8193 and is one of the commits in the evolving PR #8251.