### PR TITLE
Implement notnull mode for skipscan

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -117,6 +117,7 @@ TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
 bool ts_guc_enable_event_triggers = false;
+bool ts_guc_debug_skip_scan_info = false;
 
 /* Only settable in debug mode for testing */
 TSDLLEXPORT bool ts_guc_enable_null_compression = true;
@@ -687,6 +688,17 @@ _guc_init(void)
 							 1.0,
 							 0.0,
 							 1.0,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("debug_skip_scan_info"),
+							 "Print debug info about SkipScan",
+							 "Print debug info about SkipScan distinct columns",
+							 &ts_guc_debug_skip_scan_info,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -72,6 +72,7 @@ extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 extern bool ts_guc_enable_event_triggers;
 extern TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan;
 extern TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier;
+extern TSDLLEXPORT bool ts_guc_debug_skip_scan_info;
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;

--- a/tsl/src/nodes/skip_scan/exec.c
+++ b/tsl/src/nodes/skip_scan/exec.c
@@ -74,7 +74,7 @@ typedef struct SkipKeyData
 	int distinct_col_attnum;
 	int distinct_typ_len;
 	int sk_attno;
-	bool nulls_first;
+	SkipKeyNullStatus nulls;
 } SkipKeyData;
 
 typedef struct SkipScanState
@@ -175,13 +175,13 @@ skip_scan_begin(CustomScanState *node, EState *estate, int eflags)
 static bool
 has_nulls_first(SkipScanState *state)
 {
-	return state->skip_keys[0].nulls_first;
+	return state->skip_keys[0].nulls == SKIPKEY_NULLS_FIRST;
 }
 
 static bool
 has_nulls_last(SkipScanState *state)
 {
-	return !has_nulls_first(state);
+	return state->skip_keys[0].nulls == SKIPKEY_NULLS_LAST;
 }
 
 static void
@@ -447,7 +447,7 @@ tsl_skip_scan_state_create(CustomScan *cscan)
 		state->skip_keys[i].distinct_col_attnum = linitial_int(skipkeyinfo);
 		state->skip_keys[i].distinct_by_val = lsecond_int(skipkeyinfo);
 		state->skip_keys[i].distinct_typ_len = lthird_int(skipkeyinfo);
-		state->skip_keys[i].nulls_first = lfourth_int(skipkeyinfo);
+		state->skip_keys[i].nulls = lfourth_int(skipkeyinfo);
 		state->skip_keys[i].sk_attno = list_nth_int(skipkeyinfo, 4);
 
 		state->skip_keys[i].prev_is_null = true;

--- a/tsl/src/nodes/skip_scan/skip_scan.h
+++ b/tsl/src/nodes/skip_scan/skip_scan.h
@@ -8,6 +8,13 @@
 #include <postgres.h>
 #include <nodes/plannodes.h>
 
