### PR TITLE
Remove buckets and batches info from hash explain in tests

### DIFF
--- a/test/expected/agg_bookends-15.out
+++ b/test/expected/agg_bookends-15.out
@@ -97,7 +97,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -109,7 +108,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -122,7 +120,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -135,7 +132,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -147,7 +143,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -159,7 +154,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -269,7 +263,6 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Append (actual rows=11 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
@@ -386,7 +379,6 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Append (actual rows=11 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)

--- a/test/expected/agg_bookends-16.out
+++ b/test/expected/agg_bookends-16.out
@@ -97,7 +97,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -109,7 +108,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -122,7 +120,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -135,7 +132,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -147,7 +143,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -159,7 +154,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -269,7 +263,6 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Append (actual rows=11 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
@@ -386,7 +379,6 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Append (actual rows=11 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)

--- a/test/expected/agg_bookends-17.out
+++ b/test/expected/agg_bookends-17.out
@@ -96,7 +96,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -108,7 +107,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -121,7 +119,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -134,7 +131,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -146,7 +142,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -158,7 +153,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
@@ -263,7 +257,6 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Append (actual rows=11 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
@@ -367,7 +360,6 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          ->  Append (actual rows=11 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)

--- a/test/expected/agg_bookends-18.out
+++ b/test/expected/agg_bookends-18.out
@@ -121,7 +121,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Buffers: shared hit=1
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=1
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6.00 loops=1)
                Buffers: shared hit=1
@@ -138,7 +137,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Buffers: shared hit=1
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=1
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6.00 loops=1)
                Buffers: shared hit=1
@@ -156,7 +154,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Buffers: shared hit=10
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=10
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6.00 loops=1)
                Buffers: shared hit=10
@@ -174,7 +171,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Buffers: shared hit=3
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=3
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6.00 loops=1)
                Buffers: shared hit=1
@@ -191,7 +187,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Buffers: shared hit=13
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=13
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6.00 loops=1)
                Buffers: shared hit=1
@@ -208,7 +203,6 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    Buffers: shared hit=7
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=7
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6.00 loops=1)
                Buffers: shared hit=1
@@ -375,7 +369,6 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
    Buffers: shared hit=5
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=5
          ->  Append (actual rows=11.00 loops=1)
                Buffers: shared hit=5
@@ -545,7 +538,6 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
    Buffers: shared hit=5
    ->  HashAggregate (actual rows=2.00 loops=1)
          Group Key: _hyper_1_1_chunk.gp
-         
          Buffers: shared hit=5
          ->  Append (actual rows=11.00 loops=1)
                Buffers: shared hit=5

--- a/test/expected/append-15.out
+++ b/test/expected/append-15.out
@@ -444,11 +444,9 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
          Hash Cond: (time_bucket('@ 30 days'::interval, "time"."time") = data.btime)
          ->  Function Scan on generate_series "time" (actual rows=6 loops=1)
          ->  Hash (actual rows=3 loops=1)
-                
                ->  Subquery Scan on data (actual rows=3 loops=1)
                      ->  HashAggregate (actual rows=3 loops=1)
                            Group Key: time_bucket('@ 30 days'::interval, append_test."time")
-                           
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
@@ -1647,7 +1645,6 @@ ORDER BY time DESC, device_id;
    Hash Cond: (g."time" = m_1."time")
    ->  Function Scan on generate_series g (actual rows=32 loops=1)
    ->  Hash (actual rows=26787 loops=1)
