### PR TITLE
Fix PostgreSQL 18 explain system compatibility

### DIFF
--- a/src/import/ts_explain.h
+++ b/src/import/ts_explain.h
@@ -18,7 +18,13 @@
 #include <nodes/execnodes.h>
 #include <nodes/pg_list.h>
 
+#include <compat/compat.h>
 #include "export.h"
+
+#if PG18_GE
+#include <commands/explain_format.h>
+#include <commands/explain_state.h>
+#endif
 
 extern TSDLLEXPORT void ts_show_scan_qual(List *qual, const char *qlabel, PlanState *planstate,
 										  List *ancestors, ExplainState *es);

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -26,11 +26,16 @@
 
 #include <math.h>
 
+#include "compat/compat.h"
 #include "loader/lwlocks.h"
 #include "nodes/chunk_append/chunk_append.h"
 #include "planner/planner.h"
 #include "transform.h"
 #include "ts_catalog/chunk_column_stats.h"
+
+#if PG18_GE
+#include <commands/explain_format.h>
+#endif
 
 #define INVALID_SUBPLAN_INDEX (-1)
 #define NO_MATCHING_SUBPLANS (-2)

--- a/src/nodes/constraint_aware_append/constraint_aware_append.c
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.c
@@ -34,6 +34,10 @@
 #include "nodes/chunk_append/transform.h"
 #include "utils.h"
 
+#if PG18_GE
+#include <commands/explain_format.h>
+#endif
+
 /*
  * Exclude child relations (chunks) at execution time based on constraints.
  *

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -5,13 +5,19 @@
  */
 
 #include <postgres.h>
+#include <commands/explain_format.h>
 #include <nodes/execnodes.h>
 #include <nodes/makefuncs.h>
 
+#include "compat/compat.h"
 #include "chunk_tuple_routing.h"
 #include "nodes/chunk_append/chunk_append.h"
 #include "nodes/chunk_dispatch/chunk_dispatch.h"
 #include "nodes/modify_hypertable.h"
+
+#if PG18_GE
+#include <commands/explain_format.h>
+#endif
 
 static ChunkDispatchState *
 get_chunk_dispatch_state(PlanState *substate)

--- a/tsl/src/hypercore/arrow_cache_explain.c
+++ b/tsl/src/hypercore/arrow_cache_explain.c
@@ -14,6 +14,11 @@
 #include <compat/compat.h>
 #include "arrow_cache_explain.h"
 
+#if PG18_GE
+#include <commands/explain_format.h>
+#include <commands/explain_state.h>
+#endif
+
 bool decompress_cache_print = false;
 struct DecompressCacheStats decompress_cache_stats;
 static ExplainOneQuery_hook_type prev_ExplainOneQuery_hook = NULL;


### PR DESCRIPTION
Add necessary includes and conditional compilation for PostgreSQL 18's
reorganized explain system. In PG18, explain functionality was split
into separate headers:
- ExplainState moved to commands/explain_state.h
- Explain functions moved to commands/explain_format.h
