### PR TITLE
Remove unnecessary code from Continuous Aggregate

### DIFF
--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -327,7 +327,7 @@ continuous_agg_formdata_fill(FormData_continuous_agg *fd, const TupleInfo *ti)
  * Fill the fields of a integer based bucketing function
  */
 static void
-cagg_fill_bucket_function_integer_based(ContinuousAggsBucketFunction *bf, bool *isnull,
+cagg_fill_bucket_function_integer_based(ContinuousAggBucketFunction *bf, bool *isnull,
 										Datum *values)
 {
 	/* Bucket width */
@@ -358,7 +358,7 @@ cagg_fill_bucket_function_integer_based(ContinuousAggsBucketFunction *bf, bool *
  * Fill the fields of a time based bucketing function
  */
 static void
-cagg_fill_bucket_function_time_based(ContinuousAggsBucketFunction *bf, bool *isnull, Datum *values)
+cagg_fill_bucket_function_time_based(ContinuousAggBucketFunction *bf, bool *isnull, Datum *values)
 {
 	/*
 	 * bucket_width
@@ -406,7 +406,7 @@ cagg_fill_bucket_function_time_based(ContinuousAggsBucketFunction *bf, bool *isn
 }
 
 static void
-continuous_agg_fill_bucket_function(int32 mat_hypertable_id, ContinuousAggsBucketFunction *bf)
+continuous_agg_fill_bucket_function(int32 mat_hypertable_id, ContinuousAggBucketFunction *bf)
 {
 	ScanIterator iterator;
 	int count = 0;
@@ -490,14 +490,14 @@ continuous_agg_init(ContinuousAgg *cagg, const Form_continuous_agg fd)
 	Assert(OidIsValid(cagg->relid));
 	Assert(OidIsValid(cagg->partition_type));
 
-	cagg->bucket_function = palloc0(sizeof(ContinuousAggsBucketFunction));
+	cagg->bucket_function = palloc0(sizeof(ContinuousAggBucketFunction));
 	continuous_agg_fill_bucket_function(cagg->data.mat_hypertable_id, cagg->bucket_function);
 }
 
-TSDLLEXPORT CaggsInfo
+TSDLLEXPORT ContinuousAggInfo
 ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id)
 {
-	CaggsInfo all_caggs_info;
+	ContinuousAggInfo all_caggs_info;
 
 	List *caggs = ts_continuous_aggs_find_by_raw_table_id(raw_hypertable_id);
 	ListCell *lc;
@@ -1358,11 +1358,11 @@ ts_continuous_agg_bucket_on_interval(Oid bucket_function)
 
 /*
  * Calls the desired time bucket function depending on the arguments. If the experimental flag is
- * set on ContinuousAggsBucketFunction, one of time_bucket_ng() versions is used. This is a common
+ * set on ContinuousAggBucketFunction, one of time_bucket_ng() versions is used. This is a common
  * procedure used by ts_compute_* below.
  */
 static Datum
-generic_time_bucket(const ContinuousAggsBucketFunction *bf, Datum timestamp)
+generic_time_bucket(const ContinuousAggBucketFunction *bf, Datum timestamp)
 {
 	FuncInfo *func_info = ts_func_cache_get_bucketing_func(bf->bucket_function);
 	Ensure(func_info != NULL, "unable to get bucket function for Oid %d", bf->bucket_function);
@@ -1456,7 +1456,7 @@ generic_time_bucket(const ContinuousAggsBucketFunction *bf, Datum timestamp)
  * Otherwise, it happens in UTC.
  */
 static Datum
-generic_add_interval(const ContinuousAggsBucketFunction *bf, Datum timestamp)
+generic_add_interval(const ContinuousAggBucketFunction *bf, Datum timestamp)
 {
 	Datum tzname = 0;
 	bool has_timezone = (bf->bucket_time_timezone != NULL);
@@ -1497,7 +1497,7 @@ generic_add_interval(const ContinuousAggsBucketFunction *bf, Datum timestamp)
  */
 void
 ts_compute_inscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
-													  const ContinuousAggsBucketFunction *bf)
+													  const ContinuousAggBucketFunction *bf)
 {
 	Datum start_old, end_old, start_aligned, end_aliged;
 
@@ -1535,7 +1535,7 @@ ts_compute_inscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
  */
 void
 ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
-														  const ContinuousAggsBucketFunction *bf)
+														  const ContinuousAggBucketFunction *bf)
 {
 	Datum start_old, end_old, start_new, end_new;
 
@@ -1566,7 +1566,7 @@ ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *e
  */
 int64
 ts_compute_beginning_of_the_next_bucket_variable(int64 timeval,
-												 const ContinuousAggsBucketFunction *bf)
+												 const ContinuousAggBucketFunction *bf)
 {
 	Datum val_new;
 	Datum val_old;
@@ -1635,7 +1635,7 @@ ts_continuous_agg_get_query(ContinuousAgg *cagg)
  * Get the width of a fixed size bucket
  */
 int64
-ts_continuous_agg_fixed_bucket_width(const ContinuousAggsBucketFunction *bucket_function)
+ts_continuous_agg_fixed_bucket_width(const ContinuousAggBucketFunction *bucket_function)
 {
 	Assert(bucket_function->bucket_fixed_interval == true);
 
@@ -1655,7 +1655,7 @@ ts_continuous_agg_fixed_bucket_width(const ContinuousAggsBucketFunction *bucket_
  * Get the width of a bucket
  */
 int64
-ts_continuous_agg_bucket_width(const ContinuousAggsBucketFunction *bucket_function)
+ts_continuous_agg_bucket_width(const ContinuousAggBucketFunction *bucket_function)
 {
 	int64 bucket_width;
 

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -65,7 +65,7 @@ typedef enum ContinuousAggInvalidateUsing
 /*
  * Information about the bucketing function.
  */
-typedef struct ContinuousAggsBucketFunction
+typedef struct ContinuousAggBucketFunction
 {
 	/* Oid of the bucketing function. In the catalog table, the regprocedure is used. This ensures
 	 * that the Oid is mapped to a string when a backup is taken and the string is converted back to
@@ -102,14 +102,14 @@ typedef struct ContinuousAggsBucketFunction
 	int64 bucket_integer_width;
 	int64 bucket_integer_offset;
 
-} ContinuousAggsBucketFunction;
+} ContinuousAggBucketFunction;
 
 typedef struct ContinuousAgg
 {
 	FormData_continuous_agg data;
 
 	/* Info about the time bucketing function */
-	ContinuousAggsBucketFunction *bucket_function;
+	ContinuousAggBucketFunction *bucket_function;
 
 	/* Relid of the user-facing view */
 	Oid relid;
@@ -138,21 +138,21 @@ typedef enum ContinuousAggHypertableStatus
 	HypertableIsMaterializationAndRaw = HypertableIsMaterialization | HypertableIsRawTable,
 } ContinuousAggHypertableStatus;
 
-typedef struct CaggsInfoData
+typedef struct ContinuousAggInfo
 {
 	/* (int32) elements */
 	List *mat_hypertable_ids;
-	/* (const ContinuousAggsBucketFunction *) elements; stores NULL for fixed buckets */
+	/* (const ContinuousAggBucketFunction *) elements; stores NULL for fixed buckets */
 	List *bucket_functions;
-} CaggsInfo;
+} ContinuousAggInfo;
 
-typedef struct CaggPolicyOffset
+typedef struct ContinuousAggPolicyOffset
 {
 	Datum value;
 	Oid type;
 	bool isnull;
 	const char *name;
-} CaggPolicyOffset;
+} ContinuousAggPolicyOffset;
 
 static inline bool
 has_invalidation_trigger(Oid relid)
@@ -162,7 +162,7 @@ has_invalidation_trigger(Oid relid)
 
 extern TSDLLEXPORT Oid ts_cagg_permissions_check(Oid cagg_oid, Oid userid);
 
-extern TSDLLEXPORT CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
+extern TSDLLEXPORT ContinuousAggInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
 extern TSDLLEXPORT ContinuousAgg *
 ts_continuous_agg_find_by_mat_hypertable_id(int32 mat_hypertable_id, bool missing_ok);
 
@@ -200,17 +200,17 @@ extern TSDLLEXPORT bool ts_continuous_agg_bucket_on_interval(Oid bucket_function
 
 extern TSDLLEXPORT void
 ts_compute_inscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
-													  const ContinuousAggsBucketFunction *bf);
+													  const ContinuousAggBucketFunction *bf);
 extern TSDLLEXPORT void
 ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
-														  const ContinuousAggsBucketFunction *bf);
+														  const ContinuousAggBucketFunction *bf);
 extern TSDLLEXPORT int64 ts_compute_beginning_of_the_next_bucket_variable(
-	int64 timeval, const ContinuousAggsBucketFunction *bf);
+	int64 timeval, const ContinuousAggBucketFunction *bf);
 
 extern TSDLLEXPORT Query *ts_continuous_agg_get_query(ContinuousAgg *cagg);
 
 extern TSDLLEXPORT int64
-ts_continuous_agg_fixed_bucket_width(const ContinuousAggsBucketFunction *bucket_function);
+ts_continuous_agg_fixed_bucket_width(const ContinuousAggBucketFunction *bucket_function);
 extern TSDLLEXPORT int64
-ts_continuous_agg_bucket_width(const ContinuousAggsBucketFunction *bucket_function);
+ts_continuous_agg_bucket_width(const ContinuousAggBucketFunction *bucket_function);
 extern TSDLLEXPORT void ts_get_invalidation_replication_slot_name(char *slotname, Size szslot);

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -448,7 +448,7 @@ validate_window_size(const ContinuousAgg *cagg, const CaggPolicyConfig *config)
 
 static void
 parse_offset_arg(const ContinuousAgg *cagg, Oid offset_type, NullableDatum arg,
-				 CaggPolicyOffset *offset)
+				 ContinuousAggPolicyOffset *offset)
 {
 	offset->isnull = arg.isnull;
 

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -384,7 +384,7 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 						PGC_S_SESSION);
 	}
 