-          
          ->  Append (actual rows=26787 loops=1)
                ->  Seq Scan on _hyper_5_17_chunk m_1 (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_5_18_chunk m_2 (actual rows=6048 loops=1)
@@ -2197,7 +2194,6 @@ psql:include/append_query.sql:414: NOTICE:  Stable function now_s() called!
    Single Copy: true
    ->  HashAggregate (actual rows=3 loops=1)
          Group Key: append_test."time", append_test.colorid
-         Worker 0:  
          ->  Custom Scan (ConstraintAwareAppend) (actual rows=3 loops=1)
                Hypertable: append_test
                Chunks excluded during startup: 1

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -444,11 +444,9 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
          Hash Cond: (time_bucket('@ 30 days'::interval, "time"."time") = data.btime)
          ->  Function Scan on generate_series "time" (actual rows=6 loops=1)
          ->  Hash (actual rows=3 loops=1)
-                
                ->  Subquery Scan on data (actual rows=3 loops=1)
                      ->  HashAggregate (actual rows=3 loops=1)
                            Group Key: time_bucket('@ 30 days'::interval, append_test."time")
-                           
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
@@ -1647,7 +1645,6 @@ ORDER BY time DESC, device_id;
    Hash Cond: (g."time" = m_1."time")
    ->  Function Scan on generate_series g (actual rows=32 loops=1)
    ->  Hash (actual rows=26787 loops=1)
-          
          ->  Append (actual rows=26787 loops=1)
                ->  Seq Scan on _hyper_5_17_chunk m_1 (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_5_18_chunk m_2 (actual rows=6048 loops=1)
@@ -2197,7 +2194,6 @@ psql:include/append_query.sql:414: NOTICE:  Stable function now_s() called!
    Single Copy: true
    ->  HashAggregate (actual rows=3 loops=1)
          Group Key: append_test."time", append_test.colorid
-         Worker 0:  
          ->  Custom Scan (ConstraintAwareAppend) (actual rows=3 loops=1)
                Hypertable: append_test
                Chunks excluded during startup: 1

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -444,11 +444,9 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
          Hash Cond: (time_bucket('@ 30 days'::interval, "time"."time") = data.btime)
          ->  Function Scan on generate_series "time" (actual rows=6 loops=1)
          ->  Hash (actual rows=3 loops=1)
-                
                ->  Subquery Scan on data (actual rows=3 loops=1)
                      ->  HashAggregate (actual rows=3 loops=1)
                            Group Key: time_bucket('@ 30 days'::interval, append_test."time")
-                           
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
@@ -1647,7 +1645,6 @@ ORDER BY time DESC, device_id;
    Hash Cond: (g."time" = m_1."time")
    ->  Function Scan on generate_series g (actual rows=32 loops=1)
    ->  Hash (actual rows=26787 loops=1)
-          
          ->  Append (actual rows=26787 loops=1)
                ->  Seq Scan on _hyper_5_17_chunk m_1 (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_5_18_chunk m_2 (actual rows=6048 loops=1)
@@ -2192,7 +2189,6 @@ psql:include/append_query.sql:414: NOTICE:  Stable function now_s() called!
    Single Copy: true
    ->  HashAggregate (actual rows=3 loops=1)
          Group Key: append_test."time", append_test.colorid
-         Worker 0:  
          ->  Custom Scan (ConstraintAwareAppend) (actual rows=3 loops=1)
                Hypertable: append_test
                Chunks excluded during startup: 1

--- a/test/expected/append-18.out
+++ b/test/expected/append-18.out
@@ -444,11 +444,9 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
          Hash Cond: (time_bucket('@ 30 days'::interval, "time"."time") = data.btime)
          ->  Function Scan on generate_series "time" (actual rows=6.00 loops=1)
          ->  Hash (actual rows=3.00 loops=1)
-                
                ->  Subquery Scan on data (actual rows=3.00 loops=1)
                      ->  HashAggregate (actual rows=3.00 loops=1)
                            Group Key: time_bucket('@ 30 days'::interval, append_test."time")
-                           
                            ->  Result (actual rows=5.00 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5.00 loops=1)
                                        Chunks excluded during startup: 0
@@ -2305,7 +2303,6 @@ LEFT JOIN i2661 ht ON
          ->  Seq Scan on _hyper_7_33_chunk ht_3 (actual rows=961.00 loops=1)
                Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
    ->  Hash (actual rows=13.00 loops=1)
-          
          ->  ProjectSet (actual rows=13.00 loops=1)
                ->  Result (actual rows=1.00 loops=1)
 (14 rows)
@@ -2484,7 +2481,6 @@ psql:include/append_query.sql:414: NOTICE:  Stable function now_s() called!
    Single Copy: true
    ->  HashAggregate (actual rows=3.00 loops=1)
          Group Key: append_test."time", append_test.colorid
-         Worker 0:  
          ->  Custom Scan (ConstraintAwareAppend) (actual rows=3.00 loops=1)
                Hypertable: append_test
                Chunks excluded during startup: 1

--- a/test/runner_cleanup_output.sh
+++ b/test/runner_cleanup_output.sh
@@ -7,12 +7,12 @@ RUNNER=${1:-""}
 
 sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
      -e 's! Disk: [0-9]\{1,\}kB!!' \
-     -e 's! Buckets: [0-9]\+!!' \
-     -e 's! Batches: [0-9]\+!!' \
      -e 's! Memory: [0-9]\{1,\}kB!!' \
      -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
      -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' \
      -e '/Heap Fetches: [0-9]\{1,\}/d' \
+     -e '/Buckets: [0-9]\{1,\}/d' \
+     -e '/Batches: [0-9]\{1,\}/d' \
      -e '/found [0-9]\{1,\} removable, [0-9]\{1,\} nonremovable row versions in [0-9]\{1,\} pages/d' | \
 grep -av 'DEBUG:  rehashing catalog cache id' | \
 grep -av 'DEBUG:  compacted fsync request queue from' | \

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -444,7 +444,6 @@ SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY ROLLUP(t);
          Hash Key: _hyper_3_5_chunk.timecustom
          Group Key: ()
          Worker 0:  actual rows=7 loops=1
-           
          ->  Append (actual rows=11 loops=1)
                Worker 0:  actual rows=11 loops=1
                ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk (actual rows=7 loops=1)

--- a/tsl/test/expected/cagg_planning.out
+++ b/tsl/test/expected/cagg_planning.out
@@ -215,16 +215,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")), _hyper_1_3_chunk.device
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"), _hyper_1_3_chunk.device
-                                 
                                  ->  Index Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"), _hyper_1_14_chunk.device
-                                 
                                  ->  Index Scan using _hyper_1_14_chunk_metrics_time_idx on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (25 rows)
@@ -239,16 +236,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")), _hyper_1_14_chunk.device
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"), _hyper_1_14_chunk.device
-                                 
                                  ->  Index Scan using _hyper_1_14_chunk_metrics_time_idx on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"), _hyper_1_3_chunk.device
-                                 
                                  ->  Index Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_5 (actual rows=4 loops=1)
@@ -325,16 +319,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                            Index Cond: (time_bucket < 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: _hyper_1_3_chunk.device, (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: _hyper_1_3_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Index Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: _hyper_1_14_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Index Scan using _hyper_1_14_chunk_metrics_time_idx on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (24 rows)
@@ -354,16 +345,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                            Index Cond: (time_bucket < 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: _hyper_1_3_chunk.device, (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: _hyper_1_3_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Index Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: _hyper_1_14_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Index Scan using _hyper_1_14_chunk_metrics_time_idx on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Index Cond: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (24 rows)
@@ -445,17 +433,14 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (28 rows)
@@ -470,16 +455,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
@@ -511,17 +493,14 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (28 rows)
@@ -536,16 +515,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
@@ -577,17 +553,14 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (28 rows)
@@ -602,16 +575,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
@@ -643,17 +613,14 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")), _hyper_1_3_chunk.device
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"), _hyper_1_3_chunk.device
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"), _hyper_1_14_chunk.device
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
 (28 rows)
@@ -668,16 +635,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                Sort Method: quicksort 
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")), _hyper_1_14_chunk.device
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"), _hyper_1_14_chunk.device
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time"), _hyper_1_3_chunk.device
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
@@ -763,16 +727,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                            Filter: (time_bucket < 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: _hyper_1_14_chunk.device, (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: _hyper_1_14_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: _hyper_1_3_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
@@ -793,16 +754,13 @@ SHOW timescaledb.enable_cagg_sort_pushdown;
                            Filter: (time_bucket < 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                ->  Finalize HashAggregate (actual rows=2 loops=1)
                      Group Key: _hyper_1_14_chunk.device, (time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time"))
-                     
                      ->  Append (actual rows=3 loops=1)
                            ->  Partial HashAggregate (actual rows=1 loops=1)
                                  Group Key: _hyper_1_14_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_14_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_14_chunk (actual rows=2 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                            ->  Partial HashAggregate (actual rows=2 loops=1)
                                  Group Key: _hyper_1_3_chunk.device, time_bucket('@ 3 days'::interval, _hyper_1_3_chunk."time")
-                                 
                                  ->  Seq Scan on _hyper_1_3_chunk (actual rows=4 loops=1)
                                        Filter: ("time" >= 'Sat Jan 11 16:00:00 2020 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -419,7 +419,6 @@ PREPARE cagg_scan_1h AS SELECT * FROM chunks_1h;
 ------------------------------------------------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: time_bucket('@ 1 hour'::interval, chunks."time"), chunks.device
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -440,7 +439,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
          Index Cond: (bucket < 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time"), _hyper_7_16_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_16_chunk_chunks_time_idx on _hyper_7_16_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
@@ -469,16 +467,13 @@ INSERT INTO chunks VALUES ('2001-08-01 01:01:01+01', 1, 2);
          Index Cond: (bucket < 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
    ->  Finalize HashAggregate (actual rows=1 loops=1)
          Group Key: (time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time")), _hyper_7_16_chunk.device
-         
          ->  Append (actual rows=1 loops=1)
                ->  Partial HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time"), _hyper_7_16_chunk.device
-                     
                      ->  Index Scan using _hyper_7_16_chunk_chunks_time_idx on _hyper_7_16_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
                ->  Partial HashAggregate (actual rows=1 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_18_chunk."time"), _hyper_7_18_chunk.device
-                     
                      ->  Index Scan using _hyper_7_18_chunk_chunks_time_idx on _hyper_7_18_chunk (actual rows=1 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
 (17 rows)
@@ -491,16 +486,13 @@ INSERT INTO chunks VALUES ('2001-08-01 01:01:01+01', 1, 2);
          Index Cond: (bucket < 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
    ->  Finalize HashAggregate (actual rows=1 loops=1)
          Group Key: (time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time")), _hyper_7_16_chunk.device
-         
          ->  Append (actual rows=1 loops=1)
                ->  Partial HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time"), _hyper_7_16_chunk.device
-                     
                      ->  Index Scan using _hyper_7_16_chunk_chunks_time_idx on _hyper_7_16_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
                ->  Partial HashAggregate (actual rows=1 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_18_chunk."time"), _hyper_7_18_chunk.device
-                     
                      ->  Index Scan using _hyper_7_18_chunk_chunks_time_idx on _hyper_7_18_chunk (actual rows=1 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
 (17 rows)
@@ -514,21 +506,17 @@ INSERT INTO chunks VALUES ('2002-08-01 01:01:01+01', 1, 2);
          Index Cond: (bucket < 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
    ->  Finalize HashAggregate (actual rows=2 loops=1)
          Group Key: (time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time")), _hyper_7_16_chunk.device
-         
          ->  Append (actual rows=2 loops=1)
                ->  Partial HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time"), _hyper_7_16_chunk.device
-                     
                      ->  Index Scan using _hyper_7_16_chunk_chunks_time_idx on _hyper_7_16_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
                ->  Partial HashAggregate (actual rows=1 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_18_chunk."time"), _hyper_7_18_chunk.device
-                     
                      ->  Index Scan using _hyper_7_18_chunk_chunks_time_idx on _hyper_7_18_chunk (actual rows=1 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
                ->  Partial HashAggregate (actual rows=1 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_19_chunk."time"), _hyper_7_19_chunk.device
-                     
                      ->  Index Scan using _hyper_7_19_chunk_chunks_time_idx on _hyper_7_19_chunk (actual rows=1 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
 (22 rows)
@@ -541,21 +529,17 @@ INSERT INTO chunks VALUES ('2002-08-01 01:01:01+01', 1, 2);
          Index Cond: (bucket < 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
    ->  Finalize HashAggregate (actual rows=2 loops=1)
          Group Key: (time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time")), _hyper_7_16_chunk.device
-         
          ->  Append (actual rows=2 loops=1)
                ->  Partial HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_16_chunk."time"), _hyper_7_16_chunk.device
-                     
                      ->  Index Scan using _hyper_7_16_chunk_chunks_time_idx on _hyper_7_16_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
                ->  Partial HashAggregate (actual rows=1 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_18_chunk."time"), _hyper_7_18_chunk.device
-                     
                      ->  Index Scan using _hyper_7_18_chunk_chunks_time_idx on _hyper_7_18_chunk (actual rows=1 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
                ->  Partial HashAggregate (actual rows=1 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_19_chunk."time"), _hyper_7_19_chunk.device
-                     
                      ->  Index Scan using _hyper_7_19_chunk_chunks_time_idx on _hyper_7_19_chunk (actual rows=1 loops=1)
                            Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2000 PDT'::timestamp with time zone)
 (22 rows)
@@ -575,7 +559,6 @@ CALL refresh_continuous_aggregate('chunks_1h', '2000-01-01', '2021-06-01');
                Index Cond: (bucket < 'Wed Jul 31 18:00:00 2002 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_19_chunk."time"), _hyper_7_19_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_19_chunk_chunks_time_idx on _hyper_7_19_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Wed Jul 31 18:00:00 2002 PDT'::timestamp with time zone)
@@ -594,7 +577,6 @@ CALL refresh_continuous_aggregate('chunks_1h', '2000-01-01', '2021-06-01');
                Index Cond: (bucket < 'Wed Jul 31 18:00:00 2002 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_19_chunk."time"), _hyper_7_19_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_19_chunk_chunks_time_idx on _hyper_7_19_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Wed Jul 31 18:00:00 2002 PDT'::timestamp with time zone)
@@ -618,7 +600,6 @@ SET timescaledb.enable_constraint_aware_append = OFF;
                Index Cond: (bucket < 'Wed Jul 31 18:00:00 2002 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_19_chunk."time"), _hyper_7_19_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_19_chunk_chunks_time_idx on _hyper_7_19_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Wed Jul 31 18:00:00 2002 PDT'::timestamp with time zone)
@@ -650,7 +631,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Thu Jul 31 18:00:00 2003 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_22_chunk."time"), _hyper_7_22_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_22_chunk_chunks_time_idx on _hyper_7_22_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Thu Jul 31 18:00:00 2003 PDT'::timestamp with time zone)
@@ -700,7 +680,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Sat Jul 31 18:00:00 2004 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_24_chunk."time"), _hyper_7_24_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_24_chunk_chunks_time_idx on _hyper_7_24_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Sat Jul 31 18:00:00 2004 PDT'::timestamp with time zone)
@@ -738,7 +717,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Mon Jul 31 18:00:00 2006 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_28_chunk."time"), _hyper_7_28_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_28_chunk_chunks_time_idx on _hyper_7_28_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2006 PDT'::timestamp with time zone)
@@ -766,7 +744,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Mon Jul 31 18:00:00 2006 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_28_chunk."time"), _hyper_7_28_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_28_chunk_chunks_time_idx on _hyper_7_28_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2006 PDT'::timestamp with time zone)
@@ -793,7 +770,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Mon Jul 31 18:00:00 2006 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_28_chunk."time"), _hyper_7_28_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_28_chunk_chunks_time_idx on _hyper_7_28_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Mon Jul 31 18:00:00 2006 PDT'::timestamp with time zone)
@@ -824,7 +800,6 @@ CALL refresh_continuous_aggregate('chunks_1h', '2000-01-01', '2021-06-01');
                Index Cond: (bucket < 'Tue Jul 31 18:00:00 2007 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_30_chunk."time"), _hyper_7_30_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_30_chunk_chunks_time_idx on _hyper_7_30_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Tue Jul 31 18:00:00 2007 PDT'::timestamp with time zone)
@@ -928,7 +903,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Tue Jul 31 18:00:00 2007 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, "time"), device
-         
          ->  Result (actual rows=0 loops=1)
                One-Time Filter: false
 (23 rows)
@@ -967,7 +941,6 @@ SELECT * FROM _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_wa
                Index Cond: (bucket < 'Thu Jul 31 18:00:00 2008 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_32_chunk."time"), _hyper_7_32_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Index Scan using _hyper_7_32_chunk_chunks_time_idx on _hyper_7_32_chunk (actual rows=0 loops=1)
                      Index Cond: ("time" >= 'Thu Jul 31 18:00:00 2008 PDT'::timestamp with time zone)
@@ -1008,11 +981,9 @@ PREPARE cagg_scan_1d AS SELECT * FROM chunks_1d;
          Index Cond: (bucket < 'Fri Aug 01 17:00:00 2008 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, (time_bucket('@ 1 hour'::interval, "time"))), device
-         
          ->  Result (actual rows=0 loops=1)
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, "time"), device
-                     
                      ->  Result (actual rows=0 loops=1)
                            One-Time Filter: false
 (12 rows)
@@ -1031,11 +1002,9 @@ CALL refresh_continuous_aggregate('chunks_1d', '2000-01-01', '2021-06-01');
                Index Cond: (bucket < 'Sat Aug 01 17:00:00 2009 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, (time_bucket('@ 1 hour'::interval, "time"))), device
-         
          ->  Result (actual rows=0 loops=1)
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, "time"), device
-                     
                      ->  Result (actual rows=0 loops=1)
                            One-Time Filter: false
 (15 rows)
@@ -1056,11 +1025,9 @@ CALL refresh_continuous_aggregate('chunks_1d', '2000-01-01', '2021-06-01');
                Index Cond: (bucket < 'Sun Aug 01 17:00:00 2010 PDT'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, (time_bucket('@ 1 hour'::interval, "time"))), device
-         
          ->  Result (actual rows=0 loops=1)
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, "time"), device
-                     
                      ->  Result (actual rows=0 loops=1)
                            One-Time Filter: false
 (17 rows)
@@ -1215,12 +1182,10 @@ CALL refresh_continuous_aggregate('chunks_1h', '2000-01-01', '2021-06-01');
                Index Cond: (bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
    ->  Finalize HashAggregate (actual rows=0 loops=1)
          Group Key: (time_bucket('@ 1 hour'::interval, chunks."time")), chunks.device
-         
          ->  Custom Scan (ChunkAppend) on chunks (actual rows=0 loops=1)
                Chunks excluded during startup: 1
                ->  Partial HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_49_chunk."time"), _hyper_7_49_chunk.device
-                     
                      ->  Index Scan using _hyper_7_49_chunk_chunks_time_idx on _hyper_7_49_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
 (45 rows)
@@ -1273,7 +1238,6 @@ CALL refresh_continuous_aggregate('chunks_1h', '2000-01-01', '2021-06-01');
    ->  Subquery Scan on "*SELECT* 2" (actual rows=0 loops=1)
          ->  HashAggregate (actual rows=0 loops=1)
                Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"), _hyper_7_51_chunk.device
-               
                ->  Result (actual rows=0 loops=1)
                      ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= 'Wed Dec 31 17:00:00 2014 PST'::timestamp with time zone)
@@ -1334,12 +1298,10 @@ CREATE TABLE continuous_agg_test(time int, data int);
                Index Cond: (bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
    ->  Finalize HashAggregate (actual rows=0 loops=1)
          Group Key: (time_bucket('@ 1 hour'::interval, chunks."time")), chunks.device
-         
          ->  Custom Scan (ChunkAppend) on chunks (actual rows=0 loops=1)
                Chunks excluded during startup: 2
                ->  Partial HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"), _hyper_7_51_chunk.device
-                     
                      ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk (actual rows=0 loops=1)
                            Index Cond: ("time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
    ->  Append (actual rows=3 loops=1)
@@ -1385,12 +1347,10 @@ CREATE TABLE continuous_agg_test(time int, data int);
                One-Time Filter: (_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)) IS NOT NULL)
                ->  Finalize HashAggregate (actual rows=0 loops=1)
                      Group Key: (time_bucket('@ 1 hour'::interval, chunks_1."time")), chunks_1.device
-                     
                      ->  Custom Scan (ChunkAppend) on chunks chunks_1 (actual rows=0 loops=1)
                            Chunks excluded during startup: 2
                            ->  Partial HashAggregate (actual rows=0 loops=1)
                                  Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk_1."time"), _hyper_7_51_chunk_1.device
-                                 
                                  ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk _hyper_7_51_chunk_1 (actual rows=0 loops=1)
                                        Index Cond: ("time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
 (98 rows)
@@ -1441,7 +1401,6 @@ CREATE TABLE continuous_agg_test(time int, data int);
          ->  Subquery Scan on "*SELECT* 2" (actual rows=0 loops=1)
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"), _hyper_7_51_chunk.device
-                     
                      ->  Result (actual rows=0 loops=1)
                            ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk (actual rows=0 loops=1)
                                  Index Cond: ("time" >= 'Wed Dec 31 17:00:00 2014 PST'::timestamp with time zone)
@@ -1489,7 +1448,6 @@ SELECT * FROM integer_ht_cagg;
          Index Cond: (time_bucket < 30)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket(5, "time")
-         
          ->  Result (actual rows=0 loops=1)
                One-Time Filter: false
 (8 rows)
@@ -1536,7 +1494,6 @@ SELECT * FROM big_integer_ht_cagg;
          Index Cond: (time_bucket < '30'::bigint)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('5'::bigint, "time")
-         
          ->  Result (actual rows=0 loops=1)
                One-Time Filter: false
 (8 rows)
@@ -1583,7 +1540,6 @@ SELECT * FROM small_integer_ht_cagg;
          Index Cond: (time_bucket < '30'::bigint)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('5'::bigint, "time")
-         
          ->  Result (actual rows=0 loops=1)
                One-Time Filter: false
 (8 rows)
@@ -1691,7 +1647,6 @@ UNION ALL
                Index Cond: (bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, _materialized_hypertable_8_1.bucket), _materialized_hypertable_8_1.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Append (actual rows=0 loops=1)
                      ->  Custom Scan (ChunkAppend) on _materialized_hypertable_8 _materialized_hypertable_8_1 (actual rows=0 loops=1)
@@ -1700,12 +1655,10 @@ UNION ALL
                                  Index Cond: ((bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone)) AND (bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone)))
                      ->  Finalize HashAggregate (actual rows=0 loops=1)
                            Group Key: (time_bucket('@ 1 hour'::interval, chunks."time")), chunks.device
-                           
                            ->  Custom Scan (ChunkAppend) on chunks (actual rows=0 loops=1)
                                  Chunks excluded during startup: 2
                                  ->  Partial HashAggregate (actual rows=0 loops=1)
                                        Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"), _hyper_7_51_chunk.device
-                                       
                                        ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk (actual rows=0 loops=1)
                                              Index Cond: ("time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 hour'::interval, "time") >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
@@ -1763,7 +1716,6 @@ UNION ALL
                Index Cond: (bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, _materialized_hypertable_8_1.bucket), _materialized_hypertable_8_1.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  Append (actual rows=0 loops=1)
                      ->  Custom Scan (ChunkAppend) on _materialized_hypertable_8 _materialized_hypertable_8_1 (actual rows=0 loops=1)
@@ -1772,12 +1724,10 @@ UNION ALL
                                  Index Cond: ((bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone)) AND (bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone)))
                      ->  Finalize HashAggregate (actual rows=0 loops=1)
                            Group Key: (time_bucket('@ 1 hour'::interval, chunks."time")), chunks.device
-                           
                            ->  Custom Scan (ChunkAppend) on chunks (actual rows=0 loops=1)
                                  Chunks excluded during startup: 2
                                  ->  Partial HashAggregate (actual rows=0 loops=1)
                                        Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"), _hyper_7_51_chunk.device
-                                       
                                        ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk (actual rows=0 loops=1)
                                              Index Cond: ("time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 hour'::interval, "time") >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone))
@@ -1834,11 +1784,9 @@ UNION ALL
                Index Cond: (bucket < 'Wed Dec 31 17:00:00 2014 PST'::timestamp with time zone)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, (time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"))), _hyper_7_51_chunk.device
-         
          ->  Result (actual rows=0 loops=1)
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('@ 1 hour'::interval, _hyper_7_51_chunk."time"), _hyper_7_51_chunk.device
-                     
                      ->  Result (actual rows=0 loops=1)
                            ->  Index Scan using _hyper_7_51_chunk_chunks_time_idx on _hyper_7_51_chunk (actual rows=0 loops=1)
                                  Index Cond: (("time" >= 'Wed Dec 31 17:00:00 2014 PST'::timestamp with time zone) AND ("time" >= 'Wed Dec 31 17:00:00 2014 PST'::timestamp with time zone))
@@ -1863,7 +1811,6 @@ SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_h
                      Index Cond: (time_bucket < '30'::bigint)
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('5'::bigint, "time")
-                     
                      ->  Result (actual rows=0 loops=1)
                            One-Time Filter: false
 (12 rows)
@@ -1881,7 +1828,6 @@ SELECT * FROM cagg WHERE time_bucket > 10;
          Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket('5'::bigint, "time")
-         
          ->  Result (actual rows=0 loops=1)
                One-Time Filter: false
 (8 rows)
@@ -1904,7 +1850,6 @@ SELECT * FROM cagg, other WHERE time_bucket > 10;
                      Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
                ->  HashAggregate (actual rows=0 loops=1)
                      Group Key: time_bucket('5'::bigint, "time")
-                     
                      ->  Result (actual rows=0 loops=1)
                            One-Time Filter: false
 (11 rows)

--- a/tsl/test/expected/compress_qualpushdown_saop.out
+++ b/tsl/test/expected/compress_qualpushdown_saop.out
@@ -468,7 +468,6 @@ select * from saop, arrays where segmentby = any(a);
                Sort Method: top-N heapsort 
                ->  HashAggregate (actual rows=23 loops=1)
                      Group Key: _hyper_1_1_chunk_1.segmentby
-                     
                      ->  Append (actual rows=100000 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50000 loops=1)
                                  ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69 loops=1)
@@ -506,7 +505,6 @@ select * from saop, arrays where with_minmax = any(a);
                            Sort Method: top-N heapsort 
                            ->  HashAggregate (actual rows=23 loops=1)
                                  Group Key: _hyper_1_1_chunk_1.segmentby
-                                 
                                  ->  Append (actual rows=100000 loops=1)
                                        ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50000 loops=1)
                                              ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69 loops=1)
@@ -535,7 +533,6 @@ select * from saop, arrays where with_bloom = any(a);
                            Sort Method: top-N heapsort 
                            ->  HashAggregate (actual rows=23 loops=1)
                                  Group Key: _hyper_1_1_chunk_1.segmentby
-                                 
                                  ->  Append (actual rows=100000 loops=1)
                                        ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50000 loops=1)
                                              ->  Index Scan using compress_hyper_2_3_chunk_segmentby__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69 loops=1)

--- a/tsl/test/expected/compress_sort_transform.out
+++ b/tsl/test/expected/compress_sort_transform.out
@@ -412,7 +412,6 @@ group by 1
                      ->  Index Only Scan Backward using _hyper_1_1_chunk_ht_metrics_partially_compressed_time_idx on _hyper_1_1_chunk a_1 (actual rows=720 loops=1)
                            Index Cond: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)
                ->  Hash (actual rows=1800 loops=1)
-                      
                      ->  Append (actual rows=1800 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk b_1 (actual rows=1080 loops=1)
                                  Vectorized Filter: ("time" < 'Tue Jan 07 00:00:00 2020 PST'::timestamp with time zone)

--- a/tsl/test/expected/merge_append_partially_compressed.out
+++ b/tsl/test/expected/merge_append_partially_compressed.out
@@ -1045,7 +1045,6 @@ ORDER BY t1.x1, jt.y1;
          Hash Cond: (jt.x1 = t1_1.x1)
          ->  Seq Scan on join_table jt (actual rows=2 loops=1)
          ->  Hash (actual rows=10005 loops=1)
-                
                ->  Append (actual rows=10005 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk t1_1 (actual rows=10004 loops=1)
                            ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=13 loops=1)

--- a/tsl/test/expected/modify_exclusion.out
+++ b/tsl/test/expected/modify_exclusion.out
@@ -1133,11 +1133,9 @@ BEGIN;
                            Index Cond: (metrics_int4_4."time" < length(version()))
                ->  Hash (actual rows=4 loops=1)
                      Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
-                      
                      ->  HashAggregate (actual rows=4 loops=1)
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
-                           
                            ->  Append (actual rows=4 loops=1)
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1 loops=1)
                                        Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
@@ -1175,11 +1173,9 @@ BEGIN;
                            Output: metrics_int4_4."time", metrics_int4_4.tableoid, metrics_int4_4.ctid
                ->  Hash (actual rows=4 loops=1)
                      Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
-                      
                      ->  HashAggregate (actual rows=4 loops=1)
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
-                           
                            ->  Append (actual rows=4 loops=1)
                                  ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1 loops=1)
                                        Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
@@ -1225,11 +1221,9 @@ BEGIN;
                            Index Cond: (metrics_int4_4."time" < length(version()))
                ->  Hash (actual rows=4 loops=1)
                      Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
-                      
                      ->  HashAggregate (actual rows=4 loops=1)
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
-                           
                            ->  Append (actual rows=4 loops=1)
                                  ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1 loops=1)
                                        Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
@@ -1275,11 +1269,9 @@ BEGIN;
                            Index Cond: (metrics_int4_4."time" < length(version()))
                ->  Hash (actual rows=4 loops=1)
                      Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
-                      
                      ->  HashAggregate (actual rows=4 loops=1)
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
-                           
                            ->  Append (actual rows=4 loops=1)
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1 loops=1)
                                        Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
@@ -1317,11 +1309,9 @@ BEGIN;
                            Output: metrics_int4_4."time", metrics_int4_4.tableoid, metrics_int4_4.ctid
                ->  Hash (actual rows=4 loops=1)
                      Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
-                      
                      ->  HashAggregate (actual rows=4 loops=1)
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
-                           
                            ->  Append (actual rows=4 loops=1)
                                  ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1 loops=1)
                                        Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
@@ -1367,11 +1357,9 @@ BEGIN;
                            Index Cond: (metrics_int4_4."time" < length(version()))
                ->  Hash (actual rows=4 loops=1)
                      Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
-                      
                      ->  HashAggregate (actual rows=4 loops=1)
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
-                           
                            ->  Append (actual rows=4 loops=1)
                                  ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1 loops=1)
                                        Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -137,7 +137,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=12 loops=1)
          Group Key: dev
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -253,7 +252,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: dev_name
-         
          ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
                Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
                Heap Blocks: exact=13
@@ -273,7 +271,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (dev % 3)
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -426,7 +423,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -438,7 +434,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val, 'q1_9'::text
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -450,7 +445,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10021 loops=1)
          Group Key: dev, "time", 'q1_10'::text
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -470,7 +464,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=102 loops=1)
    Group Key: time_bucket(10, "time"), 'q1_12'::text
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -479,7 +472,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=4 loops=1)
    Group Key: length(dev_name), 'q1_13'::text
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -488,7 +480,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=1002 loops=1)
    Group Key: (3 * "time"), 'q1_14'::text
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -497,7 +488,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=12 loops=1)
    Group Key: ('Device '::text || dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -794,7 +784,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------
  HashAggregate (actual rows=10022 loops=1)
    Group Key: skip_scan.*
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -1160,7 +1149,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -1501,7 +1489,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_1_1_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -1709,7 +1696,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.dev_name
-         
          ->  Append (actual rows=2000 loops=1)
                ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
                      Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
@@ -1745,7 +1731,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (_hyper_1_1_chunk.dev % 3)
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2000,7 +1985,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -2016,7 +2000,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val, 'q1_9'::text
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2033,7 +2016,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", 'q1_10'::text
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2069,7 +2051,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=100 loops=1)
    Group Key: time_bucket(10, _hyper_1_1_chunk."time"), 'q1_12'::text
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2083,7 +2064,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=3 loops=1)
    Group Key: length(_hyper_1_1_chunk.dev_name), 'q1_13'::text
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2097,7 +2077,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=1000 loops=1)
    Group Key: (3 * _hyper_1_1_chunk."time"), 'q1_14'::text
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2111,7 +2090,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2701,7 +2679,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_ht.*)::skip_scan_ht)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -3379,7 +3356,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan_ht.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -4178,7 +4154,6 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_3_5_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Sort (actual rows=11 loops=1)
@@ -4634,7 +4609,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -4654,7 +4628,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val, 'q1_9'::text
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4675,7 +4648,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", 'q1_10'::text
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4728,7 +4700,6 @@ stable expression in targetlist on skip_scan_htc
 ---------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: (_hyper_3_5_chunk.dev + 1), 'q1_13'::text
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -5062,7 +5033,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_htc.*)::skip_scan_htc)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -5274,7 +5244,6 @@ stable expression in targetlist on skip_scan_htc
 ---------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -137,7 +137,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=12 loops=1)
          Group Key: dev
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -253,7 +252,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: dev_name
-         
          ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
                Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
                Heap Blocks: exact=13
