### PR TITLE
Show available timescaledb ALTER options when encountering unsupported options

### DIFF
--- a/.unreleased/pr_8371
+++ b/.unreleased/pr_8371
@@ -1,0 +1,1 @@
+Implements: #8371 Show available timescaledb ALTER options when encountering unsupported options

--- a/src/with_clause/with_clause_parser.c
+++ b/src/with_clause/with_clause_parser.c
@@ -56,6 +56,24 @@ ts_with_clause_filter(const List *def_elems, List **within_namespace, List **not
 
 static Datum parse_arg(WithClauseDefinition arg, DefElem *def);
 
+static char *
+ts_with_clause_definition_names(const WithClauseDefinition *args, Size nargs)
+{
+	StringInfoData buf;
+	Size i;
+
+	initStringInfo(&buf);
+
+	for (i = 0; i < nargs; i++)
+	{
+		if (i > 0)
+			appendStringInfoString(&buf, ", ");
+		appendStringInfoString(&buf, args[i].arg_names[0]);
+	}
+
+	return buf.data;
+}
+
 /*
  * Deserialize and apply the values in a WITH clause based on the on_arg table.
  *
@@ -111,7 +129,9 @@ ts_with_clauses_parse(const List *def_elems, const WithClauseDefinition *args, S
 		if (!argument_recognized)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("unrecognized parameter \"%s.%s\"", def->defnamespace, def->defname)));
+					 errmsg("unrecognized parameter \"%s.%s\"", def->defnamespace, def->defname),
+					 errhint("Valid timescaledb parameters are: %s",
+							 ts_with_clause_definition_names(args, nargs))));
 	}
 
 	return results;

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -20,6 +20,18 @@ NOTICE:  adding not-null constraint to column "time"
  (1,public,alter_before,t)
 (1 row)
 
+-- Test error hint for invalid timescaledb options on ALTER TABLE
+\set ON_ERROR_STOP 0
+-- Invalid timescaledb option should show hint with valid options
+\set VERBOSITY default
+ALTER TABLE alter_before SET (tsdb.invalid_option = true);
+ERROR:  unrecognized parameter "tsdb.invalid_option"
+HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval
+ALTER TABLE alter_before SET (timescaledb.nonexistent = false);
+ERROR:  unrecognized parameter "timescaledb.nonexistent"
+HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
 INSERT INTO alter_before VALUES ('2017-03-22T09:18:22', 23.5, 1);
 SELECT * FROM alter_before;
            time           | temp | colorid | notes | notes_2 

--- a/test/expected/create_table_with.out
+++ b/test/expected/create_table_with.out
@@ -10,10 +10,13 @@ CREATE TABLE t1(time timestamptz, device text, value float) WITH (autovacuum_ena
 DROP TABLE t1;
 -- test error cases
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
 ERROR:  hypertable option requires time_column
+HINT:  Use "timescaledb.partition_column" to specify the column to use as partitioning column.
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
 ERROR:  hypertable option requires time_column
+HINT:  Use "timescaledb.partition_column" to specify the column to use as partitioning column.
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column=NULL);
 ERROR:  column "null" does not exist
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='');
@@ -22,23 +25,38 @@ CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertabl
 ERROR:  column "foo" does not exist
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.partition_column='time');
 ERROR:  timescaledb options requires hypertable option
+HINT:  Use "timescaledb.hypertable" to enable creating a hypertable.
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.partition_column='time');
 ERROR:  timescaledb options requires hypertable option
+HINT:  Use "timescaledb.hypertable" to enable creating a hypertable.
 CREATE TABLE t2(time timestamptz , device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval='foo');
 ERROR:  invalid input syntax for type interval: "foo"
 CREATE TABLE t2(time int2 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval='3 months');
 ERROR:  invalid input syntax for type smallint: "3 months"
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes='time');
 ERROR:  invalid value for tsdb.create_default_indexes 'time'
+HINT:  tsdb.create_default_indexes must be a valid bool
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes=2);
 ERROR:  invalid value for tsdb.create_default_indexes '2'
+HINT:  tsdb.create_default_indexes must be a valid bool
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes=-1);
 ERROR:  invalid value for tsdb.create_default_indexes '-1'
+HINT:  tsdb.create_default_indexes must be a valid bool
 CREATE TABLE t2(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
 ERROR:  functionality not supported under the current "apache" license. Learn more at https://tsdb.co/pdbir1r3
-CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore,tsdb.hypertable,tsdb.partition_column='time');
+HINT:  To access all features and the best time-series experience, try out Timescale Cloud.
+CREATE TABLE t2(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore,tsdb.hypertable,tsdb.partition_column='time');
 ERROR:  functionality not supported under the current "apache" license. Learn more at https://tsdb.co/pdbir1r3
+HINT:  To access all features and the best time-series experience, try out Timescale Cloud.
+-- Test error hint for invalid timescaledb options during CREATE TABLE
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.invalid_option = true);
+ERROR:  unrecognized parameter "tsdb.invalid_option"
+HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_column, chunk_interval, create_default_indexes, associated_schema, associated_table_prefix, orderby, segmentby
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.nonexistent_param = false);
+ERROR:  unrecognized parameter "timescaledb.nonexistent_param"
+HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_column, chunk_interval, create_default_indexes, associated_schema, associated_table_prefix, orderby, segmentby
 \set ON_ERROR_STOP 1
+\set VERBOSITY terse
 BEGIN;
 CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore=false,tsdb.hypertable,tsdb.partition_column='time');
 CREATE TABLE t4(time timestamp, device text, value float) WITH (tsdb.columnstore=false,tsdb.hypertable,timescaledb.partition_column='time');

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -17,6 +17,15 @@ ALTER TABLE alter_before ALTER COLUMN notes SET STORAGE EXTERNAL;
 
 SELECT create_hypertable('alter_before', 'time', chunk_time_interval => 2628000000000);
 
+-- Test error hint for invalid timescaledb options on ALTER TABLE
+\set ON_ERROR_STOP 0
+-- Invalid timescaledb option should show hint with valid options
+\set VERBOSITY default
+ALTER TABLE alter_before SET (tsdb.invalid_option = true);
+ALTER TABLE alter_before SET (timescaledb.nonexistent = false);
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+
 INSERT INTO alter_before VALUES ('2017-03-22T09:18:22', 23.5, 1);
 
 SELECT * FROM alter_before;

--- a/test/sql/create_table_with.sql
+++ b/test/sql/create_table_with.sql
@@ -13,6 +13,7 @@ DROP TABLE t1;
 
 -- test error cases
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable);
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.hypertable);
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column=NULL);
@@ -26,8 +27,12 @@ CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_de
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes=2);
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.create_default_indexes=-1);
 CREATE TABLE t2(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
-CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore,tsdb.hypertable,tsdb.partition_column='time');
+CREATE TABLE t2(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore,tsdb.hypertable,tsdb.partition_column='time');
+-- Test error hint for invalid timescaledb options during CREATE TABLE
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.invalid_option = true);
+CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.nonexistent_param = false);
 \set ON_ERROR_STOP 1
+\set VERBOSITY terse
 
 
 BEGIN;

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -26,6 +26,7 @@ select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 ERROR:  unrecognized parameter "timescaledb.myfill"
+HINT:  Valid timescaledb parameters are: continuous, create_group_indexes, materialized_only, columnstore, finalized, chunk_interval, segmentby, orderby, compress_chunk_interval, invalidate_using
 --valid PG option
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, check_option = LOCAL )
 as


### PR DESCRIPTION
Currently we just return `unrecognized parameter "tsdb.foo"` when
encountering unrecognized options in ALTER TABLE. This change
lists all available options in these situations.

ALTER table t1 SET (tsdb.foo=bar);
ERROR:  22023: unrecognized parameter "tsdb.foo"
HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval
