### PR TITLE
Add support for UUID compression

### DIFF
--- a/.unreleased/pr_8393
+++ b/.unreleased/pr_8393
@@ -1,0 +1,1 @@
+Implements: #8393 Add specialized compression for UUIDs. Best suited for UUID v7, but still works with other UUID versions. This is experimental at the moment and backward compatibility is not guaranteed.

--- a/sql/pre_install/insert_data.sql
+++ b/sql/pre_install/insert_data.sql
@@ -10,4 +10,6 @@ insert into _timescaledb_catalog.compression_algorithm( id, version, name, descr
 ( 3, 1, 'COMPRESSION_ALGORITHM_GORILLA', 'gorilla'),
 ( 4, 1, 'COMPRESSION_ALGORITHM_DELTADELTA', 'deltadelta'),
 ( 5, 1, 'COMPRESSION_ALGORITHM_BOOL', 'bool'),
-( 6, 1, 'COMPRESSION_ALGORITHM_NULL', 'null');
+( 6, 1, 'COMPRESSION_ALGORITHM_NULL', 'null'),
+( 7, 1, 'COMPRESSION_ALGORITHM_UUID', 'uuid');
+

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -79,3 +79,6 @@ CREATE PROCEDURE _timescaledb_functions.policy_compression_execute(
 )
 AS $$ BEGIN END $$ LANGUAGE PLPGSQL;
 
+INSERT INTO _timescaledb_catalog.compression_algorithm( id, version, name, description) values
+( 7, 1, 'COMPRESSION_ALGORITHM_UUID', 'uuid');
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -100,3 +100,6 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.generate_uuid_v7;
 DROP FUNCTION IF EXISTS _timescaledb_functions.uuid_v7_from_timestamptz;
 DROP FUNCTION IF EXISTS _timescaledb_functions.timestamptz_from_uuid_v7;
 DROP FUNCTION IF EXISTS _timescaledb_functions.uuid_version;
+
+DELETE FROM _timescaledb_catalog.compression_algorithm WHERE id = 7 AND version = 1 AND name = 'COMPRESSION_ALGORITHM_UUID';
+

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -83,6 +83,8 @@ CROSSMODULE_WRAPPER(array_compressor_append);
 CROSSMODULE_WRAPPER(array_compressor_finish);
 CROSSMODULE_WRAPPER(bool_compressor_append);
 CROSSMODULE_WRAPPER(bool_compressor_finish);
+CROSSMODULE_WRAPPER(uuid_compressor_append);
+CROSSMODULE_WRAPPER(uuid_compressor_finish);
 CROSSMODULE_WRAPPER(create_compressed_chunk);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
@@ -395,6 +397,8 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.array_compressor_finish = error_no_default_fn_pg_community,
 	.bool_compressor_append = error_no_default_fn_pg_community,
 	.bool_compressor_finish = error_no_default_fn_pg_community,
+	.uuid_compressor_append = error_no_default_fn_pg_community,
+	.uuid_compressor_finish = error_no_default_fn_pg_community,
 	.bloom1_contains = error_no_default_fn_pg_community,
 
 	.decompress_batches_for_insert = error_no_default_fn_chunk_insert_state_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -163,6 +163,8 @@ typedef struct CrossModuleFunctions
 	PGFunction array_compressor_finish;
 	PGFunction bool_compressor_append;
 	PGFunction bool_compressor_finish;
+	PGFunction uuid_compressor_append;
+	PGFunction uuid_compressor_finish;
 	PGFunction bloom1_contains;
 
 	PGFunction create_chunk;

--- a/src/guc.c
+++ b/src/guc.c
@@ -104,6 +104,7 @@ bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
+TSDLLEXPORT bool ts_guc_enable_uuid_compression = false;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
@@ -783,6 +784,17 @@ _guc_init(void)
 							 "Enable bool compression",
 							 &ts_guc_enable_bool_compression,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_uuid_compression"),
+							 "Enable uuid compression functionality",
+							 "Enable uuid compression",
+							 &ts_guc_enable_uuid_compression,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -60,6 +60,7 @@ extern bool ts_guc_enable_chunk_skipping;
 extern TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression;
 extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
+extern TSDLLEXPORT bool ts_guc_enable_uuid_compression;
 extern TSDLLEXPORT int ts_guc_compression_batch_size_limit;
 extern TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit;
 #if PG16_GE

--- a/src/uuid.h
+++ b/src/uuid.h
@@ -9,4 +9,4 @@
 #include <utils/uuid.h>
 
 extern pg_uuid_t *ts_uuid_create(void);
-extern pg_uuid_t *ts_create_uuid_v7_from_timestamptz(TimestampTz ts);
+extern TSDLLEXPORT pg_uuid_t *ts_create_uuid_v7_from_timestamptz(TimestampTz ts);

--- a/tsl/src/compression/README.md
+++ b/tsl/src/compression/README.md
@@ -76,6 +76,20 @@ row based iterators then walk through the bitmap. The bool compressor differs fr
 the other compressors in that it stores the last non-value as a place holder for
 the null values. This is done to make vectorization easier.
 
+### UUID Compressor
+
+The uuid compressor is a compression algorithm that aims at storing UUID v7 values
+compressed as much as possible by taking advantage of the timestamp values being
+present in the UUID.
+
+The first part of the UUID where the timestamp resides is stored using the delta-delta
+algorithm. The second part of the UUID is stored without compression, as a sequence of
+uint64 values.
+
+The algorithm checks the cardinality of the values in the compressed batch and based on
+the cardinality it decides wether it is worth to recompress the batch using the dictionary
+compression algorithm. In that case it recompresses and stores the UUIDs as a dictionary.
+
 # Merging chunks while compressing #
 
 ## Setup ##

--- a/tsl/src/compression/algorithms/CMakeLists.txt
+++ b/tsl/src/compression/algorithms/CMakeLists.txt
@@ -5,5 +5,6 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary.c
     ${CMAKE_CURRENT_SOURCE_DIR}/gorilla.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bool_compress.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/null.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/null.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/uuid_compress.c)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/compression/algorithms/uuid_compress.c
