### PR TITLE
Update the tuples estimate in decompression planning

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -842,20 +842,35 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, con
 	compressed_rel->consider_parallel = chunk_rel->consider_parallel;
 	/* translate chunk_rel->baserestrictinfo */
 	pushdown_quals(root, compression_info->settings, chunk_rel, compressed_rel, consider_partial);
+
+    /*
+	 * Estimate the size of decompressed chunk based on the compressed chunk.
+     */
 	set_baserel_size_estimates(root, compressed_rel);
+
 	double new_row_estimate = compressed_rel->rows * TARGET_COMPRESSED_BATCH_SIZE;
 
+	/*
+	 * The tuple estimates derived from pg_class will be empty, so we have to
+	 * compute that based on the compressed relation as well. Wrong estimates
+	 * there lead to wrong join order choice and wrong low cost for Sort over
+	 * Append.
+	 */
+	double new_tuples_estimate = compressed_rel->tuples * TARGET_COMPRESSED_BATCH_SIZE;
+	
 	if (!compression_info->single_chunk)
 	{
 		/* adjust the parent's estimate by the diff of new and old estimate */
 		AppendRelInfo *chunk_info = ts_get_appendrelinfo(root, chunk_rel->relid, false);
 		Assert(chunk_info->parent_reloid == ht->main_table_relid);
-		ht_relid = chunk_info->parent_relid;
+		const Index ht_relid = chunk_info->parent_relid;
 		RelOptInfo *hypertable_rel = root->simple_rel_array[ht_relid];
 		hypertable_rel->rows += (new_row_estimate - chunk_rel->rows);
+		hypertable_rel->tuples += (new_tuples_estimate - chunk_rel->tuples);
 	}
 
 	chunk_rel->rows = new_row_estimate;
+	chunk_rel->tuples = new_tuples_estimate;
 
 	create_compressed_scan_paths(root, compressed_rel, compression_info, &sort_info);
 

--- a/tsl/test/expected/compress_bitmap_scan.out
+++ b/tsl/test/expected/compress_bitmap_scan.out
@@ -113,63 +113,73 @@ select * from bscan t1, bscan t2
 where (t2.id = 1 or t2.id = 2)
     and t1.s = t2.s
     and t1.payload = -537;
-                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=50 loops=1)
+                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=50 loops=1)
    Output: t1_1.ts, t1_1.s, t1_1.id, t1_1.payload, t2_1.ts, t2_1.s, t2_1.id, t2_1.payload