+typedef enum SkipKeyNullStatus
+{
+	SKIPKEY_NOT_NULL = 0,
+	SKIPKEY_NULLS_FIRST,
+	SKIPKEY_NULLS_LAST
+} SkipKeyNullStatus;
+
 extern void tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel,
 									RelOptInfo *output_rel, UpperRelationKind stage);
 extern Node *tsl_skip_scan_state_create(CustomScan *cscan);

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -169,6 +169,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                Index Cond: (dev > NULL::integer)
 (5 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -188,6 +198,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -220,6 +240,16 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                Index Cond: (dev < NULL::integer)
 (5 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -239,6 +269,16 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -634,6 +674,16 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -1283,7 +1333,7 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
                      ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 1021
+                           Rows Removed by Filter: 1000
 (8 rows)
 
 -- RuntimeKeys
@@ -1558,6 +1608,27 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                      Index Cond: (dev > NULL::integer)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -1599,6 +1670,27 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1664,6 +1756,27 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                      Index Cond: (dev < NULL::integer)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -1683,6 +1796,16 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -2394,6 +2517,27 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -3563,19 +3707,19 @@ DEALLOCATE prep;
                      ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
 (22 rows)
 
 -- RuntimeKeys
@@ -4125,6 +4269,55 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                      ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (15 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4185,6 +4378,31 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev, skip_scan_htc."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
                                                                                QUERY PLAN                                                                                
@@ -4456,6 +4674,31 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                            Index Cond: (dev = 1)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 AND dev_name IS NOT NULL ORDER BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+(19 rows)
+
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4708,6 +4951,35 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(23 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
                                                                               QUERY PLAN                                                                              
@@ -5252,6 +5524,31 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+(19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
                                                                               QUERY PLAN                                                                              
@@ -6326,22 +6623,22 @@ DEALLOCATE prep;
                            ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
 (26 rows)
 
 -- RuntimeKeys
@@ -8028,22 +8325,22 @@ DEALLOCATE prep;
                            ->  Custom Scan (ColumnarScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
 (26 rows)
 
 -- RuntimeKeys

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -169,6 +169,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                Index Cond: (dev > NULL::integer)
 (5 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -188,6 +198,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -220,6 +240,16 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                Index Cond: (dev < NULL::integer)
 (5 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -239,6 +269,16 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -634,6 +674,16 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -1282,7 +1332,7 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
                      ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 1021
+                           Rows Removed by Filter: 1000
 (8 rows)
 
 -- RuntimeKeys
@@ -1557,6 +1607,27 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                      Index Cond: (dev > NULL::integer)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -1598,6 +1669,27 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1663,6 +1755,27 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                      Index Cond: (dev < NULL::integer)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -1682,6 +1795,16 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -2393,6 +2516,27 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -3558,19 +3702,19 @@ DEALLOCATE prep;
                      ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
 (22 rows)
 
 -- RuntimeKeys
@@ -4120,6 +4264,55 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                      ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (15 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4180,6 +4373,31 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev, skip_scan_htc."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
                                                                                QUERY PLAN                                                                                
@@ -4451,6 +4669,31 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                            Index Cond: (dev = 1)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 AND dev_name IS NOT NULL ORDER BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+(19 rows)
+
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4703,6 +4946,35 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(23 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
                                                                               QUERY PLAN                                                                              
@@ -5247,6 +5519,31 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+(19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
                                                                               QUERY PLAN                                                                              
@@ -6317,22 +6614,22 @@ DEALLOCATE prep;
                            ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
 (26 rows)
 
 -- RuntimeKeys
@@ -8015,22 +8312,22 @@ DEALLOCATE prep;
                            ->  Custom Scan (ColumnarScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
 (26 rows)
 
 -- RuntimeKeys

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -169,6 +169,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                Index Cond: (dev > NULL::integer)
 (5 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -188,6 +198,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -220,6 +240,16 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                Index Cond: (dev < NULL::integer)
 (5 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -239,6 +269,16 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -634,6 +674,16 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (5 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -1282,7 +1332,7 @@ DEALLOCATE prep;
                ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
                      ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 1021
+                           Rows Removed by Filter: 1000
 (8 rows)
 
 -- RuntimeKeys
@@ -1558,6 +1608,27 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                      Index Cond: (dev > NULL::integer)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -1599,6 +1670,27 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
+(19 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (19 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1664,6 +1756,27 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                      Index Cond: (dev < NULL::integer)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -1683,6 +1796,16 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(5 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (5 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -2394,6 +2517,27 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
+(19 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
@@ -3559,19 +3703,19 @@ DEALLOCATE prep;
                      ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
                      ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
                            ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 255
+                                 Rows Removed by Filter: 250
 (22 rows)
 
 -- RuntimeKeys
@@ -4122,6 +4266,55 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                      ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (15 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4182,6 +4375,31 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev, time DESC;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev, skip_scan_htc."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
                                                                                QUERY PLAN                                                                                
@@ -4453,6 +4671,31 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                            Index Cond: (dev = 1)
 (19 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 AND dev_name IS NOT NULL ORDER BY dev_name;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+(19 rows)
+
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4705,6 +4948,35 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     Vectorized Filter: (dev_name IS NOT NULL)
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11 loops=1)
+(23 rows)
 
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
                                                                               QUERY PLAN                                                                              
@@ -5249,6 +5521,31 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
 (15 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+(19 rows)
 
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
                                                                               QUERY PLAN                                                                              
@@ -6319,22 +6616,22 @@ DEALLOCATE prep;
                            ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
 (26 rows)
 
 -- RuntimeKeys
@@ -8018,22 +8315,22 @@ DEALLOCATE prep;
                            ->  Custom Scan (ColumnarScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                      ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                            ->  Custom Scan (ColumnarScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                                  ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
                                        Filter: (dev <> "*VALUES*".column1)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
 (26 rows)
 
 -- RuntimeKeys

--- a/tsl/test/expected/plan_skip_scan_dagg.out
+++ b/tsl/test/expected/plan_skip_scan_dagg.out
@@ -160,6 +160,17 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                Index Cond: (dev < NULL::integer)
 (6 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+(6 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -171,6 +182,17 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev > NULL::integer)
+(6 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (6 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -195,6 +217,17 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                Index Cond: (dev < NULL::integer)
 (6 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+(6 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -215,6 +248,17 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
          ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(6 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: dev
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (6 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -537,6 +581,17 @@ stable expression in targetlist on skip_scan
    ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
          ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
                Index Cond: (dev_name > NULL::text)
+(6 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=11 loops=1)
+   Group Key: dev_name
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (6 rows)
 
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
@@ -1044,7 +1099,7 @@ DEALLOCATE prep;
                ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
                      Index Cond: (dev > NULL::integer)
                      Filter: (dev <> "*VALUES*".column1)
-                     Rows Removed by Filter: 1021
+                     Rows Removed by Filter: 1000
 (9 rows)
 
 -- RuntimeKeys
@@ -1216,6 +1271,28 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
                      Index Cond: (dev < NULL::integer)
 (20 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_ht.dev
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+(20 rows)
+
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
@@ -1238,6 +1315,28 @@ CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev > NULL::integer)
+(20 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_ht.dev
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
 (20 rows)
 
 DROP INDEX skip_scan_idx_dev_nulls_first;
@@ -1284,6 +1383,28 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
                      Index Cond: (dev < NULL::integer)
 (20 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_ht.dev
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev < NULL::integer) AND (dev IS NOT NULL))
+(20 rows)
+
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
@@ -1304,6 +1425,17 @@ CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
                Index Cond: (("time" = 100) AND (dev > NULL::integer))
+(6 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: _hyper_1_1_chunk.dev
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev IS NOT NULL))
 (6 rows)
 
 DROP INDEX skip_scan_idx_time_dev_idx;
@@ -1895,6 +2027,28 @@ stable expression in targetlist on skip_scan_ht
          ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
                      Index Cond: (dev_name > NULL::text)
+(20 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_ht.dev_name
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NOT NULL))
 (20 rows)
 
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
@@ -2837,22 +2991,22 @@ DEALLOCATE prep;
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
                            Index Cond: (dev > NULL::integer)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 255
+                           Rows Removed by Filter: 250
                ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
                            Index Cond: (dev > NULL::integer)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 255
+                           Rows Removed by Filter: 250
                ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
                            Index Cond: (dev > NULL::integer)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 255
+                           Rows Removed by Filter: 250
                ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
                            Index Cond: (dev > NULL::integer)
                            Filter: (dev <> "*VALUES*".column1)
-                           Rows Removed by Filter: 255
+                           Rows Removed by Filter: 250
 (29 rows)
 
 -- RuntimeKeys
@@ -3318,6 +3472,57 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                      ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=11 loops=1)
 (16 rows)
 
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_htc.dev
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(20 rows)
+
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_htc.dev
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_21_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_21_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(20 rows)
+
 -- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
                                        QUERY PLAN                                       
@@ -3409,6 +3614,32 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan Backward using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=11 loops=1)
 (16 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_htc.dev
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_22_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_22_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_23_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_23_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_24_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_24_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_25_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_25_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(20 rows)
 
 -- multicolumn compressed index with dev as leading column and with extra distinct column pinned
 -- TODO: should be able to apply SkipScan here, issue created: #7998
@@ -4253,6 +4484,32 @@ stable expression in targetlist on skip_scan_htc
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
                      ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=11 loops=1)
 (16 rows)
+
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=10 loops=1)
+   Group Key: skip_scan_htc.dev_name
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_30_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_30_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_31_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_31_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_32_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_32_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_33_chunk_dev_name__ts_meta_min_1__ts_meta__idx on compress_hyper_4_33_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev_name IS NOT NULL)
+(20 rows)
 
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
                                                                            QUERY PLAN                                                                           
@@ -5165,22 +5422,22 @@ DEALLOCATE prep;
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_4_34_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_34_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_4_35_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_35_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_4_36_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_36_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_4_37_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_37_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
 (25 rows)
 
 -- RuntimeKeys
@@ -6612,22 +6869,22 @@ DEALLOCATE prep;
                      ->  Custom Scan (ColumnarScan) on _hyper_5_9_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_6_10_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_10_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (SkipScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                      ->  Custom Scan (ColumnarScan) on _hyper_5_11_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_6_14_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_14_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (SkipScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                      ->  Custom Scan (ColumnarScan) on _hyper_5_12_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_6_15_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_15_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (SkipScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                      ->  Custom Scan (ColumnarScan) on _hyper_5_13_chunk (actual rows=9 loops=2)
                            ->  Index Scan using compress_hyper_6_16_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_6_16_chunk (actual rows=9 loops=2)
                                  Filter: (dev <> "*VALUES*".column1)
-                                 Rows Removed by Filter: 2
+                                 Rows Removed by Filter: 1
 (25 rows)
 
 -- RuntimeKeys

--- a/tsl/test/expected/plan_skip_scan_notnull.out
+++ b/tsl/test/expected/plan_skip_scan_notnull.out
@@ -1,0 +1,1962 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+-- create compressed hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (3,public,skip_scan_htc,t)
+(1 row)
+
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f1;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f2;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htc DROP COLUMN f3;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htc(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_htc;
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan set (autovacuum_enabled = off);
+alter table skip_scan_nulls set (autovacuum_enabled = off);
+alter table skip_scan_ht set (autovacuum_enabled = off);
+alter table skip_scan_htc set (autovacuum_enabled = off);
+-- create compressed hypertable with different physical layouts in the compressed chunks
+CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (5,public,skip_scan_htcl,t)
+(1 row)
+
+ALTER TABLE skip_scan_htcl SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+-- Make sure 1st compressed chunk has columns which will be dropped later, it also doesn't have NULLs
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+(1 row)
+
+ALTER TABLE skip_scan_htcl DROP COLUMN f1;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f2;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_htcl DROP COLUMN f3;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_htcl(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+-- The rest of the compressed chunks do not have dropped columns
+-- compressed chunks #2 and #3 have attnos out of sync with uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htcl') ch order by 1 desc limit 3;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+(3 rows)
+
+ANALYZE skip_scan_htcl;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+alter table skip_scan_htcl set (autovacuum_enabled = off);
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+-- test SkipScan NOT NULL mode
+-- also sets up "skip_scan_b" table with a bool column and a not null column
+\ir include/skip_scan_notnull_setup.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test 2-key index "(dev,dev_name)" where index qual may not be on a skip col
+-- Make sure it's the only index to be used for "dev" skipscan key
+-- skip_scan table
+CREATE INDEX skip_scan_dev_devname_idx ON skip_scan(dev,dev_name);
+-- skip_scan_ht table
+CREATE INDEX skip_scan_ht_dev_devname_idx ON skip_scan_ht(dev,dev_name);
+-- skip_scan_htc table
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+-- table with a bool column
+CREATE TABLE skip_scan_b as select dev, coalesce(time,100) time, nullif(dev%3,2)::boolean as b from skip_scan;
+CREATE INDEX skip_scan_b_idx ON skip_scan_b(b);
+--table with not null constraint
+CREATE TABLE skip_scan_nn as select coalesce(dev,0) dev, coalesce(time,100) time from skip_scan;
+ALTER TABLE skip_scan_nn ALTER COLUMN dev SET NOT NULL;
+CREATE INDEX skip_scan_nn_idx ON skip_scan_nn(dev);
+SET timescaledb.debug_skip_scan_info  TO true;
+\set TABLE skip_scan
+\ir include/skip_scan_notnull.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Base queries with regular NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE;
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_dev_devname_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+(5 rows)
+
+-- Index quals except IS NULL discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=8 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=8 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=8 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > 2))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev >= 1) AND (dev <= 5))
+(5 rows)
+
+-- next two filters produce small output for which we may select seqscan, don't want it
+set enable_seqscan=0;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+(5 rows)
+
+-- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+(5 rows)
+
+-- Complex expressions over IS NOT NULL are non-strict filters
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+               Rows Removed by Filter: 21
+(7 rows)
+
+reset enable_seqscan;
+-- Strict Index filters discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=4 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Filter: ((dev * 2) < 8)
+               Rows Removed by Filter: 7000
+(7 rows)
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Filter: ((dev < 2) OR (dev > 0))
+               Rows Removed by Filter: 21
+(7 rows)
+
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=2 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=2 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Filter: (COALESCE(dev, '-1'::integer) < 1)
+               Rows Removed by Filter: 10000
+(7 rows)
+
+-- Strict non-index filters on relation discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=10 loops=1)
+               Filter: ((dev + "time") < 100)
+               Rows Removed by Filter: 1
+(5 rows)
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=10 loops=1)
+               Filter: (((dev + "time") < 100) OR (dev > 0))
+               Rows Removed by Filter: 22
+(5 rows)
+
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=11 loops=1)
+               Filter: ((COALESCE(dev, 20) + "time") < 100)
+               Rows Removed by Filter: 1
+(5 rows)
+
+-- If at least one filter is strict then it filters out NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=10 loops=1)
+               Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+               Rows Removed by Filter: 1
+(5 rows)
+
+-- Index qual on a non-skip key: skip key can be NULL
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=9 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev_name > 'device_1'::text))
+(5 rows)
+
+-- Index quals on several keys including skip key
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=8 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=8 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=8 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > 2) AND (dev_name > 'device_1'::text))
+(5 rows)
+
+-- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
+-- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=9 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (ROW(dev, dev_name) > ROW(1, 'device_1'::text)))
+(5 rows)
+
+-- Satisfying (dev_name>'device_1') may allow NULLs into dev
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=9 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (ROW(dev_name, dev) > ROW('device_1'::text, 1)))
+(5 rows)
+
+-- Non-index qual row comparison: row comparison in general is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=10 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+               Rows Removed by Filter: 22
+(7 rows)
+
+-- Different SkipScan column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_devname_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev = 1) AND (dev_name > NULL::text) AND (dev_name IS NOT NULL))
+(5 rows)
+
+-- Boolean and NOT NULL constraint tests
+-- Boolean column index qual is strict
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_b (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_b_idx on skip_scan_b (actual rows=1 loops=1)
+               Index Cond: ((b > NULL::boolean) AND (b = true))
+(5 rows)
+
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_b (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_b_idx on skip_scan_b (actual rows=1 loops=1)
+               Index Cond: ((b > NULL::boolean) AND (b = false))
+(5 rows)
+
+-- Boolean column predicates could be non-strict filters, below filter can accept NULLs
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_b (actual rows=2 loops=1)
+         ->  Index Only Scan using skip_scan_b_idx on skip_scan_b (actual rows=2 loops=1)
+               Index Cond: (b > NULL::boolean)
+               Filter: (b IS NOT TRUE)
+               Rows Removed by Filter: 4000
+(7 rows)
+
+-- dev is declared NOT NULL
+:PREFIX SELECT DISTINCT dev FROM skip_scan_nn;
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nn (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_nn_idx on skip_scan_nn (actual rows=11 loops=1)
+               Index Cond: (dev > NULL::integer)
+(5 rows)
+
+-- Set up hypertable with bool column
+SELECT create_hypertable('skip_scan_b', 'time', chunk_time_interval => 500, create_default_indexes => false, migrate_data => true);
+NOTICE:  migrating data to chunks
+    create_hypertable     
+--------------------------
+ (7,public,skip_scan_b,t)
+(1 row)
+
+-- Set up hypertable with not null column
+SELECT create_hypertable('skip_scan_nn', 'time', chunk_time_interval => 500, create_default_indexes => false, migrate_data => true);
+NOTICE:  migrating data to chunks
+     create_hypertable     
+---------------------------
+ (8,public,skip_scan_nn,t)
+(1 row)
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_notnull.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Base queries with regular NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE;
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: skip_scan_ht.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+(19 rows)
+
+-- Index quals except IS NULL discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NOT NULL))
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=8 loops=1)
+   ->  Merge Append (actual rows=32 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2))
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 1) AND (dev <= 5))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 1) AND (dev <= 5))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 1) AND (dev <= 5))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev >= 1) AND (dev <= 5))
+(19 rows)
+
+-- next two filters produce small output for which we may select seqscan, don't want it
+set enable_seqscan=0;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev = ANY ('{1,2,3}'::integer[])))
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+(19 rows)
+
+-- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+(19 rows)
+
+-- Complex expressions over IS NOT NULL are non-strict filters
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                     Rows Removed by Filter: 5
+(27 rows)
+
+reset enable_seqscan;
+-- Strict Index filters discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev * 2) < 8)
+                     Rows Removed by Filter: 1750
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev * 2) < 8)
+                     Rows Removed by Filter: 1750
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev * 2) < 8)
+                     Rows Removed by Filter: 1750
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev * 2) < 8)
+                     Rows Removed by Filter: 1750
+(27 rows)
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev < 2) OR (dev > 0))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev < 2) OR (dev > 0))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev < 2) OR (dev > 0))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: ((dev < 2) OR (dev > 0))
+                     Rows Removed by Filter: 5
+(27 rows)
+
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+(27 rows)
+
+-- Strict non-index filters on relation discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Filter: ((dev + "time") < 100)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 2500
+(18 rows)
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+(19 rows)
+
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=11 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 2505
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 2505
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 2505
+(18 rows)
+
+-- If at least one filter is strict then it filters out NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 2500
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 2500
+(18 rows)
+
+-- Index qual on a non-skip key: skip key can be NULL
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev_name > 'device_1'::text))
+(19 rows)
+
+-- Index quals on several keys including skip key
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=8 loops=1)
+   ->  Merge Append (actual rows=32 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=8 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=8 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 2) AND (dev_name > 'device_1'::text))
+(19 rows)
+
+-- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
+-- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev, dev_name) > ROW(1, 'device_1'::text)))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev, dev_name) > ROW(1, 'device_1'::text)))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev, dev_name) > ROW(1, 'device_1'::text)))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev, dev_name) > ROW(1, 'device_1'::text)))
+(19 rows)
+
+-- Satisfying (dev_name>'device_1') may allow NULLs into dev
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev_name, dev) > ROW('device_1'::text, 1)))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev_name, dev) > ROW('device_1'::text, 1)))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev_name, dev) > ROW('device_1'::text, 1)))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (ROW(dev_name, dev) > ROW('device_1'::text, 1)))
+(19 rows)
+
+-- Non-index qual row comparison: row comparison in general is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_ht.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+(27 rows)
+
+-- Different SkipScan column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_ht.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev = 1) AND (dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev = 1) AND (dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev = 1) AND (dev_name > NULL::text) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev = 1) AND (dev_name > NULL::text) AND (dev_name IS NOT NULL))
+(19 rows)
+
+-- Boolean and NOT NULL constraint tests
+-- Boolean column index qual is strict
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=3 loops=1)
+         Sort Key: skip_scan_b.b
+         ->  Custom Scan (SkipScan) on _hyper_7_21_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_7_21_chunk_skip_scan_b_idx on _hyper_7_21_chunk (actual rows=1 loops=1)
+                     Index Cond: ((b > NULL::boolean) AND (b = true))
+         ->  Custom Scan (SkipScan) on _hyper_7_22_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_7_22_chunk_skip_scan_b_idx on _hyper_7_22_chunk (actual rows=1 loops=1)
+                     Index Cond: ((b > NULL::boolean) AND (b = true))
+         ->  Custom Scan (SkipScan) on _hyper_7_23_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_7_23_chunk_skip_scan_b_idx on _hyper_7_23_chunk (actual rows=1 loops=1)
+                     Index Cond: ((b > NULL::boolean) AND (b = true))
+(15 rows)
+
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=3 loops=1)
+         Sort Key: skip_scan_b.b
+         ->  Custom Scan (SkipScan) on _hyper_7_21_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_7_21_chunk_skip_scan_b_idx on _hyper_7_21_chunk (actual rows=1 loops=1)
+                     Index Cond: ((b > NULL::boolean) AND (b = false))
+         ->  Custom Scan (SkipScan) on _hyper_7_22_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_7_22_chunk_skip_scan_b_idx on _hyper_7_22_chunk (actual rows=1 loops=1)
+                     Index Cond: ((b > NULL::boolean) AND (b = false))
+         ->  Custom Scan (SkipScan) on _hyper_7_23_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_7_23_chunk_skip_scan_b_idx on _hyper_7_23_chunk (actual rows=1 loops=1)
+                     Index Cond: ((b > NULL::boolean) AND (b = false))
+(15 rows)
+
+-- Boolean column predicates could be non-strict filters, below filter can accept NULLs
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=6 loops=1)
+         Sort Key: skip_scan_b.b
+         ->  Custom Scan (SkipScan) on _hyper_7_21_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_7_21_chunk_skip_scan_b_idx on _hyper_7_21_chunk (actual rows=2 loops=1)
+                     Index Cond: (b > NULL::boolean)
+                     Filter: (b IS NOT TRUE)
+                     Rows Removed by Filter: 1996
+         ->  Custom Scan (SkipScan) on _hyper_7_22_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_7_22_chunk_skip_scan_b_idx on _hyper_7_22_chunk (actual rows=2 loops=1)
+                     Index Cond: (b > NULL::boolean)
+                     Filter: (b IS NOT TRUE)
+                     Rows Removed by Filter: 2000
+         ->  Custom Scan (SkipScan) on _hyper_7_23_chunk (actual rows=2 loops=1)
+               ->  Index Only Scan using _hyper_7_23_chunk_skip_scan_b_idx on _hyper_7_23_chunk (actual rows=2 loops=1)
+                     Index Cond: (b > NULL::boolean)
+                     Filter: (b IS NOT TRUE)
+                     Rows Removed by Filter: 4
+(21 rows)
+
+-- dev is declared NOT NULL
+:PREFIX SELECT DISTINCT dev FROM skip_scan_nn;
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=32 loops=1)
+         Sort Key: skip_scan_nn.dev
+         ->  Custom Scan (SkipScan) on _hyper_8_24_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_8_24_chunk_skip_scan_nn_idx on _hyper_8_24_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_8_25_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_8_25_chunk_skip_scan_nn_idx on _hyper_8_25_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+         ->  Custom Scan (SkipScan) on _hyper_8_26_chunk (actual rows=10 loops=1)
+               ->  Index Only Scan using _hyper_8_26_chunk_skip_scan_nn_idx on _hyper_8_26_chunk (actual rows=10 loops=1)
+                     Index Cond: (dev > NULL::integer)
+(15 rows)
+
+-- Compress on bool column
+ALTER TABLE skip_scan_b SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='b');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_b') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_21_chunk
+ _timescaledb_internal._hyper_7_22_chunk
+ _timescaledb_internal._hyper_7_23_chunk
+(3 rows)
+
+-- Compress on not null column
+ALTER TABLE skip_scan_nn SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_nn') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_8_24_chunk
+ _timescaledb_internal._hyper_8_25_chunk
+ _timescaledb_internal._hyper_8_26_chunk
+(3 rows)
+
+\set TABLE skip_scan_htc
+\ir include/skip_scan_notnull.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Base queries with regular NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE;
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(15 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: skip_scan_htc.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=11 loops=1)
+                     ->  Index Scan Backward using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(15 rows)
+
+-- Index quals except IS NULL discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=8 loops=1)
+   ->  Merge Append (actual rows=32 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=8 loops=1)
+                           Index Cond: (dev > 2)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=8 loops=1)
+                           Index Cond: (dev > 2)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=8 loops=1)
+                           Index Cond: (dev > 2)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=8 loops=1)
+                           Index Cond: (dev > 2)
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev >= 1) AND (dev <= 5))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev >= 1) AND (dev <= 5))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev >= 1) AND (dev <= 5))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=5 loops=1)
+                           Index Cond: ((dev >= 1) AND (dev <= 5))
+(19 rows)
+
+-- next two filters produce small output for which we may select seqscan, don't want it
+set enable_seqscan=0;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=1 loops=1)
+                           Index Cond: (dev IS NULL)
+(19 rows)
+
+-- Complex expressions over IS NOT NULL are non-strict filters
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=10 loops=1)
+                           Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                           Rows Removed by Filter: 1
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                           Rows Removed by Filter: 1
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                           Rows Removed by Filter: 1
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Filter: ((((dev IS NOT NULL))::integer + 1) > 1)
+                           Rows Removed by Filter: 1
+(23 rows)
+
+reset enable_seqscan;
+-- Strict Index filters discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=3 loops=1)
+                           Filter: ((dev * 2) < 8)
+                           Rows Removed by Filter: 7
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=3 loops=1)
+                           Filter: ((dev * 2) < 8)
+                           Rows Removed by Filter: 7
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=3 loops=1)
+                           Filter: ((dev * 2) < 8)
+                           Rows Removed by Filter: 7
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=3 loops=1)
+                           Filter: ((dev * 2) < 8)
+                           Rows Removed by Filter: 7
+(23 rows)
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=10 loops=1)
+                           Filter: ((dev < 2) OR (dev > 0))
+                           Rows Removed by Filter: 1
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+                           Filter: ((dev < 2) OR (dev > 0))
+                           Rows Removed by Filter: 1
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+                           Filter: ((dev < 2) OR (dev > 0))
+                           Rows Removed by Filter: 1
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+                           Filter: ((dev < 2) OR (dev > 0))
+                           Rows Removed by Filter: 1
+(23 rows)
+
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     Filter: (COALESCE(dev, '-1'::integer) < 1)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- Strict non-index filters on relation discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 1555
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     Filter: ((dev + "time") < 100)
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+(23 rows)
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     Filter: (((dev + "time") < 100) OR (dev > 0))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=11 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=11 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 1558
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 2505
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 2505
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     Filter: ((COALESCE(dev, 20) + "time") < 100)
+                     Rows Removed by Filter: 2505
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- If at least one filter is strict then it filters out NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 1555
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=0 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=0 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=0 loops=1)
+                     Filter: (((COALESCE(dev, 20) + "time") < 100) AND ((dev + "time") < 100))
+                     Rows Removed by Filter: 2500
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=10 loops=1)
+(23 rows)
+
+-- Index qual on a non-skip key: skip key can be NULL
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev_name > 'device_1'::text)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev_name > 'device_1'::text)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev_name > 'device_1'::text)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev_name > 'device_1'::text)
+(19 rows)
+
+-- Index quals on several keys including skip key
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=8 loops=1)
+   ->  Merge Append (actual rows=32 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > 2) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > 2) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > 2) AND (dev_name > 'device_1'::text))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=8 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=8 loops=1)
+                           Index Cond: ((dev > 2) AND (dev_name > 'device_1'::text))
+(19 rows)
+
+-- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
+-- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev, dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev, dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev, dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev, dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- Satisfying (dev_name>'device_1') may allow NULLs into dev
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=9 loops=1)
+   ->  Merge Append (actual rows=36 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev_name, dev) > ROW('device_1'::text, 1))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev_name, dev) > ROW('device_1'::text, 1))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev_name, dev) > ROW('device_1'::text, 1))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=9 loops=1)
+                     Filter: (ROW(dev_name, dev) > ROW('device_1'::text, 1))
+                     Rows Removed by Filter: 255
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- Non-index qual row comparison: row comparison in general is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=40 loops=1)
+         Sort Key: skip_scan_htc.dev
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=10 loops=1)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=10 loops=1)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=10 loops=1)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=10 loops=1)
+                     Filter: (ROW((dev + 1), dev_name) > ROW(1, 'device_1'::text))
+                     Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=11 loops=1)
+(23 rows)
+
+-- Different SkipScan column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: skip_scan_htc.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_17_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_18_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_19_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+         ->  Custom Scan (SkipScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx on compress_hyper_4_20_chunk (actual rows=1 loops=1)
+                           Index Cond: ((dev = 1) AND (dev_name IS NOT NULL))
+(19 rows)
+
+-- Boolean and NOT NULL constraint tests
+-- Boolean column index qual is strict
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=3 loops=1)
+         Sort Key: skip_scan_b.b
+         ->  Custom Scan (SkipScan) on _hyper_7_21_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_21_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_9_27_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_27_chunk (actual rows=1 loops=1)
+                           Index Cond: (b = true)
+         ->  Custom Scan (SkipScan) on _hyper_7_22_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_22_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_9_28_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_28_chunk (actual rows=1 loops=1)
+                           Index Cond: (b = true)
+         ->  Custom Scan (SkipScan) on _hyper_7_23_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_23_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_9_29_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_29_chunk (actual rows=1 loops=1)
+                           Index Cond: (b = true)
+(15 rows)
+
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=3 loops=1)
+         Sort Key: skip_scan_b.b
+         ->  Custom Scan (SkipScan) on _hyper_7_21_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_21_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_9_27_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_27_chunk (actual rows=1 loops=1)
+                           Index Cond: (b = false)
+         ->  Custom Scan (SkipScan) on _hyper_7_22_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_22_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_9_28_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_28_chunk (actual rows=1 loops=1)
+                           Index Cond: (b = false)
+         ->  Custom Scan (SkipScan) on _hyper_7_23_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_23_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_9_29_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_29_chunk (actual rows=1 loops=1)
+                           Index Cond: (b = false)
+(15 rows)
+
+-- Boolean column predicates could be non-strict filters, below filter can accept NULLs
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=6 loops=1)
+         Sort Key: skip_scan_b.b
+         ->  Custom Scan (SkipScan) on _hyper_7_21_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_21_chunk (actual rows=2 loops=1)
+                     Filter: (b IS NOT TRUE)
+                     Rows Removed by Filter: 1996
+                     ->  Index Scan using compress_hyper_9_27_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_27_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_7_22_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_22_chunk (actual rows=2 loops=1)
+                     Filter: (b IS NOT TRUE)
+                     Rows Removed by Filter: 2000
+                     ->  Index Scan using compress_hyper_9_28_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_28_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_7_23_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_7_23_chunk (actual rows=2 loops=1)
+                     Filter: (b IS NOT TRUE)
+                     Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_9_29_chunk_b__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_9_29_chunk (actual rows=3 loops=1)
+(18 rows)
+
+-- dev is declared NOT NULL
+:PREFIX SELECT DISTINCT dev FROM skip_scan_nn;
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=32 loops=1)
+         Sort Key: skip_scan_nn.dev
+         ->  Custom Scan (SkipScan) on _hyper_8_24_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_8_24_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_10_30_chunk_dev__ts_meta_min_1__ts_meta_max__idx on compress_hyper_10_30_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_8_25_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_8_25_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using compress_hyper_10_31_chunk_dev__ts_meta_min_1__ts_meta_max__idx on compress_hyper_10_31_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_8_26_chunk (actual rows=10 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_8_26_chunk (actual rows=10 loops=1)
+                     ->  Index Scan using compress_hyper_10_32_chunk_dev__ts_meta_min_1__ts_meta_max__idx on compress_hyper_10_32_chunk (actual rows=10 loops=1)
+(12 rows)
+
+RESET timescaledb.debug_skip_scan_info;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -137,22 +137,30 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -215,6 +223,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -370,22 +380,30 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -448,6 +466,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -618,22 +638,30 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -696,6 +724,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -851,22 +881,30 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -929,6 +967,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -1102,11 +1142,16 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev DESC NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 -- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 -- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev, time DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
 -- multicolumn sort not matching compression index
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -1132,6 +1177,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
 -- dev_name is not a leading column
 :PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 AND dev_name IS NOT NULL ORDER BY dev_name;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
 -- Basic tests for "segmentby = 'dev'"
 -----------------------------------------
@@ -1155,6 +1202,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
 -- DISTINCT ON queries
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -1194,6 +1243,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
@@ -1331,11 +1382,16 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev DESC NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 -- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 -- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev, time DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
 -- multicolumn sort not matching compression index
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time DESC;
@@ -1361,6 +1417,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE ORDER BY dev, dev_name DESC;
 -- dev_name is not a leading column
 :PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 AND dev_name IS NOT NULL ORDER BY dev_name;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
 -- Basic tests for "segmentby = 'dev'"
 -----------------------------------------
@@ -1384,6 +1442,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev + 1, 'q1_13' FROM :TABLE;
 -- DISTINCT ON queries
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -1423,6 +1483,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT 'Device ' || dev_name FROM :TABLE;
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;

--- a/tsl/test/expected/skip_scan_dagg.out
+++ b/tsl/test/expected/skip_scan_dagg.out
@@ -136,20 +136,28 @@ SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS
 CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -207,6 +215,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
@@ -319,20 +329,28 @@ SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS
 CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -390,6 +408,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
@@ -517,20 +537,28 @@ SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS
 CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -588,6 +616,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
@@ -700,20 +730,28 @@ SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS
 CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_time_idx;
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 -- hash index is not ordered so can't use skipscan
 CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
@@ -771,6 +809,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT count(DISTINCT dev), dev, tableoid::regclass, 'q2_11' FROM :TABLE GROUP BY dev, tableoid ORDER BY dev, tableoid;
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
@@ -902,6 +942,9 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev;
 -- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
 -- multicolumn "segmentby = 'dev, dev_name'"
@@ -911,6 +954,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn compressed index with dev as leading column
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 -- multicolumn compressed index with dev as leading column and with extra distinct column pinned
 -- TODO: should be able to apply SkipScan here, issue created: #7998
 :PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev_name = 'device_1';
@@ -982,6 +1027,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;
@@ -1099,6 +1146,9 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev;
 -- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
 -- multicolumn "segmentby = 'dev, dev_name'"
@@ -1108,6 +1158,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn compressed index with dev as leading column
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 -- multicolumn compressed index with dev as leading column and with extra distinct column pinned
 -- TODO: should be able to apply SkipScan here, issue created: #7998
 :PREFIX SELECT count(DISTINCT dev), count(DISTINCT dev_name) FROM :TABLE WHERE dev_name = 'device_1';
@@ -1179,6 +1231,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT length(dev_name)), 'q1_13' FROM :TABLE;
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_FILES
     merge_compress.sql
     modify_exclusion.sql
     move.sql
