### PR TITLE
Add rerun variants to test commands to only rerun failed tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,12 @@ if(PG_REGRESS)
     USES_TERMINAL)
 
   add_custom_target(
+    regresscheck-rerun
+    COMMAND
+      ${PRIMARY_TEST_DIR}/ci_rerun.sh regresscheck
+    USES_TERMINAL)
+
+  add_custom_target(
     regresschecklocal
     COMMAND
       ${CMAKE_COMMAND} -E env ${PG_REGRESS_ENV} TEST_PGPORT=${TEST_PGPORT_LOCAL}
@@ -55,6 +61,12 @@ if(PG_ISOLATION_REGRESS)
       ${PG_ISOLATION_REGRESS_OPTS_EXTRA} ${PG_ISOLATION_REGRESS_OPTS_INOUT}
       ${PG_REGRESS_OPTS_TEMP_INSTANCE}
       --temp-config=${TEST_OUTPUT_DIR}/postgresql.conf
+    USES_TERMINAL)
+
+  add_custom_target(
+    isolationcheck-rerun
+    COMMAND
+      ${PRIMARY_TEST_DIR}/ci_rerun.sh isolationcheck
     USES_TERMINAL)
 
   add_custom_target(
@@ -107,6 +119,12 @@ add_custom_command(
   POST_BUILD
   COMMAND cmake --build ${CMAKE_CURRENT_BINARY_DIR} --target
           installcheck-post-hook)
+
+add_custom_target(
+  installcheck-rerun
+  COMMAND
+    ${PRIMARY_TEST_DIR}/ci_rerun.sh installcheck
+  USES_TERMINAL)
 
 # installchecklocal tests against an existing postgres instance
 add_custom_target(installchecklocal DEPENDS ${_local_install_checks})

--- a/test/ci_rerun.sh
+++ b/test/ci_rerun.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+subcommand=$1
+out_files="regression.out"
+
+if [ "$subcommand" == "installcheck" ]; then
+  out_files=$(find .. -name "regression.out")
+fi
+
+failed=$(grep -h -P "^not ok|FAILED" $out_files | sed -r -e 's!^not ok [0-9]+ +[+-] ([a-z0-9_-]+) .*$!\1!' -e 's!^(test|    ) ([a-z0-9_-]+) +... FAILED.*$!\2!')
+
+failed="${failed//$'\n'/ }"
+
+make -k $subcommand TESTS="$failed"
+

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -21,6 +21,12 @@ if(PG_REGRESS)
     USES_TERMINAL)
 
   add_custom_target(
+    regresscheck-t-rerun
+    COMMAND
+      ${PRIMARY_TEST_DIR}/ci_rerun.sh regresscheck-t
+    USES_TERMINAL)
+
+  add_custom_target(
     regresschecklocal-t
     COMMAND
       ${CMAKE_COMMAND} -E env ${PG_REGRESS_ENV}
@@ -43,6 +49,12 @@ if(PG_REGRESS)
       ${PG_REGRESS_OPTS_BASE} ${PG_REGRESS_SHARED_OPTS_EXTRA}
       ${PG_REGRESS_SHARED_OPTS_INOUT} ${PG_REGRESS_OPTS_TEMP_INSTANCE}
       --temp-config=${TEST_OUTPUT_DIR}/postgresql.conf
+    USES_TERMINAL)
+
+  add_custom_target(
+    regresscheck-shared-rerun
+    COMMAND
+      ${PRIMARY_TEST_DIR}/ci_rerun.sh regresscheck-shared
     USES_TERMINAL)
 
   add_custom_target(
@@ -92,6 +104,12 @@ if(PG_ISOLATION_REGRESS)
       ${PG_REGRESS_OPTS_BASE} ${PG_ISOLATION_REGRESS_OPTS_EXTRA}
       ${PG_ISOLATION_REGRESS_OPTS_INOUT} ${PG_REGRESS_OPTS_TEMP_INSTANCE}
       --temp-config=${TEST_OUTPUT_DIR}/postgresql.conf
+    USES_TERMINAL)
+
+  add_custom_target(
+    isolationcheck-t-rerun
+    COMMAND
+      ${PRIMARY_TEST_DIR}/ci_rerun.sh isolationcheck-t
     USES_TERMINAL)
 
   add_custom_target(


### PR DESCRIPTION
These commands will only rerun the failed tests from a previous
run.

This adds the following variants:
installcheck-rerun
regresscheck-rerun
regresscheck-t-rerun
regresscheck-shared-rerun
isolationcheck-rerun
isolationcheck-t-rerun

Example:
 $ make isolationcheck-t-rerun
 TESTS attach_chunk_isolation
 SKIPS
 # initializing database system by running initdb
 # using temp instance on port 55432 with PID 1967764
 not ok 1     - attach_chunk_isolation                     61 ms
 1..1
 # 1 of 1 tests failed.
