### PR TITLE
Fix pr-approvals workflow

### DIFF
--- a/.github/workflows/pr-approvals.yaml
+++ b/.github/workflows/pr-approvals.yaml
@@ -20,12 +20,12 @@ jobs:
       - name: Check for sufficient approvals
         shell: bash --norc --noprofile {0}
         env:
-          BODY: ${{ github.event.pull_request.body }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
           echo "PR number is $PR_NUMBER"
+          BODY=$(gh pr view $PR_NUMBER -q .body --json body)
           if ! echo "$BODY" | egrep -qsi '^disable-check:.*\<approval-count\>'
           then
             # Get the list of modified files in this pull request


### PR DESCRIPTION
When the pr review workflow was triggered by pull_request_review
instead of pull_request the BODY variable would be empty and any
disable messages would be ignored. Fix this by using github client
instead to get the pull request body.