+    plan_skip_scan_notnull.sql
     policy_generalization.sql
     reorder.sql
     size_utils_tsl.sql

--- a/tsl/test/sql/include/skip_scan_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_comp_query.sql
@@ -18,6 +18,10 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev DESC NULLS FIRST;
+
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 
 -- NULLS FIRST doesn't match segmentby NULL direction
@@ -25,6 +29,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- multicolumn sort with dev as leading column matching (segmentby dev, order by time DESC) compression index
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev, time DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev, time FROM :TABLE ORDER BY dev DESC, time;
 
 -- multicolumn sort not matching compression index
@@ -55,6 +61,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- dev_name is not a leading column
 :PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 ORDER BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev = 1 AND dev_name IS NOT NULL ORDER BY dev_name;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev = 1;
 
 -- Basic tests for "segmentby = 'dev'"
@@ -87,6 +95,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- DISTINCT ON queries
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
@@ -133,6 +143,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;

--- a/tsl/test/sql/include/skip_scan_dagg_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_comp_query.sql
@@ -18,6 +18,10 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC NULLS FIRST;
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev;
+
 -- NULLS FIRST doesn't match segmentby NULL direction
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
 
@@ -29,6 +33,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn compressed index with dev as leading column
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 
 -- multicolumn compressed index with dev as leading column and with extra distinct column pinned
 -- TODO: should be able to apply SkipScan here, issue created: #7998
