### PR TITLE
Refactor string output for Postgres type code

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1015,15 +1015,6 @@ chunk_create_from_hypercube_after_lock(const Hypertable *ht, Hypercube *cube,
 
 		if (chunk_exists)
 		{
-			Oid outfuncid = InvalidOid;
-			bool isvarlena;
-
-			Datum start_ts =
-				ts_internal_to_time_value(cube->slices[0]->fd.range_start, dim->fd.column_type);
-			Datum end_ts =
-				ts_internal_to_time_value(cube->slices[0]->fd.range_end, dim->fd.column_type);
-			getTypeOutputInfo(dim->fd.column_type, &outfuncid, &isvarlena);
-			Assert(!isvarlena);
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("Cannot insert into tiered chunk range of %s.%s - attempt to create "
@@ -1031,8 +1022,10 @@ chunk_create_from_hypercube_after_lock(const Hypertable *ht, Hypercube *cube,
 							"with range  [%s %s] failed",
 							NameStr(ht->fd.schema_name),
 							NameStr(ht->fd.table_name),
-							DatumGetCString(OidFunctionCall1(outfuncid, start_ts)),
-							DatumGetCString(OidFunctionCall1(outfuncid, end_ts))),
+							ts_internal_to_time_string(cube->slices[0]->fd.range_start,
+													   dim->fd.column_type),
+							ts_internal_to_time_string(cube->slices[0]->fd.range_end,
+													   dim->fd.column_type)),
 					 errhint(
 						 "Hypertable has tiered data with time range that overlaps the insert")));
 		}

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -278,12 +278,10 @@ ts_chunk_constraint_dimensional_create(const Dimension *dim, const DimensionSlic
 									   const char *name)
 {
 	Constraint *constr = NULL;
-	bool isvarlena;
 	Node *dimdef;
 	ColumnRef *colref;
-	Datum startdat, enddat;
 	List *compexprs = NIL;
-	Oid outfuncid;
+	Oid type;
 
 	if (slice->fd.range_start == PG_INT64_MIN && slice->fd.range_end == PG_INT64_MAX)
 		return NULL;
@@ -308,16 +306,12 @@ ts_chunk_constraint_dimensional_create(const Dimension *dim, const DimensionSlic
 			/* The dimension has a time function to compute the time value so
 			 * need to convert the range values to the time type returned by
 			 * the partitioning function. */
-			getTypeOutputInfo(partinfo->partfunc.rettype, &outfuncid, &isvarlena);
-			startdat = ts_internal_to_time_value(slice->fd.range_start, partinfo->partfunc.rettype);
-			enddat = ts_internal_to_time_value(slice->fd.range_end, partinfo->partfunc.rettype);
+			type = partinfo->partfunc.rettype;
 		}
 		else
 		{
-			/* Closed dimension, just use the integer output function */
-			getTypeOutputInfo(INT8OID, &outfuncid, &isvarlena);
-			startdat = Int64GetDatum(slice->fd.range_start);
-			enddat = Int64GetDatum(slice->fd.range_end);
+			/* Closed dimension, just use the INT8 type */
+			type = INT8OID;
 		}
 	}
 	else
@@ -326,28 +320,24 @@ ts_chunk_constraint_dimensional_create(const Dimension *dim, const DimensionSlic
 		Assert(IS_OPEN_DIMENSION(dim));
 
 		dimdef = (Node *) colref;
-		getTypeOutputInfo(dim->fd.column_type, &outfuncid, &isvarlena);
-		startdat = ts_internal_to_time_value(slice->fd.range_start, dim->fd.column_type);
-		enddat = ts_internal_to_time_value(slice->fd.range_end, dim->fd.column_type);
+		type = dim->fd.column_type;
 	}
 
 	/*
-	 * Convert internal format datums to string (output) datums.
-	 *
 	 * We are forcing ISO datestyle here to prevent parsing errors with
 	 * certain timezone/datestyle combinations.
 	 */
 	int current_datestyle = DateStyle;
 	DateStyle = USE_ISO_DATES;
