### PR TITLE
Prepare for building against PG18

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -35,6 +35,7 @@
 #define is_supported_pg_version_15(version) ((version >= 150010) && (version < 160000))
 #define is_supported_pg_version_16(version) ((version >= 160006) && (version < 170000))
 #define is_supported_pg_version_17(version) ((version >= 170002) && (version < 180000))
+#define is_supported_pg_version_18(version) ((version >= 180000) && (version < 190000))
 
 /*
  * PG16 support is a WIP and not complete yet.
@@ -42,11 +43,12 @@
  */
 #define is_supported_pg_version(version)                                                           \
 	(is_supported_pg_version_15(version) || is_supported_pg_version_16(version) ||                 \
-	 is_supported_pg_version_17(version))
+	 is_supported_pg_version_17(version) || is_supported_pg_version_18(version))
 
 #define PG15 is_supported_pg_version_15(PG_VERSION_NUM)
 #define PG16 is_supported_pg_version_16(PG_VERSION_NUM)
 #define PG17 is_supported_pg_version_17(PG_VERSION_NUM)
+#define PG18 is_supported_pg_version_18(PG_VERSION_NUM)
 
 #define PG15_LT (PG_VERSION_NUM < 150000)
 #define PG15_GE (PG_VERSION_NUM >= 150000)
@@ -54,6 +56,8 @@
 #define PG16_GE (PG_VERSION_NUM >= 160000)
 #define PG17_LT (PG_VERSION_NUM < 170000)
 #define PG17_GE (PG_VERSION_NUM >= 170000)
+#define PG18_LT (PG_VERSION_NUM < 180000)
+#define PG18_GE (PG_VERSION_NUM >= 180000)
 
 #if !(is_supported_pg_version(PG_VERSION_NUM))
 #error "Unsupported PostgreSQL version"


### PR DESCRIPTION
This patch adds macros to enable building against PG18. Building
against PG18 will still be blocked unless -DEXPERIMENTAL=ON is
passed.

Disable-check: force-changelog-file
