### PR TITLE
Fix cluster_rel signature for PG18

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3662,7 +3662,12 @@ process_cluster_start(ProcessUtilityArgs *args)
 			 * Since we keep OIDs between transactions, there is a potential
 			 * issue if an OID gets reassigned between two subtransactions
 			 */
+#if PG18_LT
 			cluster_rel(cim->chunkoid, cim->indexoid, get_cluster_options(stmt));
+#else
+			Relation rel = table_open(cim->chunkoid, AccessExclusiveLock);
+			cluster_rel(rel, cim->indexoid, get_cluster_options(stmt));
+#endif
 			PopActiveSnapshot();
 			CommitTransactionCommand();
 		}


### PR DESCRIPTION
Update cluster_rel call to use new signature that expects a Relation
parameter instead of OID in PostgreSQL 18. Opens relation with
AccessExclusiveLock before calling cluster_rel to match upstream
API changes.

https://github.com/postgres/postgres/commit/cc811f92 Adjust signature of cluster_rel() and its subroutines

Disable-check: force-changelog-file
