### PR TITLE
Fix argument names in the error messages thrown by `policy_compression_add`

### DIFF
--- a/tsl/src/bgw_policy/compression_api.h
+++ b/tsl/src/bgw_policy/compression_api.h
@@ -26,5 +26,5 @@ Datum policy_compression_add_internal(Oid user_rel_oid, Datum compress_after_dat
 									  Interval *default_schedule_interval,
 									  bool user_defined_schedule_interval, bool if_not_exists,
 									  bool fixed_schedule, TimestampTz initial_start,
-									  const char *timezone);
+									  const char *timezone, bool is_columnstore_policy);
 bool policy_compression_remove_internal(Oid user_rel_oid, bool if_exists);

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -242,7 +242,8 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 											if_exists,
 											false,
 											DT_NOBEGIN,
-											NULL);
+											NULL,
+											false);
 	}
 
 	if (all_policies.retention && all_policies.retention->create_policy)

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -731,3 +731,44 @@ ERROR:  config must not be NULL
 SELECT _timescaledb_functions.policy_retention_check(NULL);
 ERROR:  config must not be NULL
 \set ON_ERROR_STOP 1
+-- `add_compression_policy()` and `add_columnstore_policy()` share the same
+-- C-function, but their arguments have different names and hence they are
+-- supposed to have slightly different error messages
+create table test_errors (time timestamptz NOT NULL, a int, b int);
+select create_hypertable('test_errors', 'time');
+     create_hypertable     
+---------------------------
+ (12,public,test_errors,t)
+(1 row)
+
+alter table test_errors set (timescaledb.compress);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for converting to columnstore. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "test_errors" is set to ""
+NOTICE:  default order by for hypertable "test_errors" is set to ""time" DESC"
+create materialized view test_errors_cagg
+with (timescaledb.continuous, timescaledb.materialized_only=false) as
+select time_bucket('1 week', time) as bucket from test_errors group by 1;
+NOTICE:  continuous aggregate "test_errors_cagg" is already up-to-date
+alter materialized view test_errors_cagg SET (timescaledb.compress);
+NOTICE:  defaulting compress_orderby to bucket
+SELECT add_continuous_aggregate_policy('test_errors_cagg', '1 year', '1 day', '1 hour');
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1011
+(1 row)
+
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+select add_compression_policy('test_errors', compress_after => NULL);
+ERROR:  need to specify one of "compress_after" or "compress_created_before"
+CALL add_columnstore_policy('test_errors', after => NULL);
+ERROR:  need to specify one of "after" or "created_before"
+select add_compression_policy('test_errors', compress_after => '1 day');
+ERROR:  unsupported "compress_after" argument type, expected type : interval
+CALL add_columnstore_policy('test_errors', after => '1 day');
+ERROR:  unsupported "after" argument type, expected type : interval
+select add_compression_policy('test_errors_cagg', compress_created_before => '1 day'::interval);
+ERROR:  cannot use "compress_created_before" with continuous aggregate "test_errors_cagg" 
+CALL add_columnstore_policy('test_errors_cagg', created_before => '1 day'::interval);
+ERROR:  cannot use "created_before" with continuous aggregate "test_errors_cagg" 
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -559,9 +559,9 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT add_continuous_aggregate_policy('i2980_cagg2', '10 day'::interval, '6 day'::interval);
 ERROR:  function add_continuous_aggregate_policy(unknown, interval, interval) does not exist at character 8
 SELECT add_compression_policy('i2980_cagg2', '3'::integer);
-ERROR:  unsupported compress_after argument type, expected type : interval
+ERROR:  unsupported "compress_after" argument type, expected type : interval
 SELECT add_compression_policy('i2980_cagg2', 13::integer);
-ERROR:  unsupported compress_after argument type, expected type : interval
+ERROR:  unsupported "compress_after" argument type, expected type : interval
 SELECT materialization_hypertable_schema || '.' || materialization_hypertable_name AS "MAT_TABLE_NAME"
 FROM timescaledb_information.continuous_aggregates
 WHERE view_name = 'i2980_cagg2'


### PR DESCRIPTION
Fixes https://github.com/timescale/timescaledb/issues/8367

`add_compression_policy()` and `add_columnstore_policy()` share the same C-function, but their arguments have different names. We have to respect that in the error messages we show users. In this patch we introduce different error messages depending on which SQL function/procedure was invoked.