### PR TITLE
Add a debug GUC to force batch sorted merge plan

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -144,8 +144,6 @@ TSDLLEXPORT char *ts_guc_license = TS_LICENSE_DEFAULT;
 char *ts_last_tune_time = NULL;
 char *ts_last_tune_version = NULL;
 
-bool ts_guc_debug_require_batch_sorted_merge = false;
-
 bool ts_guc_debug_allow_cagg_with_deprecated_funcs = false;
 
 /*
@@ -169,19 +167,22 @@ char *ts_current_timestamp_mock = NULL;
 
 int ts_guc_debug_toast_tuple_target = 128;
 
-#ifdef TS_DEBUG
-
-bool ts_guc_debug_have_int128;
-
 static const struct config_enum_entry debug_require_options[] = { { "allow", DRO_Allow, false },
 																  { "forbid", DRO_Forbid, false },
 																  { "require", DRO_Require, false },
+																  { "force", DRO_Force, false },
 																  { NULL, 0, false } };
+
+#ifdef TS_DEBUG
+
+bool ts_guc_debug_have_int128;
 
 DebugRequireOption ts_guc_debug_require_vector_qual = DRO_Allow;
 
 DebugRequireOption ts_guc_debug_require_vector_agg = DRO_Allow;
 #endif
+
+DebugRequireOption ts_guc_debug_require_batch_sorted_merge = false;
 
 bool ts_guc_debug_compression_path_info = false;
 bool ts_guc_enable_rowlevel_compression_locking = false;
@@ -1271,11 +1272,12 @@ _guc_init(void)
 							 /* assign_hook= */ NULL,
 							 /* show_hook= */ NULL);
 
-	DefineCustomBoolVariable(/* name= */ MAKE_EXTOPTION("debug_require_batch_sorted_merge"),
+	DefineCustomEnumVariable(/* name= */ MAKE_EXTOPTION("debug_require_batch_sorted_merge"),
 							 /* short_desc= */ "require batch sorted merge in DecompressChunk node",
 							 /* long_desc= */ "this is for debugging purposes",
-							 /* valueAddr= */ &ts_guc_debug_require_batch_sorted_merge,
-							 /* bootValue= */ false,
+							 /* valueAddr= */ (int *) &ts_guc_debug_require_batch_sorted_merge,
+							 /* bootValue= */ DRO_Allow,
+							 /* options = */ debug_require_options,
 							 /* context= */ PGC_USERSET,
 							 /* flags= */ 0,
 							 /* check_hook= */ NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -119,14 +119,15 @@ extern char *ts_current_timestamp_mock;
 
 extern TSDLLEXPORT int ts_guc_debug_toast_tuple_target;
 
-#ifdef TS_DEBUG
 typedef enum DebugRequireOption
 {
 	DRO_Allow = 0,
 	DRO_Forbid,
-	DRO_Require
+	DRO_Require,
+	DRO_Force,
 } DebugRequireOption;
 
+#ifdef TS_DEBUG
 extern TSDLLEXPORT DebugRequireOption ts_guc_debug_require_vector_qual;
 
 extern TSDLLEXPORT DebugRequireOption ts_guc_debug_require_vector_agg;
@@ -136,7 +137,7 @@ extern TSDLLEXPORT DebugRequireOption ts_guc_debug_require_vector_agg;
 extern TSDLLEXPORT bool ts_guc_debug_compression_path_info;
 extern TSDLLEXPORT bool ts_guc_enable_rowlevel_compression_locking;
 
-extern TSDLLEXPORT bool ts_guc_debug_require_batch_sorted_merge;
+extern TSDLLEXPORT DebugRequireOption ts_guc_debug_require_batch_sorted_merge;
 
 extern TSDLLEXPORT bool ts_guc_debug_allow_cagg_with_deprecated_funcs;
 

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -383,11 +383,20 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 		chunk_state->exec_methods.ExecCustomScan = decompress_chunk_exec_fifo;
 	}
 
-	if (ts_guc_debug_require_batch_sorted_merge && !dcontext->batch_sorted_merge)
+	if ((ts_guc_debug_require_batch_sorted_merge == DRO_Require ||
+		 ts_guc_debug_require_batch_sorted_merge == DRO_Force) &&
+		!dcontext->batch_sorted_merge)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("debug: batch sorted merge is required but not used")));
+	}
+
+	if (ts_guc_debug_require_batch_sorted_merge == DRO_Forbid && dcontext->batch_sorted_merge)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("debug: batch sorted merge is used when it is forbidden")));
 	}
 
 	/* Constify stable expressions in vectorized predicates. */

