### PR TITLE
Flush catalog cache on relcache invalidation

### DIFF
--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -58,6 +58,7 @@ cache_invalidate_relcache_all(void)
 {
 	ts_hypertable_cache_invalidate_callback();
 	ts_bgw_job_cache_invalidate_callback();
+	ts_catalog_reset();
 }
 
 static Oid hypertable_proxy_table_oid = InvalidOid;


### PR DESCRIPTION
concurrent reindex will alter the oids of the indexes so we need
to flush our catalog cache which caches index oids
