### PR TITLE
Add tests to ignore when running ABI tests

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -44,6 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         pg: [ 15, 16, 17 ]
+        ignores:
+          - 'net telemetry'
         include:
           - pg: 15
             builder: ${{ fromJson(needs.config.outputs.pg15_abi_min) }}
@@ -100,7 +102,7 @@ jobs:
           set -o pipefail
           [ -f /usr/bin/gmake ] || ln -s /usr/bin/make /usr/bin/gmake
           sudo -u postgres make -C build_abi -k regresscheck regresscheck-t \
-            regresscheck-shared IGNORES="${{matrix.ignores}}" | tee installcheck.log
+            regresscheck-shared IGNORES="${{ matrix.ignores }}" | tee installcheck.log
         EOF
 
     - name: Show regression diffs

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -44,6 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         pg: [ 15, 16, 17 ]
+        ignores:
+          - 'net telemetry bgw_launcher'
         include:
           - pg: 15
             abi_min: ${{ fromJson(needs.config.outputs.pg15_abi_min) }}
@@ -136,7 +138,7 @@ jobs:
       id: regresscheck
       run: |
           set -o pipefail
-          make -k -C build_snapshot installcheck IGNORES=bgw_launcher | tee installcheck.log
+          make -k -C build_snapshot installcheck IGNORES="${{ matrix.ignores }}" | tee installcheck.log
 
     - name: Show regression diffs
       if: always()


### PR DESCRIPTION
The matrix was referencing an `ignores` variable, but none where defined, so adding it.