### PR TITLE
Fix DML issue with expression indexes and BHS

### DIFF
--- a/.unreleased/pr_8323
+++ b/.unreleased/pr_8323
@@ -1,0 +1,1 @@
+Fixes: #8323 Fix DML issue with expression indexes and BHS

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -1059,6 +1059,9 @@ decompress_chunk_walker(PlanState *ps, struct decompress_chunk_context *ctx)
 				 * data. To circumvent this issue, we change the internal scan state to use the
 				 * transaction snapshot and execute a rescan so the scan state is set correctly and
 				 * includes the new data.
+				 *
+				 * From PG17 this has changed since the scan state is not initialized with
+				 * the node.
 				 */
 				if (should_rescan)
 				{
@@ -1066,7 +1069,7 @@ decompress_chunk_walker(PlanState *ps, struct decompress_chunk_context *ctx)
 					if (ss && ss->ss_currentScanDesc)
 					{
 						ss->ss_currentScanDesc->rs_snapshot = GetTransactionSnapshot();
-						ExecReScan(ps);
+						table_rescan(ss->ss_currentScanDesc, NULL);
 					}
 				}
 			}

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -1939,6 +1939,53 @@ SELECT count(*) FROM tab1 WHERE device_id = 1;
 (1 row)
 
 ROLLBACK;
+-- verify we can work with expression indexes and toastable types
+-- when the subquery returns a zero result set we used to end up
+-- trying to detoast a 0 value and segfaulting
+BEGIN;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX test ON tab1(repeat('t', device_id));
+CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
+ANALYZE tab1;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (costs off) UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Update on tab1
+         Update on _hyper_21_39_chunk tab1_1
+         Update on _hyper_21_40_chunk tab1_2
+         Update on _hyper_21_41_chunk tab1_3
+         ->  Nested Loop
+               ->  Subquery Scan on devices
+                     ->  HashAggregate
+                           Group Key: repeat
+                           ->  Result
+                                 One-Time Filter: false
+               ->  Append
+                     ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
+                           Recheck Cond: (repeat('t'::text, device_id) = devices.repeat)
+                           ->  Bitmap Index Scan on _hyper_21_39_chunk_test
+                                 Index Cond: (repeat('t'::text, device_id) = devices.repeat)
+                     ->  Seq Scan on _hyper_21_40_chunk tab1_2
+                           Filter: (devices.repeat = repeat('t'::text, device_id))
+                     ->  Seq Scan on _hyper_21_41_chunk tab1_3
+                           Filter: (devices.repeat = repeat('t'::text, device_id))
+(20 rows)
+
+UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+ROLLBACK;
 -- create hypertable with space partitioning and compression
 CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab2(time);

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -1939,6 +1939,53 @@ SELECT count(*) FROM tab1 WHERE device_id = 1;
 (1 row)
 
 ROLLBACK;
+-- verify we can work with expression indexes and toastable types
+-- when the subquery returns a zero result set we used to end up
+-- trying to detoast a 0 value and segfaulting
+BEGIN;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX test ON tab1(repeat('t', device_id));
+CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
+ANALYZE tab1;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (costs off) UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Update on tab1
+         Update on _hyper_21_39_chunk tab1_1
+         Update on _hyper_21_40_chunk tab1_2
+         Update on _hyper_21_41_chunk tab1_3
+         ->  Nested Loop
+               ->  Subquery Scan on devices
+                     ->  HashAggregate
+                           Group Key: repeat
+                           ->  Result
+                                 One-Time Filter: false
+               ->  Append
+                     ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
+                           Recheck Cond: (repeat('t'::text, device_id) = devices.repeat)
+                           ->  Bitmap Index Scan on _hyper_21_39_chunk_test
+                                 Index Cond: (repeat('t'::text, device_id) = devices.repeat)
+                     ->  Seq Scan on _hyper_21_40_chunk tab1_2
+                           Filter: (devices.repeat = repeat('t'::text, device_id))
+                     ->  Seq Scan on _hyper_21_41_chunk tab1_3
+                           Filter: (devices.repeat = repeat('t'::text, device_id))
+(20 rows)
+
+UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+ROLLBACK;
 -- create hypertable with space partitioning and compression
 CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab2(time);

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -1939,6 +1939,53 @@ SELECT count(*) FROM tab1 WHERE device_id = 1;
 (1 row)
 
 ROLLBACK;
+-- verify we can work with expression indexes and toastable types
+-- when the subquery returns a zero result set we used to end up
+-- trying to detoast a 0 value and segfaulting
+BEGIN;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX test ON tab1(repeat('t', device_id));
+CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
+ANALYZE tab1;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (costs off) UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Update on tab1
+         Update on _hyper_21_39_chunk tab1_1
+         Update on _hyper_21_40_chunk tab1_2
+         Update on _hyper_21_41_chunk tab1_3
+         ->  Nested Loop
+               ->  Subquery Scan on devices
+                     ->  HashAggregate
+                           Group Key: repeat
+                           ->  Result
+                                 One-Time Filter: false
+               ->  Append
+                     ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
+                           Recheck Cond: (repeat('t'::text, device_id) = devices.repeat)
+                           ->  Bitmap Index Scan on _hyper_21_39_chunk_test
+                                 Index Cond: (repeat('t'::text, device_id) = devices.repeat)
+                     ->  Seq Scan on _hyper_21_40_chunk tab1_2
+                           Filter: (devices.repeat = repeat('t'::text, device_id))
+                     ->  Seq Scan on _hyper_21_41_chunk tab1_3
+                           Filter: (devices.repeat = repeat('t'::text, device_id))
+(20 rows)
+
+UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+ROLLBACK;
 -- create hypertable with space partitioning and compression
 CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab2(time);

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1015,6 +1015,30 @@ DELETE FROM tab1 WHERE tab1.device_id = 1;
 SELECT count(*) FROM tab1 WHERE device_id = 1;
 ROLLBACK;
 
+-- verify we can work with expression indexes and toastable types
+-- when the subquery returns a zero result set we used to end up
+-- trying to detoast a 0 value and segfaulting
+BEGIN;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX test ON tab1(repeat('t', device_id));
+CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
+ANALYZE tab1;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (costs off) UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+UPDATE tab1
+SET v0 = 0 FROM
+	(SELECT repeat, count(*)
+	FROM join_table
+	WHERE false group by 1) as devices
+WHERE repeat('t', device_id) = devices.repeat;
+ROLLBACK;
+
 -- create hypertable with space partitioning and compression
 CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab2(time);


### PR DESCRIPTION
Running a rescan in certain scenarios on a bitmap
heap scan node would cause segfaults due to zero
value parametrization on toastable types. This
change avoids the rescan and only rescans the
underlying table scan. This workaround should
be completely removed once we drop PG16 support
since the underlying scan is no longer initialized with 
the node initalization in PG17.