-	CaggRefreshContext context = { .callctx = CAGG_REFRESH_POLICY };
+	ContinuousAggRefreshContext context = { .callctx = CAGG_REFRESH_POLICY };
 
 	/* Try to split window range into a list of ranges */
 	List *refresh_window_list =

--- a/tsl/src/bgw_policy/policies_v2.h
+++ b/tsl/src/bgw_policy/policies_v2.h
@@ -73,8 +73,8 @@ extern Datum policies_show(PG_FUNCTION_ARGS);
 typedef struct CaggPolicyConfig
 {
 	Oid partition_type;
-	CaggPolicyOffset offset_start;
-	CaggPolicyOffset offset_end;
+	ContinuousAggPolicyOffset offset_start;
+	ContinuousAggPolicyOffset offset_end;
 } CaggPolicyConfig;
 
 typedef struct refresh_policy

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -48,7 +48,7 @@ typedef struct FinalizeQueryInfo
 	bool finalized;			/* finalized form? */
 } FinalizeQueryInfo;
 
-typedef struct MatTableColumnInfo
+typedef struct MaterializationHypertableColumnInfo
 {
 	List *matcollist;		 /* column defns for materialization tbl*/
 	List *partial_seltlist;	 /* tlist entries for populating the materialization table columns */
@@ -59,9 +59,9 @@ typedef struct MatTableColumnInfo
 									matpartcolname */
 	int matpartcolno;			 /*index of partitioning column in matcollist */
 	char *matpartcolname;		 /*name of the partition column */
-} MatTableColumnInfo;
+} MaterializationHypertableColumnInfo;
 
