### PR TITLE
Improved pre & post release actions

### DIFF
--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -1,6 +1,8 @@
 name: Nightly - Update smoke test on release branch
 
-# Requires private GitHub action to deploy the last commit
+# QA: run the upgrade smoke tests with the last 10 releases 
+# against the the next version.
+# Requires upstream GitHub action to deploy the last commit
 # from the release branch to the QA service in Cloud
 
 "on":
@@ -12,6 +14,26 @@ name: Nightly - Update smoke test on release branch
       - .github/workflows/nightly_cloud_smoke_test.yaml
 
 jobs:
+  get-next-version:
+    runs-on: ubuntu-latest
+    outputs:
+      next_version: ${{ steps.fetch.outputs.next_version }}
+    steps:
+    - name: Get next version
+      # Get newest release branch with most recent commits
+      id: fetch
+      run: |
+        RELEASE_BRANCH=$(git ls-remote --heads https://github.com/timescale/timescaledb.git | \
+          grep -Eo 'refs/heads/[2-9]+\.[0-9]+\.x' | \
+          sed 's|refs/heads/||' | \
+          sort -V | \
+          tail -n1)
+        echo "current release branch: ${RELEASE_BRANCH}"
+        curl --fail -o version.config "https://raw.githubusercontent.com/timescale/timescaledb/refs/heads/${RELEASE_BRANCH}/version.config"
+        NEXT_VERSION=$(head -1 version.config | cut -d ' ' -f 3 | cut -d '-' -f 1)
+        echo "next version: ${NEXT_VERSION} .."
+        echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+
   generate-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -41,7 +63,7 @@ jobs:
           echo $matrix
 
   test-version:
-    needs: generate-matrix
+    needs: [generate-matrix, get-next-version]
     runs-on: ubuntu-latest
     strategy:
       # run sequentially
@@ -59,28 +81,15 @@ jobs:
           yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
           sudo apt-get update
           sudo apt-get install postgresql-17 
-
-      - name: Read versions
-        # Get two of the version parameters for test_update_smoke.sh
-        id: versions
-        run: |
-          # Read current version of TimescaleDB from version.config
-          # version will only be a proper version in a release branch 
-          if grep '^version = [0-9.]\+$' version.config; then
-            version=$(sed -ne 's!^version = !!p' version.config)
-          else
-            version=$(sed -ne 's!^previous_version = !!p' version.config)
-          fi
-          echo "version=${version}" >>$GITHUB_OUTPUT
     
-      - name: "Run update smoke test with v${{ matrix.version }} to ${{ steps.versions.outputs.version }}"
+      - name: "Run update smoke test with v${{ matrix.version }} to ${{needs.get-next-version.outputs.next_version}}"
         # Now run the test.  Currently the cloud instance is always up.
         # only run the test if the versions are not equal
         run: |
           PATH="/usr/lib/postgresql/17/bin:$PATH"
           ./scripts/test_update_smoke.sh \
               ${{ matrix.version }} \
-              ${{ steps.versions.outputs.version }} \
+              ${{needs.get-next-version.outputs.next_version}} \
               "${{ secrets.DB_TEAM_QA_SERVICE_CONNECTION_STRING }}"
       
       - name: Show logs

--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  post-release-ceremony:
-    name: Post Release Ceremony
+  main-branch:
+    name: Post Release Ceremony - main branch
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: |
           ./scripts/release/build_post_release_artefacts.sh ${{ github.event.release.tag_name }}
 
-      - name: Create Pull Request for forward ported artefacts
+      - name: PR for forward ported artefacts
         id: cpr_fwdp
         uses: peter-evans/create-pull-request@v7
         with:
@@ -48,3 +48,58 @@ jobs:
         if: ${{ steps.cpr_fwdp.outputs.pull-request-number }}
         run: |
           echo "Pull Request: ${{ steps.cpr_fwdp.outputs.pull-request-url }}"
+
+  release-branch:
+    name: Post Release Ceremony - release branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout TimescaleDB
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Bump to next version on release branch
+        run: |
+          TAGGED_VERSION=$(head -1 version.config | cut -d ' ' -f 3 | cut -d '-' -f 1)
+          if [[ "$TAGGED_VERSION" != "$${{ github.event.release.tag_name }}" ]]; then
+            echo "The tag: ${{ github.event.release.tag_name }} and the release version ${TAGGED_VERSION} do not match." >&2
+            exit 1
+          fi
+
+          RELEASE_BRANCH="${TAGGED_VERSION/%.d/.x}"
+          NEXT_VERSION=$(echo "$TAGGED_VERSION" | awk -F. '{printf "%d.%d.%d", $1, $2, $3+1}')
+          
+          echo "tagged version: ${TAGGED_VERSION}"
+          echo "next version: ${NEXT_VERSION}"
+
+          # adjust version.config file
+          sed -i \
+            -e "s/^version = .*/version = $NEXT_VERSION/" \
+            -e "s/^previous_version = .*/previous_version = $TAGGED_VERSION/" \
+            version.config
+
+          cat version.config
+
+          echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
+          echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_ENV
+
+      - name: PR for next version on release branch
+        id: cpr_next_version
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          branch: "release/${{ github.event.release.tag_name }}--bump-to-next-version"
+          base: ${{ env.RELEASE_BRANCH }}
+          delete-branch: true
+          title: "Bump to next version: ${{ env.NEXT_VERSION }}"
+          body: "Change to the next patch version ${{ env.NEXT_VERSION }} after the release of ${{ github.event.release.tag_name }}."
+          labels: |
+            release
+          add-paths: |
+            version.config
+      
+      - name: "Validate patch version bump PR"
+        if: ${{ steps.cpr_next_version.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request: ${{ steps.cpr_next_version.outputs.pull-request-url }}"


### PR DESCRIPTION
- the nightly QA action did not pull the latest release branch, when there was no tag for it yet. Hence, this would only be active after the first tag on that release branch. This was fixed now and run through on a fork, [result](https://github.com/philkra/timescaledb/actions/runs/16069603868)
- add automation to create a follow-up PR on the release branch to bump the patch versions immediately

Disable-check: approval-count
Disable-check: force-changelog-file