@@ -273,7 +271,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (dev % 3)
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -426,7 +423,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -438,7 +434,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -450,7 +445,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10021 loops=1)
          Group Key: dev, "time"
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -470,7 +464,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=102 loops=1)
    Group Key: time_bucket(10, "time")
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -479,7 +472,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=4 loops=1)
    Group Key: length(dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -488,7 +480,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=1002 loops=1)
    Group Key: (3 * "time")
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -497,7 +488,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=12 loops=1)
    Group Key: ('Device '::text || dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -794,7 +784,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------
  HashAggregate (actual rows=10022 loops=1)
    Group Key: skip_scan.*
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -1159,7 +1148,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -1500,7 +1488,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_1_1_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -1708,7 +1695,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.dev_name
-         
          ->  Append (actual rows=2000 loops=1)
                ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
                      Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
@@ -1744,7 +1730,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (_hyper_1_1_chunk.dev % 3)
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -1999,7 +1984,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -2015,7 +1999,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2032,7 +2015,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2068,7 +2050,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=100 loops=1)
    Group Key: time_bucket(10, _hyper_1_1_chunk."time")
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2082,7 +2063,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=3 loops=1)
    Group Key: length(_hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2096,7 +2076,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=1000 loops=1)
    Group Key: (3 * _hyper_1_1_chunk."time")
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2110,7 +2089,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2700,7 +2678,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_ht.*)::skip_scan_ht)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -3374,7 +3351,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan_ht.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -4173,7 +4149,6 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_3_5_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Sort (actual rows=11 loops=1)
@@ -4629,7 +4604,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -4649,7 +4623,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4670,7 +4643,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4723,7 +4695,6 @@ stable expression in targetlist on skip_scan_htc
 ---------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: (_hyper_3_5_chunk.dev + 1)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -5057,7 +5028,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_htc.*)::skip_scan_htc)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -5269,7 +5239,6 @@ stable expression in targetlist on skip_scan_htc
 ---------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -137,7 +137,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=12 loops=1)
          Group Key: dev
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -253,7 +252,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: dev_name
-         
          ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
                Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
                Heap Blocks: exact=13