-typedef struct CAggTimebucketInfo
+typedef struct ContinuousAggTimeBucketInfo
 {
 	int32 htid;						/* hypertable id */
 	int32 parent_mat_hypertable_id; /* parent materialization hypertable id */
@@ -73,23 +73,23 @@ typedef struct CAggTimebucketInfo
 	int64 htpartcol_interval_len;	/* interval length setting for primary partitioning column */
 
 	/* General bucket information */
-	ContinuousAggsBucketFunction *bf;
-} CAggTimebucketInfo;
+	ContinuousAggBucketFunction *bf;
+} ContinuousAggTimeBucketInfo;
 
-typedef enum CaggRefreshCallContext
+typedef enum ContinuousAggRefreshCallContext
 {
 	CAGG_REFRESH_CREATION,
 	CAGG_REFRESH_WINDOW,
 	CAGG_REFRESH_POLICY,
 	CAGG_REFRESH_POLICY_BATCHED
-} CaggRefreshCallContext;
+} ContinuousAggRefreshCallContext;
 
-typedef struct CaggRefreshContext
+typedef struct ContinuousAggRefreshContext
 {
-	CaggRefreshCallContext callctx;
+	ContinuousAggRefreshCallContext callctx;
 	int32 processing_batch;
 	int32 number_of_batches;
-} CaggRefreshContext;
+} ContinuousAggRefreshContext;
 
 #define IS_TIME_BUCKET_INFO_TIME_BASED(bucket_function)                                            \
 	(bucket_function->bucket_width_type == INTERVALOID)
@@ -109,14 +109,16 @@ typedef struct CaggRefreshContext
 		(selquery)->rtable = NULL;                                                                 \
 	} while (0);
 
-extern CAggTimebucketInfo cagg_validate_query(const Query *query, const bool finalized,
-											  const char *cagg_schema, const char *cagg_name,
-											  const bool is_cagg_create);
+extern ContinuousAggTimeBucketInfo cagg_validate_query(const Query *query, const bool finalized,
+													   const char *cagg_schema,
+													   const char *cagg_name,
+													   const bool is_cagg_create);
 extern Query *destroy_union_query(Query *q);
 extern void RemoveRangeTableEntries(Query *query);