-   ->  Append (actual rows=18 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk t2_1 (actual rows=10 loops=1)
-               Output: t2_1.ts, t2_1.s, t2_1.id, t2_1.payload
-               Vectorized Filter: ((t2_1.id = 1) OR (t2_1.id = 2))
-               Rows Removed by Filter: 13990
-               Batches Removed by Filter: 4
-               Bulk Decompression: true
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=14 loops=1)
-                     Output: compress_hyper_2_3_chunk_1._ts_meta_count, compress_hyper_2_3_chunk_1.s, compress_hyper_2_3_chunk_1._ts_meta_min_2, compress_hyper_2_3_chunk_1._ts_meta_max_2, compress_hyper_2_3_chunk_1.ts, compress_hyper_2_3_chunk_1._ts_meta_min_1, compress_hyper_2_3_chunk_1._ts_meta_max_1, compress_hyper_2_3_chunk_1.id, compress_hyper_2_3_chunk_1._ts_meta_v2_bloom1_payload, compress_hyper_2_3_chunk_1.payload
-                     Recheck Cond: (((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 1)) OR ((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 2)))
-                     Heap Blocks: exact=6
-                     ->  BitmapOr (actual rows=0 loops=1)
-                           ->  Bitmap Index Scan on compress_hyper_2_3_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=9 loops=1)
-                                 Index Cond: ((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 1))
-                           ->  Bitmap Index Scan on compress_hyper_2_3_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=14 loops=1)
-                                 Index Cond: ((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 2))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk t2_2 (actual rows=8 loops=1)
-               Output: t2_2.ts, t2_2.s, t2_2.id, t2_2.payload
-               Vectorized Filter: ((t2_2.id = 1) OR (t2_2.id = 2))
-               Rows Removed by Filter: 11992
-               Batches Removed by Filter: 4
-               Bulk Decompression: true
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=12 loops=1)
-                     Output: compress_hyper_2_4_chunk_1._ts_meta_count, compress_hyper_2_4_chunk_1.s, compress_hyper_2_4_chunk_1._ts_meta_min_2, compress_hyper_2_4_chunk_1._ts_meta_max_2, compress_hyper_2_4_chunk_1.ts, compress_hyper_2_4_chunk_1._ts_meta_min_1, compress_hyper_2_4_chunk_1._ts_meta_max_1, compress_hyper_2_4_chunk_1.id, compress_hyper_2_4_chunk_1._ts_meta_v2_bloom1_payload, compress_hyper_2_4_chunk_1.payload
-                     Recheck Cond: (((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 1)) OR ((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 2)))
-                     Heap Blocks: exact=6
-                     ->  BitmapOr (actual rows=0 loops=1)
-                           ->  Bitmap Index Scan on compress_hyper_2_4_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=8 loops=1)
-                                 Index Cond: ((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 1))
-                           ->  Bitmap Index Scan on compress_hyper_2_4_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=12 loops=1)
-                                 Index Cond: ((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 2))
-   ->  Append (actual rows=3 loops=18)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk t1_1 (actual rows=1 loops=18)
+   Merge Cond: (t2_1.s = t1_1.s)
+   ->  Sort (actual rows=18 loops=1)
+         Output: t2_1.ts, t2_1.s, t2_1.id, t2_1.payload
+         Sort Key: t2_1.s
+         Sort Method: quicksort 
+         ->  Append (actual rows=18 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk t2_1 (actual rows=10 loops=1)
+                     Output: t2_1.ts, t2_1.s, t2_1.id, t2_1.payload
+                     Vectorized Filter: ((t2_1.id = 1) OR (t2_1.id = 2))
+                     Rows Removed by Filter: 13990
+                     Batches Removed by Filter: 4
+                     Bulk Decompression: true
+                     ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=14 loops=1)
+                           Output: compress_hyper_2_3_chunk_1._ts_meta_count, compress_hyper_2_3_chunk_1.s, compress_hyper_2_3_chunk_1._ts_meta_min_2, compress_hyper_2_3_chunk_1._ts_meta_max_2, compress_hyper_2_3_chunk_1.ts, compress_hyper_2_3_chunk_1._ts_meta_min_1, compress_hyper_2_3_chunk_1._ts_meta_max_1, compress_hyper_2_3_chunk_1.id, compress_hyper_2_3_chunk_1._ts_meta_v2_bloom1_payload, compress_hyper_2_3_chunk_1.payload
+                           Recheck Cond: (((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 1)) OR ((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 2)))
+                           Heap Blocks: exact=6
+                           ->  BitmapOr (actual rows=0 loops=1)
+                                 ->  Bitmap Index Scan on compress_hyper_2_3_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=9 loops=1)
+                                       Index Cond: ((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 1))
+                                 ->  Bitmap Index Scan on compress_hyper_2_3_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=14 loops=1)
+                                       Index Cond: ((compress_hyper_2_3_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_3_chunk_1._ts_meta_max_1 >= 2))
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk t2_2 (actual rows=8 loops=1)
+                     Output: t2_2.ts, t2_2.s, t2_2.id, t2_2.payload
+                     Vectorized Filter: ((t2_2.id = 1) OR (t2_2.id = 2))
+                     Rows Removed by Filter: 11992
+                     Batches Removed by Filter: 4
+                     Bulk Decompression: true
+                     ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=12 loops=1)
+                           Output: compress_hyper_2_4_chunk_1._ts_meta_count, compress_hyper_2_4_chunk_1.s, compress_hyper_2_4_chunk_1._ts_meta_min_2, compress_hyper_2_4_chunk_1._ts_meta_max_2, compress_hyper_2_4_chunk_1.ts, compress_hyper_2_4_chunk_1._ts_meta_min_1, compress_hyper_2_4_chunk_1._ts_meta_max_1, compress_hyper_2_4_chunk_1.id, compress_hyper_2_4_chunk_1._ts_meta_v2_bloom1_payload, compress_hyper_2_4_chunk_1.payload
+                           Recheck Cond: (((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 1)) OR ((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 2)))
+                           Heap Blocks: exact=6
+                           ->  BitmapOr (actual rows=0 loops=1)
+                                 ->  Bitmap Index Scan on compress_hyper_2_4_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=8 loops=1)
+                                       Index Cond: ((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 1) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 1))
+                                 ->  Bitmap Index Scan on compress_hyper_2_4_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx (actual rows=12 loops=1)
+                                       Index Cond: ((compress_hyper_2_4_chunk_1._ts_meta_min_1 <= 2) AND (compress_hyper_2_4_chunk_1._ts_meta_max_1 >= 2))
+   ->  Materialize (actual rows=618 loops=1)
+         Output: t1_1.ts, t1_1.s, t1_1.id, t1_1.payload
+         ->  Sort (actual rows=618 loops=1)
                Output: t1_1.ts, t1_1.s, t1_1.id, t1_1.payload