-	startdat = OidFunctionCall1(outfuncid, startdat);
-	enddat = OidFunctionCall1(outfuncid, enddat);
+	char *start_str = ts_internal_to_time_string(slice->fd.range_start, type);
+	char *end_str = ts_internal_to_time_string(slice->fd.range_end, type);
 	DateStyle = current_datestyle;
 
 	/* Elide range constraint for +INF or -INF */
 	if (slice->fd.range_start != PG_INT64_MIN)
 	{
 		A_Const *start_const = makeNode(A_Const);
-		memcpy(&start_const->val, makeString(DatumGetCString(startdat)), sizeof(start_const->val));
+		memcpy(&start_const->val, makeString(start_str), sizeof(start_const->val));
 		start_const->location = -1;
 		A_Expr *ge_expr = makeSimpleA_Expr(AEXPR_OP, ">=", dimdef, (Node *) start_const, -1);
 		compexprs = lappend(compexprs, ge_expr);
@@ -356,7 +346,7 @@ ts_chunk_constraint_dimensional_create(const Dimension *dim, const DimensionSlic
 	if (slice->fd.range_end != PG_INT64_MAX)
 	{
 		A_Const *end_const = makeNode(A_Const);
-		memcpy(&end_const->val, makeString(DatumGetCString(enddat)), sizeof(end_const->val));
+		memcpy(&end_const->val, makeString(end_str), sizeof(end_const->val));
 		end_const->location = -1;
 		A_Expr *lt_expr = makeSimpleA_Expr(AEXPR_OP, "<", dimdef, (Node *) end_const, -1);
 		compexprs = lappend(compexprs, lt_expr);

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -100,14 +100,6 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 			const Dimension *time_dim = hyperspace_get_open_dimension(ctr->hypertable->space, 0);
 			Assert(time_dim != NULL);
 
-			Oid outfuncid = InvalidOid;
-			bool isvarlena;
-			getTypeOutputInfo(time_dim->fd.column_type, &outfuncid, &isvarlena);
-			Assert(!isvarlena);
-			Datum start_ts = ts_internal_to_time_value(chunk->cube->slices[0]->fd.range_start,
-													   time_dim->fd.column_type);
-			Datum end_ts = ts_internal_to_time_value(chunk->cube->slices[0]->fd.range_end,
-													 time_dim->fd.column_type);
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("Cannot insert into tiered chunk range of %s.%s - attempt to create "
@@ -115,8 +107,10 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 							"with range  [%s %s] failed",
 							NameStr(ctr->hypertable->fd.schema_name),
 							NameStr(ctr->hypertable->fd.table_name),
-							DatumGetCString(OidFunctionCall1(outfuncid, start_ts)),
-							DatumGetCString(OidFunctionCall1(outfuncid, end_ts))),
+							ts_internal_to_time_string(chunk->cube->slices[0]->fd.range_start,
+													   time_dim->fd.column_type),
+							ts_internal_to_time_string(chunk->cube->slices[0]->fd.range_end,
+													   time_dim->fd.column_type)),
 					 errhint(
 						 "Hypertable has tiered data with time range that overlaps the insert")));
 		}

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1714,11 +1714,7 @@ ts_dimension_info_out(PG_FUNCTION_ARGS)
 
 			if (OidIsValid(info->interval_type))
 			{
-				bool isvarlena;
-				Oid outfuncid;
-				getTypeOutputInfo(info->interval_type, &outfuncid, &isvarlena);
-				Assert(OidIsValid(outfuncid));
-				argvalstr = OidOutputFunctionCall(outfuncid, info->interval_datum);
+				argvalstr = ts_datum_to_string(info->interval_datum, info->interval_type);
 			}
 
 			appendStringInfo(&str,

--- a/src/jsonb_utils.c
+++ b/src/jsonb_utils.c
@@ -14,6 +14,7 @@
 #include "compat/compat.h"
 #include "export.h"
 #include "jsonb_utils.h"
+#include "utils.h"
 
 static void ts_jsonb_add_pair(JsonbParseState *state, JsonbValue *key, JsonbValue *value);
 
@@ -75,27 +76,24 @@ ts_jsonb_set_value_by_type(JsonbValue *value, Oid typeid, Datum datum)
 {
 	switch (typeid)
 	{
-		Oid typeOut;
-		bool isvarlena;
-		char *str;
-		PGFunction func;
-
 		case INT2OID:
 		case INT4OID:
 		case INT8OID:
 		case NUMERICOID:
-			func = get_convert_func(typeid);
+		{
+			PGFunction func = get_convert_func(typeid);
 			value->type = jbvNumeric;
 			value->val.numeric = DatumGetNumeric(func ? DirectFunctionCall1(func, datum) : datum);
 			break;
-
+		}
 		default:
-			getTypeOutputInfo(typeid, &typeOut, &isvarlena);
-			str = OidOutputFunctionCall(typeOut, datum);
+		{
+			char *str = ts_datum_to_string(datum, typeid);
 			value->type = jbvString;
 			value->val.string.val = str;
 			value->val.string.len = strlen(str);
 			break;
+		}
 	}
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -381,16 +381,23 @@ ts_internal_to_time_int64(int64 value, Oid type)
 }
 
 TSDLLEXPORT char *
-ts_internal_to_time_string(int64 value, Oid type)
+ts_datum_to_string(Datum value, Oid type)
 {
-	Datum time_datum = ts_internal_to_time_value(value, type);
 	Oid typoutputfunc;
 	bool typIsVarlena;
 	FmgrInfo typoutputinfo;
 
 	getTypeOutputInfo(type, &typoutputfunc, &typIsVarlena);
 	fmgr_info(typoutputfunc, &typoutputinfo);
-	return OutputFunctionCall(&typoutputinfo, time_datum);
+	return OutputFunctionCall(&typoutputinfo, value);
+}
+
+TSDLLEXPORT char *
+ts_internal_to_time_string(int64 value, Oid type)
+{
+	Datum time_datum = ts_internal_to_time_value(value, type);
+
+	return ts_datum_to_string(time_datum, type);
 }
 
 TS_FUNCTION_INFO_V1(ts_pg_unix_microseconds_to_interval);

--- a/src/utils.h
+++ b/src/utils.h
@@ -146,6 +146,7 @@ extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_
 extern TSDLLEXPORT Datum ts_internal_to_time_value(int64 value, Oid type);
 extern TSDLLEXPORT int64 ts_internal_to_time_int64(int64 value, Oid type);
 extern TSDLLEXPORT Datum ts_internal_to_interval_value(int64 value, Oid type);
+extern TSDLLEXPORT char *ts_datum_to_string(Datum value, Oid type);
 extern TSDLLEXPORT char *ts_internal_to_time_string(int64 value, Oid type);
 
 /*

--- a/src/with_clause/with_clause_parser.c
+++ b/src/with_clause/with_clause_parser.c
@@ -120,17 +120,11 @@ ts_with_clauses_parse(const List *def_elems, const WithClauseDefinition *args, S
 extern TSDLLEXPORT char *
 ts_with_clause_result_deparse_value(const WithClauseResult *result)
 {
-	Oid oid = result->definition->type_id;
-	Ensure(OidIsValid(oid), "argument \"%d\" has invalid OID", oid);
+	Ensure(OidIsValid(result->definition->type_id),
+		   "argument \"%d\" has invalid OID",
+		   result->definition->type_id);
 
-	Oid in_fn;
-	bool typIsVarlena pg_attribute_unused();
-
-	getTypeOutputInfo(oid, &in_fn, &typIsVarlena);
-	Ensure(OidIsValid(in_fn), "no output function for type with OID %d", oid);
-
-	char *val = OidOutputFunctionCall(in_fn, result->parsed);
-	return val;
+	return ts_datum_to_string(result->parsed, result->definition->type_id);
 }
 
 static Datum

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -34,7 +34,7 @@ typedef struct PolicyRetentionData
 {
 	Oid object_relid;
 	Datum boundary;
-	Datum boundary_type;
+	Oid boundary_type;
 	bool use_creation_time;
 } PolicyRetentionData;
 

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -2326,27 +2326,19 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 		 */
 		if (split_at < (slice->fd.range_start + 1) || split_at > (slice->fd.range_end - 2))
 		{
-			Oid outfuncid = InvalidOid;
-			bool isvarlena = false;
-
-			getTypeOutputInfo(splitdim_type, &outfuncid, &isvarlena);
-			Datum split_at_str = OidFunctionCall1(outfuncid, dim_datum);
-
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("cannot split chunk at %s", DatumGetCString(split_at_str))));
+					 errmsg("cannot split chunk at %s",
+							ts_datum_to_string(dim_datum, splitdim_type))));
 		}
 	}
 	else
 		split_at = slice->fd.range_start + (interval_range / 2);
 
