### PR TITLE
Replace \dt with test.relation view for PG18 compatibility

### DIFF
--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -656,9 +656,8 @@ INSERT INTO original_name.my_table2 (date, quantity) VALUES ('2018-07-04T21:00:0
 ALTER SCHEMA original_name RENAME TO new_name;
 DROP SCHEMA new_name CASCADE;
 NOTICE:  drop cascades to 4 other objects
-\dt new_name.*;
-      List of relations
- Schema | Name | Type | Owner 
+SELECT * FROM test.relation WHERE schema = 'new_name';
+ schema | name | type | owner 
 --------+------+------+-------
 (0 rows)
 

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -59,9 +59,8 @@ CREATE SCHEMA IF NOT EXISTS "customSchema" AUTHORIZATION :ROLE_DEFAULT_PERM_USER
 GRANT CREATE ON SCHEMA "one_Partition" TO :ROLE_DEFAULT_PERM_USER_2;
 --test creating and using schema as non-superuser
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
-\dt
-                 List of relations
- Schema |     Name      | Type  |       Owner       
+SELECT * FROM test.relation ORDER BY schema, name;
+ schema |     name      | type  |       owner       
 --------+---------------+-------+-------------------
  public | one_Partition | table | default_perm_user
 (1 row)

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -75,9 +75,8 @@ ORDER BY c.id;
 ----------+---------------+--------------+-------------+-------------+-----------
 (0 rows)
 
-\dt "_timescaledb_internal"._hyper*
-      List of relations
- Schema | Name | Type | Owner 
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+ schema | name | type | owner 
 --------+------+------+-------
 (0 rows)
 
@@ -135,9 +134,8 @@ ORDER BY c.id;
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (12 rows)
 
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_1_1_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_1_2_chunk  | table | default_perm_user
@@ -490,9 +488,8 @@ SELECT * FROM show_chunks('drop_chunk_test2');
  _timescaledb_internal._hyper_2_12_chunk
 (5 rows)
 
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_1_2_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
@@ -541,28 +538,24 @@ ORDER BY c.id;
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (9 rows)
 
-\dt "_timescaledb_internal".*
-                             List of relations
-        Schema         |          Name          | Type  |       Owner       
------------------------+------------------------+-------+-------------------
- _timescaledb_internal | _hyper_1_3_chunk       | table | default_perm_user
- _timescaledb_internal | _hyper_1_4_chunk       | table | default_perm_user
- _timescaledb_internal | _hyper_1_5_chunk       | table | default_perm_user
- _timescaledb_internal | _hyper_1_6_chunk       | table | default_perm_user
- _timescaledb_internal | _hyper_2_10_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_2_11_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_2_12_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_2_8_chunk       | table | default_perm_user
- _timescaledb_internal | _hyper_2_9_chunk       | table | default_perm_user
- _timescaledb_internal | _hyper_3_14_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_3_15_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_3_16_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_3_17_chunk      | table | default_perm_user
- _timescaledb_internal | _hyper_3_18_chunk      | table | default_perm_user
- _timescaledb_internal | bgw_job_stat           | table | super_user
- _timescaledb_internal | bgw_job_stat_history   | table | super_user
- _timescaledb_internal | bgw_policy_chunk_stats | table | super_user
-(17 rows)
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_1_4_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_1_5_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_1_6_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_10_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_3_14_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_3_15_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_3_16_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_3_17_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_3_18_chunk | table | default_perm_user
+(14 rows)
 
 -- next two calls of show_chunks should give same set of chunks as above when combined
 SELECT show_chunks('drop_chunk_test1');
@@ -615,9 +608,8 @@ ORDER BY c.id;
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (9 rows)
 
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_1_4_chunk  | table | default_perm_user
@@ -660,9 +652,8 @@ ORDER BY c.id;
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (8 rows)
 
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_1_4_chunk  | table | default_perm_user
@@ -706,9 +697,8 @@ SELECT show_chunks('drop_chunk_test1');
  _timescaledb_internal._hyper_1_4_chunk
 (2 rows)
 
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_1_4_chunk  | table | default_perm_user
@@ -1030,9 +1020,8 @@ BEGIN;
 (1 row)
 
 ROLLBACK;
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
  _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
@@ -1061,9 +1050,8 @@ SELECT drop_chunks('drop_chunk_test3', created_after => interval '1 minute');
 -------------
 (0 rows)
 
-\dt "_timescaledb_internal"._hyper*
-                           List of relations
-        Schema         |       Name        | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name        | type  |       owner       
 -----------------------+-------------------+-------+-------------------
  _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
  _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -11,9 +11,8 @@ create table test_schema.test_table(time BIGINT, temp float8, device_id text, de
 SELECT * FROM _timescaledb_functions.get_create_command('test_table');
 ERROR:  hypertable "test_table" not found
 \set ON_ERROR_STOP 1
-\dt "test_schema".*
-                  List of relations
-   Schema    |    Name    | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = 'test_schema';
+   schema    |    name    | type  |       owner       
 -------------+------------+-------+-------------------
  test_schema | test_table | table | default_perm_user
 (1 row)
@@ -454,9 +453,8 @@ SELECT * FROM _timescaledb_functions.get_create_command('test_1dim');
  SELECT create_hypertable('test_schema.test_1dim', 'time', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
 (1 row)
 
-\dt "test_schema".*
-                        List of relations
-   Schema    |          Name          | Type  |       Owner       
+SELECT * FROM test.relation WHERE schema = 'test_schema';
+   schema    |          name          | type  |       owner       
 -------------+------------------------+-------+-------------------
  test_schema | test_1dim              | table | default_perm_user
  test_schema | test_table             | table | default_perm_user

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -184,47 +184,36 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 (0 rows)
 
-\dt  "public".*
-      List of relations
- Schema | Name | Type | Owner 
---------+------+------+-------
-(0 rows)
-
-\dt  "_timescaledb_catalog".*
-                                      List of relations
-        Schema        |                       Name                       | Type  |   Owner    
-----------------------+--------------------------------------------------+-------+------------
- _timescaledb_catalog | chunk                                            | table | super_user
- _timescaledb_catalog | chunk_column_stats                               | table | super_user
- _timescaledb_catalog | chunk_constraint                                 | table | super_user
- _timescaledb_catalog | chunk_index                                      | table | super_user
- _timescaledb_catalog | compression_algorithm                            | table | super_user
- _timescaledb_catalog | compression_chunk_size                           | table | super_user
- _timescaledb_catalog | compression_settings                             | table | super_user
- _timescaledb_catalog | continuous_agg                                   | table | super_user
- _timescaledb_catalog | continuous_agg_migrate_plan                      | table | super_user
- _timescaledb_catalog | continuous_agg_migrate_plan_step                 | table | super_user
- _timescaledb_catalog | continuous_aggs_bucket_function                  | table | super_user
- _timescaledb_catalog | continuous_aggs_hypertable_invalidation_log      | table | super_user
- _timescaledb_catalog | continuous_aggs_invalidation_threshold           | table | super_user
- _timescaledb_catalog | continuous_aggs_materialization_invalidation_log | table | super_user
- _timescaledb_catalog | continuous_aggs_watermark                        | table | super_user
- _timescaledb_catalog | dimension                                        | table | super_user
- _timescaledb_catalog | dimension_slice                                  | table | super_user
- _timescaledb_catalog | hypertable                                       | table | super_user
- _timescaledb_catalog | metadata                                         | table | super_user
- _timescaledb_catalog | tablespace                                       | table | super_user
- _timescaledb_catalog | telemetry_event                                  | table | super_user
-(21 rows)
-
-\dt "_timescaledb_internal".*
-                          List of relations
-        Schema         |          Name          | Type  |   Owner    
------------------------+------------------------+-------+------------
- _timescaledb_internal | bgw_job_stat           | table | super_user
- _timescaledb_internal | bgw_job_stat_history   | table | super_user
- _timescaledb_internal | bgw_policy_chunk_stats | table | super_user
-(3 rows)
+SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_catalog', '_timescaledb_internal');
+        schema         |                       name                       
+-----------------------+--------------------------------------------------
+ _timescaledb_catalog  | chunk
+ _timescaledb_catalog  | chunk_column_stats
+ _timescaledb_catalog  | chunk_constraint
+ _timescaledb_catalog  | chunk_index
+ _timescaledb_catalog  | compression_algorithm
+ _timescaledb_catalog  | compression_chunk_size
+ _timescaledb_catalog  | compression_settings
+ _timescaledb_catalog  | continuous_agg
+ _timescaledb_catalog  | continuous_agg_migrate_plan
+ _timescaledb_catalog  | continuous_agg_migrate_plan_step
+ _timescaledb_catalog  | continuous_aggs_bucket_function
+ _timescaledb_catalog  | continuous_aggs_hypertable_invalidation_log
+ _timescaledb_catalog  | continuous_aggs_invalidation_threshold
+ _timescaledb_catalog  | continuous_aggs_materialization_invalidation_log
+ _timescaledb_catalog  | continuous_aggs_watermark
+ _timescaledb_catalog  | dimension
+ _timescaledb_catalog  | dimension_slice
+ _timescaledb_catalog  | hypertable
+ _timescaledb_catalog  | metadata
+ _timescaledb_catalog  | tablespace
+ _timescaledb_catalog  | telemetry_event
+ _timescaledb_internal | bgw_job_stat
+ _timescaledb_internal | bgw_job_stat_history
+ _timescaledb_internal | bgw_policy_chunk_stats
+ _timescaledb_internal | compressed_chunk_stats
+ _timescaledb_internal | hypertable_chunk_local_size
+(26 rows)
 
 -- Test that renaming ordinary table works
 CREATE TABLE renametable (foo int);

--- a/test/expected/trusted_extension.out
+++ b/test/expected/trusted_extension.out
@@ -42,12 +42,11 @@ SELECT * FROM timescaledb_information.hypertables;
  public            | t               | test_role_1 |              1 |          2 | f                   |             | time              | timestamp with time zone
 (1 row)
 
-\dt+ _timescaledb_internal._hyper_*
-                                            List of relations
-        Schema         |       Name       | Type  |    Owner    | Persistence |    Size    | Description 
------------------------+------------------+-------+-------------+-------------+------------+-------------
- _timescaledb_internal | _hyper_1_1_chunk | table | test_role_1 | permanent   | 8192 bytes | 
- _timescaledb_internal | _hyper_1_2_chunk | table | test_role_1 | permanent   | 8192 bytes | 
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
+        schema         |       name       | type  |    owner    
+-----------------------+------------------+-------+-------------
+ _timescaledb_internal | _hyper_1_1_chunk | table | test_role_1
+ _timescaledb_internal | _hyper_1_2_chunk | table | test_role_1
 (2 rows)
 
 DROP EXTENSION timescaledb CASCADE;

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -363,7 +363,7 @@ INSERT INTO original_name.my_table2 (date, quantity) VALUES ('2018-07-04T21:00:0
 ALTER SCHEMA original_name RENAME TO new_name;
 
 DROP SCHEMA new_name CASCADE;
-\dt new_name.*;
+SELECT * FROM test.relation WHERE schema = 'new_name';
 
 -- Make sure we can't rename internal schemas
 \set ON_ERROR_STOP 0

--- a/test/sql/alternate_users.sql
+++ b/test/sql/alternate_users.sql
@@ -22,7 +22,7 @@ GRANT CREATE ON SCHEMA "one_Partition" TO :ROLE_DEFAULT_PERM_USER_2;
 
 --test creating and using schema as non-superuser
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
-\dt
+SELECT * FROM test.relation ORDER BY schema, name;
 
 \set ON_ERROR_STOP 0
 SELECT * FROM "one_Partition";

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -45,7 +45,7 @@ INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id =
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2')
 ORDER BY c.id;
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 SELECT  _timescaledb_functions.get_partition_for_key('dev1'::text);
 SELECT  _timescaledb_functions.get_partition_for_key('dev7'::varchar(5));
@@ -79,7 +79,7 @@ INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_d
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2')
 ORDER BY c.id;
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 -- next two calls of show_chunks should give same set of chunks as above when combined
 SELECT show_chunks('drop_chunk_test1');
@@ -160,7 +160,7 @@ ORDER BY c.id;
 SELECT show_chunks('drop_chunk_test1');
 SELECT * FROM show_chunks('drop_chunk_test2');
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', older_than => 3)::NAME'
 \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test1\', older_than => 3)::NAME'
@@ -177,7 +177,7 @@ INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id =
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2')
 ORDER BY c.id;
 
-\dt "_timescaledb_internal".*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 -- next two calls of show_chunks should give same set of chunks as above when combined
 SELECT show_chunks('drop_chunk_test1');
@@ -200,7 +200,7 @@ INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id =
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2' OR h.table_name = 'drop_chunk_test3')
 ORDER BY c.id;
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 \set ON_ERROR_STOP 0
 -- should error because no hypertable
 SELECT drop_chunks('drop_chunk_test4', older_than => 5);
@@ -219,7 +219,7 @@ INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id =
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2')
 ORDER BY c.id;
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 -- newer_than tests
 -- show_chunks and drop_chunks output should be the same
@@ -240,7 +240,7 @@ ORDER BY c.id;
 
 SELECT show_chunks('drop_chunk_test1');
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '_hyper%';
 
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', older_than=>4, newer_than=>3)::NAME'
@@ -386,7 +386,7 @@ BEGIN;
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
 ROLLBACK;
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(interval '1 minute');
@@ -399,7 +399,7 @@ SELECT drop_chunks('drop_chunk_test3', interval '1 minute');
 -- time to identify the affected chunks.
 SELECT drop_chunks('drop_chunk_test3', created_after => interval '1 minute');
 
-\dt "_timescaledb_internal"._hyper*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 CREATE TABLE PUBLIC.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -14,7 +14,7 @@ create table test_schema.test_table(time BIGINT, temp float8, device_id text, de
 SELECT * FROM _timescaledb_functions.get_create_command('test_table');
 \set ON_ERROR_STOP 1
 
-\dt "test_schema".*
+SELECT * FROM test.relation WHERE schema = 'test_schema';
 \d _timescaledb_catalog.chunk
 
 create table test_schema.test_table_no_not_null(time BIGINT, device_id text);
@@ -200,7 +200,7 @@ create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
 SELECT * FROM _timescaledb_functions.get_create_command('test_1dim');
 
-\dt "test_schema".*
+SELECT * FROM test.relation WHERE schema = 'test_schema';
 
 select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
 

--- a/test/sql/drop_rename_hypertable.sql
+++ b/test/sql/drop_rename_hypertable.sql
@@ -25,9 +25,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 DROP TABLE "newschema"."newname";
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-\dt  "public".*
-\dt  "_timescaledb_catalog".*
-\dt "_timescaledb_internal".*
+SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_catalog', '_timescaledb_internal');
 
 -- Test that renaming ordinary table works
 

--- a/test/sql/trusted_extension.sql
+++ b/test/sql/trusted_extension.sql
@@ -26,7 +26,7 @@ INSERT INTO t VALUES ('2000-01-01'), ('2001-01-01');
 
 SELECT * FROM t ORDER BY 1;
 SELECT * FROM timescaledb_information.hypertables;
-\dt+ _timescaledb_internal._hyper_*
+SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
 
 DROP EXTENSION timescaledb CASCADE;
 

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -366,3 +366,27 @@ ORDER BY 1;
 
 GRANT SELECT ON test.extension TO PUBLIC;
 
+-- View to replace \dt commands in tests for consistent output across PostgreSQL versions
+CREATE OR REPLACE VIEW test.relation AS
+SELECT
+    n.nspname AS schema,
+    c.relname AS name,
+    CASE c.relkind
+        WHEN 'r' THEN 'table'
+        WHEN 'v' THEN 'view'
+        WHEN 'm' THEN 'materialized view'
+        WHEN 'f' THEN 'foreign table'
+        WHEN 'p' THEN 'partitioned table'
+        ELSE c.relkind::text
+    END AS type,
+    pg_catalog.pg_get_userbyid(c.relowner) AS owner
+FROM pg_catalog.pg_class c
+LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('r','p','v','m','f','')
+  AND n.nspname <> 'information_schema'
+  AND n.nspname <> 'pg_catalog'
+  AND n.nspname !~ '^pg_toast'
+ORDER BY 1, 2;
+
+GRANT SELECT ON test.relation TO PUBLIC;
+


### PR DESCRIPTION
The \dt psql command output format can vary between PostgreSQL
versions. This change introduces a test.relation view that provides
consistent table listing output across all supported PostgreSQL
versions.
