### PR TITLE
Fix CreateConstraintEntry signature for PG18

### DIFF
--- a/src/foreign_key.c
+++ b/src/foreign_key.c
@@ -168,6 +168,9 @@ clone_constraint_on_chunk(const Chunk *chunk, Relation parentRel, Form_pg_constr
 									   CONSTRAINT_FOREIGN,
 									   fk->condeferrable,
 									   fk->condeferred,
+#if PG18_GE
+									   true, /* isEnforced */
+#endif
 									   fk->convalidated,
 									   fk->oid,
 									   fk->conrelid,
@@ -193,6 +196,9 @@ clone_constraint_on_chunk(const Chunk *chunk, Relation parentRel, Form_pg_constr
 									   false,
 									   1,
 									   false,
+#if PG18_GE
+									   false, /* conPeriod */
+#endif
 									   false);
 
 	ObjectAddress address, referenced;


### PR DESCRIPTION
PG18 added isEnforced and conPeriod parameters
to CreateConstraintEntry. Add version guards for the new
parameters to maintain compatibility.

https://github.com/postgres/postgres/commit/fc0438b4 Add temporal PRIMARY KEY and UNIQUE constraints
https://github.com/postgres/postgres/commit/ca87c415 Add support for NOT ENFORCED in CHECK constraints

Disable-check: force-changelog-file