-               Vectorized Filter: (t1_1.payload = '-537'::integer)
-               Rows Removed by Filter: 1115
-               Batches Removed by Filter: 1
-               Bulk Decompression: true
-               ->  Index Scan using compress_hyper_2_3_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=1 loops=18)
-                     Output: compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk.s, compress_hyper_2_3_chunk._ts_meta_min_2, compress_hyper_2_3_chunk._ts_meta_max_2, compress_hyper_2_3_chunk.ts, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1, compress_hyper_2_3_chunk.id, compress_hyper_2_3_chunk._ts_meta_v2_bloom1_payload, compress_hyper_2_3_chunk.payload
-                     Index Cond: (compress_hyper_2_3_chunk.s = t2_1.s)
-                     Filter: _timescaledb_functions.bloom1_contains(compress_hyper_2_3_chunk._ts_meta_v2_bloom1_payload, '-537'::integer)
-                     Rows Removed by Filter: 2
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk t1_2 (actual rows=1 loops=18)
-               Output: t1_2.ts, t1_2.s, t1_2.id, t1_2.payload
-               Vectorized Filter: (t1_2.payload = '-537'::integer)
-               Rows Removed by Filter: 1115
-               Bulk Decompression: true
-               ->  Index Scan using compress_hyper_2_4_chunk_s__ts_meta_min_1__ts_meta_max_1__t_idx on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=1 loops=18)
-                     Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.s, compress_hyper_2_4_chunk._ts_meta_min_2, compress_hyper_2_4_chunk._ts_meta_max_2, compress_hyper_2_4_chunk.ts, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk.id, compress_hyper_2_4_chunk._ts_meta_v2_bloom1_payload, compress_hyper_2_4_chunk.payload
-                     Index Cond: (compress_hyper_2_4_chunk.s = t2_1.s)
-                     Filter: _timescaledb_functions.bloom1_contains(compress_hyper_2_4_chunk._ts_meta_v2_bloom1_payload, '-537'::integer)
-                     Rows Removed by Filter: 2
-(55 rows)
+               Sort Key: t1_1.s
+               Sort Method: quicksort 
+               ->  Append (actual rows=674 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk t1_1 (actual rows=337 loops=1)
+                           Output: t1_1.ts, t1_1.s, t1_1.id, t1_1.payload
+                           Vectorized Filter: (t1_1.payload = '-537'::integer)
+                           Rows Removed by Filter: 259321
+                           Batches Removed by Filter: 3
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=276 loops=1)
+                                 Output: compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk.s, compress_hyper_2_3_chunk._ts_meta_min_2, compress_hyper_2_3_chunk._ts_meta_max_2, compress_hyper_2_3_chunk.ts, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1, compress_hyper_2_3_chunk.id, compress_hyper_2_3_chunk._ts_meta_v2_bloom1_payload, compress_hyper_2_3_chunk.payload
+                                 Filter: _timescaledb_functions.bloom1_contains(compress_hyper_2_3_chunk._ts_meta_v2_bloom1_payload, '-537'::integer)
+                                 Rows Removed by Filter: 441
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk t1_2 (actual rows=337 loops=1)
+                           Output: t1_2.ts, t1_2.s, t1_2.id, t1_2.payload
+                           Vectorized Filter: (t1_2.payload = '-537'::integer)
+                           Rows Removed by Filter: 258227
+                           Batches Removed by Filter: 3
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=274 loops=1)
+                                 Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.s, compress_hyper_2_4_chunk._ts_meta_min_2, compress_hyper_2_4_chunk._ts_meta_max_2, compress_hyper_2_4_chunk.ts, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk.id, compress_hyper_2_4_chunk._ts_meta_v2_bloom1_payload, compress_hyper_2_4_chunk.payload
+                                 Filter: _timescaledb_functions.bloom1_contains(compress_hyper_2_4_chunk._ts_meta_v2_bloom1_payload, '-537'::integer)
+                                 Rows Removed by Filter: 443
+(65 rows)
 
 ;

