### PR TITLE
Fix MERGE behaviour with updated values

### DIFF
--- a/.unreleased/pr_8471
+++ b/.unreleased/pr_8471
@@ -1,0 +1,1 @@
+Fixes: #8471 Fix MERGE behaviour with updated values

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -131,7 +131,6 @@ typedef struct ModifyTableContext
  */
 typedef struct UpdateContext
 {
-	bool updated; /* did UPDATE actually occur? */
 	bool		crossPartUpdate;	/* was it a cross-partition update? */
 #if PG16_LT
 	bool updateIndexes; /* index update required? */
@@ -2994,7 +2993,7 @@ lmerge_matched:;
 										  newslot,
 										  mtstate->canSetTag,
 										  &updateCxt);
-				if (result == TM_Ok && updateCxt.updated)
+				if (result == TM_Ok)
 				{
 					ExecUpdateEpilogue(context,
 									   &updateCxt,
@@ -3002,7 +3001,7 @@ lmerge_matched:;
 									   tupleid,
 									   NULL,
 									   newslot);
-					mtstate->mt_merge_updated = 1;
+					mtstate->mt_merge_updated += 1;
 				}
 
 				break;

--- a/tsl/test/expected/cagg_refresh_using_merge.out
+++ b/tsl/test/expected/cagg_refresh_using_merge.out
@@ -995,3 +995,30 @@ SELECT * FROM conditions_nullable_daily ORDER BY 1, 2 NULLS LAST, 3 NULLS LAST;
 DROP MATERIALIZED VIEW conditions_nullable_daily;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_41_chunk
 DROP TABLE conditions CASCADE;
+-- test cagg refresh with updated values
+CREATE TABLE metrics(time timestamptz NOT NULL, device text, value float8) WITH (tsdb.hypertable,tsdb.partition_column='time');
+INSERT INTO metrics
+SELECT time, 'd'||device::text, 1
+FROM generate_series('2025-02-05 17:00+00'::timestamptz,'2025-02-05 19:00+00'::timestamptz, '5 min'::interval) AS g(time), generate_series(1, 10) AS device;
+CREATE MATERIALIZED VIEW metrics_summary WITH (timescaledb.continuous) AS
+SELECT device, time_bucket('00:05:00'::interval, time) AS bucket, sum(value) AS value FROM metrics GROUP BY 1, 2;
+NOTICE:  refreshing continuous aggregate "metrics_summary"
+UPDATE metrics SET value = value - 1 WHERE device='d1' and time ='2025-02-05 17:40:00+00';
+CALL refresh_continuous_aggregate('metrics_summary', '2025-02-04', '2025-02-10');
+SET enable_bitmapscan TO off;
+SET enable_seqscan TO true; SET enable_indexscan TO false;
+-- should be 250
+SELECT count(*) FROM metrics_summary WHERE bucket >= '2025-02-05 17:00:00+00' AND bucket < '2025-02-05 23:00:00+00';
+ count 
+-------
+   250
+(1 row)
+
+SET enable_seqscan TO false; SET enable_indexscan TO true;
+-- should match the result of the previous query
+SELECT count(*) FROM metrics_summary WHERE bucket >= '2025-02-05 17:00:00+00' AND bucket < '2025-02-05 23:00:00+00';
+ count 
+-------
+   250
+(1 row)
+


### PR DESCRIPTION
There was a problem in ModifyHypertable when using MERGE with
updated values leading to index corruption. This was caused by
some oversight in a refactoring of ModifyHypertable.
