### PR TITLE
Remove code to deal with multiversion downgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,12 +191,6 @@ option(EXPERIMENTAL "Skip postgres version compatibility check" OFF)
 option(GENERATE_DOWNGRADE_SCRIPT
        "Generate downgrade script. Defaults to not generate a downgrade script."
        OFF)
-cmake_dependent_option(
-  GENERATE_OLD_DOWNGRADE_SCRIPTS
-  "Generate downgrade scripts for old versions. Requires setting GENERATE_DOWNGRADE_SCRIPT to ON. Defaults to OFF."
-  OFF
-  "GENERATE_DOWNGRADE_SCRIPT"
-  ON)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   # CMAKE_BUILD_TYPE is set at CMake configuration type. But usage of

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -52,49 +52,6 @@ set(MOD_FILES
 # specified in version.config
 set(CURRENT_REV_FILE reverse-dev.sql)
 
-# Files for generating old downgrade scripts. This should only include files for
-# downgrade from one version to its previous version since we do not support
-# skipping versions when downgrading.
-set(OLD_REV_FILES
-    2.9.1--2.9.0.sql
-    2.9.2--2.9.1.sql
-    2.9.3--2.9.2.sql
-    2.10.0--2.9.3.sql
-    2.10.1--2.10.0.sql
-    2.10.2--2.10.1.sql
-    2.10.3--2.10.2.sql
-    2.11.0--2.10.3.sql
-    2.11.1--2.11.0.sql
-    2.11.2--2.11.1.sql
-    2.12.0--2.11.2.sql
-    2.12.1--2.12.0.sql
-    2.12.2--2.12.1.sql
-    2.13.0--2.12.2.sql
-    2.13.1--2.13.0.sql
-    2.14.0--2.13.1.sql
-    2.14.1--2.14.0.sql
-    2.14.2--2.14.1.sql
-    2.15.0--2.14.2.sql
-    2.15.1--2.15.0.sql
-    2.15.2--2.15.1.sql
-    2.15.3--2.15.2.sql
-    2.16.0--2.15.3.sql
-    2.16.1--2.16.0.sql
-    2.17.0--2.16.1.sql
-    2.17.1--2.17.0.sql
-    2.17.2--2.17.1.sql
-    2.18.0--2.17.2.sql
-    2.18.1--2.18.0.sql
-    2.18.2--2.18.1.sql
-    2.19.0--2.18.2.sql
-    2.19.1--2.19.0.sql
-    2.19.2--2.19.1.sql
-    2.19.3--2.19.2.sql
-    2.20.0--2.19.3.sql
-    2.20.1--2.20.0.sql
-    2.20.2--2.20.1.sql
-    2.20.3--2.20.2.sql)
-
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")
 set(LOADER_PATHNAME "$libdir/timescaledb")
 
@@ -121,26 +78,6 @@ else()
     ${CMAKE_CURRENT_SOURCE_DIR}/updates
     FILES
     ${CURRENT_REV_FILE})
-  if(GENERATE_OLD_DOWNGRADE_SCRIPTS)
-    foreach(_downgrade_file ${OLD_REV_FILES})
-      if(${_downgrade_file} MATCHES
-         "([0-9]+\\.[0-9]+\\.*[0-9]*)--([0-9]+\\.[0-9]+\\.*[0-9]*).sql")
-        set(_source_version ${CMAKE_MATCH_1})
-        set(_target_version ${CMAKE_MATCH_2})
-        generate_downgrade_script(
-          SOURCE_VERSION
-          ${_source_version}
-          TARGET_VERSION
-          ${_target_version}
-          INPUT_DIRECTORY
-          ${CMAKE_CURRENT_SOURCE_DIR}/updates
-          FILES
-          ${_downgrade_file})
-      else()
-        message(FATAL_ERROR "${_downgrade_file} is not a downgrade file")
-      endif()
-    endforeach()
-  endif()
 endif()
 
 # Function to replace @MODULE_PATHNAME@ in source files, producing an output


### PR DESCRIPTION
We only ever generated downgrade script for previous version so
this codepath was untested and removing allows us to get rid of
OLD_REV_FILES list, simplifying the release generation.
