### PR TITLE
Adjust HEAP_RELOPT_NAMESPACES variable definition

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -676,7 +676,11 @@ static void
 create_toast_table(CreateStmt *stmt, Oid chunk_oid)
 {
 	/* similar to tcop/utility.c */
-	static char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#if PG18_LT
+	char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#else
+	const char *const validnsps[] = HEAP_RELOPT_NAMESPACES;
+#endif
 	Datum toast_options =
 		transformRelOptions((Datum) 0, stmt->options, "toast", validnsps, true, false);
 

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -104,7 +104,11 @@ compression_chunk_create(Chunk *src_chunk, Chunk *chunk, List *column_defs, Oid 
 	ObjectAddress tbladdress;
 	CatalogSecurityContext sec_ctx;
 	Datum toast_options;
-	static char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#if PG18_LT
+	char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#else
+	const char *const validnsps[] = HEAP_RELOPT_NAMESPACES;
+#endif
 	CompressionSettings *settings = ts_compression_settings_get(src_chunk->hypertable_relid);
 
 	Oid owner = ts_rel_get_owner(chunk->hypertable_relid);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -428,7 +428,11 @@ mattablecolumninfo_create_materialization_table(MatTableColumnInfo *matcolinfo, 
 	char *matpartcolname = matcolinfo->matpartcolname;
 	CreateStmt *create;
 	Datum toast_options;
-	static char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#if PG18_LT
+	char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#else
+	const char *const validnsps[] = HEAP_RELOPT_NAMESPACES;
+#endif
 	int32 mat_htid;
 	Oid mat_relid;
 	Cache *hcache;


### PR DESCRIPTION
PG18 changes transformRelOptions signature to have validnsps argument be
const.

https://github.com/postgres/postgres/commit/1e35951e

Disable-check: force-changelog-file
