### PR TITLE
Don't use \dx in tests

### DIFF
--- a/test/expected/loader-oss.out
+++ b/test/expected/loader-oss.out
@@ -6,7 +6,7 @@
 CREATE DATABASE :"TEST_DBNAME_2";
 DROP EXTENSION timescaledb;
 --no extension
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -29,7 +29,7 @@ WARNING:  mock post_analyze_hook "mock-1"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -53,7 +53,7 @@ ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 --no extension
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -76,7 +76,7 @@ WARNING:  mock post_analyze_hook "mock-1"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -111,7 +111,7 @@ WARNING:  mock function call "mock-1"
  
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -208,7 +208,7 @@ ALTER EXTENSION timescaledb UPDATE TO 'mock-2';
 ERROR:  extension "timescaledb" cannot be updated after the old version has already been loaded
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -217,7 +217,7 @@ ERROR:  extension "timescaledb" cannot be updated after the old version has alre
 
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -237,7 +237,7 @@ WARNING:  mock post_analyze_hook "mock-2"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -255,7 +255,7 @@ SELECT 1;
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -272,7 +272,7 @@ WARNING:  mock post_analyze_hook "mock-2"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -291,7 +291,7 @@ WARNING:  mock post_analyze_hook "mock-1"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -302,7 +302,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 --try a broken upgrade
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock init "mock-2"
 WARNING:  mock post_analyze_hook "mock-2"
                                       List of installed extensions
@@ -324,7 +324,7 @@ WARNING:  mock post_analyze_hook "mock-2"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -342,7 +342,7 @@ SELECT 1;
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -360,7 +360,7 @@ WARNING:  mock post_analyze_hook "mock-3"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-3"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -388,7 +388,7 @@ server closed the connection unexpectedly
 	before or while processing the request.
 connection to server was lost
 --mock-4 not installed.
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -401,7 +401,7 @@ CREATE EXTENSION timescaledb VERSION 'mock-broken';
 WARNING:  mock init "mock-broken"
 \set ON_ERROR_STOP 0
 --intentional broken version
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-broken"
 ERROR:  mock broken "mock-broken"
 SELECT 1;
@@ -418,7 +418,7 @@ ERROR:  mock broken "mock-broken"
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 --can drop extension now. Since drop first command.
 DROP EXTENSION timescaledb;
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -474,7 +474,7 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 connection to server was lost
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-6"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -485,8 +485,8 @@ WARNING:  mock post_analyze_hook "mock-6"
 
 --TEST: create extension when old .so already loaded
 \c :TEST_DBNAME :ROLE_SUPERUSER
---force load of extension with (\dx)
-\dx
+--force load of extension with (SELECT * FROM test.extension;)
+SELECT * FROM test.extension;
 WARNING:  mock init "mock-1"
 WARNING:  mock post_analyze_hook "mock-1"
                                       List of installed extensions
@@ -498,7 +498,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 DROP EXTENSION timescaledb;
 WARNING:  mock post_analyze_hook "mock-1"
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -509,7 +509,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
-\dx
+SELECT * FROM test.extension;
                  List of installed extensions
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -520,7 +520,7 @@ ERROR:  extension "timescaledb" has already been loaded with another version
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 WARNING:  mock init "mock-2"
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            

