### PR TITLE
Avoid flakes in materialization check

### DIFF
--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -13,6 +13,7 @@ name: Nightly - Update smoke test on release branch
     paths:
       - .github/workflows/nightly_cloud_smoke_test.yaml
       - scripts/test_update_smoke.sh
+      - test/sql/updates/*.sql
 
 jobs:
   get-next-version:

--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -29,9 +29,7 @@ SELECT maxtemp FROM mat_ignoreinval ORDER BY 1;
 SELECT materialization_id FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE lowest_modified_value = -9223372036854775808 ORDER BY 1;
 
-BEGIN;
 SELECT count(*) FROM mat_inval;
 CALL refresh_continuous_aggregate('mat_inval',NULL,NULL);
-COMMIT;
-
+SELECT pg_sleep(0.1); -- ensure refresh completes
 SELECT count(*) FROM mat_inval;

--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -29,7 +29,9 @@ SELECT maxtemp FROM mat_ignoreinval ORDER BY 1;
 SELECT materialization_id FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE lowest_modified_value = -9223372036854775808 ORDER BY 1;
 
+BEGIN;
 SELECT count(*) FROM mat_inval;
 CALL refresh_continuous_aggregate('mat_inval',NULL,NULL);
-VACUUM (FULL, ANALYZE) mat_inval;
+COMMIT;
+
 SELECT count(*) FROM mat_inval;


### PR DESCRIPTION
The nightly upgrade tests are flakey due to the following check: https://github.com/timescale/timescaledb/actions/runs/16710897537/job/47295644172#step:4:99

We tried VACCUM, which did not take effect as expected, using sleep now as initially used in https://github.com/timescale/timescaledb/pull/8419

Disable-check: approval-count
Disable-check: force-changelog-file