--- a/tsl/test/expected/compression_sorted_merge.out
+++ b/tsl/test/expected/compression_sorted_merge.out
@@ -79,6 +79,7 @@ ANALYZE test_with_defined_null;
 ------
 -- Tests based on ordering
 ------
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 -- Should be optimized (implicit NULLS first)
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC;
@@ -112,22 +113,6 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
                Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
 (10 rows)
-
--- Should not be optimized (NULL order wrong)
-:PREFIX
-SELECT * FROM test1 ORDER BY time DESC NULLS LAST;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sort Key: _hyper_1_1_chunk."time" DESC NULLS LAST
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
-(9 rows)
 
 -- Should be optimized (implicit NULLS last)
 :PREFIX
@@ -165,22 +150,6 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
 (11 rows)
 
--- Should not be optimized (NULL order wrong)
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS FIRST;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sort Key: _hyper_1_1_chunk."time" NULLS FIRST
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
-(9 rows)
-
 -- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
@@ -214,22 +183,6 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NU
          ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
                Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
 (10 rows)
-
--- Should not be optimized (wrong order for x4)
-:PREFIX
-SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 DESC NULLS FIRST;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4 DESC
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
-(9 rows)
 
 -- Should be optimized (backward scan)
 :PREFIX
@@ -285,22 +238,6 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC N
                Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
 (11 rows)
 
--- Should not be optimized (wrong order for x4 in backward scan)
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sort Key: _hyper_1_1_chunk."time" NULLS FIRST, _hyper_1_1_chunk.x3 DESC NULLS LAST, _hyper_1_1_chunk.x4
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
-(9 rows)
-
 -- Should be optimized
 :PREFIX
 SELECT * FROM test2 ORDER BY time ASC;
@@ -351,38 +288,6 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC, x4 DESC;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
                Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
 (10 rows)
-
--- Should not be optimized (wrong order for x3)
-:PREFIX
-SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS LAST, x4 DESC;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sort Key: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4 DESC
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
-         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-(9 rows)
-
--- Should not be optimized (wrong order for x3)
-:PREFIX
-SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS FIRST, x4 DESC;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sort Key: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x3 NULLS FIRST, _hyper_3_3_chunk.x4 DESC
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
-         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-(9 rows)
 
 -- Should be optimized (backward scan)
 :PREFIX
@@ -438,38 +343,6 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
                Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
 (11 rows)
 
--- Should not be optimized (wrong order for x3 in backward scan)
-:PREFIX
-SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS FIRST, x4 NULLS FIRST;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sort Key: _hyper_3_3_chunk."time" DESC NULLS LAST, _hyper_3_3_chunk.x3 DESC, _hyper_3_3_chunk.x4 NULLS FIRST
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
-         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-(9 rows)
-
--- Should not be optimized (wrong order for x3 in backward scan)
-:PREFIX
-SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS LAST, x4 NULLS FIRST;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4 loops=1)
-   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sort Key: _hyper_3_3_chunk."time" DESC NULLS LAST, _hyper_3_3_chunk.x3 DESC NULLS LAST, _hyper_3_3_chunk.x4 NULLS FIRST
-   Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
-         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-(9 rows)
-
 -- Should be optimized
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
@@ -504,6 +377,135 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2 loops=1)
                Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
 (11 rows)