@@ -118,6 +124,8 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;

--- a/tsl/test/sql/include/skip_scan_dagg_query.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_query.sql
@@ -13,24 +13,31 @@ SELECT current_setting('timescaledb.enable_skipscan_for_distinct_aggregates') AS
 CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
-
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev  NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 
 -- multicolumn index with dev as leading column
 CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE GROUP BY dev ORDER BY dev DESC;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE dev IS NOT NULL GROUP BY dev ORDER BY dev DESC;
 DROP INDEX skip_scan_idx_dev_time_idx;
 
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE WHERE time = 100;
 :PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 GROUP BY dev;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev), dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL GROUP BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 
 -- hash index is not ordered so can't use skipscan
@@ -100,6 +107,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 
 -- DISTINCT aggs grouped on their TEXT args
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_1' FROM :TABLE GROUP BY dev_name;
+-- Test not-NULL mode
+:PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_11' FROM :TABLE WHERE dev_name IS NOT NULL GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_2', NULL FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_3', length(md5(now()::text)) FROM :TABLE GROUP BY dev_name;
 :PREFIX SELECT count(DISTINCT dev_name), dev_name, 'q3_4', length(md5(random()::text)) FROM :TABLE GROUP BY dev_name;

--- a/tsl/test/sql/include/skip_scan_notnull.sql
+++ b/tsl/test/sql/include/skip_scan_notnull.sql
@@ -1,0 +1,77 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Base queries with regular NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE;
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
+
+-- Index quals except IS NULL discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
+
+-- next two filters produce small output for which we may select seqscan, don't want it
+set enable_seqscan=0;
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
+
+-- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
+
+-- Complex expressions over IS NOT NULL are non-strict filters
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
+reset enable_seqscan;
+
+-- Strict Index filters discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
+
+-- Strict non-index filters on relation discard NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
+
+-- OR is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
+-- Coalesce is non-strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
+
+-- If at least one filter is strict then it filters out NULLs
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
+
+-- Index qual on a non-skip key: skip key can be NULL
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
+
+-- Index quals on several keys including skip key
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
+
+-- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
+-- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
+
+-- Satisfying (dev_name>'device_1') may allow NULLs into dev
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
+
+-- Non-index qual row comparison: row comparison in general is not strict
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
+
+-- Different SkipScan column
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
+
+-- Boolean and NOT NULL constraint tests
+
+-- Boolean column index qual is strict
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
+-- Boolean column predicates could be non-strict filters, below filter can accept NULLs
+:PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
+
+-- dev is declared NOT NULL
+:PREFIX SELECT DISTINCT dev FROM skip_scan_nn;

