### PR TITLE
Fix the timestamp extraction from UUIDv7

### DIFF
--- a/src/uuid.c
+++ b/src/uuid.c
@@ -130,14 +130,14 @@ ts_timestamptz_from_uuid_v7(PG_FUNCTION_ARGS)
 	uint64 timestamp = (pg_ntoh64(timestamp_be)) >> 16;
 
 	/* Get the sub ms part as well, reversing the scaling */
-	uint32 subms_timestamp = ((uuid->data[6] << 8) | uuid->data[7]) * 1000 / (1 << 12);
+	uint32 subms_timestamp = (((uuid->data[6] & 0xF) << 8) | uuid->data[7]) * 1000 / (1 << 12);
 
 	/* Milliseconds timestamp from PG Epoch (2000-01-01) */
-	uint64 timestamp_micros =
+	uint64 timestamp_millis =
 		(timestamp - ((uint64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * SECS_PER_DAY) * 1000ULL);
 
 	/* Add up the whole to get microseconds */
-	TimestampTz ts = timestamp_micros * 1000 + subms_timestamp;
+	TimestampTz ts = timestamp_millis * 1000 + subms_timestamp;
 
 	return TimestampTzGetDatum(ts);
 }

--- a/tsl/test/expected/compression_uuid.out
+++ b/tsl/test/expected/compression_uuid.out
@@ -78,3 +78,27 @@ ORDER BY 1;
             7 |   107
 (2 rows)
 
+-- Sub ms timestamp test:
+--   generate all microseconds timestamps between the two dates below and
+--   generate a UUID v7 based on the timestamp and
+--   extract the timestamp from the UUID and
+--   compare the timestamp to the original one
+--   1 microsecond difference is allowed due to scaling of decimals to binaries
+--
+CREATE TABLE subms AS SELECT _timescaledb_functions.uuid_v7_from_timestamptz(x) u, x ts
+FROM
+  generate_series('2025-01-01:00:00:00'::timestamptz, '2025-01-01:00:00:03'::timestamptz, '1 microsecond'::interval) x;
+SELECT u, ts, ts2
+FROM
+  (
+    SELECT
+      u, ts, _timescaledb_functions.timestamptz_from_uuid_v7(u) ts2
+    FROM
+      subms
+  ) x
+WHERE
+  (x.ts - x.ts2) > '00:00:00.000001' OR (x.ts - x.ts2) < '-00:00:00.000001';
+ u | ts | ts2 
+---+----+-----
+(0 rows)
+


### PR DESCRIPTION
Subms timestamp extraction logic had a bug which caused the milliseconds and below to be wrong.

Disable-check: force-changelog-file