+
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+-- Should not be optimized (wrong order for x3 in backward scan)
+:PREFIX
+SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS FIRST, x4 NULLS FIRST;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+   Sort Key: _hyper_3_3_chunk."time" DESC NULLS LAST, _hyper_3_3_chunk.x3 DESC, _hyper_3_3_chunk.x4 NULLS FIRST
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
+         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+(9 rows)
+
+-- Should not be optimized (wrong order for x3 in backward scan)
+:PREFIX
+SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS LAST, x4 NULLS FIRST;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+   Sort Key: _hyper_3_3_chunk."time" DESC NULLS LAST, _hyper_3_3_chunk.x3 DESC NULLS LAST, _hyper_3_3_chunk.x4 NULLS FIRST
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
+         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+(9 rows)
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test1 ORDER BY time DESC NULLS LAST;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+   Sort Key: _hyper_1_1_chunk."time" DESC NULLS LAST
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
+(9 rows)
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS FIRST;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+   Sort Key: _hyper_1_1_chunk."time" NULLS FIRST
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
+(9 rows)
+
+-- Should not be optimized (wrong order for x4)
+:PREFIX
+SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 DESC NULLS FIRST;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+   Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4 DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
+(9 rows)
+
+-- Should not be optimized (wrong order for x4 in backward scan)
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+   Sort Key: _hyper_1_1_chunk."time" NULLS FIRST, _hyper_1_1_chunk.x3 DESC NULLS LAST, _hyper_1_1_chunk.x4
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
+(9 rows)
+
+-- Should not be optimized (wrong order for x3)
+:PREFIX
+SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS LAST, x4 DESC;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+   Sort Key: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4 DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
+         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+(9 rows)
+
+-- Should not be optimized (wrong order for x3)
+:PREFIX
+SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS FIRST, x4 DESC;
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+   Sort Key: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x3 NULLS FIRST, _hyper_3_3_chunk.x4 DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
+         Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+(9 rows)
 
 -- Should not be optimized
 :PREFIX
@@ -540,6 +542,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 ------
 -- Tests based on attributes
 ------
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 -- Should be optimized (some batches qualify by pushed down filter on _ts_meta_max_3)
 :PREFIX
 SELECT * FROM test1 WHERE x4 > 0 ORDER BY time DESC;
@@ -639,6 +642,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4, x3, x4;
                Rows Removed by Filter: 3
 (13 rows)
 
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 -- Should not be optimized
 :PREFIX
 SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x4, x3;
@@ -677,28 +681,10 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time ASC, x3, x4;
                Rows Removed by Filter: 3
 (12 rows)
 
--- Test that the enable_sort GUC doesn't disable the batch sorted merge plan.
-SET enable_sort TO OFF;
-:PREFIX
-SELECT * FROM test1 ORDER BY time DESC;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Batch Sorted Merge: true
-   Bulk Decompression: false
-   ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
-         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x4
-(10 rows)
-
-RESET enable_sort;
 ------
 -- Tests based on results
 ------
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 -- Forward scan
 SELECT * FROM test1 ORDER BY time DESC;
              time             | x1 | x2 | x3 | x4 | x5 
@@ -707,16 +693,6 @@ SELECT * FROM test1 ORDER BY time DESC;
  Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
  Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
-(4 rows)
-
--- Backward scan
-SELECT * FROM test1 ORDER BY time ASC NULLS FIRST;
-             time             | x1 | x2 | x3 | x4 | x5 
-------------------------------+----+----+----+----+----
- Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
- Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
- Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
- Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
 (4 rows)
 
 -- Forward scan
@@ -729,8 +705,19 @@ SELECT * FROM test2 ORDER BY time ASC;
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
 (4 rows)
 
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 -- Backward scan
-SELECT * FROM test2 ORDER BY time DESC NULLS LAST;
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+             time             | x1 | x2 | x3 | x4 | x5 
+------------------------------+----+----+----+----+----
+ Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
+ Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0
+ Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0
+ Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
+(4 rows)
+
+-- Backward scan
+SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
              time             | x1 | x2 | x3 | x4 | x5 
 ------------------------------+----+----+----+----+----
  Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0