--- a/tsl/test/sql/include/skip_scan_notnull_setup.sql
+++ b/tsl/test/sql/include/skip_scan_notnull_setup.sql
@@ -1,0 +1,25 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test 2-key index "(dev,dev_name)" where index qual may not be on a skip col
+-- Make sure it's the only index to be used for "dev" skipscan key
+
+-- skip_scan table
+CREATE INDEX skip_scan_dev_devname_idx ON skip_scan(dev,dev_name);
+
+-- skip_scan_ht table
+CREATE INDEX skip_scan_ht_dev_devname_idx ON skip_scan_ht(dev,dev_name);
+
+-- skip_scan_htc table
+ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
+
+-- table with a bool column
+CREATE TABLE skip_scan_b as select dev, coalesce(time,100) time, nullif(dev%3,2)::boolean as b from skip_scan;
+CREATE INDEX skip_scan_b_idx ON skip_scan_b(b);
+
+--table with not null constraint
+CREATE TABLE skip_scan_nn as select coalesce(dev,0) dev, coalesce(time,100) time from skip_scan;
+ALTER TABLE skip_scan_nn ALTER COLUMN dev SET NOT NULL;
+CREATE INDEX skip_scan_nn_idx ON skip_scan_nn(dev);

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -14,12 +14,16 @@ CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_nulls_last;
 
 -- NULLS FIRST index on dev
 CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev NULLS FIRST;
 DROP INDEX skip_scan_idx_dev_nulls_first;
 
 -- multicolumn index with dev as leading column
