### PR TITLE
Fix missing compression algorithms in pre_install script

### DIFF
--- a/.unreleased/pr_8307
+++ b/.unreleased/pr_8307
@@ -1,0 +1,1 @@
+Fixes: #8307 Fix missing catalog entries for bool and null compression in fresh installations

--- a/sql/pre_install/insert_data.sql
+++ b/sql/pre_install/insert_data.sql
@@ -8,4 +8,6 @@ insert into _timescaledb_catalog.compression_algorithm( id, version, name, descr
 ( 1, 1, 'COMPRESSION_ALGORITHM_ARRAY', 'array'),
 ( 2, 1, 'COMPRESSION_ALGORITHM_DICTIONARY', 'dictionary'),
 ( 3, 1, 'COMPRESSION_ALGORITHM_GORILLA', 'gorilla'),
-( 4, 1, 'COMPRESSION_ALGORITHM_DELTADELTA', 'deltadelta');
+( 4, 1, 'COMPRESSION_ALGORITHM_DELTADELTA', 'deltadelta'),
+( 5, 1, 'COMPRESSION_ALGORITHM_BOOL', 'bool'),
+( 6, 1, 'COMPRESSION_ALGORITHM_NULL', 'null');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -55,3 +55,11 @@ CREATE PROCEDURE @extschema@.refresh_continuous_aggregate(
     force                    BOOLEAN = FALSE,
     options                  JSONB = NULL
 ) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_update_placeholder';
+
+-- since we forgot to add the compression algorithms in the previous release to the preinstall script
+-- we add them here with an ON CONFLICT DO NOTHING clause
+INSERT INTO _timescaledb_catalog.compression_algorithm( id, version, name, description) values
+( 5, 1, 'COMPRESSION_ALGORITHM_BOOL', 'bool'),
+( 6, 1, 'COMPRESSION_ALGORITHM_NULL', 'null') ON CONFLICT (id) DO NOTHING
+;
+


### PR DESCRIPTION
When we added bool and null compression we did not add them to the
pre_install script but only to the update scripts so any fresh
installation would miss them and updated timescaledb versions
would get them.