@@ -739,6 +726,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS LAST;
  Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0
 (4 rows)
 
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 -- With selection on compressed column (value larger as max value for all batches, so no batch has to be opened)
 SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC;
  time | x1 | x2 | x3 | x4 | x5 
@@ -891,6 +879,7 @@ SELECT x4 FROM test1 WHERE x4 > 2 ORDER BY time DESC;
   3
 (2 rows)
 
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 -- Aggregation with count
 SELECT count(*) FROM test1;
  count 
@@ -901,6 +890,7 @@ SELECT count(*) FROM test1;
 -- Test with default values
 ALTER TABLE test1 ADD COLUMN c1 int;
 ALTER TABLE test1 ADD COLUMN c2 int NOT NULL DEFAULT 42;
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 SELECT * FROM test1 ORDER BY time DESC;
              time             | x1 | x2 | x3 | x4 | x5 | c1 | c2 
 ------------------------------+----+----+----+----+----+----+----
@@ -1081,6 +1071,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
  Sat Jan 01 00:00:00 2000 PST |  2 |    |   
 (4 rows)
 
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
              time             | x1 | x2 | x3 
 ------------------------------+----+----+----
@@ -1103,6 +1094,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 -- Tests based on compressed chunk state
 ------
 -- Should be optimized
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                            
@@ -1168,6 +1160,7 @@ ROLLBACK;
 ------
 -- Tests on a larger relation
 ------
+set timescaledb.debug_require_batch_sorted_merge to 'allow';
 CREATE TABLE sensor_data (
 time timestamptz NOT NULL,
 sensor_id integer NOT NULL,
@@ -1424,6 +1417,7 @@ SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS 
 (1 row)
 
 -- Test query plan (should not be optimized due to 1000 different segments)
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 :PREFIX
 SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                       QUERY PLAN                                                                                                                                                                      
@@ -1440,6 +1434,7 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 (9 rows)
 
 -- Test query plan with predicate (query should be optimized due to ~100 segments)
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 :PREFIX
 SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_by < 999 ORDER BY time DESC;
                                                                                                                                                                       QUERY PLAN                                                                                                                                                                      
@@ -1672,3 +1667,27 @@ SELECT t.dttm FROM test t WHERE t.dttm > '2023-05-25T14:23:12' ORDER BY t.dttm;
  Thu May 25 23:59:13 2023
 (31 rows)
 
+-- Test that the enable_sort GUC doesn't disable the batch sorted merge plan.
+SET enable_sort TO OFF;
+set timescaledb.debug_require_batch_sorted_merge = 'require';
+:PREFIX
+SELECT t.dttm FROM test t ORDER BY t.dttm LIMIT 1;
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   Output: t.dttm
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_13_25_chunk t (actual rows=1 loops=1)
+         Output: t.dttm
+         Batch Sorted Merge: true
+         Reverse: true
+         Bulk Decompression: false
+         ->  Sort (actual rows=5 loops=1)
+               Output: compress_hyper_14_26_chunk._ts_meta_count, compress_hyper_14_26_chunk.otherid, compress_hyper_14_26_chunk.valuefk, compress_hyper_14_26_chunk.otherfk, compress_hyper_14_26_chunk.id, compress_hyper_14_26_chunk._ts_meta_min_1, compress_hyper_14_26_chunk._ts_meta_max_1, compress_hyper_14_26_chunk.dttm, compress_hyper_14_26_chunk.measure
+               Sort Key: compress_hyper_14_26_chunk._ts_meta_min_1
+               Sort Method: quicksort 
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_14_26_chunk (actual rows=32 loops=1)
+                     Output: compress_hyper_14_26_chunk._ts_meta_count, compress_hyper_14_26_chunk.otherid, compress_hyper_14_26_chunk.valuefk, compress_hyper_14_26_chunk.otherfk, compress_hyper_14_26_chunk.id, compress_hyper_14_26_chunk._ts_meta_min_1, compress_hyper_14_26_chunk._ts_meta_max_1, compress_hyper_14_26_chunk.dttm, compress_hyper_14_26_chunk.measure
+(13 rows)
+
+RESET enable_sort;
+reset timescaledb.debug_require_batch_sorted_merge;

--- a/tsl/test/expected/compression_sorted_merge_columns.out
+++ b/tsl/test/expected/compression_sorted_merge_columns.out
@@ -23,7 +23,7 @@ alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', tim
 select compress_chunk(show_chunks('t')) \gset
 set enable_sort to off;
 set timescaledb.enable_decompression_sorted_merge to on;
-set timescaledb.debug_require_batch_sorted_merge to on;
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 -- set enable_sort to on;
 -- set timescaledb.enable_decompression_sorted_merge to off;
 -- set timescaledb.debug_require_batch_sorted_merge to off;
@@ -125,7 +125,7 @@ select int32 + 1 from t order by int32 + 1;
 -- Sort Merge not used because only last Order By expression can be sort-transformed, not both of them
 \set ON_ERROR_STOP 0
 select int32 + 1, timetz  + interval '1 second' from t order by int32 + 1, timetz  + interval '1 second';
-ERROR:  debug: batch sorted merge is required but not used
+ERROR:  debug: batch sorted merge is required but not possible at planning time
 \set ON_ERROR_STOP 1
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='int64,int32,timetz,time');
@@ -156,7 +156,7 @@ select int64 + 1 from t order by int64 + 1::int8;
 -- Batch sort merge won't be used as sides of OpExpr are of different types (int8 vs int4)
 \set ON_ERROR_STOP 0
 select int64 + 1 from t order by int64 + 1;
