### PR TITLE
Release 2.21.1 (#8403)

### DIFF
--- a/.unreleased/pr_8336
+++ b/.unreleased/pr_8336
@@ -1,2 +1,0 @@
-Fixes: #8336 Fix generic plans for FK checks and prepared statements
-Thanks: @CodeTherapist for reporting the issue with FK checks not working after several insert statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.21.1 (2025-07-22)
+
+This release contains one bug fix since the 2.21.0 release. We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* [#8336](https://github.com/timescale/timescaledb/pull/8336) Fix generic plans for foreign key checks and prepared statements
+
+**Thanks**
+* @CodeTherapist for reporting the issue with foreign key checks not working after several `INSERT` statements
+
 ## 2.21.0 (2025-07-08)
 
 This release contains performance improvements and bug fixes since the 2.20.3 release. We recommend that you upgrade at the next available opportunity.


### PR DESCRIPTION
## 2.21.1 (2025-07-22)

This release contains a bug fix since the 2.21.0 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#8336](https://github.com/timescale/timescaledb/pull/8336) Fix generic plans for foreign key checks and prepared statements

**Thanks**
* @CodeTherapist for reporting the issue with foreign key checks not working after several `INSERT` statements