### PR TITLE
Remove flakiness in test

### DIFF
--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -31,4 +31,5 @@ WHERE lowest_modified_value = -9223372036854775808 ORDER BY 1;
 
 SELECT count(*) FROM mat_inval;
 CALL refresh_continuous_aggregate('mat_inval',NULL,NULL);
+SELECT pg_sleep(0.1); -- ensure refresh completes
 SELECT count(*) FROM mat_inval;


### PR DESCRIPTION
The nightly tests are flaky due to this one test: https://github.com/timescale/timescaledb/actions/runs/16533774861/job/46764421771