@@ -27,12 +31,16 @@ CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_dev_time_idx;
 
 -- multicolumn index with dev as non-leading column
 CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 AND dev IS NOT NULL ORDER BY dev;
 DROP INDEX skip_scan_idx_time_dev_idx;
 
 -- hash index is not ordered so can't use skipscan
@@ -107,6 +115,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 
 -- DISTINCT ON queries on TEXT column
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+-- Test not-NULL mode
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NOT NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;

--- a/tsl/test/sql/plan_skip_scan_notnull.sql
+++ b/tsl/test/sql/plan_skip_scan_notnull.sql
@@ -1,0 +1,36 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+
+-- test SkipScan NOT NULL mode
+-- also sets up "skip_scan_b" table with a bool column and a not null column
+\ir include/skip_scan_notnull_setup.sql
+
+SET timescaledb.debug_skip_scan_info  TO true;
+\set TABLE skip_scan
+\ir include/skip_scan_notnull.sql
+
+-- Set up hypertable with bool column
+SELECT create_hypertable('skip_scan_b', 'time', chunk_time_interval => 500, create_default_indexes => false, migrate_data => true);
+-- Set up hypertable with not null column
+SELECT create_hypertable('skip_scan_nn', 'time', chunk_time_interval => 500, create_default_indexes => false, migrate_data => true);
+\set TABLE skip_scan_ht
+\ir include/skip_scan_notnull.sql
+
+-- Compress on bool column
+ALTER TABLE skip_scan_b SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='b');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_b') ch;
+-- Compress on not null column
+ALTER TABLE skip_scan_nn SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+SELECT compress_chunk(ch) FROM show_chunks('skip_scan_nn') ch;
+\set TABLE skip_scan_htc
+\ir include/skip_scan_notnull.sql
+
+RESET timescaledb.debug_skip_scan_info;


### PR DESCRIPTION
Implement not-NULL mode for SkipScan when we can deduce at planning time that a scan key is guaranteed to be not NULL. 
It allows to simplify execution by skipping null-check stages. Multikey SkipScan is much easier implemented in not-NULL mode.

We can say that a skip key is not NULL when it's declared not-NULL in the table or when it is a part of a strict filter on that table, or when there is IS NOT NULL index qual on the key.
 
Disable-check: force-changelog-file