@@ -273,7 +271,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (dev % 3)
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -426,7 +423,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -438,7 +434,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -450,7 +445,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10021 loops=1)
          Group Key: dev, "time"
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -470,7 +464,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=102 loops=1)
    Group Key: time_bucket(10, "time")
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -479,7 +472,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=4 loops=1)
    Group Key: length(dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -488,7 +480,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=1002 loops=1)
    Group Key: (3 * "time")
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -497,7 +488,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=12 loops=1)
    Group Key: ('Device '::text || dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -794,7 +784,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------
  HashAggregate (actual rows=10022 loops=1)
    Group Key: skip_scan.*
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -1159,7 +1148,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -1501,7 +1489,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_1_1_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -1709,7 +1696,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.dev_name
-         
          ->  Append (actual rows=2000 loops=1)
                ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
                      Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
@@ -1745,7 +1731,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (_hyper_1_1_chunk.dev % 3)
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2000,7 +1985,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -2016,7 +2000,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2033,7 +2016,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2069,7 +2051,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=100 loops=1)
    Group Key: time_bucket(10, _hyper_1_1_chunk."time")
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2083,7 +2064,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=3 loops=1)
    Group Key: length(_hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2097,7 +2077,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=1000 loops=1)
    Group Key: (3 * _hyper_1_1_chunk."time")
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2111,7 +2090,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2701,7 +2679,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_ht.*)::skip_scan_ht)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -3375,7 +3352,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan_ht.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -4175,7 +4151,6 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_3_5_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Sort (actual rows=11 loops=1)
@@ -4631,7 +4606,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -4651,7 +4625,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4672,7 +4645,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4725,7 +4697,6 @@ stable expression in targetlist on skip_scan_htc
 ---------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: (_hyper_3_5_chunk.dev + 1)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -5059,7 +5030,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_htc.*)::skip_scan_htc)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -5271,7 +5241,6 @@ stable expression in targetlist on skip_scan_htc
 ---------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505 loops=1)

