### PR TITLE
Don't rely on pqsignal return value

### DIFF
--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -312,14 +312,11 @@ test_job_2_error()
 	return true;
 }
 
-static pqsigfunc prev_signal_func = NULL;
-
 static void
 log_terminate_signal(SIGNAL_ARGS)
 {
 	write_stderr("job got term signal\n");
-	if (prev_signal_func != NULL)
-		prev_signal_func(postgres_signal_arg);
+	die(postgres_signal_arg);
 }
 
 TS_FUNCTION_INFO_V1(ts_bgw_test_job_sleep);
@@ -333,12 +330,8 @@ ts_bgw_test_job_sleep(PG_FUNCTION_ARGS)
 {
 	BackgroundWorkerBlockSignals();
 
-	/*
-	 * Only set prev_signal_func once to prevent it from being set to
-	 * log_terminate_signal.
-	 */
-	if (prev_signal_func == NULL)
-		prev_signal_func = pqsignal(SIGTERM, log_terminate_signal);
+	pqsignal(SIGTERM, log_terminate_signal);
+
 	/* Setup any signal handlers here */
 	BackgroundWorkerUnblockSignals();
 
@@ -364,12 +357,8 @@ test_job_3_long()
 {
 	BackgroundWorkerBlockSignals();
 
-	/*
-	 * Only set prev_signal_func once to prevent it from being set to
-	 * log_terminate_signal.
-	 */
-	if (prev_signal_func == NULL)
-		prev_signal_func = pqsignal(SIGTERM, log_terminate_signal);
+	pqsignal(SIGTERM, log_terminate_signal);
+
 	/* Setup any signal handlers here */
 	BackgroundWorkerUnblockSignals();
 


### PR DESCRIPTION
PG18 changes pqsignal to return void

https://github.com/postgres/postgres/commit/d4a43b28