+++ b/tsl/src/compression/algorithms/uuid_compress.c
@@ -1,0 +1,625 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include "uuid_compress.h"
+#include "adts/uint64_vec.h"
+#include "common/hashfn.h"
+#include "compression/arrow_c_data_interface.h"
+#include "compression/compression.h"
+#include "deltadelta.h"
+#include "dictionary.h"
+#include "lib/hyperloglog.h"
+#include "null.h"
+#include "simple8b_rle.h"
+
+#ifdef TS_USE_UMASH
+#include "import/umash.h"
+#endif
+
+typedef struct UuidCompressed
+{
+	CompressedDataHeaderFields; /* this uses 5 bytes */
+	uint8 padding;				/* padding to get the size to even bytes */
+	uint16 num_nulls;
+	uint32 timestamp_size;
+	uint32 rand_b_and_variant_size;
+	/* 8-byte alignment sentinel for the following fields */
+	uint64 alignment_sentinel[FLEXIBLE_ARRAY_MEMBER];
+} UuidCompressed;
+
+typedef struct UuidDecompressionIterator
+{
+	DecompressionIterator base;
+	int32 position;		   /* position within the total */
+	int32 total_elements;  /* total number of entries plus nulls */
+	int32 values_position; /* position in the non-null values */
+	DecompressionIterator *timestamp_iter;
+	pg_uuid_t *uuid_buffer; /* preallocate buffer and prefill with the rand_b_and_variant */
+} UuidDecompressionIterator;
+
+/*
+ * HyperLogLog parameters.
+ *
+ * The bit width is set such that the error rate is acceptable and also allocate
+ * little memory. 8 uses 256 bytes and the error rate is 6.5%
+ */
+#define HLL_BIT_WIDTH 8
+#define HLL_ERROR_RATE 0.065
+#define HLL_MIN_CARDINALITY 20
+
+/*
+ * The UUID compressor is using delta delta compression for the first 8
+ * bytes of the UUID and stores the rest as a uint64_vec. At the same time
+ * it keeps track of the cardinality of values. if the cardinality
+ * indicates that we are better off with the dictionary compressor, we will
+ * recompress it at the end.
+ */
+typedef struct UuidCompressor
+{
+	/* Delta-delta encoding for timestamp, version and rand_a. */
+	DeltaDeltaCompressor *timestamp;
+
+	/* We store the rand_b and variant parts together as a uint64_vec
+	 * to avoid having to store two separate bitmaps.
+	 */
+	uint64_vec rand_b_and_variant;
+
+	/* HLL state to estimate the cardinality. This is used to check if
+	 * we are better off with recompressing the data as a dictionary.
+	 */
+	hyperLogLogState cardinality;
+
+	/* Number of nulls in the data. */
+	uint16 num_nulls;
+
+	/* Number of elements in the timestamp part. */
+	uint16 num_values;
+} UuidCompressor;
+
+typedef struct ExtendedCompressor
+{
+	Compressor base;
+	UuidCompressor *internal;
+} ExtendedCompressor;
+
+/*
+ * Local helpers
+ */
+static void uuid_compressor_append_uuid(Compressor *compressor, Datum val);
+static void uuid_compressor_append_null_value(Compressor *compressor);
+static void *uuid_compressor_finish_and_reset(Compressor *compressor);
+static void decompression_iterator_init(UuidDecompressionIterator *iter, void *compressed,
+										Oid element_type, bool forward);
+
+const Compressor uuid_compressor_initializer = {
+	.append_val = uuid_compressor_append_uuid,
+	.append_null = uuid_compressor_append_null_value,
+	.is_full = NULL,
+	.finish = uuid_compressor_finish_and_reset,
+};
+
+/*
+ * Compressor framework functions and definitions for the uuid_compress algorithm.
+ */
+
+extern UuidCompressor *
+uuid_compressor_alloc(void)
+{
+	UuidCompressor *compressor = palloc0(sizeof(*compressor));
+	compressor->timestamp = delta_delta_compressor_alloc();
+	uint64_vec_init(&compressor->rand_b_and_variant,
+					CurrentMemoryContext,
+					TARGET_COMPRESSED_BATCH_SIZE);
+	initHyperLogLog(&compressor->cardinality, HLL_BIT_WIDTH);
+	return compressor;
+}
+
+extern void
+uuid_compressor_append_null(UuidCompressor *compressor)
+{
+	delta_delta_compressor_append_null(compressor->timestamp);
+	compressor->num_nulls++;
+}
+
+#ifdef TS_USE_UMASH
+static inline uint32
+uuid_compress_hash(pg_uuid_t *uuid)
+{
+	static struct umash_params params = { 0 };
+	if (params.poly[0][0] == 0)
+	{
+		umash_params_derive(&params, 0x12345abcdef67890ULL, NULL);
+		Assert(params.poly[0][0] != 0);
+	}
+
+	uint64 h = umash_full(&params,
+						  /* seed = */ ~0ULL,
+						  /* which = */ 0,
+						  uuid->data,
+						  16);
+
+	return (uint32) (h ^ (h >> 32));
+}
+#else
+static inline uint32
+uuid_compress_hash(pg_uuid_t *uuid)
+{
+	return hash_bytes((unsigned char *) uuid->data, sizeof(*uuid));
+}
+#endif
+
+extern void
+uuid_compressor_append_value(UuidCompressor *compressor, pg_uuid_t next_val)
+{
+	uint64_t components[2];
+	memcpy(components, next_val.data, sizeof(components));
+
+	/* The first component is the timestamp, version and rand_a. */
+	uint64_t timestamp = pg_ntoh64(components[0]);
+	/* The second part is the rand_b and variant. */
+	uint64_t rand_b_and_variant = components[1];
+
+	delta_delta_compressor_append_value(compressor->timestamp, timestamp);
+	uint64_vec_append(&compressor->rand_b_and_variant, rand_b_and_variant);
+
+	uint32 h = uuid_compress_hash(&next_val);
+	addHyperLogLog(&compressor->cardinality, h);
+	compressor->num_values++;
+}
+
+static size_t
+uuid_compressor_estimate_dictionary_storage(UuidCompressor *compressor,
+											size_t nulls_compressed_size)
+{
+	double cardinality = (double) compressor->rand_b_and_variant.num_elements;
+	double cardinality_and_error = cardinality;
+
+	/* Don't use HLL if there are too few elements to estimate the cardinality. */
+	if (cardinality > HLL_MIN_CARDINALITY)
+	{
+		cardinality = estimateHyperLogLog(&compressor->cardinality);
+		cardinality_and_error = cardinality * (1.0 - HLL_ERROR_RATE);
+	}
+
+	int array_index_bytes = ((int) cardinality_and_error * 5 + 63) / 64 * 8;
+
+	double estimated_dictionary_storage =
+		/* 16 bytes per values in dictionary/array/values */
+		cardinality_and_error * 16 +
+		/* a single RLE block for the sizes in dictionary/array/sizes */
+		16 +
+		/* no nulls in dictionary/array/nulls */
+		0 +
+		/* 5 bits on average for the indexes in dictionary/array/indexes */
+		array_index_bytes +
+		/* storing nulls is the same as in the delta-delta compressor */
+		nulls_compressed_size;
+
+	return estimated_dictionary_storage;
+}
+
+extern void *
+uuid_compressor_finish(UuidCompressor *compressor)
+{
+	if (compressor == NULL)
+		return NULL;
+
+	if (compressor->num_values == 0)
+		return NULL;
+
+	size_t nulls_compressed_size = 0;
+	size_t timestamp_compressed_size =
+		delta_delta_compressor_compressed_size(compressor->timestamp, &nulls_compressed_size);
+	size_t estimated_dictionary_storage =
+		uuid_compressor_estimate_dictionary_storage(compressor, nulls_compressed_size);
+	size_t rand_b_and_variant_compressed_size =
+		compressor->rand_b_and_variant.num_elements * sizeof(uint64_t);
+	Assert(compressor->rand_b_and_variant.num_elements == compressor->num_values);
+	size_t total_compressed_size =
+		sizeof(UuidCompressed) + timestamp_compressed_size + rand_b_and_variant_compressed_size;
+
+	/* TODO: this is temporary: to iterate over the delta-delta compressed data
+	 * we need to finalize the compression, so even if we knew that the dictionary
+	 * compression is better we still need to allocate, finish and memcpy the
+	 * entries. This is clearly a waste. To solve this we will need an interface
+	 * to iterate over compressed data without finalizing it.
+	 */
+	char *compressed_data = palloc(total_compressed_size);
+	UuidCompressed *compressed = (UuidCompressed *) compressed_data;
+	SET_VARSIZE(&compressed->vl_len_, total_compressed_size);
+	compressed->compression_algorithm = COMPRESSION_ALGORITHM_UUID;
+	compressed->num_nulls = compressor->num_nulls;
+	Ensure(compressed->num_nulls == compressor->num_nulls,
+		   "unexpected number of nulls, it doesn't fit into the header");
+	compressed->timestamp_size = timestamp_compressed_size;
+	compressed->rand_b_and_variant_size = rand_b_and_variant_compressed_size;
+
+	compressed_data += sizeof(*compressed);
+	char *timestamp_compressed_data = compressed_data;
+	compressed_data =
+		delta_delta_compressor_finish_into(compressor->timestamp, timestamp_compressed_data);
+	/* Make sure delta-delta took exactly the size it said it will */
+	Assert(compressed_data - timestamp_compressed_data == (long) timestamp_compressed_size);
+	memcpy(compressed_data,
+		   compressor->rand_b_and_variant.data,
+		   rand_b_and_variant_compressed_size);
+
+	if (total_compressed_size > estimated_dictionary_storage)
+	{
+		/* Recompress as dictionary */
+		DictionaryCompressor *dict_compressor = dictionary_compressor_alloc(UUIDOID);
+		DecompressionIterator *iter =
+			delta_delta_decompression_iterator_from_datum_forward(PointerGetDatum(
+																	  timestamp_compressed_data),
+																  INT8OID);
+		uint32 value_position = 0;
+		for (DecompressResult r = delta_delta_decompression_iterator_try_next_forward(iter);
+			 !r.is_done;
+			 r = delta_delta_decompression_iterator_try_next_forward(iter))
+		{
+			if (r.is_null)
+			{
+				dictionary_compressor_append_null(dict_compressor);
+			}
+			else
+			{
+				uint64_t components[2];
+				components[0] = pg_hton64(DatumGetInt64(r.val));
+				components[1] = compressor->rand_b_and_variant.data[value_position];
+				pg_uuid_t uuid;
+				memcpy(uuid.data, components, sizeof(components));
+				dictionary_compressor_append(dict_compressor, UUIDPGetDatum(&uuid));
+				++value_position;
+			}
+		}
+
+		void *dict_compressed = dictionary_compressor_finish(dict_compressor);
+		if (VARSIZE(dict_compressed) < total_compressed_size)
+		{
+			/* We are better off with the dictionary compression, inline with the estimated size */
+			pfree(compressed);
+			compressed = dict_compressed;
+		}
+		else
+		{
+			/* We are better off with the original compression, contrary to the estimated size.
+			 * This is OK, as the estimate is probabilistic.
+			 */
+			pfree(dict_compressed);
+		}
+		pfree(dict_compressor);
+		pfree(iter);
+	}
+
+	return compressed;
+}
+
+extern bool
+uuid_compressed_has_nulls(const CompressedDataHeader *header)
+{
+	const UuidCompressed *uc = (const UuidCompressed *) header;
+	return uc->num_nulls > 0;
+}
+
+extern DecompressResult
+uuid_decompression_iterator_try_next_forward(DecompressionIterator *iter)
+{
+	Assert(iter->compression_algorithm == COMPRESSION_ALGORITHM_UUID && iter->forward);
+	Assert(iter->element_type == UUIDOID);
+
+	UuidDecompressionIterator *uuid_iter = (UuidDecompressionIterator *) iter;
+
+	DecompressResult r =
+		delta_delta_decompression_iterator_try_next_forward(uuid_iter->timestamp_iter);
+	if (r.is_done)
+	{
+		CheckCompressedData(uuid_iter->position >= uuid_iter->total_elements);
+		return (DecompressResult){
+			.is_done = true,
+		};
+	}
+
+	if (r.is_null)
+	{
+		uuid_iter->position++;
+		return (DecompressResult){
+			.is_null = true,
+		};
+	}
+
+	pg_uuid_t *current_uuid = &uuid_iter->uuid_buffer[uuid_iter->values_position];
+	uuid_iter->values_position++;
+	uuid_iter->position++;
+
+	uint64 first_part = pg_hton64(DatumGetInt64(r.val));
+	memcpy(current_uuid->data, &first_part, sizeof(first_part));
+
+	return (DecompressResult){
+		.val = PointerGetDatum(current_uuid),
+	};
+}
+
+extern DecompressionIterator *
+uuid_decompression_iterator_from_datum_forward(Datum uuid_compressed, Oid element_type)
+{
+	UuidDecompressionIterator *iterator = palloc0(sizeof(*iterator));
+	decompression_iterator_init(iterator,
+								(void *) PG_DETOAST_DATUM(uuid_compressed),
+								element_type,
+								true);
+	return &iterator->base;
+}
+
+extern DecompressResult
+uuid_decompression_iterator_try_next_reverse(DecompressionIterator *iter)
+{
+	Assert(iter->compression_algorithm == COMPRESSION_ALGORITHM_UUID && !iter->forward);
+	Assert(iter->element_type == UUIDOID);
+
+	UuidDecompressionIterator *uuid_iter = (UuidDecompressionIterator *) iter;
+
+	DecompressResult r =
+		delta_delta_decompression_iterator_try_next_reverse(uuid_iter->timestamp_iter);
+	if (r.is_done)
+	{
+		CheckCompressedData(uuid_iter->position == -1);
+		CheckCompressedData(uuid_iter->values_position == -1);
+		return (DecompressResult){
+			.is_done = true,
+		};
+	}
+
+	if (r.is_null)
+	{
+		uuid_iter->position--;
+		return (DecompressResult){
+			.is_null = true,
+		};
+	}
+
+	Assert(uuid_iter->values_position >= 0);
+	pg_uuid_t *current_uuid = &uuid_iter->uuid_buffer[uuid_iter->values_position];
+	uuid_iter->values_position--;
+	uuid_iter->position--;
+
+	uint64 first_part = pg_hton64(DatumGetInt64(r.val));
+	memcpy(current_uuid->data, &first_part, sizeof(first_part));
+
+	return (DecompressResult){
+		.val = PointerGetDatum(current_uuid),
+	};
+}
+
+extern DecompressionIterator *
+uuid_decompression_iterator_from_datum_reverse(Datum uuid_compressed, Oid element_type)
+{
+	UuidDecompressionIterator *iterator = palloc(sizeof(*iterator));
+	decompression_iterator_init(iterator,
+								(void *) PG_DETOAST_DATUM(uuid_compressed),
+								element_type,
+								false);
+	return &iterator->base;
+}
+
+extern void
+uuid_compressed_send(CompressedDataHeader *header, StringInfo buffer)
+{
+	const UuidCompressed *data = (UuidCompressed *) header;
+	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_UUID);
+
+	pq_sendint16(buffer, data->num_nulls);
+	pq_sendint32(buffer, data->timestamp_size);
+	pq_sendint32(buffer, data->rand_b_and_variant_size);
+
+	char *ptr = (char *) data->alignment_sentinel;
+	deltadelta_compressed_send((CompressedDataHeader *) ptr, buffer);
+	ptr += data->timestamp_size;
+	uint64 *rand_b_and_variant = (uint64 *) ptr;
+	uint32 num_elements = data->rand_b_and_variant_size / sizeof(uint64);
+	for (uint32 i = 0; i < num_elements; i++)
+		pq_sendint64(buffer, rand_b_and_variant[i]);
+}
+
+extern Datum
+uuid_compressed_recv(StringInfo buffer)
+{
+	size_t total_compressed_sized = 0;
+	uint16 num_nulls = pq_getmsgint(buffer, 2);
+	uint32 timestamp_size = pq_getmsgint32(buffer);
+	uint32 rand_b_and_variant_size = pq_getmsgint32(buffer);
+
+	total_compressed_sized = sizeof(UuidCompressed) + timestamp_size + rand_b_and_variant_size;
+	CheckCompressedData(total_compressed_sized <= MaxAllocSize);
+
+	char *result = palloc(total_compressed_sized);
+	UuidCompressed *compressed = (UuidCompressed *) result;
+	compressed->num_nulls = num_nulls;
+	compressed->timestamp_size = timestamp_size;
+	compressed->rand_b_and_variant_size = rand_b_and_variant_size;
+	SET_VARSIZE(&compressed->vl_len_, total_compressed_sized);
+	compressed->compression_algorithm = COMPRESSION_ALGORITHM_UUID;
+
+	Datum delta_delta_compressed = deltadelta_compressed_recv(buffer);
+	size_t delta_delta_compressed_size = VARSIZE(delta_delta_compressed);
+	CheckCompressedData(delta_delta_compressed_size == timestamp_size);
+
+	memcpy(result + sizeof(UuidCompressed),
+		   DatumGetPointer(delta_delta_compressed),
+		   delta_delta_compressed_size);
+	uint64 *rand_b_and_variant =
+		(uint64 *) (result + sizeof(UuidCompressed) + delta_delta_compressed_size);
+	uint32 num_elements = rand_b_and_variant_size / sizeof(uint64);
+	for (uint32 i = 0; i < num_elements; i++)
+		rand_b_and_variant[i] = pq_getmsgint64(buffer);
+
+	PG_RETURN_POINTER(result);
+}
+
+extern Compressor *
+uuid_compressor_for_type(Oid element_type)
+{
+	ExtendedCompressor *compressor = palloc(sizeof(*compressor));
+	switch (element_type)
+	{
+		case UUIDOID:
+			*compressor = (ExtendedCompressor){ .base = uuid_compressor_initializer };
+			return &compressor->base;
+		default:
+			elog(ERROR, "invalid type for uuid compressor \"%s\"", format_type_be(element_type));
+	}
+
+	pg_unreachable();
+}
+
+/*
+ * Cross-module functions for the uuid_compress algorithm.
+ */
+extern Datum
+tsl_uuid_compressor_append(PG_FUNCTION_ARGS)
+{
+	MemoryContext old_context;
+	MemoryContext agg_context;
+	UuidCompressor *compressor = (UuidCompressor *) (PG_ARGISNULL(0) ? NULL : PG_GETARG_POINTER(0));
+
+	if (!AggCheckCallContext(fcinfo, &agg_context))
+	{
+		/* cannot be called directly because of internal-type argument */
+		elog(ERROR, "tsl_uuid_compressor_append called in non-aggregate context");
+	}
+
+	old_context = MemoryContextSwitchTo(agg_context);
+
+	if (compressor == NULL)
+	{
+		compressor = uuid_compressor_alloc();
+		if (PG_NARGS() > 2)
+			elog(ERROR, "append expects two arguments");
+	}
+
+	if (PG_ARGISNULL(1))
+		uuid_compressor_append_null(compressor);
+	else
+	{
+		pg_uuid_t *uuid = DatumGetUUIDP(PG_GETARG_DATUM(1));
+		Ensure(uuid != NULL, "invalid UUID");
+		uuid_compressor_append_value(compressor, *uuid);
+	}
+
+	MemoryContextSwitchTo(old_context);
+	PG_RETURN_POINTER(compressor);
+}
+
+extern Datum
+tsl_uuid_compressor_finish(PG_FUNCTION_ARGS)
+{
+	UuidCompressor *compressor = PG_ARGISNULL(0) ? NULL : (UuidCompressor *) PG_GETARG_POINTER(0);
+	void *compressed;
+	if (compressor == NULL)
+		PG_RETURN_NULL();
+
+	compressed = uuid_compressor_finish(compressor);
+	if (compressed == NULL)
+		PG_RETURN_NULL();
+	PG_RETURN_POINTER(compressed);
+}
+
+/*
+ * Local helpers
+ */
+static void
+uuid_compressor_append_uuid(Compressor *compressor, Datum val)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = uuid_compressor_alloc();
+
+	pg_uuid_t *uuid = DatumGetUUIDP(val);
+	Ensure(uuid != NULL, "invalid UUID");
+	uuid_compressor_append_value(extended->internal, *uuid);
+}
+
+static void
+uuid_compressor_append_null_value(Compressor *compressor)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	if (extended->internal == NULL)
+		extended->internal = uuid_compressor_alloc();
+
+	uuid_compressor_append_null(extended->internal);
+}
+
+static void *
+uuid_compressor_finish_and_reset(Compressor *compressor)
+{
+	ExtendedCompressor *extended = (ExtendedCompressor *) compressor;
+	void *compressed = NULL;
+	if (extended != NULL && extended->internal != NULL)
+	{
+		compressed = uuid_compressor_finish(extended->internal);
+		pfree(extended->internal);
+		extended->internal = NULL;
+	}
+	return compressed;
+}
+
+static void
+decompression_iterator_init(UuidDecompressionIterator *iter, void *compressed, Oid element_type,
+							bool forward)
+{
+	Assert(element_type == UUIDOID);
+
+	StringInfoData si = { .data = compressed, .len = VARSIZE(compressed) };
+	UuidCompressed *header = consumeCompressedData(&si, sizeof(UuidCompressed));
+	char *timestamp_compressed_data;
+	char *rand_b_and_variant_compressed_data;
+
+	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_UUID);
+	timestamp_compressed_data = consumeCompressedData(&si, header->timestamp_size);
+	rand_b_and_variant_compressed_data =
+		consumeCompressedData(&si, header->rand_b_and_variant_size);
+
+	int32 num_values = (int32) (header->rand_b_and_variant_size / sizeof(uint64));
+	int32 total_elements = (int32) header->num_nulls + num_values;
+
+	CheckCompressedData(num_values > 0);
+
+	DecompressionIterator *timestamp_iter =
+		forward ?
+			delta_delta_decompression_iterator_from_datum_forward(PointerGetDatum(
+																	  timestamp_compressed_data),
+																  INT8OID) :
+			delta_delta_decompression_iterator_from_datum_reverse(PointerGetDatum(
+																	  timestamp_compressed_data),
+																  INT8OID);
+	uint64 *rand_b_and_variant = (uint64 *) palloc(header->rand_b_and_variant_size);
+	memcpy(rand_b_and_variant, rand_b_and_variant_compressed_data, header->rand_b_and_variant_size);
+	pg_uuid_t *uuid_buffer = (pg_uuid_t *) palloc(num_values * sizeof(pg_uuid_t));
+	for (int32 i = 0; i < num_values; i++)
+	{
+		uint64 components[2] = { 0, rand_b_and_variant[i] };
+		memcpy(uuid_buffer[i].data, components, sizeof(components));
+	}
+	pfree(rand_b_and_variant);
+
+	*iter = (UuidDecompressionIterator){
+		.base = { .compression_algorithm = COMPRESSION_ALGORITHM_UUID,
+				  .forward = forward,
+				  .element_type = element_type,
+				  .try_next = (forward ? uuid_decompression_iterator_try_next_forward :
+										 uuid_decompression_iterator_try_next_reverse) },
+		.position = (forward ? 0 : total_elements - 1),
+		.timestamp_iter = timestamp_iter,
+		.total_elements = total_elements,
+		.values_position = (forward ? 0 : num_values - 1),
+		.uuid_buffer = uuid_buffer,
+	};
+}
+
+static void
+pg_attribute_unused() silence_unused_warning(void)
+{
+	simple8brle_serialized_recv(NULL);
+}