--- a/tsl/test/expected/compress_qualpushdown_saop.out
+++ b/tsl/test/expected/compress_qualpushdown_saop.out
@@ -459,21 +459,18 @@ select * from saop where segmentby = '1' or (with_bloom = stable_lower('1') and 
 explain (analyze, costs off, timing off, summary off)
 with arrays as (select array[segmentby] a from saop group by segmentby order by segmentby limit 10)
 select * from saop, arrays where segmentby = any(a);
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=43479 loops=1)
    ->  Limit (actual rows=10 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: _hyper_1_1_chunk_1.segmentby
-               Sort Method: top-N heapsort 
-               ->  HashAggregate (actual rows=23 loops=1)
-                     Group Key: _hyper_1_1_chunk_1.segmentby
-                     Batches: 1 
-                     ->  Append (actual rows=100000 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50000 loops=1)
-                                 ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=50000 loops=1)
-                                 ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=69 loops=1)
+         ->  Group (actual rows=10 loops=1)
+               Group Key: _hyper_1_1_chunk_1.segmentby
+               ->  Merge Append (actual rows=39132 loops=1)
+                     Sort Key: _hyper_1_1_chunk_1.segmentby
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=19566 loops=1)
+                           ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=28 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=19567 loops=1)
+                           ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=28 loops=1)
    ->  Append (actual rows=4348 loops=10)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2174 loops=10)
                Filter: (segmentby = ANY ((ARRAY[_hyper_1_1_chunk_1.segmentby])))
@@ -483,13 +480,13 @@ select * from saop, arrays where segmentby = any(a);
                Filter: (segmentby = ANY ((ARRAY[_hyper_1_1_chunk_1.segmentby])))
                ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk (actual rows=3 loops=10)
                      Index Cond: (segmentby = ANY ((ARRAY[_hyper_1_1_chunk_1.segmentby])))
-(22 rows)
+(19 rows)
 
 explain (analyze, costs off, timing off, summary off)
 with arrays as (select array[segmentby] a from saop group by segmentby order by segmentby limit 10)
 select * from saop, arrays where with_minmax = any(a);
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=34481 loops=1)
    Join Filter: (_hyper_1_1_chunk.with_minmax = ANY (arrays.a))
    Rows Removed by Join Filter: 965519
@@ -501,24 +498,21 @@ select * from saop, arrays where with_minmax = any(a);
    ->  Materialize (actual rows=10 loops=100000)
          ->  Subquery Scan on arrays (actual rows=10 loops=1)
                ->  Limit (actual rows=10 loops=1)
-                     ->  Sort (actual rows=10 loops=1)
-                           Sort Key: _hyper_1_1_chunk_1.segmentby
-                           Sort Method: top-N heapsort 
-                           ->  HashAggregate (actual rows=23 loops=1)
-                                 Group Key: _hyper_1_1_chunk_1.segmentby
-                                 Batches: 1 
-                                 ->  Append (actual rows=100000 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50000 loops=1)
-                                             ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=50000 loops=1)
-                                             ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=69 loops=1)
-(22 rows)
+                     ->  Group (actual rows=10 loops=1)
+                           Group Key: _hyper_1_1_chunk_1.segmentby
+                           ->  Merge Append (actual rows=39132 loops=1)
+                                 Sort Key: _hyper_1_1_chunk_1.segmentby
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=19566 loops=1)
+                                       ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=28 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=19567 loops=1)
+                                       ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=28 loops=1)
+(19 rows)
 
 explain (analyze, costs off, timing off, summary off)
 with arrays as (select array[segmentby] a from saop group by segmentby order by segmentby limit 10)
 select * from saop, arrays where with_bloom = any(a);
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=473 loops=1)
    Join Filter: (_hyper_1_1_chunk.with_bloom = ANY (arrays.a))
    Rows Removed by Join Filter: 999527
@@ -530,18 +524,15 @@ select * from saop, arrays where with_bloom = any(a);
    ->  Materialize (actual rows=10 loops=100000)
          ->  Subquery Scan on arrays (actual rows=10 loops=1)
                ->  Limit (actual rows=10 loops=1)
