### PR TITLE
Fix UUID tests

### DIFF
--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -552,7 +552,7 @@ tsl_uuid_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryCon
 	Assert(element_type == UUIDOID);
 
 	compressed = PointerGetDatum(PG_DETOAST_DATUM(compressed));
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE_ANY(compressed) };
 	const DictionaryCompressed *header = consumeCompressedData(&si, sizeof(DictionaryCompressed));
 
 	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_DICTIONARY);

--- a/tsl/src/compression/algorithms/uuid_compress.c
+++ b/tsl/src/compression/algorithms/uuid_compress.c
@@ -560,7 +560,7 @@ uuid_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
 	ArrowArray *timestamp_array = NULL;
 
 	void *detoasted = PG_DETOAST_DATUM(compressed);
-	StringInfoData si = { .data = detoasted, .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = detoasted, .len = VARSIZE_ANY(compressed) };
 	UuidCompressed *header = consumeCompressedData(&si, sizeof(UuidCompressed));
 	char *timestamp_compressed_data = NULL;
 	char *rand_b_and_variant_compressed_data;

--- a/tsl/test/expected/compression_uuid.out
+++ b/tsl/test/expected/compression_uuid.out
@@ -288,7 +288,10 @@ FROM
   uuids
 WHERE
 -- The filters are here just to test, they don't blow up with random data from v4
-  _timescaledb_functions.timestamptz_from_uuid_v7(u) > '2000-01-01:01:01:01'::timestamptz
+-- NOTE that we have v4 and v7 data in the table so the timestamp filter alone makes
+-- the test flaky
+  _timescaledb_functions.timestamptz_from_uuid_v7(u) > '2000-01-01:01:01:01'::timestamptz OR
+  _timescaledb_functions.uuid_version(u) >= 1
 GROUP BY 1
 ORDER BY 1;
  uuid_version | count 

--- a/tsl/test/sql/compression_uuid.sql
+++ b/tsl/test/sql/compression_uuid.sql
@@ -205,7 +205,10 @@ FROM
   uuids
 WHERE
 -- The filters are here just to test, they don't blow up with random data from v4
-  _timescaledb_functions.timestamptz_from_uuid_v7(u) > '2000-01-01:01:01:01'::timestamptz
+-- NOTE that we have v4 and v7 data in the table so the timestamp filter alone makes
+-- the test flaky
+  _timescaledb_functions.timestamptz_from_uuid_v7(u) > '2000-01-01:01:01:01'::timestamptz OR
+  _timescaledb_functions.uuid_version(u) >= 1
 GROUP BY 1
 ORDER BY 1;
 


### PR DESCRIPTION
Fixing the sanitizer tests that flags up unaligned access that I added in the unit tests to test exactly that.

Fixing the flakyness of the UUID filtering test that filtered timestamps on a table that has v4 (random) data, so the timestamp returned may or may not match the timesptamp filter.

Disable-check: force-changelog-file