-ERROR:  debug: batch sorted merge is required but not used
+ERROR:  debug: batch sorted merge is required but not possible at planning time
 \set ON_ERROR_STOP 1
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='s,int32,time desc');
@@ -175,5 +175,5 @@ select * from t order by s, int32, time desc;
 -- Batch sort merge won't be used as only Int and Date/Time types are allowed in OpExpr
 \set ON_ERROR_STOP 0
 select s||'1' from t order by s||'1';
-ERROR:  debug: batch sorted merge is required but not used
+ERROR:  debug: batch sorted merge is required but not possible at planning time
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/compression_sorted_merge_filter.out
+++ b/tsl/test/expected/compression_sorted_merge_filter.out
@@ -22,7 +22,7 @@ select compress_chunk(x, true) from show_chunks('batches') x;
 (1 row)
 
 analyze batches;
-set timescaledb.debug_require_batch_sorted_merge to true;
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 set enable_sort to off;
 select ts from batches where ts != '2022-02-02 00:00:02' order by ts;
             ts            
@@ -38,7 +38,7 @@ select ts from batches where ts != '2022-02-02 00:00:02' order by ts;
 \set ON_ERROR_STOP off
 set timescaledb.enable_decompression_sorted_merge to off;
 select ts from batches where ts != '2022-02-02 00:00:02' order by ts;
-ERROR:  debug: batch sorted merge is required but not used
+ERROR:  debug: batch sorted merge is required but not possible at planning time
 reset timescaledb.enable_decompression_sorted_merge;
 \set ON_ERROR_STOP on
 -- middle batch entirely filtered out

--- a/tsl/test/sql/compression_sorted_merge.sql
+++ b/tsl/test/sql/compression_sorted_merge.sql
@@ -75,6 +75,8 @@ ANALYZE test_with_defined_null;
 -- Tests based on ordering
 ------
 
+set timescaledb.debug_require_batch_sorted_merge to 'force';
+
 -- Should be optimized (implicit NULLS first)
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC;
@@ -82,10 +84,6 @@ SELECT * FROM test1 ORDER BY time DESC;
 -- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST;
-
--- Should not be optimized (NULL order wrong)
-:PREFIX
-SELECT * FROM test1 ORDER BY time DESC NULLS LAST;
 
 -- Should be optimized (implicit NULLS last)
 :PREFIX
