### PR TITLE
Support ALTER TABLE RESET for compression settings

### DIFF
--- a/.unreleased/pr_8401
+++ b/.unreleased/pr_8401
@@ -1,0 +1,1 @@
+Implements: #8401 Support ALTER TABLE RESET for compression settings

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -55,6 +55,14 @@ ts_alter_table_with_clause_parse(const List *defelems)
 								 TS_ARRAY_LEN(alter_table_with_clause_def));
 }
 
+WithClauseResult *
+ts_alter_table_reset_with_clause_parse(const List *defelems)
+{
+	return ts_with_clauses_parse_reset(defelems,
+									   alter_table_with_clause_def,
+									   TS_ARRAY_LEN(alter_table_with_clause_def));
+}
+
 static inline void
 throw_segment_by_error(char *segment_by)
 {

--- a/src/with_clause/alter_table_with_clause.h
+++ b/src/with_clause/alter_table_with_clause.h
@@ -38,6 +38,7 @@ typedef struct
 } OrderBySettings;
 
 extern TSDLLEXPORT WithClauseResult *ts_alter_table_with_clause_parse(const List *defelems);
+extern TSDLLEXPORT WithClauseResult *ts_alter_table_reset_with_clause_parse(const List *defelems);
 extern TSDLLEXPORT ArrayType *ts_compress_hypertable_parse_segment_by(WithClauseResult segmentby,
 																	  Hypertable *hypertable);
 extern TSDLLEXPORT OrderBySettings ts_compress_hypertable_parse_order_by(WithClauseResult orderby,

--- a/src/with_clause/with_clause_parser.h
+++ b/src/with_clause/with_clause_parser.h
@@ -34,4 +34,7 @@ extern TSDLLEXPORT void ts_with_clause_filter(const List *def_elems, List **with
 extern TSDLLEXPORT WithClauseResult *
 ts_with_clauses_parse(const List *def_elems, const WithClauseDefinition *args, Size nargs);
 
+extern TSDLLEXPORT WithClauseResult *
+ts_with_clauses_parse_reset(const List *def_elems, const WithClauseDefinition *args, Size nargs);
+
 extern TSDLLEXPORT char *ts_with_clause_result_deparse_value(const WithClauseResult *result);

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -195,6 +195,55 @@ HINT:  The timescaledb.compress_orderby option must reference distinct column.
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b');
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='');
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='c');
+-- test alter reset
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {c}       | {a,b}   | {f,f}        | {f,f}
+(1 row)
+
+ALTER TABLE foo RESET (timescaledb.compress_orderby);
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {c}       |         |              | 
+(1 row)
+
+ALTER TABLE foo RESET (timescaledb.compress_segmentby);
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                |           |         |              | 
+(1 row)
+
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='c');
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {c}       | {a,b}   | {f,f}        | {f,f}
+(1 row)
+
+-- should fail
+ALTER TABLE foo RESET (timescaledb.compress);
+ERROR:  only columnstore options segmentby and orderby can be reset
+ALTER TABLE foo RESET (timescaledb.compress, timescaledb.compress_segmentby, timescaledb.compress_orderby);
+ALTER TABLE foo RESET (timescaledb.compress_segmentby = 'a', timescaledb.compress_orderby);
+ERROR:  RESET must not include values for parameters
+ALTER TABLE foo RESET (timescaledb.compress_segmentby = '');
+ERROR:  RESET must not include values for parameters
+-- should succeed
+ALTER TABLE foo RESET (timescaledb.compress_segmentby, timescaledb.compress_orderby);
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                |           |         |              | 
+(1 row)
+
+ALTER TABLE foo SET (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='');
+create table foo_fake (a integer, b integer, c integer, t text, p point);
+ALTER TABLE foo_fake RESET (timescaledb.compress_segmentby);
+DROP TABLE foo_fake;
 --ddl on ht with compression
 ALTER TABLE foo DROP COLUMN a;
 ERROR:  cannot drop column named in partition key
@@ -203,8 +252,6 @@ ALTER TABLE foo DROP COLUMN b;
 ERROR:  cannot drop orderby or segmentby column from a hypertable with columnstore enabled
 ALTER TABLE foo ALTER COLUMN t SET NOT NULL;
 ERROR:  column "t" of relation "_hyper_10_2_chunk" contains null values
-ALTER TABLE foo RESET (timescaledb.compress);
-ERROR:  columnstore options cannot be reset
 --can add constraints as long as no data is compressed
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
 ALTER TABLE foo ADD CONSTRAINT unq UNIQUE(a);
@@ -263,7 +310,7 @@ ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', t
 ALTER TABLE foo set (timescaledb.compress='f');
 ERROR:  cannot disable columnstore on hypertable with columnstore chunks
 ALTER TABLE foo reset (timescaledb.compress);
-ERROR:  columnstore options cannot be reset
+ERROR:  only columnstore options segmentby and orderby can be reset
 SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing columnstore-enabled hypertable
 --should succeed

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -103,12 +103,35 @@ ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'b, b'
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b');
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='');
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='c');
+
+-- test alter reset
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ALTER TABLE foo RESET (timescaledb.compress_orderby);
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ALTER TABLE foo RESET (timescaledb.compress_segmentby);
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='c');
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+-- should fail
+ALTER TABLE foo RESET (timescaledb.compress);
+ALTER TABLE foo RESET (timescaledb.compress, timescaledb.compress_segmentby, timescaledb.compress_orderby);
+ALTER TABLE foo RESET (timescaledb.compress_segmentby = 'a', timescaledb.compress_orderby);
+ALTER TABLE foo RESET (timescaledb.compress_segmentby = '');
+
+-- should succeed
+ALTER TABLE foo RESET (timescaledb.compress_segmentby, timescaledb.compress_orderby);
+SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
+ALTER TABLE foo SET (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='');
+
+create table foo_fake (a integer, b integer, c integer, t text, p point);
+ALTER TABLE foo_fake RESET (timescaledb.compress_segmentby);
+DROP TABLE foo_fake;
 
 --ddl on ht with compression
 ALTER TABLE foo DROP COLUMN a;
 ALTER TABLE foo DROP COLUMN b;
 ALTER TABLE foo ALTER COLUMN t SET NOT NULL;
-ALTER TABLE foo RESET (timescaledb.compress);
 
 --can add constraints as long as no data is compressed
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);


### PR DESCRIPTION
Allows users to reset compression options like segmentby and orderby
back to their default values using ALTER TABLE RESET. This enables
easier rollback of compression configuration to default behavior
without needing to drop and recreate settings manually.