-                     ->  Sort (actual rows=10 loops=1)
-                           Sort Key: _hyper_1_1_chunk_1.segmentby
-                           Sort Method: top-N heapsort 
-                           ->  HashAggregate (actual rows=23 loops=1)
-                                 Group Key: _hyper_1_1_chunk_1.segmentby
-                                 Batches: 1 
-                                 ->  Append (actual rows=100000 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50000 loops=1)
-                                             ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=50000 loops=1)
-                                             ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=69 loops=1)
-(22 rows)
+                     ->  Group (actual rows=10 loops=1)
+                           Group Key: _hyper_1_1_chunk_1.segmentby
+                           ->  Merge Append (actual rows=39132 loops=1)
+                                 Sort Key: _hyper_1_1_chunk_1.segmentby
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=19566 loops=1)
+                                       ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=28 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=19567 loops=1)
+                                       ->  Index Scan using compress_hyper_2_4_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=28 loops=1)
+(19 rows)
 
 -- Array parameter of prepared statements.
 prepare array_param as select * from saop where with_bloom = any($1);

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -2458,10 +2458,11 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                                         QUERY PLAN                                                                                         
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Nested Loop (actual rows=10 loops=1)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
          ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=10 loops=1)
                Order: m1."time", m1.device_id
                ->  Sort (actual rows=10 loops=1)
@@ -2476,21 +2477,22 @@ FROM :TEST_TABLE m1
                      Sort Key: m1_3."time", m1_3.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
                            ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-         ->  Append (actual rows=1 loops=10)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1 loops=10)
-                     Filter: ("time" = m1."time")
-                     Rows Removed by Filter: 647
-                     ->  Index Scan using compress_hyper_5_15_chunk_device_id_device_id_peer__ts_meta_idx on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=10)
-                           Index Cond: (device_id = m1.device_id)
-               ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=0 loops=9)
-                     Index Cond: ("time" = m1."time")
-                     Filter: (m1.device_id = device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=0 loops=9)
-                     Filter: ("time" = m1."time")
-                     Rows Removed by Filter: 336
-                     ->  Index Scan using compress_hyper_5_16_chunk_device_id_device_id_peer__ts_meta_idx on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=9)
-                           Index Cond: (device_id = m1.device_id)
-(30 rows)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=10 loops=1)
+                     Order: m2."time", m2.device_id
+                     ->  Sort (actual rows=10 loops=1)
+                           Sort Key: m2_1."time", m2_1.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                     ->  Sort (never executed)
+                           Sort Key: m2_2."time", m2_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m2_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m2_3."time", m2_3.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+(32 rows)
 
 :PREFIX
 SELECT *
