### PR TITLE
Remove Philip from the reviewers list

### DIFF
--- a/.pull-review
+++ b/.pull-review
@@ -54,6 +54,7 @@ reviewers:
 # list of users who will never be notified
 review_blacklist:
   - timescale-automation
+  - philkra
 
 # ignore changes to the test output files.
 # 1. because they usually will have equivalent .sql files


### PR DESCRIPTION
He's getting selected more often on the CI-unrelated PRs than we thought he would be.

Disable-check: force-changelog-file