@@ -95,10 +93,6 @@ SELECT * FROM test1 ORDER BY time ASC;
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 
--- Should not be optimized (NULL order wrong)
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS FIRST;
-
 -- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
@@ -106,10 +100,6 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NULLS LAST;
-
--- Should not be optimized (wrong order for x4)
-:PREFIX
-SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 DESC NULLS FIRST;
 
 -- Should be optimized (backward scan)
 :PREFIX
@@ -123,10 +113,6 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST;
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC NULLS FIRST;
 
--- Should not be optimized (wrong order for x4 in backward scan)
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
-
 -- Should be optimized
 :PREFIX
 SELECT * FROM test2 ORDER BY time ASC;
@@ -138,14 +124,6 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC;
 -- Should be optimized
 :PREFIX
 SELECT * FROM test2 ORDER BY time ASC, x3 DESC, x4 DESC;
-
--- Should not be optimized (wrong order for x3)
-:PREFIX
-SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS LAST, x4 DESC;
-
--- Should not be optimized (wrong order for x3)
-:PREFIX
-SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS FIRST, x4 DESC;
 
 -- Should be optimized (backward scan)
 :PREFIX
@@ -159,14 +137,6 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 :PREFIX
 SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS LAST;
 
--- Should not be optimized (wrong order for x3 in backward scan)
-:PREFIX
-SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS FIRST, x4 NULLS FIRST;
-
--- Should not be optimized (wrong order for x3 in backward scan)
-:PREFIX
-SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS LAST, x4 NULLS FIRST;
-
 -- Should be optimized
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
@@ -175,6 +145,39 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
 
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+
+-- Should not be optimized (wrong order for x3 in backward scan)
+:PREFIX
+SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS FIRST, x4 NULLS FIRST;
+
+-- Should not be optimized (wrong order for x3 in backward scan)
+:PREFIX
+SELECT * FROM test2 ORDER BY time DESC NULLS LAST, x3 DESC NULLS LAST, x4 NULLS FIRST;
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test1 ORDER BY time DESC NULLS LAST;
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS FIRST;
+
+-- Should not be optimized (wrong order for x4)
+:PREFIX
+SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 DESC NULLS FIRST;
+
+-- Should not be optimized (wrong order for x4 in backward scan)
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
+
+-- Should not be optimized (wrong order for x3)
+:PREFIX
+SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS LAST, x4 DESC;
+
+-- Should not be optimized (wrong order for x3)
+:PREFIX
+SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS FIRST, x4 DESC;
 -- Should not be optimized
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
@@ -187,6 +190,8 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 ------
 -- Tests based on attributes
 ------
+
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 
 -- Should be optimized (some batches qualify by pushed down filter on _ts_meta_max_3)
 :PREFIX
@@ -208,6 +213,8 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x3;
 :PREFIX
 SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4, x3, x4;
 
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+
 -- Should not be optimized
 :PREFIX
 SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x4, x3;
@@ -216,27 +223,27 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x4, x3;
 :PREFIX
 SELECT * FROM test1 WHERE x4 > 100 ORDER BY time ASC, x3, x4;
 
--- Test that the enable_sort GUC doesn't disable the batch sorted merge plan.
-SET enable_sort TO OFF;
-:PREFIX
-SELECT * FROM test1 ORDER BY time DESC;
-RESET enable_sort;
-
 ------
 -- Tests based on results
 ------
 
+set timescaledb.debug_require_batch_sorted_merge to 'force';
+
 -- Forward scan
 SELECT * FROM test1 ORDER BY time DESC;
-
--- Backward scan
-SELECT * FROM test1 ORDER BY time ASC NULLS FIRST;
 
 -- Forward scan
 SELECT * FROM test2 ORDER BY time ASC;
 
+set timescaledb.debug_require_batch_sorted_merge to 'force';
+
 -- Backward scan