--- a/tsl/src/compression/algorithms/uuid_compress.h
+++ b/tsl/src/compression/algorithms/uuid_compress.h
@@ -1,0 +1,70 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+/*
+ * uuid_compress is used to encode UUID values where there are 4 distinct parts
+ * that are encoded separately. The UUID being encoded is optimised for the v7
+ * UUID format. The four parts are:
+ *
+ *  - timestamp : (delta-delta encoding)
+ *  - the version number and variant number concatenated : (simple8b_rle)
+ *  - rand_a : is encoded as an array of bits
+ *  - rand_b : is encoded as an array of bits
+ */
+
+#include <postgres.h>
+#include "compression/compression.h"
+#include <fmgr.h>
+#include <lib/stringinfo.h>
+#include <utils/uuid.h>
+
+typedef struct UuidCompressor UuidCompressor;
+typedef struct UuidCompressed UuidCompressed;
+typedef struct UuidDecompressionIterator UuidDecompressionIterator;
+
+/*
+ * Compressor framework functions and definitions for the uuid_compress algorithm.
+ */
+
+extern UuidCompressor *uuid_compressor_alloc(void);
+extern void uuid_compressor_append_null(UuidCompressor *compressor);
+extern void uuid_compressor_append_value(UuidCompressor *compressor, pg_uuid_t next_val);
+extern void *uuid_compressor_finish(UuidCompressor *compressor);
+extern bool uuid_compressed_has_nulls(const CompressedDataHeader *header);
+
+extern DecompressResult uuid_decompression_iterator_try_next_forward(DecompressionIterator *iter);
+
+extern DecompressionIterator *uuid_decompression_iterator_from_datum_forward(Datum uuid_compressed,
+																			 Oid element_type);
+
+extern DecompressResult uuid_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
+
+extern DecompressionIterator *uuid_decompression_iterator_from_datum_reverse(Datum uuid_compressed,
+																			 Oid element_type);
+
+extern void uuid_compressed_send(CompressedDataHeader *header, StringInfo buffer);
+
+extern Datum uuid_compressed_recv(StringInfo buf);
+
+extern Compressor *uuid_compressor_for_type(Oid element_type);
+
+#define UUID_COMPRESS_ALGORITHM_DEFINITION                                                         \
+	{                                                                                              \
+		.iterator_init_forward = uuid_decompression_iterator_from_datum_forward,                   \
+		.iterator_init_reverse = uuid_decompression_iterator_from_datum_reverse,                   \
+		.decompress_all = NULL, .compressed_data_send = uuid_compressed_send,                      \
+		.compressed_data_recv = uuid_compressed_recv,                                              \
+		.compressor_for_type = uuid_compressor_for_type,                                           \
+		.compressed_data_storage = TOAST_STORAGE_EXTERNAL,                                         \
+	}
+
+/*
+ * Cross-module functions for the uuid_compress algorithm.
+ */
+
+extern Datum tsl_uuid_compressor_append(PG_FUNCTION_ARGS);
+extern Datum tsl_uuid_compressor_finish(PG_FUNCTION_ARGS);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -195,6 +195,7 @@ typedef enum CompressionAlgorithm
 	COMPRESSION_ALGORITHM_DELTADELTA,
 	COMPRESSION_ALGORITHM_BOOL,
 	COMPRESSION_ALGORITHM_NULL,