-	Oid outfuncid = InvalidOid;
-	bool isvarlena = false;
-
-	getTypeOutputInfo(splitdim_type, &outfuncid, &isvarlena);
-	split_at_datum = ts_internal_to_time_value(split_at, splitdim_type);
-	Datum split_at_str = OidFunctionCall1(outfuncid, split_at_datum);
-	elog(DEBUG1, "splitting chunk %s at %s", get_rel_name(relid), DatumGetCString(split_at_str));
+	elog(DEBUG1,
+		 "splitting chunk %s at %s",
+		 get_rel_name(relid),
+		 ts_internal_to_time_string(split_at, splitdim_type));
 
 	const CompressionSettings *compress_settings = ts_compression_settings_get(relid);
 	int64 old_end = slice->fd.range_end;


### PR DESCRIPTION
Often we need to get the output string representation of a given value for certain Postgres type doing something like this:
```C
bool isvarlena;
Oid outfuncid;
getTypeOutputInfo(type, &outfuncid, &isvarlena);
Assert(OidIsValid(outfuncid));
valstr = OidOutputFunctionCall(outfuncid, datum);
```
So encapsulated this pattern into a new accessor function `ts_datum_to_string` and also use the `ts_internal_to_time_string` when necessary instead of repeat a lot of code.

Disable-check: force-changelog-file