-extern Query *build_union_query(CAggTimebucketInfo *tbinfo, int matpartcolno, Query *q1, Query *q2,
-								int materialize_htid);
-extern void mattablecolumninfo_init(MatTableColumnInfo *matcolinfo, List *grouplist);
+extern Query *build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *q1,
+								Query *q2, int materialize_htid);
+extern void mattablecolumninfo_init(MaterializationHypertableColumnInfo *matcolinfo,
+									List *grouplist);
 extern bool function_allowed_in_cagg_definition(Oid funcid);
 extern Oid get_watermark_function_oid(void);
 extern Oid cagg_get_boundary_converter_funcoid(Oid typoid);
@@ -149,4 +151,4 @@ cagg_get_time_min(const ContinuousAgg *cagg)
 	return ts_time_get_min(cagg->partition_type);
 }
 
-ContinuousAggsBucketFunction *ts_cagg_get_bucket_function_info(Oid view_oid);
+ContinuousAggBucketFunction *ts_cagg_get_bucket_function_info(Oid view_oid);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -97,11 +97,13 @@ static void create_bucket_function_catalog_entry(int32 matht_id, Oid bucket_func
 static void cagg_create_hypertable(int32 hypertable_id, Oid mat_tbloid, const char *matpartcolname,
 								   int64 mat_tbltimecol_interval);
 static void cagg_add_trigger_hypertable(Oid relid, int32 hypertable_id);
-static void mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable *ht);
+static void mattablecolumninfo_add_mattable_index(MaterializationHypertableColumnInfo *matcolinfo,
+												  Hypertable *ht);
 static ObjectAddress create_view_for_query(Query *selquery, RangeVar *viewrel);
 static void fixup_userview_query_tlist(Query *userquery, List *tlist_aliases);
 static void cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquery,
-						CAggTimebucketInfo *bucket_info, WithClauseResult *with_clause_options);
+						ContinuousAggTimeBucketInfo *bucket_info,
+						WithClauseResult *with_clause_options);
 
 #define MATPARTCOL_INTERVAL_FACTOR 10
 #define CAGG_INVALIDATION_TRIGGER "continuous_agg_invalidation_trigger"
@@ -143,11 +145,12 @@ makeMaterializedTableName(char *buf, const char *prefix, int hypertable_id)
 
 /* STATIC functions defined on the structs above. */
 static int32 mattablecolumninfo_create_materialization_table(
-	MatTableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
-	CAggTimebucketInfo *bucket_info, bool create_addl_index, char *tablespacename,
+	MaterializationHypertableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
+	ContinuousAggTimeBucketInfo *bucket_info, bool create_addl_index, char *tablespacename,
 	char *table_access_method, int64 matpartcol_interval, ObjectAddress *mataddress);
-static Query *mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo,
-														  Query *userview_query, bool finalized);
+static Query *
+mattablecolumninfo_get_partial_select_query(MaterializationHypertableColumnInfo *mattblinfo,
+											Query *userview_query, bool finalized);
 
 /*
  * Create a entry for the materialization table in table CONTINUOUS_AGGS.
@@ -467,7 +470,8 @@ cagg_add_trigger_hypertable(Oid relid, int32 hypertable_id)
  * i.e. #indexes =(  #grp-cols - 1)
  */
 static void
-mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable *ht)
+mattablecolumninfo_add_mattable_index(MaterializationHypertableColumnInfo *matcolinfo,
+									  Hypertable *ht)
 {
 	IndexStmt stmt = {
 		.type = T_IndexStmt,
@@ -533,12 +537,10 @@ mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable
  *        materialization table
  */
 static int32
-mattablecolumninfo_create_materialization_table(MatTableColumnInfo *matcolinfo, int32 hypertable_id,
-												RangeVar *mat_rel, CAggTimebucketInfo *bucket_info,
-												bool create_addl_index, char *const tablespacename,
-												char *const table_access_method,
-												int64 matpartcol_interval,
-												ObjectAddress *mataddress)
+mattablecolumninfo_create_materialization_table(
+	MaterializationHypertableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
+	ContinuousAggTimeBucketInfo *bucket_info, bool create_addl_index, char *const tablespacename,
+	char *const table_access_method, int64 matpartcol_interval, ObjectAddress *mataddress)
 {
 	Oid uid, saved_uid;
 	int sec_ctx;
@@ -608,8 +610,8 @@ mattablecolumninfo_create_materialization_table(MatTableColumnInfo *matcolinfo, 
  * the materialization columns and remove HAVING clause and ORDER BY.
  */
 static Query *
-mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo, Query *userview_query,
-											bool finalized)
+mattablecolumninfo_get_partial_select_query(MaterializationHypertableColumnInfo *mattblinfo,
+											Query *userview_query, bool finalized)
 {
 	Query *partial_selquery = NULL;
 
@@ -809,11 +811,11 @@ error_not_in_prerequisite_state(const char *wanted, const char *used)
  */
 static void
 cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquery,
-			CAggTimebucketInfo *bucket_info, WithClauseResult *with_clause_options)
+			ContinuousAggTimeBucketInfo *bucket_info, WithClauseResult *with_clause_options)
 {
 	ObjectAddress mataddress;
 	char relnamebuf[NAMEDATALEN];
-	MatTableColumnInfo mattblinfo;
+	MaterializationHypertableColumnInfo mattblinfo;
 	FinalizeQueryInfo finalqinfo;
 	CatalogSecurityContext sec_ctx;
 	bool is_create_mattbl_index;
@@ -1050,7 +1052,7 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 									WithClauseResult *with_clause_options)
 {
 	const CreateTableAsStmt *stmt = castNode(CreateTableAsStmt, node);
-	CAggTimebucketInfo timebucket_exprinfo;
+	ContinuousAggTimeBucketInfo timebucket_exprinfo;
 	Oid nspid;
 	bool finalized = with_clause_options[CreateMaterializedViewFlagFinalized].parsed;
 	ViewStmt viewstmt = {
@@ -1158,7 +1160,7 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 		refresh_window.start = cagg_get_time_min(cagg);
 		refresh_window.end = ts_time_get_noend_or_max(refresh_window.type);
 
-		CaggRefreshContext context = { .callctx = CAGG_REFRESH_CREATION };
+		ContinuousAggRefreshContext context = { .callctx = CAGG_REFRESH_CREATION };
 		continuous_agg_refresh_internal(cagg,
 										&refresh_window,
 										context,
@@ -1204,7 +1206,7 @@ cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 	relation_close(direct_view_rel, NoLock);
 	RemoveRangeTableEntries(direct_query);
 
-	CAggTimebucketInfo timebucket_exprinfo =
+	ContinuousAggTimeBucketInfo timebucket_exprinfo =
 		cagg_validate_query(direct_query,
 							agg->data.finalized,
 							NameStr(agg->data.user_view_schema),

--- a/tsl/src/continuous_aggs/finalize.c
+++ b/tsl/src/continuous_aggs/finalize.c
@@ -17,7 +17,7 @@
 #include <partialize_finalize.h>
 
 /* Static function prototypes */
-static Var *mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input,
+static Var *mattablecolumninfo_addentry(MaterializationHypertableColumnInfo *out, Node *input,
 										int original_query_resno, bool finalized,
 										bool *skip_adding);
 static inline void makeMaterializeColumnName(char *colbuf, const char *type,
@@ -44,7 +44,8 @@ makeMaterializeColumnName(char *colbuf, const char *type, int original_query_res
  * materialize table columns and partialize exprs.
  */
 void
-finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query, MatTableColumnInfo *mattblinfo)
+finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query,
+				   MaterializationHypertableColumnInfo *mattblinfo)
 {
 	ListCell *lc;
 	int resno = 1;
@@ -223,8 +224,8 @@ finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
  *
  */
 static Var *
-mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input, int original_query_resno,
-							bool finalized, bool *skip_adding)
+mattablecolumninfo_addentry(MaterializationHypertableColumnInfo *out, Node *input,
+							int original_query_resno, bool finalized, bool *skip_adding)
 {
 	int matcolno = list_length(out->matcollist) + 1;
 	char colbuf[NAMEDATALEN];

--- a/tsl/src/continuous_aggs/finalize.h
+++ b/tsl/src/continuous_aggs/finalize.h
@@ -26,6 +26,6 @@
 extern Query *finalize_query_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 											  ObjectAddress *mattbladdress);
 extern void finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query,
-							   MatTableColumnInfo *mattblinfo);
+							   MaterializationHypertableColumnInfo *mattblinfo);
 extern Query *finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 											 ObjectAddress *mattbladdress, char *relname);

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -48,6 +48,6 @@ extern InvalidationStore *
 invalidation_process_cagg_log(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
 							  long max_materializations, bool *do_merged_refresh,
 							  InternalTimeRange *ret_merged_refresh_window,
-							  CaggRefreshContext context, bool force);
+							  ContinuousAggRefreshContext context, bool force);
 
 extern void invalidation_store_free(InvalidationStore *store);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -40,13 +40,13 @@
 		 LOG :                                                                                     \
 		 DEBUG1)
 
-typedef struct CaggRefreshState
+typedef struct ContinuousAggRefreshState
 {
 	ContinuousAgg cagg;
 	Hypertable *cagg_ht;
 	InternalTimeRange refresh_window;
 	SchemaAndName partial_view;
-} CaggRefreshState;
+} ContinuousAggRefreshState;
 
 static Hypertable *cagg_get_hypertable_or_fail(int32 hypertable_id);
 static InternalTimeRange get_largest_bucketed_window(Oid timetype, int64 bucket_width);