@@ -2502,58 +2504,63 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Merge Join (actual rows=10 loops=1)
-         Merge Cond: (m1."time" = m2_1."time")
-         Join Filter: (m2_1.device_id = m1.device_id)
-         Rows Removed by Join Filter: 40
-         ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=10 loops=1)
-               Order: m1."time", m1.device_id
-               ->  Sort (actual rows=10 loops=1)
-                     Sort Key: m1_1."time", m1_1.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=3600 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-               ->  Sort (never executed)
-                     Sort Key: m1_2."time", m1_2.device_id
-                     ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
-               ->  Sort (never executed)
-                     Sort Key: m1_3."time", m1_3.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-         ->  Materialize (actual rows=50 loops=1)
-               ->  Nested Loop (actual rows=11 loops=1)
-                     Join Filter: (m2_1."time" = m3_1."time")
-                     Rows Removed by Join Filter: 17272
-                     ->  Merge Append (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
-                           ->  Sort (actual rows=3 loops=1)
-                                 Sort Key: m3_1."time"
+         Merge Cond: (m1."time" = m3_1."time")
+         ->  Merge Join (actual rows=10 loops=1)
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=10 loops=1)
+                     Order: m1."time", m1.device_id
+                     ->  Sort (actual rows=10 loops=1)
+                           Sort Key: m1_1."time", m1_1.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=3600 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Sort (never executed)
+                           Sort Key: m1_2."time", m1_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_3."time", m1_3.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+               ->  Materialize (actual rows=10 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=10 loops=1)
+                           Order: m2."time", m2.device_id
+                           ->  Sort (actual rows=10 loops=1)
+                                 Sort Key: m2_1."time", m2_1.device_id
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=720 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
-                                             Filter: (device_id = 3)
-                                             Rows Removed by Filter: 4
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
-                                 Filter: (device_id = 3)
-                                 Rows Removed by Filter: 2
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: m3_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=336 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
-                                             Filter: (device_id = 3)
-                                             Rows Removed by Filter: 4
-                     ->  Materialize (actual rows=5761 loops=3)
-                           ->  Append (actual rows=8640 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                        ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                                 ->  Seq Scan on _hyper_1_2_chunk m2_2 (actual rows=3360 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=1680 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(49 rows)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_2."time", m2_2.device_id
+                                 ->  Seq Scan on _hyper_1_2_chunk m2_2 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_3."time", m2_3.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Merge Append (actual rows=3 loops=1)
+                     Sort Key: m3_1."time"
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                                       Rows Removed by Filter: 4
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
+                           Filter: (device_id = 3)
+                           Rows Removed by Filter: 2
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: m3_3."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=336 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                                       Rows Removed by Filter: 4
+(54 rows)
 
 :PREFIX
 SELECT *
@@ -2713,36 +2720,36 @@ ORDER BY m1.time,
     m2.time,
     m2.device_id
 LIMIT 100;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1_1."time", m1_1.device_id, m2_1."time", m2_1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=8640 loops=1)
-               Hash Cond: (m1_1."time" = m2_1."time")
+         ->  Hash Right Join (actual rows=8640 loops=1)
+               Hash Cond: (m2_1."time" = m1_1."time")
                Join Filter: (m1_1.device_id = 1)
                Rows Removed by Join Filter: 6912
-               ->  Append (actual rows=8640 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=3600 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Seq Scan on _hyper_1_2_chunk m1_2 (actual rows=3360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               ->  Hash (actual rows=1728 loops=1)
-                     Buckets: 4096  Batches: 1 
-                     ->  Append (actual rows=1728 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=720 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
-                           ->  Seq Scan on _hyper_1_2_chunk m2_2 (actual rows=672 loops=1)
+               ->  Append (actual rows=1728 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 2688
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=336 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                 Rows Removed by Filter: 4
+                     ->  Seq Scan on _hyper_1_2_chunk m2_2 (actual rows=672 loops=1)
+                           Filter: (device_id = 2)
+                           Rows Removed by Filter: 2688
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=336 loops=1)
+                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
+                                 Filter: (device_id = 2)
+                                 Rows Removed by Filter: 4
+               ->  Hash (actual rows=8640 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=8640 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=3600 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (actual rows=3360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (28 rows)
 
 :PREFIX
@@ -6781,89 +6788,114 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Merge Join (actual rows=10 loops=1)
-         Merge Cond: (m1."time" = m2_1."time")
-         Join Filter: (m1.device_id = m2_1.device_id)
-         Rows Removed by Join Filter: 39
-         ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=10 loops=1)
-               Order: m1."time", m1.device_id
+         Merge Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
+         ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=10 loops=1)
+               Order: m2."time", m2.device_id
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: m1_1."time", m1_1.device_id
+                     Sort Key: m2_1."time", m2_1.device_id
                      ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m1_1."time", m1_1.device_id
+                           Sort Key: m2_1."time", m2_1.device_id
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=720 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
                      ->  Sort (actual rows=6 loops=1)
-                           Sort Key: m1_2."time", m1_2.device_id
+                           Sort Key: m2_2."time", m2_2.device_id
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=2160 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=2160 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m1_3."time", m1_3.device_id
+                           Sort Key: m2_3."time", m2_3.device_id
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=720 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
                ->  Merge Append (never executed)
-                     Sort Key: m1_4."time", m1_4.device_id
+                     Sort Key: m2_4."time", m2_4.device_id
                      ->  Sort (never executed)
-                           Sort Key: m1_4."time", m1_4.device_id
-                           ->  Seq Scan on _hyper_2_7_chunk m1_4 (never executed)
+                           Sort Key: m2_4."time", m2_4.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk m2_4 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_5."time", m1_5.device_id
-                           ->  Seq Scan on _hyper_2_8_chunk m1_5 (never executed)
+                           Sort Key: m2_5."time", m2_5.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk m2_5 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_6."time", m1_6.device_id
-                           ->  Seq Scan on _hyper_2_9_chunk m1_6 (never executed)
+                           Sort Key: m2_6."time", m2_6.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk m2_6 (never executed)
                ->  Merge Append (never executed)
-                     Sort Key: m1_7."time", m1_7.device_id
+                     Sort Key: m2_7."time", m2_7.device_id
                      ->  Sort (never executed)
-                           Sort Key: m1_7."time", m1_7.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                           Sort Key: m2_7."time", m2_7.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_8."time", m1_8.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                           Sort Key: m2_8."time", m2_8.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_9."time", m1_9.device_id
-                           ->  Seq Scan on _hyper_2_12_chunk m1_9 (never executed)
-         ->  Materialize (actual rows=49 loops=1)
-               ->  Nested Loop (actual rows=11 loops=1)
-                     Join Filter: (m2_1."time" = m3_1."time")
-                     Rows Removed by Join Filter: 17272
-                     ->  Merge Append (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
-                           ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m2_9."time", m2_9.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk m2_9 (never executed)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Merge Join (actual rows=10 loops=1)
+                     Merge Cond: (m1."time" = m3_1."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=10 loops=1)
+                           Order: m1."time", m1.device_id
+                           ->  Merge Append (actual rows=10 loops=1)
+                                 Sort Key: m1_1."time", m1_1.device_id
+                                 ->  Sort (actual rows=3 loops=1)
+                                       Sort Key: m1_1."time", m1_1.device_id
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=720 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Sort (actual rows=6 loops=1)
+                                       Sort Key: m1_2."time", m1_2.device_id
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=2160 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Sort (actual rows=3 loops=1)
+                                       Sort Key: m1_3."time", m1_3.device_id
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=720 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Merge Append (never executed)
+                                 Sort Key: m1_4."time", m1_4.device_id
+                                 ->  Sort (never executed)
+                                       Sort Key: m1_4."time", m1_4.device_id
+                                       ->  Seq Scan on _hyper_2_7_chunk m1_4 (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: m1_5."time", m1_5.device_id
+                                       ->  Seq Scan on _hyper_2_8_chunk m1_5 (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: m1_6."time", m1_6.device_id
+                                       ->  Seq Scan on _hyper_2_9_chunk m1_6 (never executed)
+                           ->  Merge Append (never executed)
+                                 Sort Key: m1_7."time", m1_7.device_id
+                                 ->  Sort (never executed)
+                                       Sort Key: m1_7."time", m1_7.device_id
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: m1_8."time", m1_8.device_id
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: m1_9."time", m1_9.device_id
+                                       ->  Seq Scan on _hyper_2_12_chunk m1_9 (never executed)
+                     ->  Materialize (actual rows=10 loops=1)
+                           ->  Merge Append (actual rows=3 loops=1)
                                  Sort Key: m3_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=720 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
-                                             Filter: (device_id = 3)
-                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
-                                 Filter: (device_id = 3)
-                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3_3 (actual rows=1 loops=1)
-                                 Filter: (device_id = 3)
-                     ->  Materialize (actual rows=5761 loops=3)
-                           ->  Append (actual rows=8640 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=2160 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=720 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
-                                 ->  Seq Scan on _hyper_2_7_chunk m2_4 (actual rows=672 loops=1)
-                                 ->  Seq Scan on _hyper_2_8_chunk m2_5 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on _hyper_2_9_chunk m2_6 (actual rows=672 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (actual rows=336 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (actual rows=1008 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
-                                 ->  Seq Scan on _hyper_2_12_chunk m2_9 (actual rows=336 loops=1)
-(80 rows)
+                                 ->  Sort (actual rows=3 loops=1)
+                                       Sort Key: m3_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=720 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                                   Filter: (device_id = 3)
+                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3_3 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+(105 rows)
 
 :PREFIX
 SELECT *
@@ -7074,62 +7106,62 @@ ORDER BY m1.time,
     m2.time,
     m2.device_id
 LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1_1."time", m1_1.device_id, m2_1."time", m2_1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=8640 loops=1)
-               Hash Cond: (m1_1."time" = m2_1."time")
+         ->  Hash Right Join (actual rows=8640 loops=1)
+               Hash Cond: (m2_1."time" = m1_1."time")
                Join Filter: (m1_1.device_id = 1)
                Rows Removed by Join Filter: 6912
-               ->  Append (actual rows=8640 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=720 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=2160 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=720 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_4 (actual rows=672 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_6 (actual rows=672 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=336 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (actual rows=1008 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
-               ->  Hash (actual rows=1728 loops=1)
-                     Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=1728 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 1
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=720 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 1
-                           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m2_4 (actual rows=0 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_5 (actual rows=672 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk m2_6 (actual rows=0 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (actual rows=0 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 1
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (actual rows=336 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=1 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk m2_9 (actual rows=0 loops=1)
-                                 Index Cond: (device_id = 2)
+               ->  Append (actual rows=1728 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
+                                 Filter: (device_id = 2)
+                                 Rows Removed by Filter: 1
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
+                                 Filter: (device_id = 2)
+                                 Rows Removed by Filter: 2
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
+                                 Filter: (device_id = 2)
+                                 Rows Removed by Filter: 1
+                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m2_4 (actual rows=0 loops=1)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_5 (actual rows=672 loops=1)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk m2_6 (actual rows=0 loops=1)
+                           Index Cond: (device_id = 2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
+                                 Filter: (device_id = 2)
+                                 Rows Removed by Filter: 1
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (actual rows=336 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=1 loops=1)
+                                 Filter: (device_id = 2)
+                                 Rows Removed by Filter: 2
+                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk m2_9 (actual rows=0 loops=1)
+                           Index Cond: (device_id = 2)
+               ->  Hash (actual rows=8640 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=8640 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=2160 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m1_4 (actual rows=672 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m1_5 (actual rows=2016 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m1_6 (actual rows=672 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=336 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (actual rows=1008 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
 (54 rows)
 
 :PREFIX
@@ -7688,36 +7720,32 @@ VACUUM ANALYZE metrics_ordered;
                      ->  Index Scan using compress_hyper_12_30_chunk_device_id_device_id_peer__ts_met_idx on compress_hyper_12_30_chunk (actual rows=5 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_3 (actual rows=1680 loops=1)
                      ->  Index Scan using compress_hyper_12_31_chunk_device_id_device_id_peer__ts_met_idx on compress_hyper_12_31_chunk (actual rows=5 loops=1)
-         ->  Memoize (actual rows=0 loops=8640)
-               Cache Key: d_1.device_id
-               Cache Mode: binary
-               Hits: 8635  Misses: 5  Evictions: 0  Overflows: 0 
-               ->  Limit (actual rows=0 loops=5)
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=5)
-                           Order: m."time" DESC
-                           Hypertables excluded during runtime: 0
-                           ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=5)
-                                 ->  Sort (actual rows=0 loops=5)
-                                       Sort Key: compress_hyper_12_31_chunk_1._ts_meta_min_1 DESC, compress_hyper_12_31_chunk_1._ts_meta_max_1 DESC
-                                       Sort Method: quicksort 
-                                       ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=5)
-                                             Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                             Rows Removed by Filter: 5
-                           ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=5)
-                                 ->  Sort (actual rows=0 loops=5)
-                                       Sort Key: compress_hyper_12_30_chunk_1._ts_meta_min_1 DESC, compress_hyper_12_30_chunk_1._ts_meta_max_1 DESC
-                                       Sort Method: quicksort 
-                                       ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=5)
-                                             Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                             Rows Removed by Filter: 5
-                           ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=5)
-                                 ->  Sort (actual rows=0 loops=5)
-                                       Sort Key: compress_hyper_12_29_chunk_1._ts_meta_min_1 DESC, compress_hyper_12_29_chunk_1._ts_meta_max_1 DESC
-                                       Sort Method: quicksort 
-                                       ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=5)
-                                             Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                             Rows Removed by Filter: 5
-(39 rows)
+         ->  Limit (actual rows=0 loops=8640)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=8640)
+                     Order: m."time" DESC
+                     Hypertables excluded during runtime: 0
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=8640)
+                           ->  Sort (actual rows=0 loops=8640)
+                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_min_1 DESC, compress_hyper_12_31_chunk_1._ts_meta_max_1 DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=8640)
+                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+                                       Rows Removed by Filter: 5
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=8640)
+                           ->  Sort (actual rows=0 loops=8640)
+                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_min_1 DESC, compress_hyper_12_30_chunk_1._ts_meta_max_1 DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=8640)
+                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+                                       Rows Removed by Filter: 5
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=8640)
+                           ->  Sort (actual rows=0 loops=8640)
+                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_min_1 DESC, compress_hyper_12_29_chunk_1._ts_meta_max_1 DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=8640)
+                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+                                       Rows Removed by Filter: 5
+(35 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression_ordered_index-17.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-17.out
@@ -564,29 +564,29 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
    ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (nd.node = mt_1.device_id)
+         Hash Cond: (mt_1.device_id = nd.node)
          Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
          Rows Removed by Join Filter: 289
-         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Hash (actual rows=1540 loops=1)
-               Buckets: 32768  Batches: 1 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Append (actual rows=1541 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 2048  Batches: 1 
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
 (21 rows)
 
 --enable all joins after the tests


### PR DESCRIPTION
We have to update the RelOptInfo.tuples for the uncompressed chunk relation and the hypertable relation, not only the RelOptInfo.rows.