### PR TITLE
Fix isBackgroundWorker compatibility for PG18

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -672,7 +672,13 @@ get_job_lock_for_delete(int32 job_id)
 		if (VirtualTransactionIdIsValid(*vxid))
 		{
 			proc = VirtualTransactionGetProcCompat(vxid);
-			if (proc != NULL && proc->isBackgroundWorker)
+			if (proc != NULL
+#if PG18_LT
+				&& proc->isBackgroundWorker
+#else
+				&& !proc->isRegularBackend
+#endif
+			)
 			{
 				/* Simply assuming that this pid corresponds to the background worker
 				 * running the job is not sufficient. The scheduler could also be the


### PR DESCRIPTION
Replace removed isBackgroundWorker field with \!isRegularBackend check
for PostgreSQL 18 compatibility. This maintains the same logic for
identifying background worker processes in job lock detection.

https://github.com/postgres/postgres/commit/508a97ee (Replace PGPROC.isBackgroundWorker with isRegularBackend)

Disable-check: force-changelog-file