@@ -57,33 +57,36 @@ compute_inscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 static InternalTimeRange
 compute_circumscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 											  const InternalTimeRange *const refresh_window,
-											  const ContinuousAggsBucketFunction *bucket_function);
-static void continuous_agg_refresh_init(CaggRefreshState *refresh, const ContinuousAgg *cagg,
+											  const ContinuousAggBucketFunction *bucket_function);
+static void continuous_agg_refresh_init(ContinuousAggRefreshState *refresh,
+										const ContinuousAgg *cagg,
 										const InternalTimeRange *refresh_window);
-static void continuous_agg_refresh_execute(const CaggRefreshState *refresh,
+static void continuous_agg_refresh_execute(const ContinuousAggRefreshState *refresh,
 										   const InternalTimeRange *bucketed_refresh_window,
 										   const int32 chunk_id);
 static void log_refresh_window(int elevel, const ContinuousAgg *cagg,
 							   const InternalTimeRange *refresh_window, const char *msg,
-							   CaggRefreshContext context);
+							   ContinuousAggRefreshContext context);
 static void continuous_agg_refresh_execute_wrapper(const InternalTimeRange *bucketed_refresh_window,
-												   const CaggRefreshContext context,
+												   const ContinuousAggRefreshContext context,
 												   const long iteration, void *arg1_refresh,
 												   void *arg2_chunk_id);
 static void update_merged_refresh_window(const InternalTimeRange *bucketed_refresh_window,
-										 const CaggRefreshContext context, const long iteration,
-										 void *arg1_merged_refresh_window, void *arg2);
+										 const ContinuousAggRefreshContext context,
+										 const long iteration, void *arg1_merged_refresh_window,
+										 void *arg2);
 static void continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 											   const InternalTimeRange *refresh_window,
 											   const InvalidationStore *invalidations,
 											   int32 chunk_id, const bool do_merged_refresh,
 											   const InternalTimeRange merged_refresh_window,
-											   const CaggRefreshContext context);
-static void emit_up_to_date_notice(const ContinuousAgg *cagg, const CaggRefreshContext context);
+											   const ContinuousAggRefreshContext context);
+static void emit_up_to_date_notice(const ContinuousAgg *cagg,
+								   const ContinuousAggRefreshContext context);
 static bool process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 												   const InternalTimeRange *refresh_window,
-												   const CaggRefreshContext context, int32 chunk_id,
-												   bool force);
+												   const ContinuousAggRefreshContext context,
+												   int32 chunk_id, bool force);
 static void fill_bucket_offset_origin(const ContinuousAgg *cagg,
 									  const InternalTimeRange *const refresh_window,
 									  NullableDatum *offset, NullableDatum *origin);
@@ -209,7 +212,7 @@ compute_inscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
  * Get the offset as Datum value of an integer based bucket
  */
 static Datum
