### PR TITLE
Fix flaky compression_defaults tests

### DIFF
--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -2,6 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE VIEW chunk_settings AS
+SELECT hypertable, count(*) as chunks, segmentby, orderby
+FROM timescaledb_information.chunk_compression_settings cs group by hypertable,segmentby,orderby ORDER BY 1,2,3,4;
 -- statitics on
 CREATE TABLE "public"."metrics" (
     "time" timestamp with time zone NOT NULL,
@@ -44,10 +47,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     27
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                 chunk                  | segmentby |   orderby   
-------------+----------------------------------------+-----------+-------------
- metrics    | _timescaledb_internal._hyper_1_1_chunk | device_id | "time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |   orderby   
+------------+--------+-----------+-------------
+ metrics    |     27 | device_id | "time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -64,10 +67,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     27
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                 chunk                  | segmentby |   orderby   
-------------+----------------------------------------+-----------+-------------
- metrics    | _timescaledb_internal._hyper_1_1_chunk | device_id | "time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |   orderby   
+------------+--------+-----------+-------------
+ metrics    |     27 | device_id | "time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -98,10 +101,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     27
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                 chunk                  | segmentby |        orderby        
-------------+----------------------------------------+-----------+-----------------------
- metrics    | _timescaledb_internal._hyper_1_1_chunk |           | device_id,"time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |        orderby        
+------------+--------+-----------+-----------------------
+ metrics    |     27 |           | device_id,"time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -120,10 +123,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     27
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                 chunk                  | segmentby |   orderby   
-------------+----------------------------------------+-----------+-------------
- metrics    | _timescaledb_internal._hyper_1_1_chunk | device_id | "time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |   orderby   
+------------+--------+-----------+-------------
+ metrics    |     27 | device_id | "time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -248,10 +251,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     27
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                 chunk                  | segmentby |   orderby   
-------------+----------------------------------------+-----------+-------------
- metrics    | _timescaledb_internal._hyper_1_1_chunk | device_id | "time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |   orderby   
+------------+--------+-----------+-------------
+ metrics    |     27 | device_id | "time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -531,10 +534,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     38
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                   chunk                   | segmentby  |   orderby   
-------------+-------------------------------------------+------------+-------------
- metrics    | _timescaledb_internal._hyper_11_163_chunk | device_id2 | "time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby  |   orderby   
+------------+--------+------------+-------------
+ metrics    |     38 | device_id2 | "time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -551,10 +554,10 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     38
 (1 row)
 
-select * from timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                   chunk                   | segmentby |   orderby   
-------------+-------------------------------------------+-----------+-------------
- metrics    | _timescaledb_internal._hyper_11_163_chunk | device_id | "time" DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |   orderby   
+------------+--------+-----------+-------------
+ metrics    |     38 | device_id | "time" DESC
 (1 row)
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
@@ -718,10 +721,10 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_table') x;
      1
 (1 row)
 
-SELECT * FROM timescaledb_information.chunk_compression_settings limit 1;
- hypertable |                   chunk                   | segmentby |   orderby    
-------------+-------------------------------------------+-----------+--------------
- test_table | _timescaledb_internal._hyper_26_277_chunk |           | uuid,ts DESC
+select * from chunk_settings;
+ hypertable | chunks | segmentby |   orderby    
+------------+--------+-----------+--------------
+ test_table |      1 |           | uuid,ts DESC
 (1 row)
 
 DROP TABLE test_table;

--- a/tsl/test/sql/compression_defaults.sql
+++ b/tsl/test/sql/compression_defaults.sql
@@ -4,6 +4,10 @@
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+CREATE VIEW chunk_settings AS
+SELECT hypertable, count(*) as chunks, segmentby, orderby
+FROM timescaledb_information.chunk_compression_settings cs group by hypertable,segmentby,orderby ORDER BY 1,2,3,4;
+
 -- statitics on
 CREATE TABLE "public"."metrics" (
     "time" timestamp with time zone NOT NULL,
@@ -32,13 +36,13 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY['devi
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 
 ALTER TABLE metrics SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'device_id');
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 
@@ -53,7 +57,7 @@ SET timescaledb.compression_segmentby_default_function   = '';
 RESET timescaledb.compression_orderby_default_function;
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 
@@ -61,7 +65,7 @@ RESET timescaledb.compression_segmentby_default_function;
 SET timescaledb.compression_orderby_default_function = '';
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 
@@ -113,7 +117,7 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY[]::te
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 
@@ -283,13 +287,13 @@ SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 
 ALTER TABLE metrics SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'device_id');
 select count(compress_chunk(x)) from show_chunks('metrics') x;
-select * from timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
 ALTER TABLE metrics SET (timescaledb.compress = false);
 DROP TABLE metrics;
@@ -405,6 +409,6 @@ ALTER TABLE test_table SET (
     timescaledb.compress_orderby = 'uuid'
 );
 SELECT count(compress_chunk(x)) FROM show_chunks('test_table') x;
-SELECT * FROM timescaledb_information.chunk_compression_settings limit 1;
+select * from chunk_settings;
 
 DROP TABLE test_table;


### PR DESCRIPTION
Don't rely on implicit ordering when checking compression settings
but use a view with explicit ordering instead.

Disable-check: approval-count
Disable-check: force-changelog-file
