### PR TITLE
Don't stop nightly cloud test on first error

### DIFF
--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -69,6 +69,7 @@ jobs:
       # run sequentially
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 1
+      fail-fast: false
     steps:
       - name: Checkout TimescaleDB
         uses: actions/checkout@v4


### PR DESCRIPTION
Don't cancel cloud test on encountering first error but keep running
the test for the remaining versions as well.