--- a/test/expected/loader-tsl.out
+++ b/test/expected/loader-tsl.out
@@ -6,8 +6,7 @@
 CREATE DATABASE :"TEST_DBNAME_2";
 DROP EXTENSION timescaledb;
 --no extension
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -29,9 +28,8 @@ WARNING:  mock post_analyze_hook "mock-1"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -53,8 +51,7 @@ ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 --no extension
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -76,9 +73,8 @@ WARNING:  mock post_analyze_hook "mock-1"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -111,9 +107,8 @@ WARNING:  mock function call "mock-1"
  
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -208,8 +203,7 @@ ALTER EXTENSION timescaledb UPDATE TO 'mock-2';
 ERROR:  extension "timescaledb" cannot be updated after the old version has already been loaded
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -217,9 +211,8 @@ ERROR:  extension "timescaledb" cannot be updated after the old version has alre
 
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -237,9 +230,8 @@ WARNING:  mock post_analyze_hook "mock-2"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -255,8 +247,7 @@ SELECT 1;
         1
 (1 row)
 
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -272,9 +263,8 @@ WARNING:  mock post_analyze_hook "mock-2"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -291,9 +281,8 @@ WARNING:  mock post_analyze_hook "mock-1"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-1"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -302,10 +291,9 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 --try a broken upgrade
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock init "mock-2"
 WARNING:  mock post_analyze_hook "mock-2"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -324,9 +312,8 @@ WARNING:  mock post_analyze_hook "mock-2"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -342,8 +329,7 @@ SELECT 1;
         1
 (1 row)
 
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -360,9 +346,8 @@ WARNING:  mock post_analyze_hook "mock-3"
         1
 (1 row)
 
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-3"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -388,8 +373,7 @@ server closed the connection unexpectedly
 	before or while processing the request.
 connection to server was lost
 --mock-4 not installed.
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -401,7 +385,7 @@ CREATE EXTENSION timescaledb VERSION 'mock-broken';
 WARNING:  mock init "mock-broken"
 \set ON_ERROR_STOP 0
 --intentional broken version
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-broken"
 ERROR:  mock broken "mock-broken"
 SELECT 1;
@@ -418,8 +402,7 @@ ERROR:  mock broken "mock-broken"
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 --can drop extension now. Since drop first command.
 DROP EXTENSION timescaledb;
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -474,9 +457,8 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 connection to server was lost
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-6"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -485,11 +467,9 @@ WARNING:  mock post_analyze_hook "mock-6"
 
 --TEST: create extension when old .so already loaded
 \c :TEST_DBNAME :ROLE_SUPERUSER
---force load of extension with (\dx)
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock init "mock-1"
 WARNING:  mock post_analyze_hook "mock-1"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -498,8 +478,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 DROP EXTENSION timescaledb;
 WARNING:  mock post_analyze_hook "mock-1"
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -509,8 +488,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
-\dx
-                 List of installed extensions
+SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -520,9 +498,8 @@ ERROR:  extension "timescaledb" has already been loaded with another version
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 WARNING:  mock init "mock-2"
-\dx
+SELECT * FROM test.extension;
 WARNING:  mock post_analyze_hook "mock-2"
-                                      List of installed extensions
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language

--- a/test/sql/loader.sql.in
+++ b/test/sql/loader.sql.in
@@ -10,13 +10,13 @@ CREATE DATABASE :"TEST_DBNAME_2";
 
 DROP EXTENSION timescaledb;
 --no extension
-\dx
+SELECT * FROM test.extension;
 SELECT 1;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-1';
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-2';
@@ -29,13 +29,14 @@ CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-2';
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 --no extension
-\dx
+SELECT * FROM test.extension;
+
 SELECT 1;
 
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 --same backend as create extension;
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 --start new backend;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -44,7 +45,7 @@ SELECT 1;
 SELECT 1;
 --test fn call after load
 SELECT mock_function();
-\dx
+SELECT * FROM test.extension;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 --test fn call as first command
@@ -83,51 +84,50 @@ ALTER EXTENSION timescaledb UPDATE TO 'mock-2';
 \set ON_ERROR_STOP 1
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
-\dx
+SELECT * FROM test.extension;
 CREATE EXTENSION timescaledb VERSION 'mock-1';
-\dx
+SELECT * FROM test.extension;
 --start a new backend to update
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 ALTER EXTENSION timescaledb UPDATE TO 'mock-2';
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 --drop extension
 DROP EXTENSION timescaledb;
 SELECT 1;