--- a/tsl/test/expected/plan_skip_scan-18.out
+++ b/tsl/test/expected/plan_skip_scan-18.out
@@ -137,7 +137,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=12 loops=1)
          Group Key: dev
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -253,7 +252,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: dev_name
-         
          ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
                Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
                Heap Blocks: exact=13
@@ -273,7 +271,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (dev % 3)
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -426,7 +423,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -438,7 +434,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10022 loops=1)
          Group Key: dev, "time", dev_name, val
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -450,7 +445,6 @@ stable expression in targetlist on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10021 loops=1)
          Group Key: dev, "time"
-         
          ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (7 rows)
 
@@ -470,7 +464,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=102 loops=1)
    Group Key: time_bucket(10, "time")
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -479,7 +472,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=4 loops=1)
    Group Key: length(dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -488,7 +480,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=1002 loops=1)
    Group Key: (3 * "time")
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -497,7 +488,6 @@ stable expression in targetlist on skip_scan
 ---------------------------------------------------------
  HashAggregate (actual rows=12 loops=1)
    Group Key: ('Device '::text || dev_name)
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -794,7 +784,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------
  HashAggregate (actual rows=10022 loops=1)
    Group Key: skip_scan.*
-   
    ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
 (4 rows)
 
@@ -1159,7 +1148,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -1501,7 +1489,6 @@ SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_1_1_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -1709,7 +1696,6 @@ CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: _hyper_1_1_chunk.dev_name
-         
          ->  Append (actual rows=2000 loops=1)
                ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
                      Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
