### PR TITLE
Fix flaky cagg_plugin

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -231,6 +231,7 @@ set(SOLO_TESTS
     cagg_ddl-${PG_VERSION_MAJOR}
     cagg_dump
     cagg_invalidation
+    cagg_plugin
     cagg_policy_incremental
     hypercore
     move


### PR DESCRIPTION
When creating a logical replication slot with a lot of concurrent transactions, `pg_create_logical_replication_slot` can fail with a memory allocation error inside `LogicalDecodingProcessRecord` because it tries to allocate too much memory.

To avoid this, we make the test a solo test for now.