### PR TITLE
Assign correct no_begin for incremental cagg refresh

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -1267,7 +1267,7 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 			 (batch == 0 && !refresh_newest_first)) &&
 			original_refresh_window->start_isnull)
 		{
-			range->start = ts_time_get_nobegin_or_min(range->type);
+			range->start = cagg_get_time_min(cagg);
 			range->start_isnull = true;
 		}
 


### PR DESCRIPTION
When assigning value for the start of the lowest refresh batch we used to use ts_time_get_nobegin_or_min if start_offset was null. That returned -infinity which was not expected if the refresh window was fixed and could cause "Timestamp out of range" error during the incremental cagg refresh.

This commit fixes the issue by using cagg_get_time_min, which returns -infinity for variable window and timestamp's min value for fixed window.

Regression test will be added in a follow-up PR

Disable-check: force-changelog-file
Disable-check: approval-count