-int_bucket_offset_to_datum(Oid type, const ContinuousAggsBucketFunction *bucket_function)
+int_bucket_offset_to_datum(Oid type, const ContinuousAggBucketFunction *bucket_function)
 {
 	Assert(bucket_function->bucket_time_based == false);
 
@@ -305,7 +308,7 @@ fill_bucket_offset_origin(const ContinuousAgg *cagg, const InternalTimeRange *co
 static InternalTimeRange
 compute_circumscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 											  const InternalTimeRange *const refresh_window,
-											  const ContinuousAggsBucketFunction *bucket_function)
+											  const ContinuousAggBucketFunction *bucket_function)
 {
 	Assert(cagg != NULL);
 	Assert(cagg->bucket_function != NULL);
@@ -384,7 +387,7 @@ compute_circumscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
  * The state holds information for executing a refresh of a continuous aggregate.
  */
 static void
-continuous_agg_refresh_init(CaggRefreshState *refresh, const ContinuousAgg *cagg,
+continuous_agg_refresh_init(ContinuousAggRefreshState *refresh, const ContinuousAgg *cagg,
 							const InternalTimeRange *refresh_window)
 {
 	MemSet(refresh, 0, sizeof(*refresh));
@@ -402,7 +405,7 @@ continuous_agg_refresh_init(CaggRefreshState *refresh, const ContinuousAgg *cagg
  * refresh state.
  */
 static void
-continuous_agg_refresh_execute(const CaggRefreshState *refresh,
+continuous_agg_refresh_execute(const ContinuousAggRefreshState *refresh,
 							   const InternalTimeRange *bucketed_refresh_window,
 							   const int32 chunk_id)
 {
@@ -434,7 +437,7 @@ continuous_agg_refresh_execute(const CaggRefreshState *refresh,
 
 static void
 log_refresh_window(int elevel, const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
-				   const char *msg, CaggRefreshContext context)
+				   const char *msg, ContinuousAggRefreshContext context)
 {
 	if (context.callctx == CAGG_REFRESH_POLICY_BATCHED)
 		elog(elevel,
@@ -455,16 +458,17 @@ log_refresh_window(int elevel, const ContinuousAgg *cagg, const InternalTimeRang
 }
 
 typedef void (*scan_refresh_ranges_funct_t)(const InternalTimeRange *bucketed_refresh_window,
-											const CaggRefreshContext context,
+											const ContinuousAggRefreshContext context,
 											const long iteration, /* 0 is first range */
 											void *arg1, void *arg2);
 
 static void
 continuous_agg_refresh_execute_wrapper(const InternalTimeRange *bucketed_refresh_window,
-									   const CaggRefreshContext context, const long iteration,
-									   void *arg1_refresh, void *arg2_chunk_id)
+									   const ContinuousAggRefreshContext context,
+									   const long iteration, void *arg1_refresh,
+									   void *arg2_chunk_id)
 {
-	const CaggRefreshState *refresh = (const CaggRefreshState *) arg1_refresh;
+	const ContinuousAggRefreshState *refresh = (const ContinuousAggRefreshState *) arg1_refresh;
 	const int32 chunk_id = *(const int32 *) arg2_chunk_id;
 	(void) iteration;
 
@@ -478,7 +482,7 @@ continuous_agg_refresh_execute_wrapper(const InternalTimeRange *bucketed_refresh
 
 static void
 update_merged_refresh_window(const InternalTimeRange *bucketed_refresh_window,
-							 const CaggRefreshContext context, const long iteration,
+							 const ContinuousAggRefreshContext context, const long iteration,
 							 void *arg1_merged_refresh_window, void *arg2)
 {
 	InternalTimeRange *merged_refresh_window = (InternalTimeRange *) arg1_merged_refresh_window;
@@ -500,8 +504,7 @@ static long
 continuous_agg_scan_refresh_window_ranges(const ContinuousAgg *cagg,
 										  const InternalTimeRange *refresh_window,
 										  const InvalidationStore *invalidations,
-										  const ContinuousAggsBucketFunction *bucket_function,
-										  const CaggRefreshContext context,
+										  const ContinuousAggRefreshContext context,
 										  scan_refresh_ranges_funct_t exec_func, void *func_arg1,
 										  void *func_arg2)
 {
@@ -534,7 +537,9 @@ continuous_agg_scan_refresh_window_ranges(const ContinuousAgg *cagg,
 		};
 
 		InternalTimeRange bucketed_refresh_window =
-			compute_circumscribed_bucketed_refresh_window(cagg, &invalidation, bucket_function);
+			compute_circumscribed_bucketed_refresh_window(cagg,
+														  &invalidation,
+														  cagg->bucket_function);
 
 		(*exec_func)(&bucketed_refresh_window, context, count, func_arg1, func_arg2);
 
@@ -578,9 +583,9 @@ continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 								   const InvalidationStore *invalidations, int32 chunk_id,
 								   const bool do_merged_refresh,
 								   const InternalTimeRange merged_refresh_window,
-								   const CaggRefreshContext context)
+								   const ContinuousAggRefreshContext context)
 {
-	CaggRefreshState refresh;
+	ContinuousAggRefreshState refresh;
 
 	continuous_agg_refresh_init(&refresh, cagg, refresh_window);
 
@@ -619,7 +624,6 @@ continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 		count = continuous_agg_scan_refresh_window_ranges(cagg,
 														  refresh_window,
 														  invalidations,
-														  cagg->bucket_function,
 														  context,
 														  continuous_agg_refresh_execute_wrapper,
 														  (void *) &refresh /* arg1 */,
@@ -675,7 +679,7 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 	else
 		refresh_window.end = ts_time_get_noend_or_max(refresh_window.type);
 
-	CaggRefreshContext context = { .callctx = CAGG_REFRESH_WINDOW };
+	ContinuousAggRefreshContext context = { .callctx = CAGG_REFRESH_WINDOW };
 	continuous_agg_refresh_internal(cagg,
 									&refresh_window,
 									context,
@@ -690,7 +694,7 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 }
 
 static void
-emit_up_to_date_notice(const ContinuousAgg *cagg, const CaggRefreshContext context)
+emit_up_to_date_notice(const ContinuousAgg *cagg, const ContinuousAggRefreshContext context)
 {
 	switch (context.callctx)
 	{
@@ -710,15 +714,13 @@ void
 continuous_agg_calculate_merged_refresh_window(const ContinuousAgg *cagg,
 											   const InternalTimeRange *refresh_window,
 											   const InvalidationStore *invalidations,
-											   const ContinuousAggsBucketFunction *bucket_function,
 											   InternalTimeRange *merged_refresh_window,
-											   const CaggRefreshContext context)
+											   const ContinuousAggRefreshContext context)
 {
 	long count pg_attribute_unused();
 	count = continuous_agg_scan_refresh_window_ranges(cagg,
 													  refresh_window,
 													  invalidations,
-													  bucket_function,
 													  context,
 													  update_merged_refresh_window,
 													  (void *) merged_refresh_window,
@@ -729,7 +731,8 @@ continuous_agg_calculate_merged_refresh_window(const ContinuousAgg *cagg,
 static bool
 process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 									   const InternalTimeRange *refresh_window,
-									   const CaggRefreshContext context, int32 chunk_id, bool force)
+									   const ContinuousAggRefreshContext context, int32 chunk_id,
+									   bool force)
 {
 	InvalidationStore *invalidations;
 	Oid hyper_relid = ts_hypertable_id_to_relid(cagg->data.mat_hypertable_id, false);
@@ -782,7 +785,7 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 void
 continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 								const InternalTimeRange *refresh_window_arg,
-								const CaggRefreshContext context, const bool start_isnull,
+								const ContinuousAggRefreshContext context, const bool start_isnull,
 								const bool end_isnull, bool bucketing_refresh_window, bool force,
 								bool process_hypertable_invalidations, bool extend_last_bucket)
 {

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -14,11 +14,11 @@
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void continuous_agg_calculate_merged_refresh_window(
 	const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
-	const InvalidationStore *invalidations, const ContinuousAggsBucketFunction *bucket_function,
-	InternalTimeRange *merged_refresh_window, const CaggRefreshContext context);
+	const InvalidationStore *invalidations, InternalTimeRange *merged_refresh_window,
+	const ContinuousAggRefreshContext context);
 extern void
 continuous_agg_refresh_internal(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
-								const CaggRefreshContext context, const bool start_isnull,
+								const ContinuousAggRefreshContext context, const bool start_isnull,
 								const bool end_isnull, bool bucketing_refresh_window, bool force,
 								bool process_hypertable_invalidations, bool extend_last_bucket);
 extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,

--- a/tsl/src/continuous_aggs/repair.c
+++ b/tsl/src/continuous_aggs/repair.c
@@ -72,7 +72,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht, bool force_
 		final_query = destroy_union_query(final_query);
 	}
 	FinalizeQueryInfo fqi;
-	MatTableColumnInfo mattblinfo;
+	MaterializationHypertableColumnInfo mattblinfo;
 	ObjectAddress mataddress = {
 		.classId = RelationRelationId,
 		.objectId = mat_ht->main_table_relid,
@@ -128,7 +128,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht, bool force_
 			 NameStr(agg->data.user_view_schema),
 			 NameStr(agg->data.user_view_name));
 
-	CAggTimebucketInfo timebucket_exprinfo =
+	ContinuousAggTimeBucketInfo timebucket_exprinfo =
 		cagg_validate_query(direct_query,
 							finalized,
 							NameStr(agg->data.user_view_schema),

--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -806,7 +806,7 @@ enum
 #define Natts_cagg_bucket_function (_Anum_cagg_bucket_function_max - 1)
 
 static Datum
-create_cagg_get_bucket_function_datum(TupleDesc tupdesc, ContinuousAggsBucketFunction *bf)
+create_cagg_get_bucket_function_datum(TupleDesc tupdesc, ContinuousAggBucketFunction *bf)
 {
 	NullableDatum datums[Natts_cagg_bucket_function] = { { 0 } };
 	HeapTuple tuple;
@@ -893,7 +893,7 @@ cagg_get_bucket_function_datum(int32 mat_hypertable_id, FunctionCallInfo fcinfo)
 	if (fcinfo != NULL && get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
 		elog(ERROR, "function returning record called in context that cannot accept type record");
 
-	ContinuousAggsBucketFunction *bf = ts_cagg_get_bucket_function_info(direct_view_oid);
+	ContinuousAggBucketFunction *bf = ts_cagg_get_bucket_function_info(direct_view_oid);
 
 	if (!OidIsValid(bf->bucket_function))
 	{


### PR DESCRIPTION
Get rid of unnecessary usage of `ContinuousAggsBucketFunction` in some places since it was added to the `ContinuousAgg` struct long time ago by 95804069.

Also renamed other data structures to keep names consistent.

Disable-check: force-changelog-file
Disable-check: approval-count