@@ -1745,7 +1731,6 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: (_hyper_1_1_chunk.dev % 3)
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2000,7 +1985,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -2016,7 +2000,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2033,7 +2016,6 @@ stable expression in targetlist on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2069,7 +2051,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=100 loops=1)
    Group Key: time_bucket(10, _hyper_1_1_chunk."time")
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2083,7 +2064,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=3 loops=1)
    Group Key: length(_hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2097,7 +2077,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=1000 loops=1)
    Group Key: (3 * _hyper_1_1_chunk."time")
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2111,7 +2090,6 @@ stable expression in targetlist on skip_scan_ht
 ---------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_1_1_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
@@ -2701,7 +2679,6 @@ DISTINCT with wholerow var
 ---------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_ht.*)::skip_scan_ht)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
@@ -3375,7 +3352,6 @@ WHERE CLAUSES
 ---------------------------------------
  HashAggregate (actual rows=0 loops=1)
    Group Key: skip_scan_ht.dev
-   
    ->  Result (actual rows=0 loops=1)
          One-Time Filter: false
 (5 rows)
@@ -4175,7 +4151,6 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_3_5_chunk.dev
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Sort (actual rows=11 loops=1)
@@ -4631,7 +4606,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                      ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -4651,7 +4625,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time", _hyper_3_5_chunk.dev_name, _hyper_3_5_chunk.val
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4672,7 +4645,6 @@ stable expression in targetlist on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=10020 loops=1)
          Group Key: _hyper_3_5_chunk.dev, _hyper_3_5_chunk."time"
