### PR TITLE
Ping on add of specific labels

### DIFF
--- a/.github/workflows/label-handling.yaml
+++ b/.github/workflows/label-handling.yaml
@@ -1,0 +1,26 @@
+#
+# Collection of actions to run when a label is added
+# to an issue or pull request
+#
+name: Label Handling
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  pr-upgrade-requires-restart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "PR: upgrade-requires-restart"
+        if: github.event.label.name == 'upgrade-requires-restart'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "📣 the `upgrade-requires-restart` label was added, pinging @timescale/database-pings"
+            })


### PR DESCRIPTION
Additive action to https://github.com/timescale/timescaledb/pull/8413 to ping if the upgrade requires restart label.

Disable-check: force-changelog-file