-SELECT * FROM test2 ORDER BY time DESC NULLS LAST;
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+
+-- Backward scan
+SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
+
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 
 -- With selection on compressed column (value larger as max value for all batches, so no batch has to be opened)
 SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC;
@@ -278,12 +285,15 @@ SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORDER BY time DESC;
 -- With projection and selection on compressed column (value smaller as max value for some batches, so batches are opened and filter has to be applied)
 SELECT x4 FROM test1 WHERE x4 > 2 ORDER BY time DESC;
 
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+
 -- Aggregation with count
 SELECT count(*) FROM test1;
 
 -- Test with default values
 ALTER TABLE test1 ADD COLUMN c1 int;
 ALTER TABLE test1 ADD COLUMN c2 int NOT NULL DEFAULT 42;
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 SELECT * FROM test1 ORDER BY time DESC;
 
 -- Recompress
@@ -324,6 +334,8 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
 -- Test with null values
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
 SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 
@@ -332,6 +344,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 ------
 
 -- Should be optimized
+set timescaledb.debug_require_batch_sorted_merge to 'force';
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 
@@ -351,6 +364,8 @@ ROLLBACK;
 ------
 -- Tests on a larger relation
 ------
+
+set timescaledb.debug_require_batch_sorted_merge to 'allow';
 
 CREATE TABLE sensor_data (
 time timestamptz NOT NULL,
@@ -495,10 +510,14 @@ ANALYZE test_costs;
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
 
 -- Test query plan (should not be optimized due to 1000 different segments)
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+
 :PREFIX
 SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 
 -- Test query plan with predicate (query should be optimized due to ~100 segments)
+set timescaledb.debug_require_batch_sorted_merge to 'require';
+
 :PREFIX
 SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_by < 999 ORDER BY time DESC;
 
@@ -638,3 +657,13 @@ VALUES  (109288, '2023-05-25 23:12:13.000000', 130, 14499, 13, 0.132165698840012
 SELECT compress_chunk(show_chunks('test', older_than => INTERVAL '1 week'), true);
 
 SELECT t.dttm FROM test t WHERE t.dttm > '2023-05-25T14:23:12' ORDER BY t.dttm;
+
+-- Test that the enable_sort GUC doesn't disable the batch sorted merge plan.
+SET enable_sort TO OFF;
+set timescaledb.debug_require_batch_sorted_merge = 'require';
+:PREFIX
+SELECT t.dttm FROM test t ORDER BY t.dttm LIMIT 1;
+RESET enable_sort;
+
+reset timescaledb.debug_require_batch_sorted_merge;
+

--- a/tsl/test/sql/compression_sorted_merge_columns.sql
+++ b/tsl/test/sql/compression_sorted_merge_columns.sql
@@ -21,7 +21,7 @@ select compress_chunk(show_chunks('t')) \gset
 
 set enable_sort to off;
 set timescaledb.enable_decompression_sorted_merge to on;
-set timescaledb.debug_require_batch_sorted_merge to on;
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 -- set enable_sort to on;
 -- set timescaledb.enable_decompression_sorted_merge to off;
 -- set timescaledb.debug_require_batch_sorted_merge to off;

--- a/tsl/test/sql/compression_sorted_merge_filter.sql
+++ b/tsl/test/sql/compression_sorted_merge_filter.sql
@@ -16,7 +16,7 @@ select compress_chunk(x, true) from show_chunks('batches') x;
 
 analyze batches;
 
-set timescaledb.debug_require_batch_sorted_merge to true;
+set timescaledb.debug_require_batch_sorted_merge to 'require';
 set enable_sort to off;
 
 select ts from batches where ts != '2022-02-02 00:00:02' order by ts;


### PR DESCRIPTION
At the moment a significant part of the tests we have for batch sorted merge relies on the completely broken cost and size estimations for plain DecompressChunk. This prevents actually fixing these estimates. At the same time, it is unfeasible to rewrite these tests entirely. Add a GUC to force the batch sorted merge plan regardless of the cost, so that we can test the correctness on small tables.