-\dx
-
+SELECT * FROM test.extension;
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 -- test db 1 still has old version
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 --try a broken upgrade
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
-\dx
+SELECT * FROM test.extension;
 \set ON_ERROR_STOP 0
 ALTER EXTENSION timescaledb UPDATE TO 'mock-3';
 \set ON_ERROR_STOP 1
 --should still be on mock-2
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 --drop extension
 DROP EXTENSION timescaledb;
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 
 --create extension anew, only upgrade was broken
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-3';
 SELECT 1;
-\dx
+SELECT * FROM test.extension;
 DROP EXTENSION timescaledb;
 SELECT 1;
 
@@ -137,7 +137,7 @@ SELECT 1;
 SELECT format($$\! utils/test_fatal_command.sh %1$s "CREATE EXTENSION timescaledb VERSION 'mock-4'"$$, :'TEST_DBNAME_2') as command_to_run \gset
 :command_to_run
 --mock-4 not installed.
-\dx
+SELECT * FROM test.extension;
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 --broken version and drop
@@ -145,7 +145,7 @@ CREATE EXTENSION timescaledb VERSION 'mock-broken';
 
 \set ON_ERROR_STOP 0
 --intentional broken version
-\dx
+SELECT * FROM test.extension;
 SELECT 1;
 SELECT 1;
 --cannot drop extension; already loaded broken version
@@ -155,7 +155,7 @@ DROP EXTENSION timescaledb;
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 --can drop extension now. Since drop first command.
 DROP EXTENSION timescaledb;
-\dx
+SELECT * FROM test.extension;
 
 --broken version and update to fixed
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
@@ -181,23 +181,22 @@ ALTER EXTENSION timescaledb UPDATE TO 'mock-6';
 --This will now be a FATAL error.
 SELECT format($$\! utils/test_fatal_command.sh %1$s "SELECT mock_function()"$$, :'TEST_DBNAME_2') as command_to_run \gset
 :command_to_run
-\dx
+SELECT * FROM test.extension;
 
 --TEST: create extension when old .so already loaded
 \c :TEST_DBNAME :ROLE_SUPERUSER
---force load of extension with (\dx)
-\dx
+SELECT * FROM test.extension;
 DROP EXTENSION timescaledb;
-\dx
+SELECT * FROM test.extension;
 
 \set ON_ERROR_STOP 0
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 \set ON_ERROR_STOP 1
-\dx
+SELECT * FROM test.extension;
 --can create in a new session.
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-2';
-\dx
+SELECT * FROM test.extension;
 
 --make sure parallel workers started after a 'DISCARD ALL' work
 CREATE TABLE test (i int, j double precision);

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -353,3 +353,16 @@ BEGIN
     RETURN false;
 END
 $BODY$;
+
+CREATE OR REPLACE VIEW test.extension AS
+SELECT e.extname AS "Name",
+       e.extversion AS "Version",
+       n.nspname AS "Schema",
+       c.description AS "Description"
+FROM pg_extension e
+LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
+LEFT JOIN pg_description c ON c.objoid = e.oid AND c.classoid = 'pg_extension'::regclass
+ORDER BY 1;
+
+GRANT SELECT ON test.extension TO PUBLIC;
+

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -82,7 +82,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
 ----------------------------------------------------------
  {                                                       +
      "views": {                                          +
-         "num_relations": 2                              +
+         "num_relations": 3                              +
      },                                                  +
      "tables": {                                         +
          "heap_size": 0,                                 +
@@ -188,7 +188,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
 ----------------------------------------------------------
  {                                                       +
      "views": {                                          +
-         "num_relations": 2                              +
+         "num_relations": 3                              +
      },                                                  +
      "tables": {                                         +
          "heap_size": 73728,                             +
@@ -308,7 +308,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
 -----------------------------------------------------------
  {                                                        +
      "views": {                                           +
-         "num_relations": 2                               +
+         "num_relations": 3                               +
      },                                                   +
      "tables": {                                          +
          "heap_size": 73728,                              +


### PR DESCRIPTION
PG18 changes \dx to include the default version making \dx output
differ between pg versions. Change the tests using \dx to use the
pg17 \dx query. We dont want to include the default version as
this would have to be changed whenever we bump version and would
also require adjusting in release branches.
