### PR TITLE
Refactor `make_range` into compat function

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -691,3 +691,11 @@ pg_cmp_u32(uint32 a, uint32 b)
 							   norderbys)                                                          \
 	index_beginscan(heapRelation, indexRelation, snapshot, instrument, nkeys, norderbys)
 #endif
+
+#if PG16_LT
+#define make_range_compat(typcache, lower, upper, empty, escontext)                                \
+	make_range(typcache, lower, upper, empty)
+#else
+#define make_range_compat(typcache, lower, upper, empty, escontext)                                \
+	make_range(typcache, lower, upper, empty, escontext)
+#endif

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -615,11 +615,7 @@ ts_make_range_from_internal_time(PG_FUNCTION_ARGS)
 
 	/* Need to check the types of the lower and upper values. They should
 	 * match the returned range. */
-#if PG16_LT
-	PG_RETURN_RANGE_P(make_range(typcache, &lower, &upper, false));
-#else
-	PG_RETURN_RANGE_P(make_range(typcache, &lower, &upper, false, escontext));
-#endif
+	PG_RETURN_RANGE_P(make_range_compat(typcache, &lower, &upper, false, escontext));
 }
 
 Datum

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -559,11 +559,7 @@ policy_refresh_cagg_check_for_overlaps(ContinuousAgg *cagg, Jsonb *policy_config
 	if (typcache == NULL || typcache->rngelemtype == NULL)
 		elog(ERROR, "cache lookup failed");
 
-#if PG16_LT
-	RangeType *range = make_range(typcache, &lower, &upper, false);
-#else
-	RangeType *range = make_range(typcache, &lower, &upper, false, NULL);
-#endif
+	RangeType *range = make_range_compat(typcache, &lower, &upper, false, NULL);
 
 	ListCell *lc;
 
@@ -606,11 +602,7 @@ policy_refresh_cagg_check_for_overlaps(ContinuousAgg *cagg, Jsonb *policy_config
 			.lower = false,
 		};
 
-#if PG16_LT
-		RangeType *range_job = make_range(typcache, &lower_job, &upper_job, false);
-#else
-		RangeType *range_job = make_range(typcache, &lower_job, &upper_job, false, NULL);
-#endif
+		RangeType *range_job = make_range_compat(typcache, &lower_job, &upper_job, false, NULL);
 
 		elog(DEBUG1,
 			 "start_offset_job: " INT64_FORMAT ", end_offset_job: " INT64_FORMAT,


### PR DESCRIPTION
Adds `make_range_compat` to make the code cleaner, since we now use it in a few places.

Disable-check: force-changelog-file