-         
          ->  Result (actual rows=10020 loops=1)
                ->  Append (actual rows=10020 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -4725,7 +4697,6 @@ stable expression in targetlist on skip_scan_htc
 ------------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: (_hyper_3_5_chunk.dev + 1)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
@@ -5059,7 +5030,6 @@ DISTINCT with wholerow var
 ------------------------------------------------------------------------------------------
  HashAggregate (actual rows=10020 loops=1)
    Group Key: ((skip_scan_htc.*)::skip_scan_htc)
-   
    ->  Append (actual rows=10020 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)
                ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11 loops=1)
@@ -5271,7 +5241,6 @@ stable expression in targetlist on skip_scan_htc
 ------------------------------------------------------------------------------------------------
  HashAggregate (actual rows=11 loops=1)
    Group Key: ('Device '::text || _hyper_3_5_chunk.dev_name)
-   
    ->  Result (actual rows=10020 loops=1)
          ->  Append (actual rows=10020 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=2505 loops=1)

--- a/tsl/test/expected/plan_skip_scan_dagg.out
+++ b/tsl/test/expected/plan_skip_scan_dagg.out
@@ -299,7 +299,6 @@ basic DISTINCT queries on skip_scan
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=12 loops=1)
          Group Key: dev, count(DISTINCT dev)
-         
          ->  GroupAggregate (actual rows=12 loops=1)
                Group Key: dev
                ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
@@ -1449,7 +1448,6 @@ basic DISTINCT queries on skip_scan_ht
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_1_1_chunk.dev, count(DISTINCT _hyper_1_1_chunk.dev)
-         
          ->  GroupAggregate (actual rows=11 loops=1)
                Group Key: _hyper_1_1_chunk.dev
                ->  Merge Append (actual rows=44 loops=1)
@@ -3580,7 +3578,6 @@ basic DISTINCT queries on skip_scan_htc
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_3_5_chunk.dev, count(DISTINCT _hyper_3_5_chunk.dev)
-         
          ->  GroupAggregate (actual rows=11 loops=1)
                Group Key: _hyper_3_5_chunk.dev
                ->  Merge Append (actual rows=44 loops=1)
@@ -5534,7 +5531,6 @@ basic DISTINCT queries on skip_scan_htcl
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=11 loops=1)
          Group Key: _hyper_5_9_chunk.dev, count(DISTINCT _hyper_5_9_chunk.dev)
