### PR TITLE
Disable poor compression ratio in nightly tests

### DIFF
--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -12,6 +12,7 @@ name: Nightly - Update smoke test on release branch
   pull_request:
     paths:
       - .github/workflows/nightly_cloud_smoke_test.yaml
+      - scripts/test_update_smoke.sh
 
 jobs:
   get-next-version:

--- a/scripts/test_update_smoke.sh
+++ b/scripts/test_update_smoke.sh
@@ -54,7 +54,7 @@ echo "**** pg_dump at   " "$(which pg_dump)"
 echo "**** pg_restore at" "$(which pg_restore)"
 
 # Extra options to pass to psql
-PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false -c enable_compression_ratio_warnings=no"
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false -c timescaledb.enable_compression_ratio_warnings=no"
 PSQL="psql -a -qX $PGOPTS"
 
 # If we are providing a URI for the connection, we parse it here and

--- a/scripts/test_update_smoke.sh
+++ b/scripts/test_update_smoke.sh
@@ -54,7 +54,7 @@ echo "**** pg_dump at   " "$(which pg_dump)"
 echo "**** pg_restore at" "$(which pg_restore)"
 
 # Extra options to pass to psql
-PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false"
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false -c enable_compression_ratio_warnings=no"
 PSQL="psql -a -qX $PGOPTS"
 
 # If we are providing a URI for the connection, we parse it here and

--- a/scripts/test_update_smoke.sh
+++ b/scripts/test_update_smoke.sh
@@ -54,7 +54,7 @@ echo "**** pg_dump at   " "$(which pg_dump)"
 echo "**** pg_restore at" "$(which pg_restore)"
 
 # Extra options to pass to psql
-PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false -c timescaledb.enable_compression_ratio_warnings=no"
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false"
 PSQL="psql -a -qX $PGOPTS"
 
 # If we are providing a URI for the connection, we parse it here and
@@ -120,6 +120,8 @@ echo "**** Update files in directory ${BASE_DIR}/test/sql/updates"
 cd ${BASE_DIR}/test/sql/updates
 
 $PSQL -c '\conninfo'
+$PSQL -c "ALTER DATABASE tsdb SET timescaledb.enable_compression_ratio_warnings = 'off'";
+
 
 # shellcheck disable=SC2207 # Prefer mapfile or read -a to split command output (or quote to avoid splitting).
 missing=($(missing_versions $CURRENT_VERSION $NEXT_VERSION))


### PR DESCRIPTION
- disables the warning
- runs the tests if the script is modified

Disable-check: approval-count
Disable-check: force-changelog-file