### PR TITLE
Trigger docs action after release

### DIFF
--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -17,6 +17,15 @@ permissions:
   pull-requests: write
 
 jobs:
+  docs:
+    name: Post Release Ceremony - Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate list of GUCs
+        run: |
+          gh workflow run tsdb-refresh-gucs-list.yaml -R timescale/docs -f tag=${{ github.event.release.tag_name }}
+
   main-branch:
     name: Post Release Ceremony - main branch
     runs-on: ubuntu-latest


### PR DESCRIPTION
The docs are featuring the GUCs from timescaledb: https://docs.tigerdata.com/api/latest/configuration/gucs/

These are generated by [an action](https://github.com/timescale/docs/actions/workflows/tsdb-refresh-gucs-list.yaml) in the docs repo, after a release, this action is called to run.

Disable-check: approval-count
Disable-check: force-changelog-file