-         
          ->  GroupAggregate (actual rows=11 loops=1)
                Group Key: _hyper_5_9_chunk.dev
                ->  Merge Append (actual rows=44 loops=1)

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -2733,7 +2733,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
@@ -2776,7 +2775,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2834,7 +2832,6 @@ LIMIT 20;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -2871,7 +2868,6 @@ LIMIT 10;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -6632,7 +6628,6 @@ WHERE device_id IN (
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-          
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                Output: "*VALUES*".column1
 (42 rows)
@@ -7103,7 +7098,6 @@ LIMIT 100;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
@@ -7163,7 +7157,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -7230,7 +7223,6 @@ LIMIT 20;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -7285,7 +7277,6 @@ LIMIT 10;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -2733,7 +2733,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
@@ -2776,7 +2775,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2834,7 +2832,6 @@ LIMIT 20;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -2871,7 +2868,6 @@ LIMIT 10;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -6632,7 +6628,6 @@ WHERE device_id IN (
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-          
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                Output: "*VALUES*".column1
 (42 rows)
@@ -7103,7 +7098,6 @@ LIMIT 100;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
@@ -7163,7 +7157,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -7230,7 +7223,6 @@ LIMIT 20;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -7285,7 +7277,6 @@ LIMIT 10;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -2733,7 +2733,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
@@ -2776,7 +2775,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2834,7 +2832,6 @@ LIMIT 20;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -2871,7 +2868,6 @@ LIMIT 10;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -6632,7 +6628,6 @@ WHERE device_id IN (
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-          
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                Output: "*VALUES*".column1
 (42 rows)
@@ -7103,7 +7098,6 @@ LIMIT 100;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
@@ -7163,7 +7157,6 @@ LIMIT 100;
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -7230,7 +7223,6 @@ LIMIT 20;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -7285,7 +7277,6 @@ LIMIT 10;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)

--- a/tsl/test/expected/transparent_decompression-18.out
+++ b/tsl/test/expected/transparent_decompression-18.out
@@ -2730,7 +2730,6 @@ LIMIT 100;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
@@ -2773,7 +2772,6 @@ LIMIT 100;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2831,7 +2829,6 @@ LIMIT 20;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -2868,7 +2865,6 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=3600 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
@@ -6629,7 +6625,6 @@ WHERE device_id IN (
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-          
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                Output: "*VALUES*".column1
 (42 rows)
@@ -7100,7 +7095,6 @@ LIMIT 100;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
@@ -7160,7 +7154,6 @@ LIMIT 100;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1680 loops=1)
                            ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Hash (actual rows=1728 loops=1)
-                      
                      ->  Append (actual rows=1728 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -7227,7 +7220,6 @@ LIMIT 20;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -7282,7 +7274,6 @@ LIMIT 10;
                            ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=336 loops=1)
                ->  Hash (actual rows=8640 loops=1)
-                      
                      ->  Append (actual rows=8640 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=720 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -575,7 +575,6 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Hash (actual rows=1540 loops=1)
-                
                ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
@@ -837,7 +836,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=0 loops=1)
                Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
@@ -870,7 +868,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=42 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=7321 loops=1)
                Hash Cond: (d."time" = m."time")
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
@@ -898,7 +895,6 @@ ORDER BY 1,
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                        Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Hash (actual rows=1541 loops=1)
-                      
                      ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
                            Hypertable: metrics_ordered_idx
                            Chunks excluded during startup: 0
@@ -948,7 +944,6 @@ ORDER BY m.v0;
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
-                
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
 (13 rows)
 
@@ -1019,7 +1014,6 @@ ORDER BY m.v0;
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 4
          ->  Hash (actual rows=0 loops=1)
-                
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7

--- a/tsl/test/expected/transparent_decompression_ordered_index-16.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-16.out
@@ -575,7 +575,6 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Hash (actual rows=1540 loops=1)
-                
                ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
@@ -837,7 +836,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=0 loops=1)
                Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
@@ -870,7 +868,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=42 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=7321 loops=1)
                Hash Cond: (d."time" = m."time")
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
@@ -898,7 +895,6 @@ ORDER BY 1,
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                        Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Hash (actual rows=1541 loops=1)
-                      
                      ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
                            Hypertable: metrics_ordered_idx
                            Chunks excluded during startup: 0
@@ -948,7 +944,6 @@ ORDER BY m.v0;
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
-                
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-17.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-17.out
@@ -575,7 +575,6 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Hash (actual rows=1540 loops=1)
-                
                ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
@@ -837,7 +836,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=0 loops=1)
                Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
@@ -870,7 +868,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=42 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=7321 loops=1)
                Hash Cond: (d."time" = m."time")
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
@@ -898,7 +895,6 @@ ORDER BY 1,
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                        Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Hash (actual rows=1541 loops=1)
-                      
                      ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
                            Hypertable: metrics_ordered_idx
                            Chunks excluded during startup: 0
@@ -948,7 +944,6 @@ ORDER BY m.v0;
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
-                
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-18.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-18.out
@@ -575,7 +575,6 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Hash (actual rows=1540 loops=1)
-                
                ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
@@ -837,7 +836,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=0 loops=1)
                Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
@@ -870,7 +868,6 @@ ORDER BY 1,
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=42 loops=1)
          Group Key: m.device_id, d.v0
-         
          ->  Hash Join (actual rows=7321 loops=1)
                Hash Cond: (d."time" = m."time")
                ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
@@ -898,7 +895,6 @@ ORDER BY 1,
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                        Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Hash (actual rows=1541 loops=1)
-                      
                      ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
                            Hypertable: metrics_ordered_idx
                            Chunks excluded during startup: 0
@@ -948,7 +944,6 @@ ORDER BY m.v0;
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
-                
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
 (13 rows)
 

--- a/tsl/test/shared/expected/decompress_join.out
+++ b/tsl/test/shared/expected/decompress_join.out
@@ -23,7 +23,6 @@ QUERY PLAN
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m_3 (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Hash (actual rows=10 loops=1)
-                
                ->  Seq Scan on compressed_join_temp t (actual rows=10 loops=1)
 (13 rows)
 

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -3951,7 +3951,6 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=20 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, tbl1_1."time")
-         
          ->  Merge Join (actual rows=9121 loops=1)
                Merge Cond: ((tbl1_1.device = tbl2_1.device) AND (tbl1_1."time" = tbl2_1."time"))
                ->  Sort (actual rows=9121 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -3951,7 +3951,6 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=20 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, tbl1_1."time")
-         
          ->  Merge Join (actual rows=9121 loops=1)
                Merge Cond: ((tbl1_1.device = tbl2_1.device) AND (tbl1_1."time" = tbl2_1."time"))
                ->  Sort (actual rows=9121 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-17.out
+++ b/tsl/test/shared/expected/ordered_append_join-17.out
@@ -3927,7 +3927,6 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=20 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, tbl1_1."time")
-         
          ->  Merge Join (actual rows=9121 loops=1)
                Merge Cond: ((tbl1_1.device = tbl2_1.device) AND (tbl1_1."time" = tbl2_1."time"))
                ->  Sort (actual rows=9121 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-18.out
+++ b/tsl/test/shared/expected/ordered_append_join-18.out
@@ -3927,7 +3927,6 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=20 loops=1)
          Group Key: time_bucket('@ 1 day'::interval, tbl1_1."time")
-         
          ->  Merge Join (actual rows=9121 loops=1)
                Merge Cond: ((tbl1_1.device = tbl2_1.device) AND (tbl1_1."time" = tbl2_1."time"))
                ->  Sort (actual rows=9121 loops=1)


### PR DESCRIPTION
This can be flaky between platforms due to different hash table sizes.