### PR TITLE
Make pgspot no longer complain about CREATE OR REPLACE FUNCTION

### DIFF
--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -14,7 +14,7 @@ jobs:
       # time_bucket with offset is intentional without explicit search_path to allow for inlining
       # policy_compression, policy_compression_execute, cagg_migrate_execute_plan and cagg_migrate
       # do not have explicit search_path because this would prevent them doing transaction control
-      PGSPOT_OPTS: --proc-without-search-path
+      PGSPOT_OPTS: --ignore PS002 --proc-without-search-path
           'extschema.time_bucket(bucket_width interval,ts timestamp,"offset" interval)'
         --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts timestamptz,"offset" interval)'
         --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts date,"offset" interval)'


### PR DESCRIPTION
Using CREATE OR REPLACE FUNCTION is not a problem when used in an
extension context because upstream changed the code to require
the function is owned by the extension if it is preexisting so
it cannot be shadowed by user controlled functions.
