### PR TITLE
Handle None case in backport script

### DIFF
--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -546,7 +546,7 @@ for index, pr_info in enumerate(
     original_description = re.sub(
         r"((fix|clos|resolv)[esd]+)(\s+#[0-9]+)",
         r"`\1`\3",
-        original_pr.body,
+        original_pr.body or "", # Match "" if pr_body is None
         flags=re.IGNORECASE,
     )
     backport_description += (

--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -546,7 +546,7 @@ for index, pr_info in enumerate(
     original_description = re.sub(
         r"((fix|clos|resolv)[esd]+)(\s+#[0-9]+)",
         r"`\1`\3",
-        original_pr.body or "", # Match "" if pr_body is None
+        original_pr.body or "",  # Match "" if pr_body is None
         flags=re.IGNORECASE,
     )
     backport_description += (


### PR DESCRIPTION
If the PR description does not have a body, the value of `pr_desc` is `None`, which makes the regex sub fail. E.g.: https://github.com/timescale/timescaledb/actions/runs/16652585974/job/47129046529#step:4:511

Disable-check: approval-count
Disable-check: force-changelog-file