### PR TITLE
Improve update test error information

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -50,6 +50,11 @@ jobs:
       run: |
         find update_test -name "*.diff" | xargs -IFILE sh -c "echo '\nFILE\n';cat FILE"
 
+    - name: Postgres Errors
+      if: failure()
+      run: |
+        find update_test -name postgres.log -exec grep ERROR {} \;
+
     - name: Check for coredumps
       if: always()
       id: collectlogs
@@ -84,7 +89,7 @@ jobs:
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: Coredumps sqlsmith ${{ matrix.os }} PG${{ matrix.pg }}
+        name: Coredumps update-test ${{ matrix.os }} PG${{ matrix.pg }}
         path: coredumps
 
     - name: Upload Artifacts

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -115,6 +115,8 @@ echo -e "\nUpdate test finished for ${VERSIONS}\n"
 
 if [ $FAIL_COUNT -gt 0 ]; then
   echo -e "Failed versions: ${FAILED_VERSIONS}\n"
+  echo -e "Postgres errors:\n"
+  find update_test -name postgres.log -exec grep ERROR {} \;
 else
   echo -e "All tests succeeded.\n"
 fi


### PR DESCRIPTION
When the update test does not fail due to diffing the instances
but during the ALTER EXTENSION itself you had to look into the
generated log artefacts to get to the bottom of the failure.
This PR adds this information to the normal workflow output.