+	COMPRESSION_ALGORITHM_UUID,
 
 	/* When adding an algorithm also add a static assert statement below */
 	/* end of real values */
@@ -319,13 +320,14 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 	StaticAssertStmt(COMPRESSION_ALGORITHM_DELTADELTA == 4, "algorithm index has changed");
 	StaticAssertStmt(COMPRESSION_ALGORITHM_BOOL == 5, "algorithm index has changed");
 	StaticAssertStmt(COMPRESSION_ALGORITHM_NULL == 6, "algorithm index has changed");
+	StaticAssertStmt(COMPRESSION_ALGORITHM_UUID == 7, "algorithm index has changed");
 
 	/*
 	 * This should change when adding a new algorithm after adding the new
 	 * algorithm to the assert list above. This statement prevents adding a
 	 * new algorithm without updating the asserts above
 	 */
-	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS == 7,
+	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS == 8,
 					 "number of algorithms have changed, the asserts should be updated");
 }
 

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -22,6 +22,7 @@
 #include "compression/algorithms/deltadelta.h"
 #include "compression/algorithms/dictionary.h"
 #include "compression/algorithms/gorilla.h"
+#include "compression/algorithms/uuid_compress.h"
 #include "compression/api.h"
 #include "compression/compression.h"
 #include "compression/create.h"
