### PR TITLE
Event trigger for Caggs

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -28,6 +28,7 @@
 #include <catalog/pg_type.h>
 #include <catalog/toasting.h>
 #include <commands/defrem.h>
+#include <commands/event_trigger.h>
 #include <commands/tablecmds.h>
 #include <commands/tablespace.h>
 #include <commands/trigger.h>
@@ -811,6 +812,10 @@ static void
 cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquery,
 			CAggTimebucketInfo *bucket_info, WithClauseResult *with_clause_options)
 {
+	/* Prepare event trigger state and invoke ddl_command_start triggers */
+	EventTriggerBeginCompleteQuery();
+	EventTriggerDDLCommandStart((Node *) stmt);
+
 	ObjectAddress mataddress;
 	char relnamebuf[NAMEDATALEN];
 	MatTableColumnInfo mattblinfo;
@@ -1043,6 +1048,11 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 		cagg_add_trigger_hypertable(bucket_info->htoid, bucket_info->htid);
 	else if (slot_prepared)
 		cagg_add_logical_decoding_slot_finalize();
+
+	/* Collect information and invoke ddl_command_end triggers */
+	EventTriggerCollectSimpleCommand(view_address, InvalidObjectAddress, (Node *) stmt);
+	EventTriggerDDLCommandEnd((Node *) stmt);
+	EventTriggerEndCompleteQuery();
 }
 
 DDLResult
@@ -1104,6 +1114,7 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 											  schema_name,
 											  stmt->into->rel->relname,
 											  true);
+
 	cagg_create(stmt, &viewstmt, (Query *) stmt->query, &timebucket_exprinfo, with_clause_options);
 
 	/* Insert the MIN of the time dimension type for the new watermark */

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -430,3 +430,61 @@ ORDER BY user_view_name;
  temperature_tz_4h_3 | time_bucket(interval,timestamp with time zone)
 (1 row)
 
+---------------------------------
+--Event trigger on cagg DDL
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- Create a base table
+create table foo(time timestamptz, val int );
+select create_hypertable('foo', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ (16,public,foo,t)
+(1 row)
+
+insert into foo values ('2025-01-01', 1);
+insert into foo values ('2025-01-02', 2);
+-- Create a trigger function that raises a notice
+CREATE OR REPLACE FUNCTION log_any_command()
+RETURNS event_trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    cmd RECORD;
+BEGIN
+    RAISE NOTICE 'command % for event %', tg_tag, tg_event;
+    FOR cmd IN SELECT * FROM pg_event_trigger_ddl_commands()
+    LOOP
+        RAISE NOTICE 'tag: %, object: %', cmd.command_tag, cmd.object_identity::regclass;
+    END LOOP;
+END;
+$$;
+--create trigger on ddl start
+CREATE EVENT TRIGGER log_ddl_start ON ddl_command_start
+EXECUTE FUNCTION log_any_command();
+--create trigger on ddl end
+CREATE EVENT TRIGGER log_ddl_end ON ddl_command_end
+EXECUTE FUNCTION log_any_command();
+--create trigger on ddl drop
+CREATE EVENT TRIGGER log_ddl_drop ON sql_drop
+EXECUTE FUNCTION log_any_command();
+--create a continuous aggregate, the trigger should now be fired too
+create materialized view foo_cagg with (timescaledb.continuous) as select time_bucket('1 day', time) as day, sum(val) as total from foo group by day;
+NOTICE:  command CREATE VIEW for event ddl_command_start
+NOTICE:  command CREATE VIEW for event ddl_command_end
+NOTICE:  tag: CREATE VIEW, object: foo_cagg
+NOTICE:  refreshing continuous aggregate "foo_cagg"
+--drop the continuous aggregate, the trigger on drop ddl should be fired, because 
+--the TimescaleDB's interceptor on the drop statement returns DDL_CONTINUE, eventually fallback to 
+--the default drop materialized view behavior
+DROP MATERIALIZED VIEW foo_cagg;
+NOTICE:  command DROP VIEW for event ddl_command_start
+NOTICE:  command DROP VIEW for event sql_drop
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  command DROP VIEW for event ddl_command_end
+--clean up
+DROP EVENT TRIGGER log_ddl_start;
+DROP EVENT TRIGGER log_ddl_end;
+DROP EVENT TRIGGER log_ddl_drop;
+DROP FUNCTION log_any_command();
+DROP TABLE foo;

--- a/tsl/test/sql/cagg_utils.sql
+++ b/tsl/test/sql/cagg_utils.sql
@@ -243,3 +243,57 @@ SELECT user_view_name, bf.bucket_func
 FROM _timescaledb_catalog.continuous_agg, LATERAL _timescaledb_functions.cagg_get_bucket_function_info(mat_hypertable_id) AS bf
 WHERE user_view_name = 'temperature_tz_4h_3'
 ORDER BY user_view_name;
+
+---------------------------------
+--Event trigger on cagg DDL
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- Create a base table
+create table foo(time timestamptz, val int );
+select create_hypertable('foo', 'time');
+insert into foo values ('2025-01-01', 1);
+insert into foo values ('2025-01-02', 2);
+
+-- Create a trigger function that raises a notice
+CREATE OR REPLACE FUNCTION log_any_command()
+RETURNS event_trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    cmd RECORD;
+BEGIN
+    RAISE NOTICE 'command % for event %', tg_tag, tg_event;
+    FOR cmd IN SELECT * FROM pg_event_trigger_ddl_commands()
+    LOOP
+        RAISE NOTICE 'tag: %, object: %', cmd.command_tag, cmd.object_identity::regclass;
+    END LOOP;
+END;
+$$;
+
+--create trigger on ddl start
+CREATE EVENT TRIGGER log_ddl_start ON ddl_command_start
+EXECUTE FUNCTION log_any_command();
+
+--create trigger on ddl end
+CREATE EVENT TRIGGER log_ddl_end ON ddl_command_end
+EXECUTE FUNCTION log_any_command();
+
+--create trigger on ddl drop
+CREATE EVENT TRIGGER log_ddl_drop ON sql_drop
+EXECUTE FUNCTION log_any_command();
+
+--create a continuous aggregate, the trigger should now be fired too
+create materialized view foo_cagg with (timescaledb.continuous) as select time_bucket('1 day', time) as day, sum(val) as total from foo group by day;
+
+--drop the continuous aggregate, the trigger on drop ddl should be fired, because 
+--the TimescaleDB's interceptor on the drop statement returns DDL_CONTINUE, eventually fallback to 
+--the default drop materialized view behavior
+DROP MATERIALIZED VIEW foo_cagg;
+
+--clean up
+DROP EVENT TRIGGER log_ddl_start;
+DROP EVENT TRIGGER log_ddl_end;
+DROP EVENT TRIGGER log_ddl_drop;
+DROP FUNCTION log_any_command();
+DROP TABLE foo;


### PR DESCRIPTION
The creation of continuous aggregate bypasses PostgreSQL's DDL processing, including the firing of corresponding event triggers (ddl_start and ddl_end). This commit explicitly calls Postgres' functions that set up and fire the event triggers at the beginning and end of the creation of a CAgg.

I found a similar patch https://github.com/timescale/timescaledb/commit/74bfb6a7bdbcc12ab58d3500d00f1920cff0490b that enabled event trigger for chunk table creation. That is under the parameter _timescaledb.enable_event_triggers_, whose default value is false. I feel that event trigger for caggs should NOT be under the same parameter and should be on by default, because from user's perspective it's just a materialized view and should behave similarly. 