### PR TITLE
Use TupleDescAttr macro to access TupleDesc attributes

### DIFF
--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -81,8 +81,8 @@ TupleDescGetAttrNumber(TupleDesc desc, const char *name)
 {
 	for (int i = 0; i < desc->natts; i++)
 	{
-		if (strcmp(name, NameStr(desc->attrs[i].attname)) == 0)
-			return desc->attrs[i].attnum;
+		if (strcmp(name, NameStr(TupleDescAttr(desc, i)->attname)) == 0)
+			return TupleDescAttr(desc, i)->attnum;
 	}
 
 	return InvalidAttrNumber;

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -95,7 +95,7 @@ build_mem_scankeys_from_slot(Oid ht_relid, CompressionSettings *settings, Relati
 		Datum value = slot_getattr(slot, ht_attno, &isnull);
 		(*slot_attnos)[key_index] = ht_attno;
 
-		Oid atttypid = out_desc->attrs[AttrNumberGetAttrOffset(attno)].atttypid;
+		Oid atttypid = TupleDescAttr(out_desc, AttrNumberGetAttrOffset(attno))->atttypid;
 		TypeCacheEntry *tce = lookup_type_cache(atttypid, TYPECACHE_BTREE_OPFAMILY);
 
 		/*
@@ -169,7 +169,8 @@ build_heap_scankeys(Oid hypertable_relid, Relation in_rel, Relation out_rel,
 			 */
 			PG_USED_FOR_ASSERTS_ONLY Oid ht_atttype = get_atttype(hypertable_relid, ht_attno);
 			PG_USED_FOR_ASSERTS_ONLY Oid slot_atttype =
-				slot->tts_tupleDescriptor->attrs[AttrNumberGetAttrOffset(ht_attno)].atttypid;
+				TupleDescAttr(slot->tts_tupleDescriptor, AttrNumberGetAttrOffset(ht_attno))
+					->atttypid;
 			Assert(ht_atttype == slot_atttype);
 
 			Datum value = slot_getattr(slot, ht_attno, &isnull);
@@ -532,7 +533,7 @@ create_segment_filter_scankey(Relation in_rel, char *segment_filter_col_name,
 	}
 	else
 	{
-		Oid atttypid = in_rel->rd_att->attrs[AttrNumberGetAttrOffset(cmp_attno)].atttypid;
+		Oid atttypid = TupleDescAttr(in_rel->rd_att, AttrNumberGetAttrOffset(cmp_attno))->atttypid;
 
 		TypeCacheEntry *tce = lookup_type_cache(atttypid, TYPECACHE_BTREE_OPFAMILY);
 		if (!OidIsValid(tce->btree_opf))
@@ -568,7 +569,8 @@ create_segment_filter_scankey(Relation in_rel, char *segment_filter_col_name,
 						   cmp_attno,
 						   strategy,
 						   subtype,
-						   in_rel->rd_att->attrs[AttrNumberGetAttrOffset(cmp_attno)].attcollation,
+						   TupleDescAttr(in_rel->rd_att, AttrNumberGetAttrOffset(cmp_attno))
+							   ->attcollation,
 						   opr,
 						   value);
 

--- a/tsl/src/hypercore/arrow_tts.c
+++ b/tsl/src/hypercore/arrow_tts.c
@@ -457,7 +457,7 @@ is_compressed_col(const TupleDesc tupdesc, AttrNumber attno)
 	if (attno == InvalidAttrNumber)
 		return false;
 
-	coltypid = tupdesc->attrs[AttrNumberGetAttrOffset(attno)].atttypid;
+	coltypid = TupleDescAttr(tupdesc, AttrNumberGetAttrOffset(attno))->atttypid;
 
 	if (typinfo == NULL)
 		typinfo = ts_custom_type_cache_get(CUSTOM_TYPE_COMPRESSED_DATA);

--- a/tsl/src/hypercore/hypercore_handler.c
+++ b/tsl/src/hypercore/hypercore_handler.c
@@ -286,7 +286,7 @@ lazy_build_hypercore_info_cache(Relation rel, bool create_chunk_constraints,
 
 	for (int i = 0; i < hcinfo->num_columns; i++)
 	{
-		const Form_pg_attribute attr = &tupdesc->attrs[i];
+		const Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
 		ColumnCompressionSettings *colsettings = &hcinfo->columns[i];
 
 		if (attr->attisdropped)

--- a/tsl/src/hypercore/vector_quals.c
+++ b/tsl/src/hypercore/vector_quals.c
@@ -60,7 +60,7 @@ vector_qual_state_get_arrow_array(VectorQualState *vqstate, Expr *expr, bool *is
 
 	if (array == NULL)
 	{
-		Form_pg_attribute attr = &slot->tts_tupleDescriptor->attrs[attoff];
+		Form_pg_attribute attr = TupleDescAttr(slot->tts_tupleDescriptor, attoff);
 		/*
 		 * If getting here, this is a non-compressed value or a compressed
 		 * column with a default value. We can treat non-compressed values the


### PR DESCRIPTION
PG18 splits TupleDesc into 2 parts. This patch changes our code to
always use TupleDescAttr to access attributes of TupleDesc.

https://github.com/postgres/postgres/commit/5983a4cf Introduce CompactAttribute array in TupleDesc, take 2