@@ -166,6 +167,8 @@ CrossModuleFunctions tsl_cm_functions = {
 	.array_compressor_finish = tsl_array_compressor_finish,
 	.bool_compressor_append = tsl_bool_compressor_append,
 	.bool_compressor_finish = tsl_bool_compressor_finish,
+	.uuid_compressor_append = tsl_uuid_compressor_append,
+	.uuid_compressor_finish = tsl_uuid_compressor_finish,
 	.bloom1_contains = bloom1_contains,
 	.process_compress_table = tsl_process_compress_table,
 	.process_altertable_cmd = tsl_process_altertable_cmd,

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -1749,6 +1749,221 @@ CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, ((NULLIF(i, (CASE W
 (1 row)
 
 DROP TABLE base_bools;
+----------------------
+-- UUID Compression --
+----------------------
+CREATE TABLE uuid_set (i int, u uuid);
+INSERT INTO uuid_set (i, u) VALUES
+(1, '0197a7a9-b48b-7c70-be05-e376afc66ee1'), (2, '0197a7a9-b48b-7c71-92cb-eb724822bb0f'), (3, '0197a7a9-b48b-7c72-bd57-49f981f064fd'), (4, '0197a7a9-b48b-7c73-b521-91172c2e770a'),
+(5, '0197a7a9-b48b-7c74-a2a4-dcdbce635d11'), (6, '0197a7a9-b48b-7c75-a810-8acf630e634f'), (7, '0197a7a9-b48b-7c76-b616-69e64a802b5c'), (8, '0197a7a9-b48b-7c77-b54f-c5f3d64d68d0'),
+(9, '0197a7a9-b48b-7c78-ab14-78b3dd81dbbc'), (10, '0197a7a9-b48b-7c79-92c7-7dde3bea6252'), (11, '0197a7a9-b48b-7c7a-8d9e-5afc3bf15234'), (12, '0197a7a9-b48b-7c7b-bc49-7150f16d8d63'),
+(13, '0197a7a9-b48b-7c7c-aa7a-60d47bf04ff8'), (14, '0197a7a9-b48b-7c7d-8cfe-9503ed9bb1c9'), (15, '0197a7a9-b48b-7c7e-9ebb-acf63f5b625e'), (16, '0197a7a9-b48b-7c7f-a0c1-ba4adf950a2a'),
+(17, '0197a7a9-b48b-7c80-a534-4eda33d89b41'), (18, '0197a7a9-b48b-7c81-abaf-e4d27888f6ea'), (19, '0197a7a9-b48b-7c82-a07c-bb5278039b67'), (20, '0197a7a9-b48b-7c83-9df3-2826632fcb42'),
+(21, '0197a7a9-b48b-7c84-8588-dc4e6f10a5be'), (22, '0197a7a9-b48b-7c85-98a4-5ba69598ba88'), (23, '0197a7a9-b48b-7c86-9a96-69906846edf4'), (24, '0197a7a9-b48b-7c87-843a-d0c409e538d2'),
+(25, '0197a7a9-b48b-7c88-a9c9-8e03283979dd'), (26, '0197a7a9-b48c-7c88-b962-5f38a5f5bb19'), (27, '0197a7a9-b48c-7c89-ad12-19c425cfe319'), (28, '0197a7a9-b48c-7c8a-9652-43b070f806b6'),
+(29, '0197a7a9-b48c-7c8b-8b95-2e4b27b7c359'), (30, '0197a7a9-b48c-7c8c-9230-5a1b6a126d4e'), (31, '0197a7a9-b48c-7c8d-98e9-3622fe1418ae'), (32, '0197a7a9-b48c-7c8e-b262-e91dcf84f985'),
+(33, '0197a7a9-b48c-7c8f-90c0-1036d19e438e'), (34, '0197a7a9-b48c-7c90-9fcb-f092518ae1e6'), (35, '0197a7a9-b48c-7c91-bf68-433e366f751d'), (36, '0197a7a9-b48c-7c92-95b6-82cb29498e5a'),
+(37, '0197a7a9-b48c-7c93-9397-6ebbb9d4194d'), (38, '0197a7a9-b48c-7c94-8484-f47122e2dea3'), (39, '0197a7a9-b48c-7c95-a6e5-fe8d062f4e3c'), (40, '0197a7a9-b48c-7c96-914c-690b7930262f'),
+(41, '0197a7a9-b48c-7c97-ac2b-473d61e0c396'), (42, '0197a7a9-b48c-7c98-93bd-ca093b30f6e8'), (43, '0197a7a9-b48c-7c99-b906-7fa2180536d3'), (44, '0197a7a9-b48c-7c9a-a090-fe01428ccefc'),
+(45, '0197a7a9-b48c-7c9b-9319-de9dd58deeee'), (46, '0197a7a9-b48c-7c9c-a9d4-ed6f3e6a41b7'), (47, '0197a7a9-b48c-7c9d-8036-4141e0780323'), (48, '0197a7a9-b48c-7c9e-bfbe-f00eb49ed7f2'),
+(49, '0197a7a9-b48c-7c9f-8ffe-71cf00a0c0c0'), (50, '0197a7a9-b48c-7ca0-822f-95ced2f95702'), (51, '0197a7a9-b48c-7ca1-8c8a-66582aec95fa'), (52, '0197a7a9-b48c-7ca2-95c3-fe80362a2251'),
+(53, '0197a7a9-b48c-7ca3-855f-f681b254a8c8'), (54, '0197a7a9-b48c-7ca4-856b-a562eca93c3f'), (55, '0197a7a9-b48c-7ca5-a30e-37c247fb4c46'), (56, '0197a7a9-b48c-7ca6-9e78-a148d54a44ac'),
+(57, '0197a7a9-b48c-7ca7-badb-4b650bf5bf5f'), (58, '0197a7a9-b48c-7ca8-8275-a8590869ef13'), (59, '0197a7a9-b48c-7ca9-b328-b54c3901223c'), (60, '0197a7a9-b48c-7caa-a15d-f5564e4e552c'),
+(61, '0197a7a9-b48c-7cab-a4ac-017259746322'), (62, '0197a7a9-b48c-7cac-bda5-74ef12abd6b8'), (63, '0197a7a9-b48c-7cad-a3cd-0e4c93eaba80'), (64, '0197a7a9-b48c-7cae-9667-de4a226418df'),
+(65, '0197a7a9-b48c-7caf-8aa2-067619170f32'), (66, '0197a7a9-b48c-7cb0-ba8c-91d9e8920845'), (67, '0197a7a9-b48c-7cb1-9681-a62bfffe9237'), (68, '0197a7a9-b48c-7cb2-b78b-037e5ee26ff6'),
+(69, '0197a7a9-b48c-7cb3-ac27-e24382445188'), (70, '0197a7a9-b48b-7c7d-8cfe-9503ed9bb1c9'), (71, '0197a7a9-b48b-7c7e-9ebb-acf63f5b625e'), (72, '0197a7a9-b48b-7c7f-a0c1-ba4adf950a2a'),
+(73, '0197a7a9-b48b-7c80-a534-4eda33d89b41'), (74, '0197a7a9-b48b-7c81-abaf-e4d27888f6ea'), (75, '0197a7a9-b48b-7c82-a07c-bb5278039b67'), (76, '0197a7a9-b48b-7c83-9df3-2826632fcb42'),
+(77, '0197a7a9-b48b-7c84-8588-dc4e6f10a5be'), (78, '0197a7a9-b48b-7c85-98a4-5ba69598ba88'), (79, '0197a7a9-b48b-7c86-9a96-69906846edf4'), (80, '0197a7a9-b48b-7c87-843a-d0c409e538d2'),
+(81, '0197a7a9-b48b-7c88-a9c9-8e03283979dd'), (82, '0197a7a9-b48c-7c88-b962-5f38a5f5bb19'), (83, '0197a7a9-b48c-7c89-ad12-19c425cfe319'), (84, '0197a7a9-b48c-7c8a-9652-43b070f806b6'),
+(85, '0197a7a9-b48c-7c8b-8b95-2e4b27b7c359'), (86, '0197a7a9-b48c-7c8c-9230-5a1b6a126d4e'), (87, '0197a7a9-b48c-7c8d-98e9-3622fe1418ae'), (88, '0197a7a9-b48c-7c8e-b262-e91dcf84f985'),
+(89, '0197a7a9-b48c-7c8f-90c0-1036d19e438e'), (90, '0197a7a9-b48c-7c90-9fcb-f092518ae1e6'), (91, '0197a7a9-b48c-7c91-bf68-433e366f751d'), (92, '0197a7a9-b48c-7c92-95b6-82cb29498e5a'),
+(93, '0197a7a9-b48c-7c93-9397-6ebbb9d4194d'), (94, '0197a7a9-b48c-7c94-8484-f47122e2dea3'), (95, '0197a7a9-b48c-7c95-a6e5-fe8d062f4e3c'), (96, '0197a7a9-b48c-7c96-914c-690b7930262f'),
+(97, '0197a7a9-b48c-7c97-ac2b-473d61e0c396'), (98, '0197a7a9-b48c-7c98-93bd-ca093b30f6e8'), (99, '0197a7a9-b48c-7c99-b906-7fa2180536d3'), (100, '0197a7a9-b48c-7c9a-a090-fe01428ccefc');
+SELECT
+  $$
+  select item from base_uuids order by rn
+  $$ AS "QUERY"
+\gset
+\set TABLE_NAME base_uuids
+\set TYPE uuid
+\set COMPRESSION_CMD _timescaledb_internal.compress_uuid(item)
+\set DECOMPRESS_FORWARD_CMD _timescaledb_internal.decompress_forward(c::_timescaledb_internal.compressed_data, NULL::uuid)
+\set DECOMPRESS_REVERSE_CMD _timescaledb_internal.decompress_reverse(c::_timescaledb_internal.compressed_data, NULL::uuid)
+SET timescaledb.enable_uuid_compression = on;
+-- basic test, flipping values between UUID v4s, UUID v7s and NULLs
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = gen_random_uuid() WHERE rn % 4 = 0;
+UPDATE base_uuids SET item = (SELECT u FROM uuid_set WHERE i = rn % 100) WHERE rn % 4 = 1;
+UPDATE base_uuids SET item = (SELECT u FROM uuid_set WHERE i = rn % 97) WHERE rn % 4 = 2;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ algorithm  | has_nulls | compressed size 
+------------+-----------+-----------------
+ DICTIONARY | t         |            6124
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_uuids;
+-- all NULLs and a single UUID v7
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = '0197a7a9-b48b-7c74-a2a4-dcdbce635d11' WHERE rn = 1;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ algorithm | has_nulls | compressed size 
+-----------+-----------+-----------------
+ ARRAY     | t         |              85
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_uuids;
+-- no NULLs
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = (SELECT u FROM uuid_set WHERE i = rn % 100);
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ algorithm  | has_nulls | compressed size 
+------------+-----------+-----------------
+ DICTIONARY | t         |            2092
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_uuids;
+-- flipping values between two UUID v7s and NULLs
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = '0197a7a9-b48b-7c74-a2a4-dcdbce635d11' WHERE rn % 3 = 0;
+UPDATE base_uuids SET item = '0197a7a9-b48b-7c74-a2a4-dcdbce635d12' WHERE rn % 3 = 1;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ algorithm  | has_nulls | compressed size 
+------------+-----------+-----------------
+ DICTIONARY | t         |             320
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_uuids;
+-- test with a set of UUID v7s
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, u as item FROM uuid_set ORDER BY i;
+\ir include/compression_test.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ algorithm | has_nulls | compressed size 
+-----------+-----------+-----------------
+ UUID      | f         |             944
+(1 row)
+
+                                   ?column?                                    | count 
+-------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed forward (expect 0) |     0
+(1 row)
+
+                                    ?column?                                    | count 
+--------------------------------------------------------------------------------+-------
+ Number of rows different between original and decompressed reversed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                              | count 
+----------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original, decompressed, and decompressed deserializeed (expect 0) |     0
+(1 row)
+
+                                              ?column?                                               | ?column? 
+-----------------------------------------------------------------------------------------------------+----------
+ Test that deserialization, decompression, recompression, and serialization results in the same text | t
+(1 row)
+
+DROP TABLE base_uuids;
+RESET timescaledb.enable_uuid_compression;
+DROP table uuid_set;
 -----------------------------------------------
 -- Interesting corrupt data found by fuzzing --
 -----------------------------------------------
@@ -1810,11 +2025,11 @@ group by 2, 3 order by 1 desc
  count | bulk_result | rowbyrow_result 
 -------+-------------+-----------------
     18 | true        | true
-    15 | XX001       | XX001
+    14 | XX001       | XX001
      8 | 08P01       | 08P01
      2 | 3F000       | 3F000
+     2 | false       | false
      1 | 22021       | 22021
-     1 | false       | false
 (6 rows)
 
 \set algo dictionary

--- a/tsl/test/expected/compression_uuid.out
+++ b/tsl/test/expected/compression_uuid.out
@@ -2,7 +2,24 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 --install necessary functions for tests
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\ir include/compression_utils.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timescaledb.enable_uuid_compression = on;
+CREATE TABLE t (ts int, u uuid);
+SELECT create_hypertable('t', 'ts', chunk_time_interval => 500);
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+(1 row)
+
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+INSERT INTO t SELECT g AS ts, NULL AS uuid FROM generate_series(1, 3000) g;
 -- The first hundred elements are generated with the Go uuid v7 routines
 CREATE TABLE uuids (i int, u uuid);
 INSERT INTO uuids (i, u) VALUES
@@ -31,11 +48,188 @@ INSERT INTO uuids (i, u) VALUES
 (89, '0197a7a9-b48c-7c8f-90c0-1036d19e438e'), (90, '0197a7a9-b48c-7c90-9fcb-f092518ae1e6'), (91, '0197a7a9-b48c-7c91-bf68-433e366f751d'), (92, '0197a7a9-b48c-7c92-95b6-82cb29498e5a'),
 (93, '0197a7a9-b48c-7c93-9397-6ebbb9d4194d'), (94, '0197a7a9-b48c-7c94-8484-f47122e2dea3'), (95, '0197a7a9-b48c-7c95-a6e5-fe8d062f4e3c'), (96, '0197a7a9-b48c-7c96-914c-690b7930262f'),
 (97, '0197a7a9-b48c-7c97-ac2b-473d61e0c396'), (98, '0197a7a9-b48c-7c98-93bd-ca093b30f6e8'), (99, '0197a7a9-b48c-7c99-b906-7fa2180536d3'), (100, '0197a7a9-b48c-7c9a-a090-fe01428ccefc');
+-- set data to be compressed with the uuid compressor
+UPDATE t SET u = (select u from uuids where i = ts) where ts <= 100;
+-- set data to be compressed with the dictionary compressor
+UPDATE t SET u = (select u from uuids where i = ts%100) where ts > 1000 and ts <= 2000;
+-- add random UUID v4s to the data
+UPDATE t SET u = gen_random_uuid() where ts > 2000;
+-- compress the data
+SELECT compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+(7 rows)
+
+-- decompress the data
+SELECT decompress_chunk(show_chunks('t'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+(7 rows)
+
+-- disable uuid compression and compress the data again
+SET timescaledb.enable_uuid_compression = off;
+SELECT compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+(7 rows)
+
+CREATE TABLE mixed_compressed (ts int, u uuid);
+SELECT create_hypertable('mixed_compressed', 'ts', chunk_time_interval => 500);
+NOTICE:  adding not-null constraint to column "ts"
+       create_hypertable       
+-------------------------------
+ (3,public,mixed_compressed,t)
+(1 row)
+
+ALTER TABLE mixed_compressed SET (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+-- the new UUID compression is OFF at this point, so we use the original method
+-- add the base uuids to the data and compress it
+INSERT INTO mixed_compressed SELECT i, u FROM uuids;
+INSERT INTO mixed_compressed SELECT i+100 as i, NULL as u FROM uuids;
+-- compress the data
+SELECT compress_chunk(show_chunks('mixed_compressed'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_22_chunk
+(1 row)
+
+-- enable uuid compression and compress the data again
+-- and add the base uuids to the data again
+SET timescaledb.enable_uuid_compression = on;
+INSERT INTO mixed_compressed SELECT i+1000 as i, u FROM uuids;
+INSERT INTO mixed_compressed SELECT i+1100 as i, NULL as u FROM uuids;
+-- compress the data
+SELECT compress_chunk(show_chunks('mixed_compressed'));
+NOTICE:  chunk "_hyper_3_22_chunk" is already converted to columnstore
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_22_chunk
+ _timescaledb_internal._hyper_3_24_chunk
+(2 rows)
+
+-- now turn it off again and add the whole data twice
+SET timescaledb.enable_uuid_compression = off;
+INSERT INTO mixed_compressed SELECT i+2000, u FROM uuids;
+INSERT INTO mixed_compressed SELECT i+2200, u FROM uuids;
+INSERT INTO mixed_compressed SELECT i+2300 as i, NULL as u FROM uuids;
+-- compress the data again
+SELECT compress_chunk(show_chunks('mixed_compressed'));
+NOTICE:  chunk "_hyper_3_22_chunk" is already converted to columnstore
+NOTICE:  chunk "_hyper_3_24_chunk" is already converted to columnstore
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_22_chunk
+ _timescaledb_internal._hyper_3_24_chunk
+ _timescaledb_internal._hyper_3_26_chunk
+(3 rows)
+
+-- turn it on again and do the same
+SET timescaledb.enable_uuid_compression = off;
+INSERT INTO mixed_compressed SELECT i+3000, u FROM uuids;
+INSERT INTO mixed_compressed SELECT i+3200, u FROM uuids;
+INSERT INTO mixed_compressed SELECT i+3300 as i, NULL as u FROM uuids;
+-- compress the data again
+SELECT compress_chunk(show_chunks('mixed_compressed'));
+NOTICE:  chunk "_hyper_3_22_chunk" is already converted to columnstore
+NOTICE:  chunk "_hyper_3_24_chunk" is already converted to columnstore
+NOTICE:  chunk "_hyper_3_26_chunk" is already converted to columnstore
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_22_chunk
+ _timescaledb_internal._hyper_3_24_chunk
+ _timescaledb_internal._hyper_3_26_chunk
+ _timescaledb_internal._hyper_3_28_chunk
+(4 rows)
+
+-- check the compression algorithm for the compressed chunks
+CREATE TABLE compressed_chunks AS
+SELECT
+	format('%I.%I', comp.schema_name, comp.table_name)::regclass as compressed_chunk,
+	ccs.compressed_heap_size,
+	ccs.compressed_toast_size,
+	ccs.compressed_index_size,
+	ccs.numrows_pre_compression,
+	ccs.numrows_post_compression
+FROM
+	show_chunks('mixed_compressed') c
+	INNER JOIN _timescaledb_catalog.chunk cat
+		ON (c = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
+	INNER JOIN _timescaledb_catalog.chunk comp
+		ON (cat.compressed_chunk_id = comp.id)
+	INNER JOIN _timescaledb_catalog.compression_chunk_size ccs
+		ON (comp.id = ccs.compressed_chunk_id);
+CREATE TABLE compression_info (compressed_chunk regclass, result text, compressed_size int, num_rows int);
+DO $$
+DECLARE
+	table_ref regclass;
+BEGIN
+	FOR table_ref IN
+		SELECT compressed_chunk as table_ref FROM compressed_chunks
+	LOOP
+		EXECUTE format(
+			'INSERT INTO compression_info (
+				SELECT
+					%L::regclass as compressed_chunk,
+					(_timescaledb_functions.compressed_data_info(u))::text as result,
+					sum(pg_column_size(u)::int) as compressed_size,
+					count(*) as num_rows
+				FROM %s
+				GROUP BY 1,2)',
+			table_ref, table_ref
+		);
+	END LOOP;
+END;
+$$;
+SELECT
+	ci.*,
+	ccs.compressed_toast_size,
+	ccs.numrows_pre_compression,
+	ccs.numrows_post_compression
+FROM
+	compression_info ci
+	INNER JOIN compressed_chunks ccs
+		ON (ci.compressed_chunk = ccs.compressed_chunk)
+ORDER BY
+	1,2,3;
+                compressed_chunk                 |     result     | compressed_size | num_rows | compressed_toast_size | numrows_pre_compression | numrows_post_compression 
+-------------------------------------------------+----------------+-----------------+----------+-----------------------+-------------------------+--------------------------
+ _timescaledb_internal.compress_hyper_4_23_chunk | (DICTIONARY,t) |            1272 |        1 |                  8192 |                     200 |                        1
+ _timescaledb_internal.compress_hyper_4_25_chunk | (UUID,t)       |             976 |        1 |                  8192 |                     200 |                        1
+ _timescaledb_internal.compress_hyper_4_27_chunk | (DICTIONARY,t) |            1352 |        1 |                  8192 |                     300 |                        1
+ _timescaledb_internal.compress_hyper_4_29_chunk | (DICTIONARY,t) |            1352 |        1 |                  8192 |                     300 |                        1
+(4 rows)
+
+-- -------------------------------
+-- Test the new UUID v7 functions
+-- -------------------------------
 -- The next 3 items are generated with the new functions
+BEGIN;
 INSERT INTO uuids VALUES (101, _timescaledb_functions.uuid_v7_from_timestamptz('2025-07-02:03:04:05'::timestamptz));
 INSERT INTO uuids VALUES (102, _timescaledb_functions.uuid_v7_from_timestamptz('2029-01-02:03:04:05'::timestamptz));
 INSERT INTO uuids VALUES (103, _timescaledb_functions.uuid_v7_from_timestamptz('2059-02-03:04:05:06'::timestamptz));
 INSERT INTO uuids VALUES (104, _timescaledb_functions.uuid_v7_from_timestamptz('2100-07-08:09:10:11'::timestamptz));
+COMMIT;
 SELECT
   to_char(_timescaledb_functions.timestamptz_from_uuid_v7(u), 'YYYY-MM-DD:HH24:MI:SS'),
   _timescaledb_functions.uuid_version(u),
@@ -54,6 +248,7 @@ ORDER BY 1,2;
 (5 rows)
 
 -- Add some v4 timestamps for sanity check
+BEGIN;
 INSERT INTO uuids VALUES (105, _timescaledb_functions.generate_uuid());
 INSERT INTO uuids VALUES (106, _timescaledb_functions.generate_uuid());
 INSERT INTO uuids VALUES (107, _timescaledb_functions.generate_uuid());
@@ -61,6 +256,30 @@ INSERT INTO uuids VALUES (107, _timescaledb_functions.generate_uuid());
 INSERT INTO uuids VALUES (108, _timescaledb_functions.generate_uuid_v7());
 INSERT INTO uuids VALUES (109, _timescaledb_functions.generate_uuid_v7());
 INSERT INTO uuids VALUES (110, _timescaledb_functions.generate_uuid_v7());
+COMMIT;
+-- There is a test flakyness that I want to debug with this:
+SELECT
+  i,
+  _timescaledb_functions.uuid_version(u)
+FROM
+  uuids
+WHERE
+  i > 100
+ORDER BY 1;
+  i  | uuid_version 
+-----+--------------
+ 101 |            7
+ 102 |            7
+ 103 |            7
+ 104 |            7
+ 105 |            4
+ 106 |            4
+ 107 |            4
+ 108 |            7
+ 109 |            7
+ 110 |            7
+(10 rows)
+
 -- The version numbers should make sense
 SELECT
   _timescaledb_functions.uuid_version(u),
@@ -102,3 +321,11 @@ WHERE
 ---+----+-----
 (0 rows)
 
+-- Cleanup
+DROP TABLE t;
+DROP TABLE subms;
+DROP TABLE uuids;
+DROP TABLE mixed_compressed;
+DROP TABLE compressed_chunks;
+DROP TABLE compression_info;
+RESET timescaledb.enable_uuid_compression;

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -415,6 +415,86 @@ CREATE TABLE base_bools AS SELECT row_number() OVER() as rn, ((NULLIF(i, (CASE W
 \ir include/compression_test.sql
 DROP TABLE base_bools;
 
+----------------------
+-- UUID Compression --
+----------------------
+
+CREATE TABLE uuid_set (i int, u uuid);
+INSERT INTO uuid_set (i, u) VALUES
+(1, '0197a7a9-b48b-7c70-be05-e376afc66ee1'), (2, '0197a7a9-b48b-7c71-92cb-eb724822bb0f'), (3, '0197a7a9-b48b-7c72-bd57-49f981f064fd'), (4, '0197a7a9-b48b-7c73-b521-91172c2e770a'),
+(5, '0197a7a9-b48b-7c74-a2a4-dcdbce635d11'), (6, '0197a7a9-b48b-7c75-a810-8acf630e634f'), (7, '0197a7a9-b48b-7c76-b616-69e64a802b5c'), (8, '0197a7a9-b48b-7c77-b54f-c5f3d64d68d0'),
+(9, '0197a7a9-b48b-7c78-ab14-78b3dd81dbbc'), (10, '0197a7a9-b48b-7c79-92c7-7dde3bea6252'), (11, '0197a7a9-b48b-7c7a-8d9e-5afc3bf15234'), (12, '0197a7a9-b48b-7c7b-bc49-7150f16d8d63'),
+(13, '0197a7a9-b48b-7c7c-aa7a-60d47bf04ff8'), (14, '0197a7a9-b48b-7c7d-8cfe-9503ed9bb1c9'), (15, '0197a7a9-b48b-7c7e-9ebb-acf63f5b625e'), (16, '0197a7a9-b48b-7c7f-a0c1-ba4adf950a2a'),
+(17, '0197a7a9-b48b-7c80-a534-4eda33d89b41'), (18, '0197a7a9-b48b-7c81-abaf-e4d27888f6ea'), (19, '0197a7a9-b48b-7c82-a07c-bb5278039b67'), (20, '0197a7a9-b48b-7c83-9df3-2826632fcb42'),
+(21, '0197a7a9-b48b-7c84-8588-dc4e6f10a5be'), (22, '0197a7a9-b48b-7c85-98a4-5ba69598ba88'), (23, '0197a7a9-b48b-7c86-9a96-69906846edf4'), (24, '0197a7a9-b48b-7c87-843a-d0c409e538d2'),
+(25, '0197a7a9-b48b-7c88-a9c9-8e03283979dd'), (26, '0197a7a9-b48c-7c88-b962-5f38a5f5bb19'), (27, '0197a7a9-b48c-7c89-ad12-19c425cfe319'), (28, '0197a7a9-b48c-7c8a-9652-43b070f806b6'),
+(29, '0197a7a9-b48c-7c8b-8b95-2e4b27b7c359'), (30, '0197a7a9-b48c-7c8c-9230-5a1b6a126d4e'), (31, '0197a7a9-b48c-7c8d-98e9-3622fe1418ae'), (32, '0197a7a9-b48c-7c8e-b262-e91dcf84f985'),
+(33, '0197a7a9-b48c-7c8f-90c0-1036d19e438e'), (34, '0197a7a9-b48c-7c90-9fcb-f092518ae1e6'), (35, '0197a7a9-b48c-7c91-bf68-433e366f751d'), (36, '0197a7a9-b48c-7c92-95b6-82cb29498e5a'),
+(37, '0197a7a9-b48c-7c93-9397-6ebbb9d4194d'), (38, '0197a7a9-b48c-7c94-8484-f47122e2dea3'), (39, '0197a7a9-b48c-7c95-a6e5-fe8d062f4e3c'), (40, '0197a7a9-b48c-7c96-914c-690b7930262f'),
+(41, '0197a7a9-b48c-7c97-ac2b-473d61e0c396'), (42, '0197a7a9-b48c-7c98-93bd-ca093b30f6e8'), (43, '0197a7a9-b48c-7c99-b906-7fa2180536d3'), (44, '0197a7a9-b48c-7c9a-a090-fe01428ccefc'),
+(45, '0197a7a9-b48c-7c9b-9319-de9dd58deeee'), (46, '0197a7a9-b48c-7c9c-a9d4-ed6f3e6a41b7'), (47, '0197a7a9-b48c-7c9d-8036-4141e0780323'), (48, '0197a7a9-b48c-7c9e-bfbe-f00eb49ed7f2'),
+(49, '0197a7a9-b48c-7c9f-8ffe-71cf00a0c0c0'), (50, '0197a7a9-b48c-7ca0-822f-95ced2f95702'), (51, '0197a7a9-b48c-7ca1-8c8a-66582aec95fa'), (52, '0197a7a9-b48c-7ca2-95c3-fe80362a2251'),
+(53, '0197a7a9-b48c-7ca3-855f-f681b254a8c8'), (54, '0197a7a9-b48c-7ca4-856b-a562eca93c3f'), (55, '0197a7a9-b48c-7ca5-a30e-37c247fb4c46'), (56, '0197a7a9-b48c-7ca6-9e78-a148d54a44ac'),
+(57, '0197a7a9-b48c-7ca7-badb-4b650bf5bf5f'), (58, '0197a7a9-b48c-7ca8-8275-a8590869ef13'), (59, '0197a7a9-b48c-7ca9-b328-b54c3901223c'), (60, '0197a7a9-b48c-7caa-a15d-f5564e4e552c'),
+(61, '0197a7a9-b48c-7cab-a4ac-017259746322'), (62, '0197a7a9-b48c-7cac-bda5-74ef12abd6b8'), (63, '0197a7a9-b48c-7cad-a3cd-0e4c93eaba80'), (64, '0197a7a9-b48c-7cae-9667-de4a226418df'),
+(65, '0197a7a9-b48c-7caf-8aa2-067619170f32'), (66, '0197a7a9-b48c-7cb0-ba8c-91d9e8920845'), (67, '0197a7a9-b48c-7cb1-9681-a62bfffe9237'), (68, '0197a7a9-b48c-7cb2-b78b-037e5ee26ff6'),
+(69, '0197a7a9-b48c-7cb3-ac27-e24382445188'), (70, '0197a7a9-b48b-7c7d-8cfe-9503ed9bb1c9'), (71, '0197a7a9-b48b-7c7e-9ebb-acf63f5b625e'), (72, '0197a7a9-b48b-7c7f-a0c1-ba4adf950a2a'),
+(73, '0197a7a9-b48b-7c80-a534-4eda33d89b41'), (74, '0197a7a9-b48b-7c81-abaf-e4d27888f6ea'), (75, '0197a7a9-b48b-7c82-a07c-bb5278039b67'), (76, '0197a7a9-b48b-7c83-9df3-2826632fcb42'),
+(77, '0197a7a9-b48b-7c84-8588-dc4e6f10a5be'), (78, '0197a7a9-b48b-7c85-98a4-5ba69598ba88'), (79, '0197a7a9-b48b-7c86-9a96-69906846edf4'), (80, '0197a7a9-b48b-7c87-843a-d0c409e538d2'),
+(81, '0197a7a9-b48b-7c88-a9c9-8e03283979dd'), (82, '0197a7a9-b48c-7c88-b962-5f38a5f5bb19'), (83, '0197a7a9-b48c-7c89-ad12-19c425cfe319'), (84, '0197a7a9-b48c-7c8a-9652-43b070f806b6'),
+(85, '0197a7a9-b48c-7c8b-8b95-2e4b27b7c359'), (86, '0197a7a9-b48c-7c8c-9230-5a1b6a126d4e'), (87, '0197a7a9-b48c-7c8d-98e9-3622fe1418ae'), (88, '0197a7a9-b48c-7c8e-b262-e91dcf84f985'),
+(89, '0197a7a9-b48c-7c8f-90c0-1036d19e438e'), (90, '0197a7a9-b48c-7c90-9fcb-f092518ae1e6'), (91, '0197a7a9-b48c-7c91-bf68-433e366f751d'), (92, '0197a7a9-b48c-7c92-95b6-82cb29498e5a'),
+(93, '0197a7a9-b48c-7c93-9397-6ebbb9d4194d'), (94, '0197a7a9-b48c-7c94-8484-f47122e2dea3'), (95, '0197a7a9-b48c-7c95-a6e5-fe8d062f4e3c'), (96, '0197a7a9-b48c-7c96-914c-690b7930262f'),
+(97, '0197a7a9-b48c-7c97-ac2b-473d61e0c396'), (98, '0197a7a9-b48c-7c98-93bd-ca093b30f6e8'), (99, '0197a7a9-b48c-7c99-b906-7fa2180536d3'), (100, '0197a7a9-b48c-7c9a-a090-fe01428ccefc');
+
+SELECT
+  $$
+  select item from base_uuids order by rn
+  $$ AS "QUERY"
+\gset
+\set TABLE_NAME base_uuids
+\set TYPE uuid
+\set COMPRESSION_CMD _timescaledb_internal.compress_uuid(item)
+\set DECOMPRESS_FORWARD_CMD _timescaledb_internal.decompress_forward(c::_timescaledb_internal.compressed_data, NULL::uuid)
+\set DECOMPRESS_REVERSE_CMD _timescaledb_internal.decompress_reverse(c::_timescaledb_internal.compressed_data, NULL::uuid)
+
+SET timescaledb.enable_uuid_compression = on;
+
+-- basic test, flipping values between UUID v4s, UUID v7s and NULLs
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = gen_random_uuid() WHERE rn % 4 = 0;
+UPDATE base_uuids SET item = (SELECT u FROM uuid_set WHERE i = rn % 100) WHERE rn % 4 = 1;
+UPDATE base_uuids SET item = (SELECT u FROM uuid_set WHERE i = rn % 97) WHERE rn % 4 = 2;
+\ir include/compression_test.sql
+DROP TABLE base_uuids;
+
+-- all NULLs and a single UUID v7
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = '0197a7a9-b48b-7c74-a2a4-dcdbce635d11' WHERE rn = 1;
+\ir include/compression_test.sql
+DROP TABLE base_uuids;
+
+-- no NULLs
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = (SELECT u FROM uuid_set WHERE i = rn % 100);
+\ir include/compression_test.sql
+DROP TABLE base_uuids;
+
+-- flipping values between two UUID v7s and NULLs
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, NULL::uuid as item FROM (SELECT generate_series(1, 1000) item) sub;
+UPDATE base_uuids SET item = '0197a7a9-b48b-7c74-a2a4-dcdbce635d11' WHERE rn % 3 = 0;
+UPDATE base_uuids SET item = '0197a7a9-b48b-7c74-a2a4-dcdbce635d12' WHERE rn % 3 = 1;
+\ir include/compression_test.sql
+DROP TABLE base_uuids;
+
+-- test with a set of UUID v7s
+CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, u as item FROM uuid_set ORDER BY i;
+\ir include/compression_test.sql
+DROP TABLE base_uuids;
+
+RESET timescaledb.enable_uuid_compression;
+DROP table uuid_set;
+
 -----------------------------------------------
 -- Interesting corrupt data found by fuzzing --
 -----------------------------------------------

--- a/tsl/test/sql/include/compression_utils.sql
+++ b/tsl/test/sql/include/compression_utils.sql
@@ -84,6 +84,16 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.bool_compressor_finish(internal
    AS :MODULE_PATHNAME, 'ts_bool_compressor_finish'
    LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.uuid_compressor_append(internal, uuid)
+   RETURNS internal
+   AS :MODULE_PATHNAME, 'ts_uuid_compressor_append'
+   LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.uuid_compressor_finish(internal)
+   RETURNS _timescaledb_internal.compressed_data
+   AS :MODULE_PATHNAME, 'ts_uuid_compressor_finish'
+   LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
 CREATE AGGREGATE _timescaledb_internal.compress_deltadelta(BIGINT) (
     STYPE = internal,
     SFUNC = _timescaledb_internal.deltadelta_compressor_append,
@@ -118,6 +128,12 @@ CREATE AGGREGATE _timescaledb_internal.compress_bool(boolean) (
     STYPE = internal,
     SFUNC = _timescaledb_internal.bool_compressor_append,
     FINALFUNC = _timescaledb_internal.bool_compressor_finish
+);
+
+CREATE AGGREGATE _timescaledb_internal.compress_uuid(uuid) (
+    STYPE = internal,
+    SFUNC = _timescaledb_internal.uuid_compressor_append,
+    FINALFUNC = _timescaledb_internal.uuid_compressor_finish
 );
 
 \set ECHO all

--- a/tsl/test/src/compression_sql_test.c
+++ b/tsl/test/src/compression_sql_test.c
@@ -40,6 +40,10 @@ get_compression_algorithm(char *name)
 	{
 		return COMPRESSION_ALGORITHM_BOOL;
 	}
+	else if (pg_strcasecmp(name, "uuid") == 0)
+	{
+		return COMPRESSION_ALGORITHM_UUID;
+	}
 
 	ereport(ERROR, (errmsg("unknown compression algorithm %s", name)));
 	return _INVALID_COMPRESSION_ALGORITHM;


### PR DESCRIPTION
This change introduces a new compression algorithm to support compressing UUIDs. This is only effective for UUID v7 type where the timestamp part is compressible and the random part is not.

The new compression reverts to dictionary compression if it detects redundant data and it estimates that dictionary compression provides better results. Note that dictionary compression reverts to Array compression if it thinks it results in better compression.

The new feature is controlled by a feature flag, which is turned off for compatibility reasons:

  `timescaledb.enable_uuid_compression=off`

This will be shipped as off for one release and then changed to `on` in subsequent releases.

The UUID compression divides the UUID into two parts. The compressible part is compressed with the delta-delta compression, and the random part is stored as a sequence of uint64s.

This change supports the row-based decompression. The bulk decompression and vectorised filtering will come in a separate change.

The UUID algorithm is experimental at the moment, as we intend to change the compression algorithm. For this reason backward compatibility is not guaranteed.