### PR TITLE
Change loglevel of not-null constraint message

### DIFF
--- a/.unreleased/pr_8493
+++ b/.unreleased/pr_8493
@@ -1,0 +1,1 @@
+Fixes: #8493 Change log level not null constraint message

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1136,7 +1136,7 @@ dimension_add_not_null_on_column(Oid table_relid, char *colname)
 		.missing_ok = false,
 	};
 
-	ereport(NOTICE,
+	ereport(DEBUG1,
 			(errmsg("adding not-null constraint to column \"%s\"", colname),
 			 errdetail("Dimensions cannot have NULL values.")));
 

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -14,7 +14,6 @@ ALTER TABLE alter_before ALTER COLUMN temp SET STATISTICS 100;
 ALTER TABLE alter_before ALTER COLUMN notes SET STORAGE EXTERNAL;
 SELECT create_hypertable('alter_before', 'time', chunk_time_interval => 2628000000000);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (1,public,alter_before,t)
@@ -66,7 +65,6 @@ ORDER BY c.relname, a.attnum;
 CREATE TABLE alter_after(id serial, time timestamp, temp float, colorid integer, notes text, notes_2 text);
 SELECT create_hypertable('alter_after', 'time', chunk_time_interval => 2628000000000);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (2,public,alter_after,t)
@@ -257,7 +255,6 @@ WHERE tablename = 'hyper_in_space' OR tablename LIKE '\_hyper\__\__\_chunk' ORDE
 
 CREATE TABLE hyper_in_space(time bigint, temp float, device int);
 SELECT create_hypertable('hyper_in_space', 'time', 'device', 4, chunk_time_interval=>1);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (3,public,hyper_in_space,t)
@@ -345,7 +342,6 @@ ERROR:  tablespace "tablespace1" is still attached to 1 hypertables
 DROP TABLE hyper_in_space;
 CREATE TABLE hyper_in_space(time bigint, temp float, device int) TABLESPACE tablespace1;
 SELECT create_hypertable('hyper_in_space', 'time', 'device', 4, chunk_time_interval=>1);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (4,public,hyper_in_space,t)
@@ -810,7 +806,6 @@ DROP ROLE role_4474;
 -- root table's setting
 CREATE TABLE replid(time timestamptz, value int);
 SELECT create_hypertable('replid', 'time', chunk_time_interval => interval '1 day', create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (16,public,replid,t)

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -78,7 +78,6 @@ ERROR:  must be owner of hypertable "one_Partition"
 CREATE TABLE "1dim"(time timestamp, temp float);
 SELECT create_hypertable('"1dim"', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (2,public,1dim,t)
@@ -203,7 +202,6 @@ DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1
 CREATE TABLE my_ht (time BIGINT, val integer);
 SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              5 | public      | my_ht      | t
@@ -442,7 +440,6 @@ CREATE TABLE plain_table_su (time timestamp, temp float);
 CREATE TABLE hypertable_su (time timestamp, temp float);
 SELECT create_hypertable('hypertable_su', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (11,public,hypertable_su,t)

--- a/test/expected/append-15.out
+++ b/test/expected/append-15.out
@@ -66,7 +66,6 @@ END;
 $$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:56: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,append_test,t)
@@ -82,7 +81,6 @@ VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:68: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -1932,7 +1930,6 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
-psql:include/append_query.sql:315: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -66,7 +66,6 @@ END;
 $$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:56: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,append_test,t)
@@ -82,7 +81,6 @@ VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:68: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -1932,7 +1930,6 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
-psql:include/append_query.sql:315: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -66,7 +66,6 @@ END;
 $$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:56: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,append_test,t)
@@ -82,7 +81,6 @@ VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append_load.sql:68: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -1927,7 +1925,6 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
-psql:include/append_query.sql:315: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit

--- a/test/expected/catalog_corruption.out
+++ b/test/expected/catalog_corruption.out
@@ -5,7 +5,6 @@
 --- Test handling of missing dimension slices
 CREATE TABLE dim_test(time TIMESTAMPTZ, device int);
 SELECT create_hypertable('dim_test', 'time', chunk_time_interval => INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (1,public,dim_test,t)

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -59,7 +59,6 @@ SELECT create_hypertable('test_adaptive', 'time',
                          chunk_sizing_func => 'calculate_chunk_interval');
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (1,public,test_adaptive,t)
@@ -73,7 +72,6 @@ SELECT create_hypertable('test_adaptive', 'time',
                          create_default_indexes => true);
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,test_adaptive,t)
@@ -281,7 +279,6 @@ SELECT create_hypertable('test_adaptive_no_index', 'time',
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 WARNING:  no index on "time" found for adaptive chunking on hypertable "test_adaptive_no_index"
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable          
 -------------------------------------
  (3,public,test_adaptive_no_index,t)
@@ -383,7 +380,6 @@ SELECT create_hypertable('test_adaptive_correct_index', 'time',
                          create_default_indexes => false);
 WARNING:  no index on "time" found for adaptive chunking on hypertable "test_adaptive_correct_index"
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
             create_hypertable             
 ------------------------------------------
  (4,public,test_adaptive_correct_index,t)
@@ -482,7 +478,6 @@ SELECT create_hypertable('test_adaptive_space', 'time', 'location', 2,
                          create_default_indexes => true);
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (5,public,test_adaptive_space,t)
@@ -728,7 +723,6 @@ SELECT create_hypertable('test_adaptive_after_multiple_dims', 'time',
                          chunk_target_size => '100MB',
                          create_default_indexes => true);
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
                create_hypertable                
 ------------------------------------------------
  (6,public,test_adaptive_after_multiple_dims,t)
@@ -763,7 +757,6 @@ SELECT create_hypertable('test_adaptive', 'time',
                          chunk_sizing_func => 'my_chunk_func_schema.calculate_chunk_interval');
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adaptive chunking is a BETA feature and is not recommended for production deployments
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (7,public,test_adaptive,t)

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -24,21 +24,18 @@ SELECT show_chunks(NULL);
 ERROR:  invalid hypertable or continuous aggregate
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (1,public,drop_chunk_test1,t)
 (1 row)
 
 SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1, create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (2,public,drop_chunk_test2,t)
 (1 row)
 
 SELECT create_hypertable('public.drop_chunk_test3', 'time', chunk_time_interval => 1, create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (3,public,drop_chunk_test3,t)
@@ -819,7 +816,6 @@ SELECT drop_chunks(format('%1$I.%2$I', schema_name, table_name)::regclass, older
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (4,public,drop_chunk_test_ts,t)
@@ -827,7 +823,6 @@ NOTICE:  adding not-null constraint to column "time"
 
 CREATE TABLE PUBLIC.drop_chunk_test_tstz(time timestamptz, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_tstz', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (5,public,drop_chunk_test_tstz,t)
@@ -1065,7 +1060,6 @@ SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE
 
 CREATE TABLE PUBLIC.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (6,public,drop_chunk_test_date,t)
@@ -1108,7 +1102,6 @@ ROLLBACK;
 SET timezone TO '-5';
 CREATE TABLE chunk_id_from_relid_test(time bigint, temp float8, device_id int);
 SELECT hypertable_id FROM create_hypertable('chunk_id_from_relid_test', 'time', chunk_time_interval => 10) \gset
-NOTICE:  adding not-null constraint to column "time"
 INSERT INTO chunk_id_from_relid_test VALUES (0, 1.1, 0), (0, 1.3, 11), (12, 2.0, 0), (12, 0.1, 11);
 SELECT _timescaledb_functions.chunk_id_from_relid(tableoid) FROM chunk_id_from_relid_test;
  chunk_id_from_relid 
@@ -1125,7 +1118,6 @@ SELECT hypertable_id FROM  create_hypertable('chunk_id_from_relid_test',
     'time', chunk_time_interval => 10,
     partitioning_column => 'device_id',
     number_partitions => 3) \gset
-NOTICE:  adding not-null constraint to column "time"
 INSERT INTO chunk_id_from_relid_test VALUES (0, 1.1, 2), (0, 1.3, 11), (12, 2.0, 2), (12, 0.1, 11);
 SELECT _timescaledb_functions.chunk_id_from_relid(tableoid) FROM chunk_id_from_relid_test;
  chunk_id_from_relid 
@@ -1150,7 +1142,6 @@ CREATE TABLE test_weird_type(a jsonb);
 SELECT create_hypertable('test_weird_type', 'a',
     time_partitioning_func=>'extract_time'::regproc,
     chunk_time_interval=>'2 hours'::interval);
-NOTICE:  adding not-null constraint to column "a"
       create_hypertable       
 ------------------------------
  (9,public,test_weird_type,t)
@@ -1231,7 +1222,6 @@ CREATE TABLE test_weird_type_i(a jsonb);
 SELECT create_hypertable('test_weird_type_i', 'a',
     time_partitioning_func=>'extract_int_time'::regproc,
     chunk_time_interval=>5);
-NOTICE:  adding not-null constraint to column "a"
         create_hypertable        
 ---------------------------------
  (10,public,test_weird_type_i,t)
@@ -1360,7 +1350,6 @@ GRANT USAGE ON SCHEMA try_schema, test1, test2, test3 TO :ROLE_DEFAULT_PERM_USER
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE try_schema.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('try_schema.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable            
 ----------------------------------------
  (11,try_schema,drop_chunk_test_date,t)
@@ -1391,14 +1380,12 @@ SELECT drop_chunks('drop_chunk_test_date', older_than=> '1 day'::interval);
 CREATE TABLE test1.hyper1 (time bigint, temp float);
 CREATE TABLE test1.hyper2 (time bigint, temp float);
 SELECT create_hypertable('test1.hyper1', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (12,test1,hyper1,t)
 (1 row)
 
 SELECT create_hypertable('test1.hyper2', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (13,test1,hyper2,t)
@@ -1422,14 +1409,12 @@ SELECT show_chunks('test1.hyper2');
 CREATE TABLE test2.hyperx (time bigint, temp float);
 CREATE TABLE test3.hyperx (time bigint, temp float);
 SELECT create_hypertable('test2.hyperx', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (14,test2,hyperx,t)
 (1 row)
 
 SELECT create_hypertable('test3.hyperx', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (15,test3,hyperx,t)
@@ -1472,7 +1457,6 @@ SELECT show_chunks('test3.hyperx');
 CREATE TABLE PUBLIC.drop_chunk_test4(time bigint, temp float8, device_id text);
 CREATE TABLE drop_chunks_table_id AS SELECT hypertable_id
       FROM create_hypertable('public.drop_chunk_test4', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
 -- TEST for internal api that drops a single chunk
 -- this drops the table and removes entry from the catalog.
 -- does not affect any materialized cagg data
@@ -1554,7 +1538,6 @@ SELECT create_hypertable('view_test', by_range('ts', INTERVAL '1 day'));
 
 -- exactly one partition per project_id
 SELECT * FROM add_dimension('view_test', 'project_id', chunk_time_interval => 1); -- exactly one partition per project; works for *integer* types
-NOTICE:  adding not-null constraint to column "project_id"
  dimension_id | schema_name | table_name | column_name | created 
 --------------+-------------+------------+-------------+---------
            22 | try_schema  | view_test  | project_id  | t

--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -3,7 +3,6 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE cluster_test(time timestamptz, temp float, location int);
 SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => interval '1 day');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (1,public,cluster_test,t)
@@ -138,7 +137,6 @@ CREATE TABLE cluster_alter(time timestamp, id text, val int);
 CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
 SELECT table_name FROM create_hypertable('cluster_alter', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------
  cluster_alter

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -567,7 +567,6 @@ CREATE TABLE hyper_ex (
     ) WHERE (not canceled)
 );
 SELECT * FROM create_hypertable('hyper_ex', 'time', chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              6 | public      | hyper_ex   | t
@@ -625,7 +624,6 @@ CREATE TABLE hyper_ex_invalid (
 );
 \set ON_ERROR_STOP 0
 SELECT * FROM create_hypertable('hyper_ex_invalid', 'time', chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 \set ON_ERROR_STOP 1
 --- NO INHERIT constraints (not allowed) ----
@@ -648,7 +646,6 @@ CREATE TABLE hyper_noinherit_alter (
     sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('hyper_noinherit_alter', 'time', chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |      table_name       | created 
 ---------------+-------------+-----------------------+---------
              8 | public      | hyper_noinherit_alter | t
@@ -664,7 +661,6 @@ CREATE TABLE hyper_unique_deferred (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_unique_deferred', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |      table_name       | created 
 ---------------+-------------+-----------------------+---------
              9 | public      | hyper_unique_deferred | t
@@ -745,7 +741,6 @@ CREATE TABLE hyper_ex_deferred (
     ) WHERE (not canceled) DEFERRABLE INITIALLY DEFERRED
 );
 SELECT * FROM create_hypertable('hyper_ex_deferred', 'time', chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |    table_name     | created 
 ---------------+-------------+-------------------+---------
             12 | public      | hyper_ex_deferred | t

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -143,7 +143,6 @@ SELECT * FROM trigger_test ORDER BY time;
 -- message.
 CREATE TABLE test(a INT NOT NULL, b TIMESTAMPTZ);
 SELECT create_hypertable('test', 'b');
-NOTICE:  adding not-null constraint to column "b"
  create_hypertable 
 -------------------
  (5,public,test,t)
@@ -724,7 +723,6 @@ SELECT * FROM table_with_layout_change ORDER BY time, value7;
 CREATE TABLE test_check(a INT, b TIMESTAMPTZ);
 ALTER TABLE test_check ADD CONSTRAINT c1 CHECK (a > 7);
 SELECT table_name FROM create_hypertable('test_check', 'b');
-NOTICE:  adding not-null constraint to column "b"
  table_name 
 ------------
  test_check

--- a/test/expected/copy_memory_usage.out
+++ b/test/expected/copy_memory_usage.out
@@ -8,7 +8,6 @@
 create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);
 -- Aim to about 100 partitions, the data is from 1995 to 2022.
 select create_hypertable('uk_price_paid', 'date', chunk_time_interval => interval '90 day');
-NOTICE:  adding not-null constraint to column "date"
      create_hypertable      
 ----------------------------
  (1,public,uk_price_paid,t)
@@ -62,7 +61,6 @@ select * from portal_memory_log where (
 -- Test plpgsql leaks
 CREATE TABLE test_ht(tm timestamptz, val float8);
 SELECT * FROM create_hypertable('test_ht', 'tm');
-NOTICE:  adding not-null constraint to column "tm"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              2 | public      | test_ht    | t

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -27,7 +27,6 @@
 --
 CREATE TABLE chunk_test(time integer, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test', 'time', 'tag', 2, chunk_time_interval => 3);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,chunk_test,t)
@@ -122,7 +121,6 @@ ORDER BY c.id, d.id;
 --test the edges of an open partition -- INT_64_MAX and INT_64_MIN.
 CREATE TABLE chunk_test_ends(time bigint, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test_ends', 'time', chunk_time_interval => 5);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (2,public,chunk_test_ends,t)
@@ -152,7 +150,6 @@ SELECT * FROM chunk_test_ends ORDER BY time asc, tag, temp;
 CREATE TABLE chunk_test2(time TIMESTAMPTZ, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test2', 'time', 'tag', 2, chunk_time_interval => 3);
 WARNING:  unexpected interval: smaller than one second
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (3,public,chunk_test2,t)
@@ -224,7 +221,6 @@ ERROR:  invalid interval: an explicit interval must be specified
 -- Issue https://github.com/timescale/timescaledb/issues/7406
 CREATE TABLE test_ht (time TIMESTAMPTZ, v1 INTEGER);
 SELECT create_hypertable('test_ht', by_range('time', INTERVAL '1 hour'));
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (4,t)

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -67,7 +67,6 @@ RESET ROLE;
 GRANT :ROLE_DEFAULT_PERM_USER TO :ROLE_DEFAULT_PERM_USER_2;
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 select * from create_hypertable('test_schema.test_table_no_not_null', 'time', 'device_id', 2, chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |       table_name       | created 
 ---------------+-------------+------------------------+---------
              1 | test_schema | test_table_no_not_null | t
@@ -90,7 +89,6 @@ RESET ROLE;
 GRANT CREATE ON SCHEMA chunk_schema TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2, chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'), associated_schema_name => 'chunk_schema');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              2 | test_schema | test_table | t
@@ -173,7 +171,6 @@ ERROR:  get_create_command only supports hypertables with up to 2 dimensions
 \set ON_ERROR_STOP 1
 --test adding one more open dimension
 select add_dimension('test_schema.test_table', 'id', chunk_time_interval => 1000);
-NOTICE:  adding not-null constraint to column "id"
           add_dimension          
 ---------------------------------
  (6,test_schema,test_table,id,t)
@@ -199,14 +196,12 @@ select * from _timescaledb_catalog.dimension;
 -- Test add_dimension: can use interval types for TIMESTAMPTZ columns
 CREATE TABLE dim_test_time(time TIMESTAMPTZ, time2 TIMESTAMPTZ, time3 BIGINT, temp float8, device int, location int);
 SELECT create_hypertable('dim_test_time', 'time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (3,public,dim_test_time,t)
 (1 row)
 
 SELECT add_dimension('dim_test_time', 'time2', chunk_time_interval => INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "time2"
           add_dimension           
 ----------------------------------
  (8,public,dim_test_time,time2,t)
@@ -221,7 +216,6 @@ SELECT add_dimension('dim_test_time', 'time3', chunk_time_interval => 'foo'::TEX
 ERROR:  invalid interval type for bigint dimension
 \set ON_ERROR_STOP 1
 SELECT add_dimension('dim_test_time', 'time3', chunk_time_interval => 500);
-NOTICE:  adding not-null constraint to column "time3"
           add_dimension           
 ----------------------------------
  (9,public,dim_test_time,time3,t)
@@ -230,7 +224,6 @@ NOTICE:  adding not-null constraint to column "time3"
 -- Test add_dimension: integrals should work on TIMESTAMPTZ columns
 CREATE TABLE dim_test_time2(time TIMESTAMPTZ, time2 TIMESTAMPTZ, temp float8, device int, location int);
 SELECT create_hypertable('dim_test_time2', 'time');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (4,public,dim_test_time2,t)
@@ -238,7 +231,6 @@ NOTICE:  adding not-null constraint to column "time"
 
 SELECT add_dimension('dim_test_time2', 'time2', chunk_time_interval => 500);
 WARNING:  unexpected interval: smaller than one second
-NOTICE:  adding not-null constraint to column "time2"
            add_dimension            
 ------------------------------------
  (11,public,dim_test_time2,time2,t)
@@ -270,7 +262,6 @@ ERROR:  cannot specify both the number of partitions and an interval
 -- test adding a new dimension on a non-empty table
 CREATE TABLE dim_test(time TIMESTAMPTZ, device int);
 SELECT create_hypertable('dim_test', 'time', chunk_time_interval => INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (5,public,dim_test,t)
@@ -360,7 +351,6 @@ DROP TABLE dim_test;
 -- test add_dimension() with existing data on table with space partitioning
 CREATE TABLE dim_test(time TIMESTAMPTZ, device int, data int);
 SELECT create_hypertable('dim_test', 'time', 'device', 2, chunk_time_interval => INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (6,public,dim_test,t)
@@ -441,7 +431,6 @@ NOTICE:  column "location" is already a dimension, skipping
 create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,test_schema,test_1dim,t)
@@ -508,7 +497,6 @@ CREATE TABLE test_schema.test_invalid_func(time timestamptz, temp float8, device
 SELECT create_hypertable('test_schema.test_invalid_func', 'time', 'device', 2, partitioning_func => 'invalid_partfunc');
 ERROR:  invalid partitioning function
 SELECT create_hypertable('test_schema.test_invalid_func', 'time');
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable          
 -------------------------------------
  (8,test_schema,test_invalid_func,t)
@@ -526,7 +514,6 @@ SELECT create_hypertable('test_schema.open_dim_part_func', 'time', time_partitio
 ERROR:  invalid partitioning function
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('test_schema.open_dim_part_func', 'time', time_partitioning_func => 'time_partfunc');
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
  (9,test_schema,open_dim_part_func,t)
@@ -538,7 +525,6 @@ SELECT add_dimension('test_schema.open_dim_part_func', 'event_time', chunk_time_
 ERROR:  invalid partitioning function
 \set ON_ERROR_STOP 1
 SELECT add_dimension('test_schema.open_dim_part_func', 'event_time', chunk_time_interval => interval '1 day', partitioning_func => 'time_partfunc');
-NOTICE:  adding not-null constraint to column "event_time"
                   add_dimension                   
 --------------------------------------------------
  (20,test_schema,open_dim_part_func,event_time,t)
@@ -562,7 +548,6 @@ ERROR:  table "test_migrate" is not empty
 \set ON_ERROR_STOP 1
 select create_hypertable('test_schema.test_migrate', 'time', migrate_data => true);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
         create_hypertable        
 ---------------------------------
@@ -613,7 +598,6 @@ select * from only _timescaledb_internal._hyper_10_10_chunk;
 create table test_schema.test_migrate_empty(time timestamp, temp float);
 select create_hypertable('test_schema.test_migrate_empty', 'time', migrate_data => true);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
  (11,test_schema,test_migrate_empty,t)
@@ -623,7 +607,6 @@ CREATE TYPE test_type AS (time timestamp, temp float);
 CREATE TABLE test_table_of_type OF test_type;
 SELECT create_hypertable('test_table_of_type', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (12,public,test_table_of_type,t)
@@ -639,7 +622,6 @@ NOTICE:  drop cascades to 3 other objects
 CREATE TABLE test_table_of_type (time timestamp, temp float);
 SELECT create_hypertable('test_table_of_type', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (13,public,test_table_of_type,t)
@@ -711,7 +693,6 @@ ERROR:  invalid partitioning function
 \set ON_ERROR_STOP 1
 -- Test that add_dimension fails due to invalid partitioning function
 select create_hypertable('test_schema.test_partfunc', 'time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (14,test_schema,test_partfunc,t)
@@ -737,7 +718,6 @@ select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func
 -- check get_create_command produces valid command
 CREATE TABLE test_schema.test_sql_cmd(time TIMESTAMPTZ, temp FLOAT8, device_id TEXT, device_type TEXT, location TEXT, id INT, id2 INT);
 SELECT create_hypertable('test_schema.test_sql_cmd','time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (15,test_schema,test_sql_cmd,t)
@@ -758,7 +738,6 @@ SELECT _timescaledb_functions.get_create_command('test_sql_cmd') AS create_cmd; 
 DROP TABLE test_schema.test_sql_cmd CASCADE;
 CREATE TABLE test_schema.test_sql_cmd(time TIMESTAMPTZ, temp FLOAT8, device_id TEXT, device_type TEXT, location TEXT, id INT, id2 INT);
 SELECT test.execute_sql(:'create_cmd');
-NOTICE:  adding not-null constraint to column "time"
                                                             execute_sql                                                            
 -----------------------------------------------------------------------------------------------------------------------------------
  SELECT create_hypertable('test_schema.test_sql_cmd', 'time', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
@@ -767,7 +746,6 @@ NOTICE:  adding not-null constraint to column "time"
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test_table_int(time bigint, junk int);
 SELECT hypertable_id AS "TEST_TABLE_INT_HYPERTABLE_ID" FROM create_hypertable('test_table_int', 'time', chunk_time_interval => 1) \gset
-NOTICE:  adding not-null constraint to column "time"
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE SCHEMA IF NOT EXISTS my_schema;
 create or replace function my_schema.dummy_now2() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 1::BIGINT';
@@ -1028,7 +1006,6 @@ create table tidrangescan_test (
   some_column bigint
 );
 select create_hypertable('tidrangescan_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (22,public,tidrangescan_test,t)

--- a/test/expected/create_table_with.out
+++ b/test/expected/create_table_with.out
@@ -60,9 +60,7 @@ HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_colu
 BEGIN;
 CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore=false,tsdb.hypertable,tsdb.partition_column='time');
 CREATE TABLE t4(time timestamp, device text, value float) WITH (tsdb.columnstore=false,tsdb.hypertable,timescaledb.partition_column='time');
-NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE t5(time date, device text, value float) WITH (tsdb.columnstore=false,tsdb.hypertable,tsdb.partition_column='time',autovacuum_enabled);
-NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE t6(time timestamptz NOT NULL, device text, value float) WITH (tsdb.columnstore=false,timescaledb.hypertable,tsdb.partition_column='time');
 SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
  hypertable_name 

--- a/test/expected/cursor.out
+++ b/test/expected/cursor.out
@@ -3,7 +3,6 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE cursor_test(time timestamptz, device_id int, temp float);
 SELECT create_hypertable('cursor_test','time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,cursor_test,t)

--- a/test/expected/custom_type.out
+++ b/test/expected/custom_type.out
@@ -65,7 +65,6 @@ SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval =
 ERROR:  invalid interval type for customtype dimension
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
-NOTICE:  adding not-null constraint to column "time_custom"
       create_hypertable       
 ------------------------------
  (1,public,customtype_test,t)

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -91,7 +91,6 @@ DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1
 CREATE TABLE my_ht (time BIGINT, val integer);
 SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_functions.interval_to_usec('1 month'));
-psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              3 | public      | my_ht      | t
@@ -387,7 +386,6 @@ CREATE TABLE alter_test(time timestamptz, temp float, color varchar(10));
 -- create hypertable with two chunks
 SELECT create_hypertable('alter_test', 'time', 'color', 2, chunk_time_interval => 2628000000000);
 WARNING:  column type "character varying" used for "color" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (9,public,alter_test,t)
@@ -512,7 +510,6 @@ ERROR:  ONLY option not supported on hypertable operations
 \set ON_ERROR_STOP 1
 CREATE TABLE alter_test_bigint(time bigint, temp float);
 SELECT create_hypertable('alter_test_bigint', 'time', chunk_time_interval => 2628000000000);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (10,public,alter_test_bigint,t)
@@ -554,7 +551,6 @@ CREATE TABLE part_custom_dim (time TIMESTAMPTZ, combo TUPLE, device TEXT);
 -- has no default hash function
 -- on PG14 custom types are hashable
 SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (12,public,part_custom_dim,t)

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -4,7 +4,6 @@
 CREATE TABLE drop_test(time timestamp, temp float8, device text);
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (1,public,drop_test,t)

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -14,7 +14,6 @@ SELECT * from _timescaledb_catalog.dimension;
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,should_drop,t)
@@ -23,7 +22,6 @@ NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE hyper_with_dependencies (time timestamp, temp float8);
 SELECT create_hypertable('hyper_with_dependencies', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
  (2,public,hyper_with_dependencies,t)
@@ -46,7 +44,6 @@ NOTICE:  drop cascades to view dependent_view
 CREATE TABLE chunk_with_dependencies (time timestamp, temp float8);
 SELECT create_hypertable('chunk_with_dependencies', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
  (3,public,chunk_with_dependencies,t)
@@ -91,7 +88,6 @@ DROP TABLE should_drop;
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (4,public,should_drop,t)

--- a/test/expected/drop_owned-15.out
+++ b/test/expected/drop_owned-15.out
@@ -7,7 +7,6 @@ GRANT ALL ON SCHEMA hypertable_schema TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE hypertable_schema.default_perm_user (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.default_perm_user', 'time', 'location', 2);
-NOTICE:  adding not-null constraint to column "time"
              create_hypertable             
 -------------------------------------------
  (1,hypertable_schema,default_perm_user,t)
@@ -17,7 +16,6 @@ INSERT INTO hypertable_schema.default_perm_user VALUES ('2001-01-01 01:01:01', 2
 RESET ROLE;
 CREATE TABLE hypertable_schema.superuser (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (2,hypertable_schema,superuser,t)

--- a/test/expected/drop_owned-16.out
+++ b/test/expected/drop_owned-16.out
@@ -7,7 +7,6 @@ GRANT ALL ON SCHEMA hypertable_schema TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE hypertable_schema.default_perm_user (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.default_perm_user', 'time', 'location', 2);
-NOTICE:  adding not-null constraint to column "time"
              create_hypertable             
 -------------------------------------------
  (1,hypertable_schema,default_perm_user,t)
@@ -17,7 +16,6 @@ INSERT INTO hypertable_schema.default_perm_user VALUES ('2001-01-01 01:01:01', 2
 RESET ROLE;
 CREATE TABLE hypertable_schema.superuser (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (2,hypertable_schema,superuser,t)

--- a/test/expected/drop_owned-17.out
+++ b/test/expected/drop_owned-17.out
@@ -7,7 +7,6 @@ GRANT ALL ON SCHEMA hypertable_schema TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE hypertable_schema.default_perm_user (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.default_perm_user', 'time', 'location', 2);
-NOTICE:  adding not-null constraint to column "time"
              create_hypertable             
 -------------------------------------------
  (1,hypertable_schema,default_perm_user,t)
@@ -17,7 +16,6 @@ INSERT INTO hypertable_schema.default_perm_user VALUES ('2001-01-01 01:01:01', 2
 RESET ROLE;
 CREATE TABLE hypertable_schema.superuser (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (2,hypertable_schema,superuser,t)

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -14,14 +14,12 @@ CREATE TABLE hypertable_schema.test1 (time timestamptz, temp float, location int
 CREATE TABLE hypertable_schema.test2 (time timestamptz, temp float, location int);
 --create two identical tables with their own chunk schemas
 SELECT create_hypertable('hypertable_schema.test1', 'time', 'location', 2, associated_schema_name => 'chunk_schema1');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (1,hypertable_schema,test1,t)
 (1 row)
 
 SELECT create_hypertable('hypertable_schema.test2', 'time', 'location', 2, associated_schema_name => 'chunk_schema2');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (2,hypertable_schema,test2,t)

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -3,7 +3,6 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE index_test(time timestamptz, temp float);
 SELECT create_hypertable('index_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,index_test,t)
@@ -24,12 +23,10 @@ CREATE UNIQUE INDEX index_test_time_idx ON index_test (time);
 -- Creating a hypertable from a table with an index that doesn't cover
 -- all partitioning columns should fail
 SELECT create_hypertable('index_test', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "device" (used in partitioning)
 \set ON_ERROR_STOP 1
 -- Partitioning on only time should work
 SELECT create_hypertable('index_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (3,public,index_test,t)
@@ -110,7 +107,6 @@ SELECT * FROM test.show_columns('index_test');
 
 -- No pre-existing UNIQUE index, so partitioning on two columns should work
 SELECT create_hypertable('index_test', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (4,public,index_test,t)
@@ -372,7 +368,6 @@ SELECT * FROM _timescaledb_catalog.chunk_index ORDER BY index_name, hypertable_i
 CREATE TABLE index_test(time timestamptz, temp float, device int) TABLESPACE tablespace1;
 -- Default indexes should be in the table's tablespace
 SELECT create_hypertable('index_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (5,public,index_test,t)
@@ -456,7 +451,6 @@ SELECT * FROM index_expr_test WHERE meta ->> 'field' = 'value1';
 CREATE TABLE index_test(time timestamptz, temp float);
 CREATE UNIQUE INDEX index_test_idx ON index_test (time, temp);
 SELECT create_hypertable('index_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (6,public,index_test,t)
@@ -471,7 +465,6 @@ ERROR:  cannot drop a hypertable index along with other objects
 -- test expression index with dropped columns
 CREATE TABLE idx_expr_test(filler int, time timestamptz, meta text);
 SELECT table_name FROM create_hypertable('idx_expr_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------
  idx_expr_test
@@ -484,7 +477,6 @@ DROP TABLE idx_expr_test CASCADE;
 -- test multicolumn expression index with dropped columns
 CREATE TABLE idx_expr_test(filler int, time timestamptz, t1 text, t2 text, t3 text);
 SELECT table_name FROM create_hypertable('idx_expr_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------
  idx_expr_test
@@ -497,7 +489,6 @@ DROP TABLE idx_expr_test CASCADE;
 -- test index with predicate and dropped columns
 CREATE TABLE idx_predicate_test(filler int, time timestamptz);
 SELECT table_name FROM create_hypertable('idx_predicate_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
      table_name     
 --------------------
  idx_predicate_test
@@ -511,7 +502,6 @@ DROP TABLE idx_predicate_test;
 -- test index with table references
 CREATE TABLE idx_tableref_test(time timestamptz);
 SELECT table_name FROM create_hypertable('idx_tableref_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
     table_name     
 -------------------
  idx_tableref_test
@@ -645,7 +635,6 @@ SELECT * FROM reindex_norm;
 
 CREATE TABLE ht_dropped(time timestamptz, d0 int, d1 int, c0 int, c1 int, c2 int);
 SELECT create_hypertable('ht_dropped','time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (13,public,ht_dropped,t)
@@ -694,7 +683,6 @@ INSERT INTO i3056(order_number,date_created) VALUES (1, '2000-01-01');
 -- #5908 test CREATE INDEX ON ONLY main table
 CREATE TABLE test(time timestamptz, temp float);
 SELECT create_hypertable('test', 'time');
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (15,public,test,t)

--- a/test/expected/information_views.out
+++ b/test/expected/information_views.out
@@ -171,7 +171,6 @@ primary_dimension_type | timestamp with time zone
 ---Add integer table --
 CREATE TABLE test_table_int(time bigint, junk int);
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (5,public,test_table_int,t)

--- a/test/expected/insert-15.out
+++ b/test/expected/insert-15.out
@@ -191,7 +191,6 @@ SELECT * FROM ONLY "two_Partitions";
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (2,public,error_test,t)
@@ -242,7 +241,6 @@ SELECT * FROM tick_character;
 
 CREATE TABLE  date_col_test(time date, temp float8, device text NOT NULL);
 SELECT create_hypertable('date_col_test', 'time', 'device', 1000, chunk_time_interval => INTERVAL '1 Day');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (4,public,date_col_test,t)
@@ -264,7 +262,6 @@ SELECT * FROM date_col_test WHERE time > '2001-01-01';
 set timescaledb.max_open_chunks_per_insert=1;
 CREATE TABLE chunk_assert_fail(i bigint, j bigint);
 SELECT create_hypertable('chunk_assert_fail', 'i', 'j', 1000, chunk_time_interval=>1);
-NOTICE:  adding not-null constraint to column "i"
        create_hypertable        
 --------------------------------
  (5,public,chunk_assert_fail,t)
@@ -282,7 +279,6 @@ select * from chunk_assert_fail;
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (6,public,one_space_test,t)
@@ -429,7 +425,6 @@ INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity'
 CREATE TABLE timestamp_inf(time TIMESTAMP);
 SELECT create_hypertable('timestamp_inf', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (7,public,timestamp_inf,t)
@@ -492,7 +487,6 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
 
 CREATE TABLE date_inf(time DATE);
 SELECT create_hypertable('date_inf', 'time');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (8,public,date_inf,t)

--- a/test/expected/insert-16.out
+++ b/test/expected/insert-16.out
@@ -191,7 +191,6 @@ SELECT * FROM ONLY "two_Partitions";
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (2,public,error_test,t)
@@ -242,7 +241,6 @@ SELECT * FROM tick_character;
 
 CREATE TABLE  date_col_test(time date, temp float8, device text NOT NULL);
 SELECT create_hypertable('date_col_test', 'time', 'device', 1000, chunk_time_interval => INTERVAL '1 Day');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (4,public,date_col_test,t)
@@ -264,7 +262,6 @@ SELECT * FROM date_col_test WHERE time > '2001-01-01';
 set timescaledb.max_open_chunks_per_insert=1;
 CREATE TABLE chunk_assert_fail(i bigint, j bigint);
 SELECT create_hypertable('chunk_assert_fail', 'i', 'j', 1000, chunk_time_interval=>1);
-NOTICE:  adding not-null constraint to column "i"
        create_hypertable        
 --------------------------------
  (5,public,chunk_assert_fail,t)
@@ -282,7 +279,6 @@ select * from chunk_assert_fail;
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (6,public,one_space_test,t)
@@ -429,7 +425,6 @@ INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity'
 CREATE TABLE timestamp_inf(time TIMESTAMP);
 SELECT create_hypertable('timestamp_inf', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (7,public,timestamp_inf,t)
@@ -492,7 +487,6 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
 
 CREATE TABLE date_inf(time DATE);
 SELECT create_hypertable('date_inf', 'time');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (8,public,date_inf,t)

--- a/test/expected/insert-17.out
+++ b/test/expected/insert-17.out
@@ -191,7 +191,6 @@ SELECT * FROM ONLY "two_Partitions";
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (2,public,error_test,t)
@@ -242,7 +241,6 @@ SELECT * FROM tick_character;
 
 CREATE TABLE  date_col_test(time date, temp float8, device text NOT NULL);
 SELECT create_hypertable('date_col_test', 'time', 'device', 1000, chunk_time_interval => INTERVAL '1 Day');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (4,public,date_col_test,t)
@@ -264,7 +262,6 @@ SELECT * FROM date_col_test WHERE time > '2001-01-01';
 set timescaledb.max_open_chunks_per_insert=1;
 CREATE TABLE chunk_assert_fail(i bigint, j bigint);
 SELECT create_hypertable('chunk_assert_fail', 'i', 'j', 1000, chunk_time_interval=>1);
-NOTICE:  adding not-null constraint to column "i"
        create_hypertable        
 --------------------------------
  (5,public,chunk_assert_fail,t)
@@ -282,7 +279,6 @@ select * from chunk_assert_fail;
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (6,public,one_space_test,t)
@@ -429,7 +425,6 @@ INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity'
 CREATE TABLE timestamp_inf(time TIMESTAMP);
 SELECT create_hypertable('timestamp_inf', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (7,public,timestamp_inf,t)
@@ -492,7 +487,6 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
 
 CREATE TABLE date_inf(time DATE);
 SELECT create_hypertable('date_inf', 'time');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (8,public,date_inf,t)

--- a/test/expected/insert_many.out
+++ b/test/expected/insert_many.out
@@ -4,7 +4,6 @@
 CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (1,public,many_partitions_test,t)
@@ -33,7 +32,6 @@ SELECT count(*) FROM  many_partitions_test;
 CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
  (2,public,many_partitions_test_1m,t)

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -211,7 +211,6 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 INSERT INTO "1dim_usec_interval" VALUES('1969-12-01T19:00:00', 21.2);
 CREATE TABLE "1dim_neg"(time INTEGER, temp float);
 SELECT create_hypertable('"1dim_neg"', 'time', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (6,public,1dim_neg,t)
@@ -287,7 +286,6 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
 CREATE TABLE "3dim" (time timestamp, temp float, device text, location text);
 SELECT create_hypertable('"3dim"', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (7,public,3dim,t)
@@ -416,7 +414,6 @@ SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>3276
 --make sure date inserts work even when the timezone changes the
 CREATE TABLE hyper_date(time date, temp float);
 SELECT create_hypertable('"hyper_date"', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (10,public,hyper_date,t)

--- a/test/expected/lateral.out
+++ b/test/expected/lateral.out
@@ -102,7 +102,6 @@ DROP TABLE orders;
 CREATE TABLE t1_timescale (a int, b int);
 CREATE TABLE t2 (a int, b int);
 SELECT create_hypertable('t1_timescale', 'a', chunk_time_interval=>1000);
-NOTICE:  adding not-null constraint to column "a"
      create_hypertable     
 ---------------------------
  (3,public,t1_timescale,t)

--- a/test/expected/multi_transaction_index.out
+++ b/test/expected/multi_transaction_index.out
@@ -24,7 +24,6 @@ SELECT * FROM test.show_columns('index_test');
 
 -- No pre-existing UNIQUE index, so partitioning on two columns should work
 SELECT create_hypertable('index_test', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,index_test,t)
@@ -257,7 +256,6 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
 -- Test that indexes are planned correctly
 CREATE TABLE index_expr_test(id serial, time timestamptz, temp float, meta int);
 select create_hypertable('index_expr_test', 'time');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (2,public,index_expr_test,t)
@@ -297,7 +295,6 @@ ROLLBACK;
 DROP TABLE index_expr_test CASCADE;
 CREATE TABLE partial_index_test(time INTEGER);
 SELECT create_hypertable('partial_index_test', 'time', chunk_time_interval => 1, create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (3,public,partial_index_test,t)

--- a/test/expected/null_exclusion-15.out
+++ b/test/expected/null_exclusion-15.out
@@ -4,7 +4,6 @@
 create table metrics(ts timestamp, id int, value float);
 select create_hypertable('metrics', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (1,public,metrics,t)

--- a/test/expected/null_exclusion-16.out
+++ b/test/expected/null_exclusion-16.out
@@ -4,7 +4,6 @@
 create table metrics(ts timestamp, id int, value float);
 select create_hypertable('metrics', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (1,public,metrics,t)

--- a/test/expected/null_exclusion-17.out
+++ b/test/expected/null_exclusion-17.out
@@ -4,7 +4,6 @@
 create table metrics(ts timestamp, id int, value float);
 select create_hypertable('metrics', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (1,public,metrics,t)

--- a/test/expected/parallel-15.out
+++ b/test/expected/parallel-15.out
@@ -10,7 +10,6 @@
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "i"
  create_hypertable 
 -------------------
  (1,public,test,t)

--- a/test/expected/parallel-16.out
+++ b/test/expected/parallel-16.out
@@ -10,7 +10,6 @@
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "i"
  create_hypertable 
 -------------------
  (1,public,test,t)

--- a/test/expected/parallel-17.out
+++ b/test/expected/parallel-17.out
@@ -10,7 +10,6 @@
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "i"
  create_hypertable 
 -------------------
  (1,public,test,t)

--- a/test/expected/partition.out
+++ b/test/expected/partition.out
@@ -3,7 +3,6 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE part_legacy(time timestamptz, temp float, device int);
 SELECT create_hypertable('part_legacy', 'time', 'device', 2, partitioning_func => '_timescaledb_functions.get_partition_for_key');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,part_legacy,t)
@@ -47,7 +46,6 @@ SELECT * FROM part_legacy WHERE device = 1;
 COMMIT;
 CREATE TABLE part_new(time timestamptz, temp float, device int);
 SELECT create_hypertable('part_new', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (2,public,part_new,t)
@@ -92,7 +90,6 @@ SELECT * FROM part_new WHERE device = 1;
 COMMIT;
 CREATE TABLE part_new_convert1(time timestamptz, temp float8, device int);
 SELECT create_hypertable('part_new_convert1', 'time', 'temp', 2);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (3,public,part_new_convert1,t)
@@ -116,7 +113,6 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_3_%_chunk');
 
 CREATE TABLE part_add_dim(time timestamptz, temp float8, device int, location int);
 SELECT create_hypertable('part_add_dim', 'time', 'temp', 2);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (4,public,part_add_dim,t)
@@ -162,7 +158,6 @@ END
 $BODY$;
 CREATE TABLE part_custom_func(time timestamptz, temp float8, device text);
 SELECT create_hypertable('part_custom_func', 'time', 'device', 2, partitioning_func => 'custom_partfunc');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (5,public,part_custom_func,t)
@@ -212,7 +207,6 @@ SELECT create_hypertable(
     1000,
     chunk_time_interval => interval '1 day',
     partitioning_func=>'simpl_type_hash');
-NOTICE:  adding not-null constraint to column "timestamp"
       create_hypertable       
 ------------------------------
  (6,public,simpl_partition,t)
@@ -252,13 +246,10 @@ CREATE TABLE hyper_with_index(time timestamptz, temp float, device int);
 CREATE UNIQUE INDEX temp_index ON hyper_with_index(temp);
 \set ON_ERROR_STOP 0
 SELECT create_hypertable('hyper_with_index', 'time');
-NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 SELECT create_hypertable('hyper_with_index', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 SELECT create_hypertable('hyper_with_index', 'time', 'temp', 2);
-NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 \set ON_ERROR_STOP 1
 DROP INDEX temp_index;
@@ -266,11 +257,9 @@ CREATE UNIQUE INDEX time_index ON hyper_with_index(time);
 \set ON_ERROR_STOP 0
 -- should error because device not in index
 SELECT create_hypertable('hyper_with_index', 'time', 'device', 4);
-NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "device" (used in partitioning)
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('hyper_with_index', 'time');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (11,public,hyper_with_index,t)
@@ -326,7 +315,6 @@ END
 $BODY$;
 CREATE TABLE part_custom_dim (time TIMESTAMPTZ, combo TUPLE, device TEXT);
 SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4, partitioning_func=>'tuple_hash');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (14,public,part_custom_dim,t)
@@ -349,7 +337,6 @@ END
 $BODY$;
 CREATE TABLE part_custom_dim (time TIMESTAMPTZ, combo TUPLE, device TEXT);
 SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4, partitioning_func=>'my_partitioning_schema.tuple_hash');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (15,public,part_custom_dim,t)
@@ -399,7 +386,6 @@ ERROR:  invalid partitioning function
 \set ON_ERROR_STOP 1
 -- Should work with time partitioning function that returns a valid time type
 SELECT create_hypertable('part_time_func', 'time', time_partitioning_func => 'time_partfunc');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (16,public,part_time_func,t)
@@ -501,7 +487,6 @@ END
 $BODY$;
 CREATE TABLE part_time_func_null_ret(time float8, temp float8, device text);
 SELECT create_hypertable('part_time_func_null_ret', 'time', time_partitioning_func => 'time_partfunc_null_ret');
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
  (17,public,part_time_func_null_ret,t)

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -12,7 +12,6 @@ ERROR:  table "partitioned_ht_create" is already partitioned
 CREATE TABLE partitioned_attachment_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
 CREATE TABLE attachment_hypertable(time timestamptz, temp float, device int);
 SELECT create_hypertable('attachment_hypertable', 'time');
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
  (1,public,attachment_hypertable,t)

--- a/test/expected/partitionwise-15.out
+++ b/test/expected/partitionwise-15.out
@@ -5,7 +5,6 @@
 -- Create a two dimensional hypertable
 CREATE TABLE hyper (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('hyper', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | hyper      | t
@@ -525,7 +524,6 @@ ORDER BY 1, 2;
 -- anything
 CREATE TABLE hyper_meta (time timestamptz, device int, info text);
 SELECT * FROM create_hypertable('hyper_meta', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              2 | public      | hyper_meta | t
@@ -679,7 +677,6 @@ END
 $BODY$;
 CREATE TABLE hyper_timepart (time float8, device int, temp float);
 SELECT * FROM create_hypertable('hyper_timepart', 'time', 'device', 2, time_partitioning_func => 'time_func');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name   | created 
 ---------------+-------------+----------------+---------
              3 | public      | hyper_timepart | t

--- a/test/expected/partitionwise-16.out
+++ b/test/expected/partitionwise-16.out
@@ -5,7 +5,6 @@
 -- Create a two dimensional hypertable
 CREATE TABLE hyper (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('hyper', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | hyper      | t
@@ -525,7 +524,6 @@ ORDER BY 1, 2;
 -- anything
 CREATE TABLE hyper_meta (time timestamptz, device int, info text);
 SELECT * FROM create_hypertable('hyper_meta', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              2 | public      | hyper_meta | t
@@ -679,7 +677,6 @@ END
 $BODY$;
 CREATE TABLE hyper_timepart (time float8, device int, temp float);
 SELECT * FROM create_hypertable('hyper_timepart', 'time', 'device', 2, time_partitioning_func => 'time_func');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name   | created 
 ---------------+-------------+----------------+---------
              3 | public      | hyper_timepart | t

--- a/test/expected/partitionwise-17.out
+++ b/test/expected/partitionwise-17.out
@@ -5,7 +5,6 @@
 -- Create a two dimensional hypertable
 CREATE TABLE hyper (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('hyper', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | hyper      | t
@@ -525,7 +524,6 @@ ORDER BY 1, 2;
 -- anything
 CREATE TABLE hyper_meta (time timestamptz, device int, info text);
 SELECT * FROM create_hypertable('hyper_meta', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              2 | public      | hyper_meta | t
@@ -679,7 +677,6 @@ END
 $BODY$;
 CREATE TABLE hyper_timepart (time float8, device int, temp float);
 SELECT * FROM create_hypertable('hyper_timepart', 'time', 'device', 2, time_partitioning_func => 'time_func');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name   | created 
 ---------------+-------------+----------------+---------
              3 | public      | hyper_timepart | t

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -12,7 +12,6 @@ ALTER TABLE hyper
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper', 'time',  chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:12: NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (1,public,hyper,t)
@@ -27,7 +26,6 @@ ALTER TABLE hyper_w_space
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 4, chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:26: NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,hyper_w_space,t)
@@ -42,7 +40,6 @@ ALTER TABLE hyper_ts
 DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
-psql:include/plan_expand_hypertable_load.sql:41: NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (3,public,hyper_ts,t)
@@ -70,7 +67,6 @@ INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM
 CREATE TABLE metrics_timestamp(time timestamp);
 SELECT create_hypertable('metrics_timestamp','time');
 psql:include/plan_expand_hypertable_load.sql:62: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (5,public,metrics_timestamp,t)
@@ -79,7 +75,6 @@ psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constr
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
 CREATE TABLE metrics_timestamptz(time timestamptz, device_id int);
 SELECT create_hypertable('metrics_timestamptz','time');
-psql:include/plan_expand_hypertable_load.sql:66: NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,metrics_timestamptz,t)
@@ -101,7 +96,6 @@ SELECT * FROM metrics_timestamptz;
 INSERT INTO metrics_timestamptz_2 VALUES ('2000-12-01'::timestamptz, 3);
 CREATE TABLE metrics_date(time date);
 SELECT create_hypertable('metrics_date','time');
-psql:include/plan_expand_hypertable_load.sql:79: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (8,public,metrics_date,t)

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -12,7 +12,6 @@ ALTER TABLE hyper
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper', 'time',  chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:12: NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (1,public,hyper,t)
@@ -27,7 +26,6 @@ ALTER TABLE hyper_w_space
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 4, chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:26: NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,hyper_w_space,t)
@@ -42,7 +40,6 @@ ALTER TABLE hyper_ts
 DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
-psql:include/plan_expand_hypertable_load.sql:41: NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (3,public,hyper_ts,t)
@@ -70,7 +67,6 @@ INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM
 CREATE TABLE metrics_timestamp(time timestamp);
 SELECT create_hypertable('metrics_timestamp','time');
 psql:include/plan_expand_hypertable_load.sql:62: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (5,public,metrics_timestamp,t)
@@ -79,7 +75,6 @@ psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constr
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
 CREATE TABLE metrics_timestamptz(time timestamptz, device_id int);
 SELECT create_hypertable('metrics_timestamptz','time');
-psql:include/plan_expand_hypertable_load.sql:66: NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,metrics_timestamptz,t)
@@ -101,7 +96,6 @@ SELECT * FROM metrics_timestamptz;
 INSERT INTO metrics_timestamptz_2 VALUES ('2000-12-01'::timestamptz, 3);
 CREATE TABLE metrics_date(time date);
 SELECT create_hypertable('metrics_date','time');
-psql:include/plan_expand_hypertable_load.sql:79: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (8,public,metrics_date,t)

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -12,7 +12,6 @@ ALTER TABLE hyper
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper', 'time',  chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:12: NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (1,public,hyper,t)
@@ -27,7 +26,6 @@ ALTER TABLE hyper_w_space
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 4, chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:26: NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,hyper_w_space,t)
@@ -42,7 +40,6 @@ ALTER TABLE hyper_ts
 DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
-psql:include/plan_expand_hypertable_load.sql:41: NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (3,public,hyper_ts,t)
@@ -70,7 +67,6 @@ INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM
 CREATE TABLE metrics_timestamp(time timestamp);
 SELECT create_hypertable('metrics_timestamp','time');
 psql:include/plan_expand_hypertable_load.sql:62: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (5,public,metrics_timestamp,t)
@@ -79,7 +75,6 @@ psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constr
 INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
 CREATE TABLE metrics_timestamptz(time timestamptz, device_id int);
 SELECT create_hypertable('metrics_timestamptz','time');
-psql:include/plan_expand_hypertable_load.sql:66: NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,metrics_timestamptz,t)
@@ -101,7 +96,6 @@ SELECT * FROM metrics_timestamptz;
 INSERT INTO metrics_timestamptz_2 VALUES ('2000-12-01'::timestamptz, 3);
 CREATE TABLE metrics_date(time date);
 SELECT create_hypertable('metrics_date','time');
-psql:include/plan_expand_hypertable_load.sql:79: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (8,public,metrics_date,t)

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -17,21 +17,18 @@ CREATE TABLE test_tz(time timestamptz, temp float8, device text);
 CREATE TABLE test_dt(time date, temp float8, device text);
 SELECT "testSchema0".create_hypertable('test_ts', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (1,public,test_ts,t)
 (1 row)
 
 SELECT "testSchema0".create_hypertable('test_tz', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (2,public,test_tz,t)
 (1 row)
 
 SELECT "testSchema0".create_hypertable('test_dt', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (3,public,test_dt,t)

--- a/test/expected/reloptions.out
+++ b/test/expected/reloptions.out
@@ -4,7 +4,6 @@
 CREATE TABLE reloptions_test(time integer, temp float8, color integer)
 WITH (fillfactor=75, autovacuum_vacuum_threshold=100);
 SELECT create_hypertable('reloptions_test', 'time', chunk_time_interval => 3);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (1,public,reloptions_test,t)

--- a/test/expected/rowsecurity-15.out
+++ b/test/expected/rowsecurity-15.out
@@ -996,8 +996,6 @@ CREATE TABLE hyper_document (
 );
 GRANT ALL ON hyper_document TO public;
 SELECT public.create_hypertable('hyper_document', 'did', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "did"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (2,regress_rls_schema,hyper_document,t)
@@ -1489,8 +1487,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security TO ON;
 CREATE TABLE dependee (x integer, y integer);
 SELECT public.create_hypertable('dependee', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (3,regress_rls_schema,dependee,t)
@@ -1498,8 +1494,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE dependent (x integer, y integer);
 SELECT public.create_hypertable('dependent', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable          
 ------------------------------------
  (4,regress_rls_schema,dependent,t)
@@ -1527,8 +1521,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualifie
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE rec1 (x integer, y integer);
 SELECT public.create_hypertable('rec1', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable       
 -------------------------------
  (5,regress_rls_schema,rec1,t)
@@ -1586,8 +1578,6 @@ ERROR:  infinite recursion detected in policy for relation "rec1"
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE s1 (a int, b text);
 SELECT public.create_hypertable('s1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (6,regress_rls_schema,s1,t)
@@ -1596,8 +1586,6 @@ DETAIL:  Dimensions cannot have NULL values.
 INSERT INTO s1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
 CREATE TABLE s2 (x int, y text);
 SELECT public.create_hypertable('s2', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (7,regress_rls_schema,s2,t)
@@ -2203,8 +2191,6 @@ NOTICE:  f_leak => yyyyyy
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE b1 (a int, b text);
 SELECT public.create_hypertable('b1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (8,regress_rls_schema,b1,t)
@@ -2463,8 +2449,6 @@ ERROR:  new row violates row-level security policy for table "document"
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE z1 (a int, b text);
 SELECT public.create_hypertable('z1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (9,regress_rls_schema,z1,t)
@@ -2472,8 +2456,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE z2 (a int, b text);
 SELECT public.create_hypertable('z2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (10,regress_rls_schema,z2,t)
@@ -3173,8 +3155,6 @@ DROP VIEW rls_view;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE x1 (a int, b text, c text);
 SELECT public.create_hypertable('x1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (11,regress_rls_schema,x1,t)
@@ -3289,8 +3269,6 @@ NOTICE:  f_leak => fgh_updt_updt
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE y1 (a int, b text);
 SELECT public.create_hypertable('y1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (12,regress_rls_schema,y1,t)
@@ -3299,8 +3277,6 @@ DETAIL:  Dimensions cannot have NULL values.
 INSERT INTO y1 VALUES(1,2);
 CREATE TABLE y2 (a int, b text);
 SELECT public.create_hypertable('y2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (13,regress_rls_schema,y2,t)
@@ -3608,8 +3584,6 @@ NOTICE:  drop cascades to 2 other objects
 \set VERBOSITY default
 CREATE TABLE t1 (a integer);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (14,regress_rls_schema,t1,t)
@@ -3657,8 +3631,6 @@ RESET SESSION AUTHORIZATION;
 DROP TABLE t1 CASCADE;
 CREATE TABLE t1 (a integer, b text);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (15,regress_rls_schema,t1,t)
@@ -3786,8 +3758,6 @@ SELECT polname, relname
 SET SESSION AUTHORIZATION regress_rls_bob;
 CREATE TABLE t2 (a integer, b text);
 SELECT public.create_hypertable('t2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (16,regress_rls_schema,t2,t)
@@ -3906,8 +3876,6 @@ SELECT * FROM t4;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE blog (id integer, author text, post text);
 SELECT public.create_hypertable('blog', 'id', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "id"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (17,regress_rls_schema,blog,t)
@@ -3915,8 +3883,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE comment (blog_id integer, message text);
 SELECT public.create_hypertable('comment', 'blog_id', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "blog_id"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (18,regress_rls_schema,comment,t)
@@ -4111,8 +4077,6 @@ DROP TABLE copy_t CASCADE;
 ERROR:  table "copy_t" does not exist
 CREATE TABLE copy_t (a integer, b text);
 SELECT public.create_hypertable('copy_t', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
         create_hypertable         
 ----------------------------------
  (19,regress_rls_schema,copy_t,t)
@@ -4204,8 +4168,6 @@ RESET SESSION AUTHORIZATION;
 SET row_security TO ON;
 CREATE TABLE copy_rel_to (a integer, b text);
 SELECT public.create_hypertable('copy_rel_to', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
            create_hypertable           
 ---------------------------------------
  (20,regress_rls_schema,copy_rel_to,t)
@@ -4280,8 +4242,6 @@ DROP TABLE copy_rel_to CASCADE;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE current_check (currentid int, payload text, rlsuser text);
 SELECT public.create_hypertable('current_check', 'currentid', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "currentid"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (21,regress_rls_schema,current_check,t)
@@ -4516,8 +4476,6 @@ ROLLBACK; -- cleanup
 BEGIN;
 CREATE TABLE t (c int);
 SELECT public.create_hypertable('t', 'c', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (22,regress_rls_schema,t,t)
@@ -4555,8 +4513,6 @@ ROLLBACK;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (23,regress_rls_schema,r1,t)
@@ -4564,8 +4520,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE r2 (a int);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (24,regress_rls_schema,r2,t)
@@ -4646,8 +4600,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (25,regress_rls_schema,r1,t)
@@ -4701,8 +4653,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (26,regress_rls_schema,r2,t)
@@ -4745,8 +4695,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1 ON DELETE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (27,regress_rls_schema,r2,t)
@@ -4778,8 +4726,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1 ON UPDATE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (28,regress_rls_schema,r2,t)
@@ -4819,8 +4765,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
@@ -4908,8 +4852,6 @@ DROP TABLE r1;
 RESET SESSION AUTHORIZATION;
 CREATE TABLE dep1 (c1 int);
 SELECT public.create_hypertable('dep1', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (31,regress_rls_schema,dep1,t)
@@ -4917,8 +4859,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE dep2 (c1 int);
 SELECT public.create_hypertable('dep2', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (32,regress_rls_schema,dep2,t)
@@ -4969,8 +4909,6 @@ CREATE ROLE regress_rls_dob_role1;
 CREATE ROLE regress_rls_dob_role2;
 CREATE TABLE dob_t1 (c1 int);
 SELECT public.create_hypertable('dob_t1', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
         create_hypertable         
 ----------------------------------
  (33,regress_rls_schema,dob_t1,t)
@@ -5009,8 +4947,6 @@ DROP ROLE regress_rls_group2;
 CREATE SCHEMA regress_rls_schema;
 CREATE TABLE rls_tbl (c1 int);
 SELECT public.create_hypertable('rls_tbl', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (34,regress_rls_schema,rls_tbl,t)
@@ -5023,8 +4959,6 @@ CREATE POLICY p3 ON rls_tbl FOR UPDATE USING (c1 <= 3) WITH CHECK (c1 > 5);
 CREATE POLICY p4 ON rls_tbl FOR DELETE USING (c1 <= 3);
 CREATE TABLE rls_tbl_force (c1 int);
 SELECT public.create_hypertable('rls_tbl_force', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (35,regress_rls_schema,rls_tbl_force,t)

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -996,8 +996,6 @@ CREATE TABLE hyper_document (
 );
 GRANT ALL ON hyper_document TO public;
 SELECT public.create_hypertable('hyper_document', 'did', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "did"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (2,regress_rls_schema,hyper_document,t)
@@ -1489,8 +1487,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security TO ON;
 CREATE TABLE dependee (x integer, y integer);
 SELECT public.create_hypertable('dependee', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (3,regress_rls_schema,dependee,t)
@@ -1498,8 +1494,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE dependent (x integer, y integer);
 SELECT public.create_hypertable('dependent', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable          
 ------------------------------------
  (4,regress_rls_schema,dependent,t)
@@ -1527,8 +1521,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualifie
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE rec1 (x integer, y integer);
 SELECT public.create_hypertable('rec1', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable       
 -------------------------------
  (5,regress_rls_schema,rec1,t)
@@ -1586,8 +1578,6 @@ ERROR:  infinite recursion detected in policy for relation "rec1"
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE s1 (a int, b text);
 SELECT public.create_hypertable('s1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (6,regress_rls_schema,s1,t)
@@ -1596,8 +1586,6 @@ DETAIL:  Dimensions cannot have NULL values.
 INSERT INTO s1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
 CREATE TABLE s2 (x int, y text);
 SELECT public.create_hypertable('s2', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (7,regress_rls_schema,s2,t)
@@ -2203,8 +2191,6 @@ NOTICE:  f_leak => yyyyyy
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE b1 (a int, b text);
 SELECT public.create_hypertable('b1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (8,regress_rls_schema,b1,t)
@@ -2463,8 +2449,6 @@ ERROR:  new row violates row-level security policy for table "document"
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE z1 (a int, b text);
 SELECT public.create_hypertable('z1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (9,regress_rls_schema,z1,t)
@@ -2472,8 +2456,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE z2 (a int, b text);
 SELECT public.create_hypertable('z2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (10,regress_rls_schema,z2,t)
@@ -3173,8 +3155,6 @@ DROP VIEW rls_view;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE x1 (a int, b text, c text);
 SELECT public.create_hypertable('x1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (11,regress_rls_schema,x1,t)
@@ -3289,8 +3269,6 @@ NOTICE:  f_leak => fgh_updt_updt
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE y1 (a int, b text);
 SELECT public.create_hypertable('y1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (12,regress_rls_schema,y1,t)
@@ -3299,8 +3277,6 @@ DETAIL:  Dimensions cannot have NULL values.
 INSERT INTO y1 VALUES(1,2);
 CREATE TABLE y2 (a int, b text);
 SELECT public.create_hypertable('y2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (13,regress_rls_schema,y2,t)
@@ -3608,8 +3584,6 @@ NOTICE:  drop cascades to 2 other objects
 \set VERBOSITY default
 CREATE TABLE t1 (a integer);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (14,regress_rls_schema,t1,t)
@@ -3657,8 +3631,6 @@ RESET SESSION AUTHORIZATION;
 DROP TABLE t1 CASCADE;
 CREATE TABLE t1 (a integer, b text);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (15,regress_rls_schema,t1,t)
@@ -3786,8 +3758,6 @@ SELECT polname, relname
 SET SESSION AUTHORIZATION regress_rls_bob;
 CREATE TABLE t2 (a integer, b text);
 SELECT public.create_hypertable('t2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (16,regress_rls_schema,t2,t)
@@ -3906,8 +3876,6 @@ SELECT * FROM t4;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE blog (id integer, author text, post text);
 SELECT public.create_hypertable('blog', 'id', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "id"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (17,regress_rls_schema,blog,t)
@@ -3915,8 +3883,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE comment (blog_id integer, message text);
 SELECT public.create_hypertable('comment', 'blog_id', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "blog_id"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (18,regress_rls_schema,comment,t)
@@ -4111,8 +4077,6 @@ DROP TABLE copy_t CASCADE;
 ERROR:  table "copy_t" does not exist
 CREATE TABLE copy_t (a integer, b text);
 SELECT public.create_hypertable('copy_t', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
         create_hypertable         
 ----------------------------------
  (19,regress_rls_schema,copy_t,t)
@@ -4204,8 +4168,6 @@ RESET SESSION AUTHORIZATION;
 SET row_security TO ON;
 CREATE TABLE copy_rel_to (a integer, b text);
 SELECT public.create_hypertable('copy_rel_to', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
            create_hypertable           
 ---------------------------------------
  (20,regress_rls_schema,copy_rel_to,t)
@@ -4280,8 +4242,6 @@ DROP TABLE copy_rel_to CASCADE;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE current_check (currentid int, payload text, rlsuser text);
 SELECT public.create_hypertable('current_check', 'currentid', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "currentid"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (21,regress_rls_schema,current_check,t)
@@ -4516,8 +4476,6 @@ ROLLBACK; -- cleanup
 BEGIN;
 CREATE TABLE t (c int);
 SELECT public.create_hypertable('t', 'c', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (22,regress_rls_schema,t,t)
@@ -4555,8 +4513,6 @@ ROLLBACK;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (23,regress_rls_schema,r1,t)
@@ -4564,8 +4520,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE r2 (a int);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (24,regress_rls_schema,r2,t)
@@ -4646,8 +4600,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (25,regress_rls_schema,r1,t)
@@ -4701,8 +4653,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (26,regress_rls_schema,r2,t)
@@ -4745,8 +4695,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1 ON DELETE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (27,regress_rls_schema,r2,t)
@@ -4778,8 +4726,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1 ON UPDATE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (28,regress_rls_schema,r2,t)
@@ -4819,8 +4765,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
@@ -4908,8 +4852,6 @@ DROP TABLE r1;
 RESET SESSION AUTHORIZATION;
 CREATE TABLE dep1 (c1 int);
 SELECT public.create_hypertable('dep1', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (31,regress_rls_schema,dep1,t)
@@ -4917,8 +4859,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE dep2 (c1 int);
 SELECT public.create_hypertable('dep2', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (32,regress_rls_schema,dep2,t)
@@ -4969,8 +4909,6 @@ CREATE ROLE regress_rls_dob_role1;
 CREATE ROLE regress_rls_dob_role2;
 CREATE TABLE dob_t1 (c1 int);
 SELECT public.create_hypertable('dob_t1', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
         create_hypertable         
 ----------------------------------
  (33,regress_rls_schema,dob_t1,t)
@@ -5009,8 +4947,6 @@ DROP ROLE regress_rls_group2;
 CREATE SCHEMA regress_rls_schema;
 CREATE TABLE rls_tbl (c1 int);
 SELECT public.create_hypertable('rls_tbl', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (34,regress_rls_schema,rls_tbl,t)
@@ -5023,8 +4959,6 @@ CREATE POLICY p3 ON rls_tbl FOR UPDATE USING (c1 <= 3) WITH CHECK (c1 > 5);
 CREATE POLICY p4 ON rls_tbl FOR DELETE USING (c1 <= 3);
 CREATE TABLE rls_tbl_force (c1 int);
 SELECT public.create_hypertable('rls_tbl_force', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (35,regress_rls_schema,rls_tbl_force,t)

--- a/test/expected/rowsecurity-17.out
+++ b/test/expected/rowsecurity-17.out
@@ -996,8 +996,6 @@ CREATE TABLE hyper_document (
 );
 GRANT ALL ON hyper_document TO public;
 SELECT public.create_hypertable('hyper_document', 'did', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "did"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (2,regress_rls_schema,hyper_document,t)
@@ -1489,8 +1487,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security TO ON;
 CREATE TABLE dependee (x integer, y integer);
 SELECT public.create_hypertable('dependee', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (3,regress_rls_schema,dependee,t)
@@ -1498,8 +1494,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE dependent (x integer, y integer);
 SELECT public.create_hypertable('dependent', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable          
 ------------------------------------
  (4,regress_rls_schema,dependent,t)
@@ -1527,8 +1521,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualifie
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE rec1 (x integer, y integer);
 SELECT public.create_hypertable('rec1', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable       
 -------------------------------
  (5,regress_rls_schema,rec1,t)
@@ -1586,8 +1578,6 @@ ERROR:  infinite recursion detected in policy for relation "rec1"
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE s1 (a int, b text);
 SELECT public.create_hypertable('s1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (6,regress_rls_schema,s1,t)
@@ -1596,8 +1586,6 @@ DETAIL:  Dimensions cannot have NULL values.
 INSERT INTO s1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
 CREATE TABLE s2 (x int, y text);
 SELECT public.create_hypertable('s2', 'x', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "x"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (7,regress_rls_schema,s2,t)
@@ -2203,8 +2191,6 @@ NOTICE:  f_leak => yyyyyy
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE b1 (a int, b text);
 SELECT public.create_hypertable('b1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (8,regress_rls_schema,b1,t)
@@ -2463,8 +2449,6 @@ ERROR:  new row violates row-level security policy for table "document"
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE z1 (a int, b text);
 SELECT public.create_hypertable('z1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (9,regress_rls_schema,z1,t)
@@ -2472,8 +2456,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE z2 (a int, b text);
 SELECT public.create_hypertable('z2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (10,regress_rls_schema,z2,t)
@@ -3173,8 +3155,6 @@ DROP VIEW rls_view;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE x1 (a int, b text, c text);
 SELECT public.create_hypertable('x1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (11,regress_rls_schema,x1,t)
@@ -3289,8 +3269,6 @@ NOTICE:  f_leak => fgh_updt_updt
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE y1 (a int, b text);
 SELECT public.create_hypertable('y1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (12,regress_rls_schema,y1,t)
@@ -3299,8 +3277,6 @@ DETAIL:  Dimensions cannot have NULL values.
 INSERT INTO y1 VALUES(1,2);
 CREATE TABLE y2 (a int, b text);
 SELECT public.create_hypertable('y2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (13,regress_rls_schema,y2,t)
@@ -3608,8 +3584,6 @@ NOTICE:  drop cascades to 2 other objects
 \set VERBOSITY default
 CREATE TABLE t1 (a integer);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (14,regress_rls_schema,t1,t)
@@ -3657,8 +3631,6 @@ RESET SESSION AUTHORIZATION;
 DROP TABLE t1 CASCADE;
 CREATE TABLE t1 (a integer, b text);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (15,regress_rls_schema,t1,t)
@@ -3786,8 +3758,6 @@ SELECT polname, relname
 SET SESSION AUTHORIZATION regress_rls_bob;
 CREATE TABLE t2 (a integer, b text);
 SELECT public.create_hypertable('t2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (16,regress_rls_schema,t2,t)
@@ -3906,8 +3876,6 @@ SELECT * FROM t4;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE blog (id integer, author text, post text);
 SELECT public.create_hypertable('blog', 'id', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "id"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (17,regress_rls_schema,blog,t)
@@ -3915,8 +3883,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE comment (blog_id integer, message text);
 SELECT public.create_hypertable('comment', 'blog_id', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "blog_id"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (18,regress_rls_schema,comment,t)
@@ -4111,8 +4077,6 @@ DROP TABLE copy_t CASCADE;
 ERROR:  table "copy_t" does not exist
 CREATE TABLE copy_t (a integer, b text);
 SELECT public.create_hypertable('copy_t', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
         create_hypertable         
 ----------------------------------
  (19,regress_rls_schema,copy_t,t)
@@ -4204,8 +4168,6 @@ RESET SESSION AUTHORIZATION;
 SET row_security TO ON;
 CREATE TABLE copy_rel_to (a integer, b text);
 SELECT public.create_hypertable('copy_rel_to', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
            create_hypertable           
 ---------------------------------------
  (20,regress_rls_schema,copy_rel_to,t)
@@ -4280,8 +4242,6 @@ DROP TABLE copy_rel_to CASCADE;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE current_check (currentid int, payload text, rlsuser text);
 SELECT public.create_hypertable('current_check', 'currentid', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "currentid"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (21,regress_rls_schema,current_check,t)
@@ -4516,8 +4476,6 @@ ROLLBACK; -- cleanup
 BEGIN;
 CREATE TABLE t (c int);
 SELECT public.create_hypertable('t', 'c', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable      
 -----------------------------
  (22,regress_rls_schema,t,t)
@@ -4555,8 +4513,6 @@ ROLLBACK;
 SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (23,regress_rls_schema,r1,t)
@@ -4564,8 +4520,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE r2 (a int);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (24,regress_rls_schema,r2,t)
@@ -4646,8 +4600,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (25,regress_rls_schema,r1,t)
@@ -4701,8 +4653,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (26,regress_rls_schema,r2,t)
@@ -4745,8 +4695,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1 ON DELETE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (27,regress_rls_schema,r2,t)
@@ -4778,8 +4726,6 @@ CREATE TABLE r1 (a int PRIMARY KEY);
 -- r1 is not a hypertable since r1.a is referenced by r2
 CREATE TABLE r2 (a int REFERENCES r1 ON UPDATE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (28,regress_rls_schema,r2,t)
@@ -4819,8 +4765,6 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
@@ -4908,8 +4852,6 @@ DROP TABLE r1;
 RESET SESSION AUTHORIZATION;
 CREATE TABLE dep1 (c1 int);
 SELECT public.create_hypertable('dep1', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (31,regress_rls_schema,dep1,t)
@@ -4917,8 +4859,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 CREATE TABLE dep2 (c1 int);
 SELECT public.create_hypertable('dep2', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
        create_hypertable        
 --------------------------------
  (32,regress_rls_schema,dep2,t)
@@ -4969,8 +4909,6 @@ CREATE ROLE regress_rls_dob_role1;
 CREATE ROLE regress_rls_dob_role2;
 CREATE TABLE dob_t1 (c1 int);
 SELECT public.create_hypertable('dob_t1', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
         create_hypertable         
 ----------------------------------
  (33,regress_rls_schema,dob_t1,t)
@@ -5009,8 +4947,6 @@ DROP ROLE regress_rls_group2;
 CREATE SCHEMA regress_rls_schema;
 CREATE TABLE rls_tbl (c1 int);
 SELECT public.create_hypertable('rls_tbl', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
          create_hypertable         
 -----------------------------------
  (34,regress_rls_schema,rls_tbl,t)
@@ -5023,8 +4959,6 @@ CREATE POLICY p3 ON rls_tbl FOR UPDATE USING (c1 <= 3) WITH CHECK (c1 > 5);
 CREATE POLICY p4 ON rls_tbl FOR DELETE USING (c1 <= 3);
 CREATE TABLE rls_tbl_force (c1 int);
 SELECT public.create_hypertable('rls_tbl_force', 'c1', chunk_time_interval=>2);
-NOTICE:  adding not-null constraint to column "c1"
-DETAIL:  Dimensions cannot have NULL values.
             create_hypertable            
 -----------------------------------------
  (35,regress_rls_schema,rls_tbl_force,t)

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -102,7 +102,6 @@ SELECT * FROM chunks_detailed_size('"public"."two_Partitions"') order by chunk_n
 CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
 SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |      table_name       | created 
 ---------------+-------------+-----------------------+---------
              2 | public      | timestamp_partitioned | t
@@ -120,7 +119,6 @@ SELECT * FROM chunks_detailed_size('timestamp_partitioned') order by chunk_name;
 CREATE TABLE timestamp_partitioned_2(time TIMESTAMP, value CHAR(9));
 SELECT * FROM create_hypertable('timestamp_partitioned_2', 'time', 'value', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |       table_name        | created 
 ---------------+-------------+-------------------------+---------
              3 | public      | timestamp_partitioned_2 | t
@@ -141,7 +139,6 @@ CREATE TABLE toast_test(time TIMESTAMP, value TEXT);
 ALTER TABLE toast_test ALTER COLUMN value SET STORAGE EXTERNAL;
 SELECT * FROM create_hypertable('toast_test', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              4 | public      | toast_test | t
@@ -420,7 +417,6 @@ SELECT
 CREATE TABLE approx_count(time TIMESTAMP, value int);
 SELECT * FROM create_hypertable('approx_count', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
              5 | public      | approx_count | t
@@ -729,7 +725,6 @@ HINT:  The operation is only possible on a hypertable or continuous aggregate.
 \set ON_ERROR_STOP 1
 -- Test size functions on empty hypertable
 SELECT * FROM create_hypertable('hypersize', 'time');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              6 | public      | hypersize  | t

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -95,7 +95,6 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE 'dev
 CREATE TABLE "int_part"(time timestamp, object_id int, temp float);
 SELECT create_hypertable('"int_part"', 'time', 'object_id', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (2,public,int_part,t)

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -8,7 +8,6 @@ CREATE ACCESS METHOD testam TYPE TABLE HANDLER heap_tableam_handler;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE testam (time timestamptz, device int, temp float) USING testam;
 SELECT create_hypertable('testam', 'time', 'device', 2);
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (1,public,testam,t)

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -19,7 +19,6 @@ CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 CREATE TABLE tspace_2dim(time timestamp, temp float, device text) TABLESPACE tablespace1;
 SELECT create_hypertable('tspace_2dim', 'time', 'device', 2);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,tspace_2dim,t)
@@ -177,7 +176,6 @@ SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
 SELECT create_hypertable('tspace_1dim', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (2,public,tspace_1dim,t)
@@ -435,7 +433,6 @@ SELECT * FROM _timescaledb_catalog.tablespace;
 CREATE TABLE tbl_1(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_1', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (3,public,tbl_1,t)
@@ -444,7 +441,6 @@ NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE tbl_2(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_2', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (4,public,tbl_2,t)
@@ -453,7 +449,6 @@ NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE tbl_3(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_3', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (5,public,tbl_3,t)
@@ -571,7 +566,6 @@ DROP TABLE tbl_3;
 CREATE TABLE tbl_1(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_1', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (6,public,tbl_1,t)

--- a/test/expected/test_utils.out
+++ b/test/expected/test_utils.out
@@ -93,7 +93,6 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- Create two chunks to scan in the test
 CREATE TABLE hyper (time timestamptz, temp float);
 SELECT create_hypertable('hyper', 'time');
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (1,public,hyper,t)

--- a/test/expected/trusted_extension.out
+++ b/test/expected/trusted_extension.out
@@ -22,7 +22,6 @@ CREATE EXTENSION timescaledb;
 RESET client_min_messages;
 CREATE TABLE t(time timestamptz);
 SELECT create_hypertable('t','time');
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (1,public,t,t)

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -71,7 +71,6 @@ ERROR:  duplicate key value violates unique constraint "1_1_upsert_test_pkey"
 CREATE TABLE upsert_test_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_unique', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (2,public,upsert_test_unique,t)
@@ -106,7 +105,6 @@ SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
 CREATE TABLE upsert_test_multi_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_multi_unique', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
  (3,public,upsert_test_multi_unique,t)
@@ -165,7 +163,6 @@ ALTER TABLE upsert_test_space DROP device_id_1, ADD device_id char(20);
 ALTER TABLE upsert_test_space ADD CONSTRAINT time_space_constraint UNIQUE (time, device_id);
 SELECT create_hypertable('upsert_test_space', 'time', 'device_id', 2, partitioning_func=>'_timescaledb_functions.get_partition_for_key'::regproc);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (4,public,upsert_test_space,t)
@@ -364,7 +361,6 @@ ERROR:  could not find arbiter index for hypertable index "multi_time_color_idx"
 CREATE TABLE upsert_test_diffchunk(time timestamp, device_id char(20), to_drop int, temp float, color text);
 SELECT create_hypertable('upsert_test_diffchunk', 'time', chunk_time_interval=> interval '1 month');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
  (5,public,upsert_test_diffchunk,t)
@@ -422,7 +418,6 @@ select * from upsert_test_diffchunk order by time, device_id;
 CREATE TABLE upsert_test_arbiter(time timestamp, to_drop int);
 SELECT create_hypertable('upsert_test_arbiter', 'time', chunk_time_interval=> interval '1 month');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,upsert_test_arbiter,t)

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -5,7 +5,6 @@ CREATE TABLE vacuum_test(time timestamp, temp float);
 -- create hypertable with three chunks
 SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,vacuum_test,t)
@@ -62,7 +61,6 @@ DROP TABLE vacuum_test;
 CREATE TABLE analyze_test(time timestamp, temp float);
 SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (2,public,analyze_test,t)
@@ -142,7 +140,6 @@ CREATE TABLE vacuum_test(time timestamp, temp float);
 -- create hypertable with three chunks
 SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (3,public,vacuum_test,t)
@@ -157,7 +154,6 @@ INSERT INTO vacuum_test VALUES ('2017-01-20T16:00:01', 17.5),
 CREATE TABLE analyze_test(time timestamp, temp float);
 SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (4,public,analyze_test,t)

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -515,7 +515,6 @@ RESET enable_hashagg;
 CREATE TABLE merge_append_test (start_time timestamptz, sensor_id int, cluster varchar (253), cost_recommendation_memory numeric);
 SELECT * FROM create_hypertable('merge_append_test', 'start_time');
 WARNING:  column type "character varying" used for "cluster" does not follow best practices
-NOTICE:  adding not-null constraint to column "start_time"
  hypertable_id | schema_name |    table_name     | created 
 ---------------+-------------+-------------------+---------
              4 | public      | merge_append_test | t

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -10,7 +10,6 @@ CREATE OR REPLACE FUNCTION reorder_called(chunk_id INT) RETURNS BOOL AS $$
 $$ LANGUAGE SQL;
 CREATE TABLE test_table(time timestamptz, chunk_id int);
 SELECT create_hypertable('test_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,test_table,t)
@@ -326,14 +325,12 @@ NOTICE:  no chunks need reordering for hypertable public.test_table
 CREATE TABLE test_table_int(time bigint, junk int);
 CREATE TABLE test_overflow_smallint(time smallint, junk int);
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (2,public,test_table_int,t)
 (1 row)
 
 SELECT create_hypertable('test_overflow_smallint', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable          
 -------------------------------------
  (3,public,test_overflow_smallint,t)
@@ -535,7 +532,6 @@ end
 $body$;
 create or replace function dummy_now() returns bigint language sql immutable as  'select 2::bigint';
 select create_hypertable('part_time_now_func', 'time', time_partitioning_func => 'time_partfunc', chunk_time_interval=>1);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (5,public,part_time_now_func,t)

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -66,7 +66,6 @@ SELECT * FROM timescaledb_information.job_stats;
 ------------------------------
 CREATE TABLE test_reorder_table(time int, chunk_id int);
 SELECT create_hypertable('test_reorder_table', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (1,public,test_reorder_table,t)
@@ -364,7 +363,6 @@ SELECT ts_bgw_params_reset_time();
 -----------------------------------
 CREATE TABLE test_drop_chunks_table(time timestamptz, drop_order int);
 SELECT create_hypertable('test_drop_chunks_table', 'time', chunk_time_interval => INTERVAL '1 week');
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable          
 -------------------------------------
  (2,public,test_drop_chunks_table,t)
@@ -576,7 +574,6 @@ SELECT * FROM timescaledb_information.job_stats;
 -- Test for date
 CREATE TABLE test_drop_chunks_table_date(time date, drop_order int);
 SELECT create_hypertable('test_drop_chunks_table_date', 'time', chunk_time_interval => INTERVAL '1 week');
-NOTICE:  adding not-null constraint to column "time"
             create_hypertable             
 ------------------------------------------
  (3,public,test_drop_chunks_table_date,t)
@@ -602,7 +599,6 @@ SELECT ts_bgw_params_reset_time();
 -- Test for timestamp
 CREATE TABLE test_drop_chunks_table_tsntz(time date, drop_order int);
 SELECT create_hypertable('test_drop_chunks_table_tsntz', 'time', chunk_time_interval => INTERVAL '1 week');
-NOTICE:  adding not-null constraint to column "time"
              create_hypertable             
 -------------------------------------------
  (4,public,test_drop_chunks_table_tsntz,t)
@@ -650,7 +646,6 @@ SELECT * FROM sorted_bgw_log;
 -- test the schedule_interval parameter for policies
 CREATE TABLE test_schedint(time timestamptz, a int, b int);
 select create_hypertable('test_schedint', 'time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (5,public,test_schedint,t)

--- a/tsl/test/expected/cagg_bgw-15.out
+++ b/tsl/test/expected/cagg_bgw-15.out
@@ -77,7 +77,6 @@ WARNING:  no privileges were granted for "public"
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test_continuous_agg_table(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable            
 ----------------------------------------
  (1,public,test_continuous_agg_table,t)
@@ -664,7 +663,6 @@ SELECT ts_bgw_params_reset_time();
 --
 CREATE TABLE test_continuous_agg_table_w_grant(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table_w_grant', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
                create_hypertable                
 ------------------------------------------------
  (5,public,test_continuous_agg_table_w_grant,t)

--- a/tsl/test/expected/cagg_bgw-16.out
+++ b/tsl/test/expected/cagg_bgw-16.out
@@ -77,7 +77,6 @@ WARNING:  no privileges were granted for "public"
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test_continuous_agg_table(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable            
 ----------------------------------------
  (1,public,test_continuous_agg_table,t)
@@ -664,7 +663,6 @@ SELECT ts_bgw_params_reset_time();
 --
 CREATE TABLE test_continuous_agg_table_w_grant(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table_w_grant', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
                create_hypertable                
 ------------------------------------------------
  (5,public,test_continuous_agg_table_w_grant,t)

--- a/tsl/test/expected/cagg_bgw-17.out
+++ b/tsl/test/expected/cagg_bgw-17.out
@@ -77,7 +77,6 @@ WARNING:  no privileges were granted for "public"
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test_continuous_agg_table(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable            
 ----------------------------------------
  (1,public,test_continuous_agg_table,t)
@@ -664,7 +663,6 @@ SELECT ts_bgw_params_reset_time();
 --
 CREATE TABLE test_continuous_agg_table_w_grant(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table_w_grant', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
                create_hypertable                
 ------------------------------------------------
  (5,public,test_continuous_agg_table_w_grant,t)

--- a/tsl/test/expected/cagg_bgw_drop_chunks.out
+++ b/tsl/test/expected/cagg_bgw_drop_chunks.out
@@ -42,7 +42,6 @@ SELECT ts_bgw_params_create();
 CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_nid
     FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 1) \gset
-NOTICE:  adding not-null constraint to column "time"
 CREATE OR REPLACE FUNCTION integer_now_test2() returns bigint LANGUAGE SQL STABLE as $$ SELECT 40::bigint  $$;
 SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
  set_integer_now_func 

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -234,8 +234,6 @@ ERROR:  invalid bucket width for time bucket function
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
 select table_name from create_hypertable( 'rowsec_tab', 'a', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
  table_name 
 ------------
  rowsec_tab
@@ -388,7 +386,6 @@ CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
     LANGUAGE SQL IMMUTABLE;
 CREATE TABLE text_time(time TEXT);
     SELECT create_hypertable('text_time', 'time', chunk_time_interval => 10, time_partitioning_func => 'text_part_func');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (9,public,text_time,t)

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -891,7 +891,6 @@ ORDER BY 1,2;
 ----------------------------------------------
 CREATE table threshold_test (time int, value int);
 SELECT create_hypertable('threshold_test', 'time', chunk_time_interval => 4);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,threshold_test,t)

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -32,8 +32,6 @@ INSERT INTO conditions (day, city, temperature, device_id) VALUES
   ('2021-06-27', 'Moscow', 31,3);
 CREATE TABLE conditions_dup AS SELECT * FROM conditions;
 SELECT table_name FROM create_hypertable('conditions_dup', 'day', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
-NOTICE:  adding not-null constraint to column "day"
-DETAIL:  Dimensions cannot have NULL values.
 NOTICE:  migrating data to chunks
 DETAIL:  Migration might take a while depending on the amount of data.
    table_name   

--- a/tsl/test/expected/cagg_migrate.out
+++ b/tsl/test/expected/cagg_migrate.out
@@ -3141,7 +3141,6 @@ SELECT setval('_timescaledb_catalog.dimension_slice_id_seq', 999, true);
 (1 row)
 
 SELECT create_hypertable('space_partitioning', 'time', chunk_time_interval=>'1 hour'::interval);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
  (1000,public,space_partitioning,t)

--- a/tsl/test/expected/cagg_multi.out
+++ b/tsl/test/expected/cagg_multi.out
@@ -6,7 +6,6 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO NOTICE;
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);
 select create_hypertable('continuous_agg_test', 'timeval', chunk_time_interval=> 2);
-NOTICE:  adding not-null constraint to column "timeval"
         create_hypertable         
 ----------------------------------
  (1,public,continuous_agg_test,t)
@@ -220,7 +219,6 @@ select view_name from timescaledb_information.continuous_aggregates;
 -- they do not meet materialization invalidation threshold for cagg2.
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);
 select create_hypertable('continuous_agg_test', 'timeval', chunk_time_interval=> 2);
-NOTICE:  adding not-null constraint to column "timeval"
         create_hypertable         
 ----------------------------------
  (4,public,continuous_agg_test,t)
@@ -368,7 +366,6 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_12_chunk
 ----TEST7 multiple continuous aggregates with real time aggregates test----
 create table foo (a integer, b integer, c integer);
 select table_name FROM create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo

--- a/tsl/test/expected/cagg_planning.out
+++ b/tsl/test/expected/cagg_planning.out
@@ -11,7 +11,6 @@ SELECT format('\! diff -u --label Baseline --label Optimized %s %s', :'TEST_RESU
 SET timezone TO PST8PDT;
 CREATE TABLE metrics(time timestamptz, device text, metric text, value float);
 SELECT create_hypertable('metrics', 'time');
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (1,public,metrics,t)

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -7,7 +7,6 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 --basic test with count
 CREATE TABLE int_tab (a integer, b integer, c integer);
 SELECT table_name FROM create_hypertable('int_tab', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  int_tab
@@ -345,7 +344,6 @@ DROP MATERIALIZED VIEW mat_m1;
 --- code coverage tests : add policy for timestamp and date based table ---
 CREATE TABLE continuous_agg_max_mat_date(time DATE);
 SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
-NOTICE:  adding not-null constraint to column "time"
             create_hypertable             
 ------------------------------------------
  (5,public,continuous_agg_max_mat_date,t)
@@ -747,7 +745,6 @@ DROP MATERIALIZED VIEW max_mat_view_date;
 CREATE TABLE continuous_agg_timestamp(time TIMESTAMP);
 SELECT create_hypertable('continuous_agg_timestamp', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
  (8,public,continuous_agg_timestamp,t)
@@ -818,7 +815,6 @@ DROP MATERIALIZED VIEW max_mat_view_timestamp;
 --smallint table
 CREATE TABLE smallint_tab (a smallint);
 SELECT table_name FROM create_hypertable('smallint_tab', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
   table_name  
 --------------
  smallint_tab
@@ -1022,7 +1018,6 @@ SELECT add_continuous_aggregate_policy('mat_smallint', '15', '10', '1h'::interva
 --bigint table
 CREATE TABLE bigint_tab (a bigint);
 SELECT table_name FROM create_hypertable('bigint_tab', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  bigint_tab

--- a/tsl/test/expected/cagg_policy_run.out
+++ b/tsl/test/expected/cagg_policy_run.out
@@ -7,7 +7,6 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 --- code coverage tests : add policy for timestamp and date based table ---
 CREATE TABLE continuous_agg_max_mat_date(time DATE);
 SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
-NOTICE:  adding not-null constraint to column "time"
             create_hypertable             
 ------------------------------------------
  (1,public,continuous_agg_max_mat_date,t)
@@ -45,7 +44,6 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
 CREATE TABLE continuous_agg_timestamp(time TIMESTAMP);
 SELECT create_hypertable('continuous_agg_timestamp', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
  (3,public,continuous_agg_timestamp,t)

--- a/tsl/test/expected/cagg_query-15.out
+++ b/tsl/test/expected/cagg_query-15.out
@@ -793,21 +793,18 @@ CREATE TABLE table_bigint (
   data bigint
 );
 SELECT create_hypertable('table_smallint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:345: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,table_smallint,t)
 (1 row)
 
 SELECT create_hypertable('table_int', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:346: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (8,public,table_int,t)
 (1 row)
 
 SELECT create_hypertable('table_bigint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:347: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (9,public,table_bigint,t)

--- a/tsl/test/expected/cagg_query-16.out
+++ b/tsl/test/expected/cagg_query-16.out
@@ -787,21 +787,18 @@ CREATE TABLE table_bigint (
   data bigint
 );
 SELECT create_hypertable('table_smallint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:345: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,table_smallint,t)
 (1 row)
 
 SELECT create_hypertable('table_int', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:346: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (8,public,table_int,t)
 (1 row)
 
 SELECT create_hypertable('table_bigint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:347: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (9,public,table_bigint,t)

--- a/tsl/test/expected/cagg_query-17.out
+++ b/tsl/test/expected/cagg_query-17.out
@@ -787,21 +787,18 @@ CREATE TABLE table_bigint (
   data bigint
 );
 SELECT create_hypertable('table_smallint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:345: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,table_smallint,t)
 (1 row)
 
 SELECT create_hypertable('table_int', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:346: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (8,public,table_int,t)
 (1 row)
 
 SELECT create_hypertable('table_bigint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:347: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (9,public,table_bigint,t)

--- a/tsl/test/expected/cagg_query_using_merge-15.out
+++ b/tsl/test/expected/cagg_query_using_merge-15.out
@@ -795,21 +795,18 @@ CREATE TABLE table_bigint (
   data bigint
 );
 SELECT create_hypertable('table_smallint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:345: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,table_smallint,t)
 (1 row)
 
 SELECT create_hypertable('table_int', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:346: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (8,public,table_int,t)
 (1 row)
 
 SELECT create_hypertable('table_bigint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:347: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (9,public,table_bigint,t)

--- a/tsl/test/expected/cagg_query_using_merge-16.out
+++ b/tsl/test/expected/cagg_query_using_merge-16.out
@@ -789,21 +789,18 @@ CREATE TABLE table_bigint (
   data bigint
 );
 SELECT create_hypertable('table_smallint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:345: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,table_smallint,t)
 (1 row)
 
 SELECT create_hypertable('table_int', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:346: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (8,public,table_int,t)
 (1 row)
 
 SELECT create_hypertable('table_bigint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:347: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (9,public,table_bigint,t)

--- a/tsl/test/expected/cagg_query_using_merge-17.out
+++ b/tsl/test/expected/cagg_query_using_merge-17.out
@@ -789,21 +789,18 @@ CREATE TABLE table_bigint (
   data bigint
 );
 SELECT create_hypertable('table_smallint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:345: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,table_smallint,t)
 (1 row)
 
 SELECT create_hypertable('table_int', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:346: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (8,public,table_int,t)
 (1 row)
 
 SELECT create_hypertable('table_bigint', 'time', chunk_time_interval => 10);
-psql:include/cagg_query_common.sql:347: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (9,public,table_bigint,t)

--- a/tsl/test/expected/cagg_union_view-15.out
+++ b/tsl/test/expected/cagg_union_view-15.out
@@ -326,7 +326,6 @@ $BODY$;
 -- test watermark interaction with just in time aggregates
 CREATE TABLE boundary_test(time int, value float);
 SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (5,public,boundary_test,t)
@@ -433,7 +432,6 @@ SELECT * FROM boundary_view ORDER BY time_bucket;
 ---- TEST union view with WHERE, GROUP BY and HAVING clause ----
 create table ht_intdata (a integer, b integer, c integer);
 select table_name FROM create_hypertable('ht_intdata', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  ht_intdata
@@ -628,28 +626,24 @@ CREATE TABLE date_table (time date, value int);
 CREATE TABLE timestamp_table (time timestamp, value int);
 CREATE TABLE timestamptz_table (time timestamptz, value int);
 SELECT create_hypertable('smallint_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (10,public,smallint_table,t)
 (1 row)
 
 SELECT create_hypertable('int_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (11,public,int_table,t)
 (1 row)
 
 SELECT create_hypertable('bigint_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (12,public,bigint_table,t)
 (1 row)
 
 SELECT create_hypertable('date_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (13,public,date_table,t)
@@ -657,14 +651,12 @@ NOTICE:  adding not-null constraint to column "time"
 
 SELECT create_hypertable('timestamp_table', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (14,public,timestamp_table,t)
 (1 row)
 
 SELECT create_hypertable('timestamptz_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (15,public,timestamptz_table,t)

--- a/tsl/test/expected/cagg_union_view-16.out
+++ b/tsl/test/expected/cagg_union_view-16.out
@@ -326,7 +326,6 @@ $BODY$;
 -- test watermark interaction with just in time aggregates
 CREATE TABLE boundary_test(time int, value float);
 SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (5,public,boundary_test,t)
@@ -433,7 +432,6 @@ SELECT * FROM boundary_view ORDER BY time_bucket;
 ---- TEST union view with WHERE, GROUP BY and HAVING clause ----
 create table ht_intdata (a integer, b integer, c integer);
 select table_name FROM create_hypertable('ht_intdata', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  ht_intdata
@@ -625,28 +623,24 @@ CREATE TABLE date_table (time date, value int);
 CREATE TABLE timestamp_table (time timestamp, value int);
 CREATE TABLE timestamptz_table (time timestamptz, value int);
 SELECT create_hypertable('smallint_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (10,public,smallint_table,t)
 (1 row)
 
 SELECT create_hypertable('int_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (11,public,int_table,t)
 (1 row)
 
 SELECT create_hypertable('bigint_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (12,public,bigint_table,t)
 (1 row)
 
 SELECT create_hypertable('date_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (13,public,date_table,t)
@@ -654,14 +648,12 @@ NOTICE:  adding not-null constraint to column "time"
 
 SELECT create_hypertable('timestamp_table', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (14,public,timestamp_table,t)
 (1 row)
 
 SELECT create_hypertable('timestamptz_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (15,public,timestamptz_table,t)

--- a/tsl/test/expected/cagg_union_view-17.out
+++ b/tsl/test/expected/cagg_union_view-17.out
@@ -326,7 +326,6 @@ $BODY$;
 -- test watermark interaction with just in time aggregates
 CREATE TABLE boundary_test(time int, value float);
 SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (5,public,boundary_test,t)
@@ -433,7 +432,6 @@ SELECT * FROM boundary_view ORDER BY time_bucket;
 ---- TEST union view with WHERE, GROUP BY and HAVING clause ----
 create table ht_intdata (a integer, b integer, c integer);
 select table_name FROM create_hypertable('ht_intdata', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  ht_intdata
@@ -625,28 +623,24 @@ CREATE TABLE date_table (time date, value int);
 CREATE TABLE timestamp_table (time timestamp, value int);
 CREATE TABLE timestamptz_table (time timestamptz, value int);
 SELECT create_hypertable('smallint_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (10,public,smallint_table,t)
 (1 row)
 
 SELECT create_hypertable('int_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (11,public,int_table,t)
 (1 row)
 
 SELECT create_hypertable('bigint_table', 'time', chunk_time_interval=>20);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (12,public,bigint_table,t)
 (1 row)
 
 SELECT create_hypertable('date_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (13,public,date_table,t)
@@ -654,14 +648,12 @@ NOTICE:  adding not-null constraint to column "time"
 
 SELECT create_hypertable('timestamp_table', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (14,public,timestamp_table,t)
 (1 row)
 
 SELECT create_hypertable('timestamptz_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (15,public,timestamptz_table,t)

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -246,7 +246,6 @@ $BODY$
 $BODY$;
 CREATE TABLE device_readings_int(time int, value float);
 SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,device_readings_int,t)
@@ -436,7 +435,6 @@ DROP TABLE sensor_data;
 -- END OF BASIC USAGE TESTS --
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  metrics

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -246,7 +246,6 @@ $BODY$
 $BODY$;
 CREATE TABLE device_readings_int(time int, value float);
 SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,device_readings_int,t)
@@ -436,7 +435,6 @@ DROP TABLE sensor_data;
 -- END OF BASIC USAGE TESTS --
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  metrics

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -246,7 +246,6 @@ $BODY$
 $BODY$;
 CREATE TABLE device_readings_int(time int, value float);
 SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,device_readings_int,t)
@@ -436,7 +435,6 @@ DROP TABLE sensor_data;
 -- END OF BASIC USAGE TESTS --
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  metrics

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -321,7 +321,6 @@ CREATE MATERIALIZED VIEW temperature_tz_4h_ts_offset
 NOTICE:  refreshing continuous aggregate "temperature_tz_4h_ts_offset"
 CREATE TABLE integer_ht(a integer, b integer, c integer);
 SELECT table_name FROM create_hypertable('integer_ht', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  integer_ht

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -4,7 +4,6 @@
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 CREATE TABLE continuous_agg_test(time int, data int);
 SELECT create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (1,public,continuous_agg_test,t)
@@ -43,7 +42,6 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE TABLE continuous_agg_test_mat(time int);
 SELECT create_hypertable('continuous_agg_test_mat', 'time', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
  (2,public,continuous_agg_test_mat,t)
@@ -214,7 +212,6 @@ TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 -- CREATE VIEW creates the invalidation trigger correctly
 CREATE TABLE ca_inval_test(time int);
 SELECT create_hypertable('ca_inval_test', 'time', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (3,public,ca_inval_test,t)
@@ -311,7 +308,6 @@ TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 -- the view was created
 CREATE TABLE ts_continuous_test(time INTEGER, location INTEGER);
     SELECT create_hypertable('ts_continuous_test', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (5,public,ts_continuous_test,t)
@@ -383,7 +379,6 @@ NOTICE:  drop cascades to 3 other objects
 ----
 CREATE TABLE chunks(time timestamptz, device int, value float);
 SELECT FROM create_hypertable('chunks','time',chunk_time_interval:='1d'::interval);
-NOTICE:  adding not-null constraint to column "time"
 --
 (1 row)
 
@@ -1409,7 +1404,6 @@ CREATE TABLE continuous_agg_test(time int, data int);
 -- Test with integer partitioning
 CREATE TABLE integer_ht(time int, data int);
 SELECT create_hypertable('integer_ht', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (10,public,integer_ht,t)
@@ -1455,7 +1449,6 @@ SELECT * FROM integer_ht_cagg;
 -- Test with big integer partitioning
 CREATE TABLE big_integer_ht(time bigint, data bigint);
 SELECT create_hypertable('big_integer_ht', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (12,public,big_integer_ht,t)
@@ -1501,7 +1494,6 @@ SELECT * FROM big_integer_ht_cagg;
 -- Test with small integer partitioning
 CREATE TABLE small_integer_ht(time bigint, data bigint);
 SELECT create_hypertable('small_integer_ht', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (14,public,small_integer_ht,t)

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -826,7 +826,6 @@ SELECT * FROM _timescaledb_catalog.chunk_column_stats;
 -- Check min/max ranges for partial chunks with segmentby columns get recalculated correctly by seementwise recompression
 CREATE TABLE chunk_skipping(time timestamptz,device text, updated_at timestamptz)
 WITH (tsdb.hypertable, tsdb.partition_column='time',tsdb.segmentby='device');
-NOTICE:  adding not-null constraint to column "time"
 SELECT enable_chunk_skipping('chunk_skipping', 'updated_at');
  enable_chunk_skipping 
 -----------------------

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -9,7 +9,6 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(
 SET timezone TO 'America/Los_Angeles';
 CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
 SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -28,7 +27,6 @@ INSERT INTO test1 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMES
 INSERT INTO test1 SELECT t, 2, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
 CREATE TABLE test2 ("Time" timestamptz, i integer, value integer);
 SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test2

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -40,7 +40,6 @@ AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE test1.hyper1 (time bigint, temp float);
 SELECT create_hypertable('test1.hyper1', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
  (1,test1,hyper1,t)

--- a/tsl/test/expected/columnar_scan_cost.out
+++ b/tsl/test/expected/columnar_scan_cost.out
@@ -5,7 +5,6 @@
 -- monitor the changes.
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (1,public,costtab,t)
@@ -140,7 +139,6 @@ explain select * from costtab where s = '1' or (fi = 200 and ts = 5000);
 -- Test a high-cardinality orderby column
 create table highcard(ts int) with (tsdb.hypertable, tsdb.partition_column = 'ts',
     tsdb.compress_orderby = 'ts', tsdb.chunk_interval = 10000000);
-NOTICE:  adding not-null constraint to column "ts"
 insert into highcard select generate_series(1, 1000000);
 select count(compress_chunk(x)) from show_chunks('highcard') x;
  count 

--- a/tsl/test/expected/columnstore_aliases.out
+++ b/tsl/test/expected/columnstore_aliases.out
@@ -30,7 +30,6 @@ $$;
 -- result of each query is not particularly important.
 CREATE TABLE test1 (ts timestamptz, i integer, b bigint, t text);
 SELECT * FROM create_hypertable('test1', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | test1      | t
@@ -86,7 +85,6 @@ SELECT * FROM hypertable_columnstore_stats('test1') where 1 = 2;
 
 CREATE TABLE test2 (ts timestamptz, i integer, b bigint, t text);
 SELECT * FROM create_hypertable('test2', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              3 | public      | test2      | t

--- a/tsl/test/expected/compress_auto_sparse_index.out
+++ b/tsl/test/expected/compress_auto_sparse_index.out
@@ -3,7 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 create table sparse(ts int, value float);
 select create_hypertable('sparse', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable  
 ---------------------
  (1,public,sparse,t)

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -39,7 +39,6 @@ SELECT ts_bgw_params_create();
 -----------------------------------
 CREATE TABLE test_retention_table(time timestamptz, drop_order int);
 SELECT create_hypertable('test_retention_table', 'time', chunk_time_interval => INTERVAL '1 week');
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (1,public,test_retention_table,t)

--- a/tsl/test/expected/compress_bitmap_scan.out
+++ b/tsl/test/expected/compress_bitmap_scan.out
@@ -13,7 +13,6 @@ set max_parallel_workers_per_gather = 0;
 set enable_memoize to off;
 create table bscan(ts int, s int, id int, payload int);
 select create_hypertable('bscan', 'ts', chunk_time_interval => 500001);
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable  
 --------------------
  (1,public,bscan,t)

--- a/tsl/test/expected/compress_bloom_sparse.out
+++ b/tsl/test/expected/compress_bloom_sparse.out
@@ -10,7 +10,6 @@ $$ language sql;
 create table bloom(x int, value text, u uuid, ts timestamp);
 select create_hypertable('bloom', 'x');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "x"
  create_hypertable  
 --------------------
  (1,public,bloom,t)
@@ -377,7 +376,6 @@ select count(*) from bloom where ts between '2021-01-07' and '2021-01-14';
 -- Test some corner cases
 create table corner(ts int, s text, c text);
 select create_hypertable('corner', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable  
 ---------------------
  (3,public,corner,t)
@@ -538,7 +536,6 @@ as
 ;
 create table badtable(ts int, s int, b badint);
 select create_hypertable('badtable', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
    create_hypertable   
 -----------------------
  (5,public,badtable,t)
@@ -781,7 +778,6 @@ select exists (select * from badtable where b = v_badint.b) from v_badint;
 -- Test a non-by-value 8-byte type.
 create table byref(ts int, x macaddr8);
 select create_hypertable('byref', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable  
 --------------------
  (7,public,byref,t)
@@ -820,7 +816,6 @@ select * from byref where x = float8tomacaddr8(mix(1));
 create table arraybloom(x int, value int[], ts timestamp);
 select create_hypertable('arraybloom', 'x');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "x"
     create_hypertable    
 -------------------------
  (9,public,arraybloom,t)

--- a/tsl/test/expected/compress_bloom_sparse_debug.out
+++ b/tsl/test/expected/compress_bloom_sparse_debug.out
@@ -8,7 +8,6 @@ CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
 $$ LANGUAGE SQL;
 create table test(ts int, s text, c text);
 select create_hypertable('test', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,test,t)
@@ -177,7 +176,6 @@ select ts_bloom1_debug_hash('2025-05-05'::timestamptz);
 create table detoaster(ts int, tag text) with (tsdb.hypertable,
     tsdb.partition_column = 'ts', tsdb.compress, tsdb.compress_orderby = 'ts')
 ;
-NOTICE:  adding not-null constraint to column "ts"
 insert into detoaster select ts, ts::text from generate_series(1, 1000) ts;
 insert into detoaster select ts, ts::text from generate_series(1000001, 1001000) ts;
 create index on detoaster(tag);

--- a/tsl/test/expected/compress_default.out
+++ b/tsl/test/expected/compress_default.out
@@ -5,7 +5,6 @@
 -- batch.
 create table t(ts int);
 select create_hypertable('t', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,t,t)

--- a/tsl/test/expected/compress_dml_copy.out
+++ b/tsl/test/expected/compress_dml_copy.out
@@ -4,7 +4,6 @@
 -- Test various cases of COPY with decompression and different chunk layouts.
 create table cdmlcopy(filler bigint, ts int, value float, metric text);
 select create_hypertable('cdmlcopy', 'ts', chunk_time_interval => 1000);
-NOTICE:  adding not-null constraint to column "ts"
    create_hypertable   
 -----------------------
  (1,public,cdmlcopy,t)

--- a/tsl/test/expected/compress_qualpushdown_saop.out
+++ b/tsl/test/expected/compress_qualpushdown_saop.out
@@ -15,7 +15,6 @@ create function volatile_lower(x text) returns text as 'lower' language internal
 set max_parallel_workers_per_gather = 0;
 create table saop(ts int, segmentby text, with_minmax text, with_bloom text);
 select create_hypertable('saop', 'ts', chunk_time_interval => 50001);
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,saop,t)

--- a/tsl/test/expected/compress_sort_transform.out
+++ b/tsl/test/expected/compress_sort_transform.out
@@ -9,7 +9,6 @@ set enable_hashagg to off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE ht_metrics_partially_compressed(time timestamptz, device int, value float);
 SELECT create_hypertable('ht_metrics_partially_compressed','time');
-NOTICE:  adding not-null constraint to column "time"
               create_hypertable               
 ----------------------------------------------
  (1,public,ht_metrics_partially_compressed,t)

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -7,7 +7,6 @@ CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings 
 create table test_settings(x int, value text, u uuid, ts timestamp);
 select create_hypertable('test_settings', 'x');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "x"
      create_hypertable      
 ----------------------------
  (1,public,test_settings,t)
@@ -165,7 +164,6 @@ drop table test_settings;
 create table test_sparse_index(x int, value text, u uuid, ts timestamp, data jsonb);
 select create_hypertable('test_sparse_index', 'x');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "x"
        create_hypertable        
 --------------------------------
  (3,public,test_sparse_index,t)
@@ -271,7 +269,6 @@ create table test_sparse_index(x int, value text, u uuid, ts timestamp) with (
     tsdb.partition_column='x',
     tsdb.order_by='x',
     tsdb.index='bloom("u"),minmax("ts")');
-NOTICE:  adding not-null constraint to column "x"
 select * from settings;
        relid       | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                 index                                                                                  
 -------------------+----------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -14,7 +14,6 @@ create table compressed_collation_ht(time timestamp, name text collate :"COLLATI
     value float);
 select create_hypertable('compressed_collation_ht', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
  (1,public,compressed_collation_ht,t)

--- a/tsl/test/expected/compressed_detoaster.out
+++ b/tsl/test/expected/compressed_detoaster.out
@@ -5,7 +5,6 @@
 -- the various ways the compressed data can be toasted.
 create table longstr(ts int default 1, s1 text);
 select create_hypertable('longstr', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (1,public,longstr,t)

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -28,7 +28,6 @@ insert into rand_minstd_state values (321);
 --basic test with count
 create table foo (a integer, b integer, c integer, d integer);
 select table_name from create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo
@@ -185,7 +184,6 @@ delete from foo where a = 10;
 --TEST2b try complex DML on compressed chunk
 create table foo_join ( a integer, newval integer);
 select table_name from create_hypertable('foo_join', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo_join
@@ -194,7 +192,6 @@ NOTICE:  adding not-null constraint to column "a"
 insert into foo_join select generate_series(0,40, 10), 111;
 create table foo_join2 ( a integer, newval integer);
 select table_name from create_hypertable('foo_join2', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo_join2
@@ -529,7 +526,6 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 SET timescaledb.enable_transparent_decompression TO ON;
 CREATE TABLE plan_inval(time timestamptz, device_id int);
 SELECT create_hypertable('plan_inval','time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (7,public,plan_inval,t)
@@ -913,7 +909,6 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='datatype_te
 --TEST try to compress a hypertable that has a continuous aggregate
 CREATE TABLE metrics(time timestamptz, device_id int, v1 float, v2 float);
 SELECT create_hypertable('metrics','time');
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (13,public,metrics,t)
@@ -1633,7 +1628,6 @@ SELECT count(*) FROM metrics;
 -- test sequence number is local to segment by
 CREATE TABLE local_seq(time timestamptz, device int);
 SELECT table_name FROM create_hypertable('local_seq','time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  local_seq
@@ -1656,7 +1650,6 @@ SELECT compress_chunk(c) FROM show_chunks('local_seq') c;
 -- hypertable fails with error "invalid child of chunk append: Node (26)"
 CREATE TABLE tidrangescan_test(time timestamptz, device_id int, v1 float, v2 float);
 SELECT create_hypertable('tidrangescan_test','time');
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (35,public,tidrangescan_test,t)
@@ -1843,7 +1836,6 @@ SELECT * FROM f_sensor_data WHERE sensor_id > 1000;
 CREATE TABLE ts_device_table(time INTEGER, device INTEGER, location INTEGER, value INTEGER);
 CREATE UNIQUE INDEX device_time_idx on ts_device_table(time, device);
 SELECT create_hypertable('ts_device_table', 'time', chunk_time_interval => 1000);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (39,public,ts_device_table,t)
@@ -1896,7 +1888,6 @@ RESET min_parallel_index_scan_size;
 RESET min_parallel_table_scan_size;
 CREATE TABLE ht_metrics_partially_compressed(time timestamptz, device int, value float);
 SELECT create_hypertable('ht_metrics_partially_compressed','time',create_default_indexes:=false);
-NOTICE:  adding not-null constraint to column "time"
                create_hypertable               
 -----------------------------------------------
  (41,public,ht_metrics_partially_compressed,t)
@@ -2729,7 +2720,6 @@ SELECT * FROM ONLY :CHUNK2;
 CREATE TABLE compressed_table (time timestamptz, a int, b int, c int);
 CREATE UNIQUE INDEX compressed_table_index ON compressed_table(time, a, b, c);
 SELECT create_hypertable('compressed_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (49,public,compressed_table,t)
@@ -2773,7 +2763,6 @@ RESET timescaledb.max_tuples_decompressed_per_dml_transaction;
 -- Test decompression with DML which compares int8 to int4
 CREATE TABLE hyper_84 (time timestamptz, device int8, location int8, temp float8);
 SELECT create_hypertable('hyper_84', 'time', create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (51,public,hyper_84,t)
@@ -2800,7 +2789,6 @@ DELETE FROM hyper_84 WHERE device = 1;
 -- Test using DELETE instead of TRUNCATE after compression
 CREATE TABLE hyper_delete (time timestamptz, device int, location int, temp float, t text);
 SELECT table_name FROM create_hypertable('hyper_delete', 'time');
-NOTICE:  adding not-null constraint to column "time"
   table_name  
 --------------
  hyper_delete
@@ -2855,7 +2843,6 @@ RESET timescaledb.enable_delete_after_compression;
 -- Test batch size limiting GUC
 CREATE TABLE hyper_85 (time timestamptz, device int8, location int8, temp float8);
 SELECT create_hypertable('hyper_85', 'time', create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (55,public,hyper_85,t)
@@ -2928,7 +2915,6 @@ SET timescaledb.enable_compression_ratio_warnings TO ON;
 -- Compressing a table with very few rows virtually guarantees a poor compression rate
 CREATE TABLE badly_compressed_ht (time timestamptz, device_id integer, a integer);
 SELECT create_hypertable('badly_compressed_ht', 'time');
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
  (57,public,badly_compressed_ht,t)

--- a/tsl/test/expected/compression_allocation.out
+++ b/tsl/test/expected/compression_allocation.out
@@ -4,7 +4,6 @@
 -- Test array compression overallocation protection
 CREATE TABLE vector_overalloc (time timestamptz, device int8, ord numeric, value text);
 SELECT create_hypertable('vector_overalloc', 'time', create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------
  (1,public,vector_overalloc,t)

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -138,7 +138,6 @@ NOTICE:  drop cascades to view dummyv1
 --smallint test
 CREATE TABLE test_table_smallint(time SMALLINT, val SMALLINT);
 SELECT create_hypertable('test_table_smallint', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (3,public,test_table_smallint,t)
@@ -179,7 +178,6 @@ ORDER BY chunk_name;
 --integer tests
 CREATE TABLE test_table_integer(time INTEGER, val INTEGER);
 SELECT create_hypertable('test_table_integer', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (5,public,test_table_integer,t)
@@ -216,7 +214,6 @@ ORDER BY chunk_name;
 --bigint test
 CREATE TABLE test_table_bigint(time BIGINT, val BIGINT);
 SELECT create_hypertable('test_table_bigint', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
  (7,public,test_table_bigint,t)
@@ -255,7 +252,6 @@ ORDER BY chunk_name;
 SET ROLE NOLOGIN_ROLE;
 CREATE TABLE test_table_nologin(time bigint, val int);
 SELECT create_hypertable('test_table_nologin', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (9,public,test_table_nologin,t)
@@ -663,7 +659,6 @@ SELECT delete_job(:JOB_RECOMPRESS);
 --compression policy should ignore frozen partially compressed chunks
 CREATE TABLE test_table_frozen(time TIMESTAMPTZ, val SMALLINT);
 SELECT create_hypertable('test_table_frozen', 'time', chunk_time_interval => '1 day'::interval);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (18,public,test_table_frozen,t)
@@ -856,7 +851,6 @@ DROP TABLE metrics2;
 --compression policy errors
 CREATE TABLE test_compression_policy_errors(time TIMESTAMPTZ, val SMALLINT);
 SELECT create_hypertable('test_compression_policy_errors', 'time', chunk_time_interval => '1 day'::interval);
-NOTICE:  adding not-null constraint to column "time"
               create_hypertable               
 ----------------------------------------------
  (22,public,test_compression_policy_errors,t)

--- a/tsl/test/expected/compression_bool_vectorized.out
+++ b/tsl/test/expected/compression_bool_vectorized.out
@@ -6,7 +6,6 @@ NOTICE:  table "t1" does not exist, skipping
 set timescaledb.enable_bool_compression = on;
 create table t1 (ts int, b bool);
 select create_hypertable('t1','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,t1,t)

--- a/tsl/test/expected/compression_bools.out
+++ b/tsl/test/expected/compression_bools.out
@@ -20,7 +20,6 @@ INSERT INTO d SELECT g AS ts, true AS b FROM generate_series(5001, 20000) g;
 -- add a few bool columns
 CREATE TABLE t (ts int, b1 bool, b2 bool, b3 bool);
 SELECT create_hypertable('t', 'ts', chunk_time_interval => 5000);
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,t,t)

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -33,7 +33,6 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 SET timezone TO 'America/Los_Angeles';
 CREATE TABLE test1 ("Time" timestamptz, i integer not null, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -656,7 +655,6 @@ DROP TABLESPACE tablespace1;
 -- Triggers are NOT fired for compress/decompress
 CREATE TABLE test1 ("Time" timestamptz, i integer);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -780,7 +778,6 @@ END
 $BODY$;
 CREATE TABLE test1 ("Time" timestamptz, intcol integer, bntcol bigint, txtcol text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
-psql:include/compression_alter.sql:8: NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -1110,7 +1107,6 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 -- test dropping columns from compressed
 CREATE TABLE test_drop(f1 text, f2 text, f3 text, time timestamptz, device int, o1 text, o2 text);
 SELECT create_hypertable('test_drop','time');
-psql:include/compression_alter.sql:149: NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (17,public,test_drop,t)
@@ -1207,7 +1203,6 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_drop
 --TEST tablespaces for compressed chunks with attach_tablespace interface --
 CREATE TABLE test2 (timec timestamptz, i integer, t integer);
 SELECT table_name from create_hypertable('test2', 'timec', chunk_time_interval=> INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "timec"
  table_name 
 ------------
  test2
@@ -2229,7 +2224,6 @@ select count(*) from test_partials group by tableoid order by count(*) desc;
 -- add test for space partioning with partial chunks
 CREATE TABLE space_part (time timestamptz, a int, b int, c int);
 SELECT create_hypertable('space_part', 'time', chunk_time_interval => INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (35,public,space_part,t)
@@ -2508,7 +2502,6 @@ CREATE TABLE hyper_ex (
     ) WHERE (not canceled)
 );
 SELECT * FROM create_hypertable('hyper_ex', 'time', chunk_time_interval=> interval '1 month');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
             39 | public      | hyper_ex   | t
@@ -2528,7 +2521,6 @@ CREATE TABLE hyper_unique_deferred (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_unique_deferred', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |      table_name       | created 
 ---------------+-------------+-----------------------+---------
             40 | public      | hyper_unique_deferred | t

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -7,8 +7,6 @@
 --table with special column names --
 create table foo2 (a integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('foo2', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
  table_name 
 ------------
  foo2
@@ -16,8 +14,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 create table foo3 (a integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('foo3', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
  table_name 
 ------------
  foo3
@@ -25,8 +21,6 @@ DETAIL:  Dimensions cannot have NULL values.
 
 create table non_compressed (a integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('non_compressed', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
    table_name   
 ----------------
  non_compressed
@@ -55,8 +49,6 @@ alter table default_skipped set (timescaledb.compress, timescaledb.compress_segm
 create table with_rls (a integer, b integer);
 ALTER TABLE with_rls ENABLE ROW LEVEL SECURITY;
 select table_name from create_hypertable('with_rls', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
  table_name 
 ------------
  with_rls
@@ -83,8 +75,6 @@ alter table default_skipped set (timescaledb.compress, timescaledb.compress_orde
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
        table_name       
 ------------------------
  reserved_column_prefix
@@ -96,8 +86,6 @@ ERROR:  cannot convert tables with reserved column prefix '_ts_meta_' to columns
 create table foo (a integer, b integer, c integer, t text, p point);
 ALTER TABLE foo ADD CONSTRAINT chk_existing CHECK(b > 0);
 select table_name from create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
  table_name 
 ------------
  foo
@@ -253,8 +241,6 @@ ALTER TABLE foo_fake RESET (timescaledb.compress_segmentby);
 ERROR:  timescaledb table options can only be specified for hypertables
 DETAIL:  foo_fake is not a hypertable
 select table_name from create_hypertable('foo_fake', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Dimensions cannot have NULL values.
  table_name 
 ------------
  foo_fake
@@ -494,8 +480,6 @@ ALTER TABLE table_constr2 SET (timescaledb.compress=false);
 -- modify the config to trigger errors at runtime
 CREATE TABLE test_table_int(time bigint, val int);
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
-DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
  (21,public,test_table_int,t)
@@ -660,8 +644,6 @@ SELECT format('CREATE TABLE data_table AS SELECT now() AS tm, %s', array_to_stri
 CREATE TABLE data_table AS SELECT now() AS tm, 125 AS c1, 125 AS c2, 125 AS c3, 125 AS c4, 125 AS c5, 125 AS c6, 125 AS c7, 125 AS c8, 125 AS c9, 125 AS c10, 125 AS c11, 125 AS c12, 125 AS c13, 125 AS c14, 125 AS c15, 125 AS c16, 125 AS c17, 125 AS c18, 125 AS c19, 125 AS c20, 125 AS c21, 125 AS c22, 125 AS c23, 125 AS c24, 125 AS c25, 125 AS c26, 125 AS c27, 125 AS c28, 125 AS c29, 125 AS c30, 125 AS c31, 125 AS c32, 125 AS c33, 125 AS c34, 125 AS c35, 125 AS c36, 125 AS c37, 125 AS c38, 125 AS c39, 125 AS c40, 125 AS c41, 125 AS c42, 125 AS c43, 125 AS c44, 125 AS c45, 125 AS c46, 125 AS c47, 125 AS c48, 125 AS c49, 125 AS c50, 125 AS c51, 125 AS c52, 125 AS c53, 125 AS c54, 125 AS c55, 125 AS c56, 125 AS c57, 125 AS c58, 125 AS c59, 125 AS c60, 125 AS c61, 125 AS c62, 125 AS c63, 125 AS c64, 125 AS c65, 125 AS c66, 125 AS c67, 125 AS c68, 125 AS c69, 125 AS c70, 125 AS c71, 125 AS c72, 125 AS c73, 125 AS c74, 125 AS c75, 125 AS c76, 125 AS c77, 125 AS c78, 125 AS c79, 125 AS c80, 125 AS c81, 125 AS c82, 125 AS c83, 125 AS c84, 125 AS c85, 125 AS c86, 125 AS c87, 125 AS c88, 125 AS c89, 125 AS c90, 125 AS c91, 125 AS c92, 125 AS c93, 125 AS c94, 125 AS c95, 125 AS c96, 125 AS c97, 125 AS c98, 125 AS c99, 125 AS c100, 125 AS c101, 125 AS c102, 125 AS c103, 125 AS c104, 125 AS c105, 125 AS c106, 125 AS c107, 125 AS c108, 125 AS c109, 125 AS c110, 125 AS c111, 125 AS c112, 125 AS c113, 125 AS c114, 125 AS c115, 125 AS c116, 125 AS c117, 125 AS c118, 125 AS c119, 125 AS c120, 125 AS c121, 125 AS c122, 125 AS c123, 125 AS c124, 125 AS c125, 125 AS c126, 125 AS c127, 125 AS c128, 125 AS c129, 125 AS c130, 125 AS c131, 125 AS c132, 125 AS c133, 125 AS c134, 125 AS c135, 125 AS c136, 125 AS c137, 125 AS c138, 125 AS c139, 125 AS c140, 125 AS c141, 125 AS c142, 125 AS c143, 125 AS c144, 125 AS c145, 125 AS c146, 125 AS c147, 125 AS c148, 125 AS c149, 125 AS c150, 125 AS c151, 125 AS c152, 125 AS c153, 125 AS c154, 125 AS c155, 125 AS c156, 125 AS c157, 125 AS c158, 125 AS c159, 125 AS c160, 125 AS c161, 125 AS c162, 125 AS c163, 125 AS c164, 125 AS c165, 125 AS c166, 125 AS c167, 125 AS c168, 125 AS c169, 125 AS c170, 125 AS c171, 125 AS c172, 125 AS c173, 125 AS c174, 125 AS c175, 125 AS c176, 125 AS c177, 125 AS c178, 125 AS c179, 125 AS c180, 125 AS c181, 125 AS c182, 125 AS c183, 125 AS c184, 125 AS c185, 125 AS c186, 125 AS c187, 125 AS c188, 125 AS c189, 125 AS c190, 125 AS c191, 125 AS c192, 125 AS c193, 125 AS c194, 125 AS c195, 125 AS c196, 125 AS c197, 125 AS c198, 125 AS c199, 125 AS c200, 125 AS c201, 125 AS c202, 125 AS c203, 125 AS c204, 125 AS c205, 125 AS c206, 125 AS c207, 125 AS c208, 125 AS c209, 125 AS c210, 125 AS c211, 125 AS c212, 125 AS c213, 125 AS c214, 125 AS c215, 125 AS c216, 125 AS c217, 125 AS c218, 125 AS c219, 125 AS c220, 125 AS c221, 125 AS c222, 125 AS c223, 125 AS c224, 125 AS c225, 125 AS c226, 125 AS c227, 125 AS c228, 125 AS c229, 125 AS c230, 125 AS c231, 125 AS c232, 125 AS c233, 125 AS c234, 125 AS c235, 125 AS c236, 125 AS c237, 125 AS c238, 125 AS c239, 125 AS c240, 125 AS c241, 125 AS c242, 125 AS c243, 125 AS c244, 125 AS c245, 125 AS c246, 125 AS c247, 125 AS c248, 125 AS c249, 125 AS c250, 125 AS c251, 125 AS c252, 125 AS c253, 125 AS c254, 125 AS c255, 125 AS c256, 125 AS c257, 125 AS c258, 125 AS c259, 125 AS c260, 125 AS c261, 125 AS c262, 125 AS c263, 125 AS c264, 125 AS c265, 125 AS c266, 125 AS c267, 125 AS c268, 125 AS c269, 125 AS c270, 125 AS c271, 125 AS c272, 125 AS c273, 125 AS c274, 125 AS c275, 125 AS c276, 125 AS c277, 125 AS c278, 125 AS c279, 125 AS c280, 125 AS c281, 125 AS c282, 125 AS c283, 125 AS c284, 125 AS c285, 125 AS c286, 125 AS c287, 125 AS c288, 125 AS c289, 125 AS c290, 125 AS c291, 125 AS c292, 125 AS c293, 125 AS c294, 125 AS c295, 125 AS c296, 125 AS c297, 125 AS c298, 125 AS c299, 125 AS c300, 125 AS c301, 125 AS c302, 125 AS c303, 125 AS c304, 125 AS c305, 125 AS c306, 125 AS c307, 125 AS c308, 125 AS c309, 125 AS c310, 125 AS c311, 125 AS c312, 125 AS c313, 125 AS c314, 125 AS c315, 125 AS c316, 125 AS c317, 125 AS c318, 125 AS c319, 125 AS c320, 125 AS c321, 125 AS c322, 125 AS c323, 125 AS c324, 125 AS c325, 125 AS c326, 125 AS c327, 125 AS c328, 125 AS c329, 125 AS c330, 125 AS c331, 125 AS c332, 125 AS c333, 125 AS c334, 125 AS c335, 125 AS c336, 125 AS c337, 125 AS c338, 125 AS c339, 125 AS c340, 125 AS c341, 125 AS c342, 125 AS c343, 125 AS c344, 125 AS c345, 125 AS c346, 125 AS c347, 125 AS c348, 125 AS c349, 125 AS c350, 125 AS c351, 125 AS c352, 125 AS c353, 125 AS c354, 125 AS c355, 125 AS c356, 125 AS c357, 125 AS c358, 125 AS c359, 125 AS c360, 125 AS c361, 125 AS c362, 125 AS c363, 125 AS c364, 125 AS c365, 125 AS c366, 125 AS c367, 125 AS c368, 125 AS c369, 125 AS c370, 125 AS c371, 125 AS c372, 125 AS c373, 125 AS c374, 125 AS c375, 125 AS c376, 125 AS c377, 125 AS c378, 125 AS c379, 125 AS c380, 125 AS c381, 125 AS c382, 125 AS c383, 125 AS c384, 125 AS c385, 125 AS c386, 125 AS c387, 125 AS c388, 125 AS c389, 125 AS c390, 125 AS c391, 125 AS c392, 125 AS c393, 125 AS c394, 125 AS c395, 125 AS c396, 125 AS c397, 125 AS c398, 125 AS c399, 125 AS c400, 125 AS c401, 125 AS c402, 125 AS c403, 125 AS c404, 125 AS c405, 125 AS c406, 125 AS c407, 125 AS c408, 125 AS c409, 125 AS c410, 125 AS c411, 125 AS c412, 125 AS c413, 125 AS c414, 125 AS c415, 125 AS c416, 125 AS c417, 125 AS c418, 125 AS c419, 125 AS c420, 125 AS c421, 125 AS c422, 125 AS c423, 125 AS c424, 125 AS c425, 125 AS c426, 125 AS c427, 125 AS c428, 125 AS c429, 125 AS c430, 125 AS c431, 125 AS c432, 125 AS c433, 125 AS c434, 125 AS c435, 125 AS c436, 125 AS c437, 125 AS c438, 125 AS c439, 125 AS c440, 125 AS c441, 125 AS c442, 125 AS c443, 125 AS c444, 125 AS c445, 125 AS c446, 125 AS c447, 125 AS c448, 125 AS c449, 125 AS c450, 125 AS c451, 125 AS c452, 125 AS c453, 125 AS c454, 125 AS c455, 125 AS c456, 125 AS c457, 125 AS c458, 125 AS c459, 125 AS c460, 125 AS c461, 125 AS c462, 125 AS c463, 125 AS c464, 125 AS c465, 125 AS c466, 125 AS c467, 125 AS c468, 125 AS c469, 125 AS c470, 125 AS c471, 125 AS c472, 125 AS c473, 125 AS c474, 125 AS c475, 125 AS c476, 125 AS c477, 125 AS c478, 125 AS c479, 125 AS c480, 125 AS c481, 125 AS c482, 125 AS c483, 125 AS c484, 125 AS c485, 125 AS c486, 125 AS c487, 125 AS c488, 125 AS c489, 125 AS c490, 125 AS c491, 125 AS c492, 125 AS c493, 125 AS c494, 125 AS c495, 125 AS c496, 125 AS c497, 125 AS c498, 125 AS c499, 125 AS c500, 125 AS c501, 125 AS c502, 125 AS c503, 125 AS c504, 125 AS c505, 125 AS c506, 125 AS c507, 125 AS c508, 125 AS c509, 125 AS c510, 125 AS c511, 125 AS c512, 125 AS c513, 125 AS c514, 125 AS c515, 125 AS c516, 125 AS c517, 125 AS c518, 125 AS c519, 125 AS c520, 125 AS c521, 125 AS c522, 125 AS c523, 125 AS c524, 125 AS c525, 125 AS c526, 125 AS c527, 125 AS c528, 125 AS c529, 125 AS c530, 125 AS c531, 125 AS c532, 125 AS c533, 125 AS c534, 125 AS c535, 125 AS c536, 125 AS c537, 125 AS c538, 125 AS c539, 125 AS c540, 125 AS c541, 125 AS c542, 125 AS c543, 125 AS c544, 125 AS c545, 125 AS c546, 125 AS c547, 125 AS c548, 125 AS c549, 125 AS c550
 CREATE TABLE ts_table (LIKE data_table);
 SELECT * FROM create_hypertable('ts_table', 'tm');
-NOTICE:  adding not-null constraint to column "tm"
-DETAIL:  Dimensions cannot have NULL values.
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
             27 | public      | ts_table   | t
@@ -755,7 +737,6 @@ CREATE TABLE main_table AS
 SELECT '2011-11-11 11:11:11'::timestamptz AS time, 'foo' AS device_id;
 CREATE UNIQUE INDEX xm ON main_table(time, device_id);
 SELECT create_hypertable('main_table', 'time', chunk_time_interval => interval '12 hour', migrate_data => TRUE);
-NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
     create_hypertable     
 --------------------------

--- a/tsl/test/expected/compression_fks.out
+++ b/tsl/test/expected/compression_fks.out
@@ -5,7 +5,6 @@
 CREATE TABLE keys(time timestamptz unique);
 CREATE TABLE ht_with_fk(time timestamptz);
 SELECT create_hypertable('ht_with_fk','time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,ht_with_fk,t)

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -63,7 +63,6 @@ CREATE OPERATOR CLASS customtype_ops
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -202,7 +201,6 @@ SELECT count(*) FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2;
 --add test for altered hypertable
 CREATE TABLE test2 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test2
@@ -579,7 +577,6 @@ DROP TABLE test6;
 CREATE TABLE test7(time INT, c1 DATE, c2 TIMESTAMP, c3 FLOAT, n TEXT);
 SELECT create_hypertable('test7', 'time', chunk_time_interval=> 200);
 WARNING:  column type "timestamp without time zone" used for "c2" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (11,public,test7,t)
@@ -657,7 +654,6 @@ create or replace function mix(x float4) returns float4 as $$ select ((hashfloat
 -- test gorilla for float4 and deltadelta for int32 and other types
 create table test8(ts date, id int, value float4, valueint2 int2, valuebool bool);
 select create_hypertable('test8', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable  
 ---------------------
  (13,public,test8,t)

--- a/tsl/test/expected/compression_indexcreate.out
+++ b/tsl/test/expected/compression_indexcreate.out
@@ -6,7 +6,6 @@ set enable_seqscan to false;
 \set PREFIX 'EXPLAIN (analyze, costs off, summary off, timing off) '
 create table segind(time timestamptz, a int, b int);
 select create_hypertable('segind', by_range('time'));
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (1,t)

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -7,7 +7,6 @@ SET timezone TO 'America/Los_Angeles';
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
-NOTICE:  adding not-null constraint to column "timec"
  table_name 
 ------------
  test1
@@ -225,7 +224,6 @@ DROP TABLE test1;
 -- also tests defaults
 CREATE TABLE test2 ( itime integer, b bigint, t text);
 SELECT table_name from create_hypertable('test2', 'itime', chunk_time_interval=> 10::integer);
-NOTICE:  adding not-null constraint to column "itime"
  table_name 
 ------------
  test2
@@ -300,7 +298,6 @@ CREATE TABLE test2 (timec timestamptz ,
       CONSTRAINT rowconstr CHECK ( b > i )
 );
 SELECT table_name from create_hypertable('test2', 'timec', chunk_time_interval=> INTERVAL '7 days');
-NOTICE:  adding not-null constraint to column "timec"
  table_name 
 ------------
  test2
@@ -368,7 +365,6 @@ CREATE TABLE vessels (timec timestamptz ,
       CONSTRAINT rowconstr CHECK ( b > i )
 );
 SELECT table_name from create_hypertable('vessels', 'timec', chunk_time_interval=> INTERVAL '7 days');
-NOTICE:  adding not-null constraint to column "timec"
  table_name 
 ------------
  vessels
@@ -761,7 +757,6 @@ DROP TABLE trigger_test;
 SET timescaledb.enable_decompression_sorted_merge = 0;
 CREATE TABLE test_ordering(time int);
 SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
-NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------
  test_ordering

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -30,7 +30,6 @@ insert into rand_minstd_state values (321);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -96,7 +95,6 @@ psql:include/compression_test_merge.sql:7: NOTICE:  table "merge_result" does no
 DROP TABLE test1;
 CREATE TABLE test2 ("Time" timestamptz, i integer, loc integer, value integer);
 SELECT table_name from create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test2
@@ -217,7 +215,6 @@ SELECT 'test2' AS "HYPERTABLE_NAME" \gset
 DROP TABLE test2;
 CREATE TABLE test3 ("Time" timestamptz, i integer, loc integer, value integer);
 SELECT table_name from create_hypertable('test3', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test3
@@ -291,7 +288,6 @@ SELECT 'test3' AS "HYPERTABLE_NAME" \gset
 DROP TABLE test3;
 CREATE TABLE test4 ("Time" timestamptz, i integer, loc integer, value integer);
 SELECT table_name from create_hypertable('test4', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test4
@@ -307,7 +303,6 @@ HINT:  consider setting "Time" as first compress_orderby column
 DROP TABLE test4;
 CREATE TABLE test5 ("Time" timestamptz, i integer, value integer);
 SELECT table_name from create_hypertable('test5', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test5
@@ -382,7 +377,6 @@ psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_190_chunk" 
 DROP TABLE test5;
 CREATE TABLE test6 ("Time" timestamptz, i integer, value integer);
 SELECT table_name from create_hypertable('test6', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test6
@@ -627,7 +621,6 @@ ERROR:  invalid value for timescaledb.compress_chunk_time_interval 'null'
 DROP TABLE test6;
 CREATE TABLE test7 ("Time" timestamptz, i integer, j integer, k integer, value integer);
 SELECT table_name from create_hypertable('test7', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test7
@@ -835,7 +828,6 @@ ROLLBACK;
 -- Test RowExclusiveLock on compressed chunk during chunk rollup using a GUC
 CREATE TABLE test10 ("Time" timestamptz, i integer, value integer);
 SELECT table_name from create_hypertable('test10', 'Time', chunk_time_interval=> INTERVAL '1 hour');
-NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test10

--- a/tsl/test/expected/compression_nulls_and_defaults.out
+++ b/tsl/test/expected/compression_nulls_and_defaults.out
@@ -17,7 +17,6 @@ drop table if exists t;
 NOTICE:  table "t" does not exist, skipping
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,t,t)
@@ -76,7 +75,6 @@ set timescaledb.enable_segmentwise_recompression to on;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (3,public,t,t)
@@ -129,7 +127,6 @@ set timescaledb.enable_segmentwise_recompression to off;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (5,public,t,t)
@@ -180,7 +177,6 @@ set timescaledb.enable_segmentwise_recompression to on;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (7,public,t,t)
@@ -228,7 +224,6 @@ set timescaledb.enable_segmentwise_recompression to off;
 drop table if exists t;
 create table t (ts int);
 select create_hypertable('t', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (9,public,t,t)
@@ -267,7 +262,6 @@ set timescaledb.enable_segmentwise_recompression to on;
 drop table if exists t;
 create table t(ts int);
 select create_hypertable('t', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (11,public,t,t)
@@ -314,7 +308,6 @@ set timescaledb.enable_segmentwise_recompression to off;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (13,public,t,t)
@@ -375,7 +368,6 @@ set timescaledb.enable_segmentwise_recompression to on;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (15,public,t,t)
@@ -452,7 +444,6 @@ select * from t;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (17,public,t,t)
@@ -525,7 +516,6 @@ select * from t;
 drop table if exists t;
 create table t(ts int, c1 int);
 select create_hypertable('t','ts');
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (19,public,t,t)
@@ -658,7 +648,6 @@ drop table if exists codecov;
 NOTICE:  table "codecov" does not exist, skipping
 create table codecov(ts int, c1 int);
 select create_hypertable('codecov','ts');
-NOTICE:  adding not-null constraint to column "ts"
    create_hypertable   
 -----------------------
  (21,public,codecov,t)

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -152,14 +152,12 @@ knowledge_date date NOT NULL
 SELECT create_hypertable('metaseg_tab', 'end_dt', chunk_time_interval=>interval '1 month', create_default_indexes=>false);
 WARNING:  column type "timestamp without time zone" used for "start_dt" does not follow best practices
 WARNING:  column type "timestamp without time zone" used for "end_dt" does not follow best practices
-NOTICE:  adding not-null constraint to column "end_dt"
     create_hypertable     
 --------------------------
  (3,public,metaseg_tab,t)
 (1 row)
 
 SELECT add_dimension('metaseg_tab', 'fmid', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "fmid"
          add_dimension         
 -------------------------------
  (3,public,metaseg_tab,fmid,t)
@@ -338,7 +336,6 @@ CREATE TABLE deleteme AS
         FROM generate_series('2008-03-01 00:00'::timestamp with time zone,
                              '2008-03-04 12:00', '1 second');
 SELECT create_hypertable('deleteme', 'timestamp', migrate_data => true);
-NOTICE:  adding not-null constraint to column "timestamp"
 NOTICE:  migrating data to chunks
    create_hypertable   
 -----------------------
@@ -417,7 +414,6 @@ DROP table deleteme_with_bytea;
 -- test sqlvaluefunction pushdown
 CREATE TABLE svf_pushdown(time timestamptz, c_date date, c_time time, c_timetz timetz, c_timestamp timestamptz, c_name text, c_bool bool);
 SELECT table_name FROM create_hypertable('svf_pushdown', 'time');
-NOTICE:  adding not-null constraint to column "time"
   table_name  
 --------------
  svf_pushdown
@@ -643,7 +639,6 @@ DROP TABLE svf_pushdown;
 -- expression tree.
 create table booltab(ts int, segmentby bool, flag bool, value int);
 select create_hypertable('booltab', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
    create_hypertable   
 -----------------------
  (13,public,booltab,t)

--- a/tsl/test/expected/compression_sorted_merge.out
+++ b/tsl/test/expected/compression_sorted_merge.out
@@ -1467,7 +1467,6 @@ WARNING:  column type "character varying" used for "block" does not follow best 
 WARNING:  column type "character varying" used for "message_name" does not follow best practices
 WARNING:  column type "character varying" used for "signal_name" does not follow best practices
 WARNING:  column type "character varying" used for "signal_string_value" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (11,public,bugtab,t)
@@ -1527,7 +1526,6 @@ CREATE TABLE test (
 );
 SELECT create_hypertable('test', 'dttm');
 WARNING:  column type "timestamp without time zone" used for "dttm" does not follow best practices
-NOTICE:  adding not-null constraint to column "dttm"
  create_hypertable  
 --------------------
  (13,public,test,t)

--- a/tsl/test/expected/compression_sorted_merge_columns.out
+++ b/tsl/test/expected/compression_sorted_merge_columns.out
@@ -5,7 +5,6 @@
 create table t(x int, time timestamp, timetz timestamptz, int32 int4, int64 int8, s text);
 select create_hypertable('t', 'x');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "x"
  create_hypertable 
 -------------------
  (1,public,t,t)

--- a/tsl/test/expected/compression_sorted_merge_distinct.out
+++ b/tsl/test/expected/compression_sorted_merge_distinct.out
@@ -9,7 +9,6 @@ create or replace function mix(x float4) returns float4 as $$ select ((hashfloat
 create table t(ts timestamp, low_card int, high_card int, value float);
 select create_hypertable('t', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,t,t)

--- a/tsl/test/expected/compression_sorted_merge_filter.out
+++ b/tsl/test/expected/compression_sorted_merge_filter.out
@@ -4,7 +4,6 @@
 create table batches(ts timestamp, id int);
 select create_hypertable('batches', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (1,public,batches,t)

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -640,7 +640,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
              9 | public      | sample_table | t
@@ -750,7 +749,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             11 | public      | sample_table | t
@@ -812,7 +810,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             13 | public      | sample_table | t
@@ -996,7 +993,6 @@ CREATE TABLE sample_table(
     d INT,
     e INT default 13);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 5);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             15 | public      | sample_table | t
@@ -1222,7 +1218,6 @@ DROP TABLE sample_table;
 -- test with different physical layout
 CREATE TABLE sample_table(time timestamptz, c1 text, c2 text, c3 text);
 SELECT create_hypertable('sample_table','time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (17,public,sample_table,t)
@@ -1308,7 +1303,6 @@ DROP TABLE sample_table;
 -- test filtering with ORDER BY columns
 CREATE TABLE sample_table(time timestamptz, c1 int, c2 int, c3 int, c4 int);
 SELECT create_hypertable('sample_table','time',chunk_time_interval=>'1 day'::interval);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (19,public,sample_table,t)
@@ -2515,7 +2509,6 @@ DROP DATABASE test5586;
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  create_hypertable 
 -------------------
  (31,public,t,t)

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -640,7 +640,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
              9 | public      | sample_table | t
@@ -750,7 +749,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             11 | public      | sample_table | t
@@ -812,7 +810,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             13 | public      | sample_table | t
@@ -996,7 +993,6 @@ CREATE TABLE sample_table(
     d INT,
     e INT default 13);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 5);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             15 | public      | sample_table | t
@@ -1222,7 +1218,6 @@ DROP TABLE sample_table;
 -- test with different physical layout
 CREATE TABLE sample_table(time timestamptz, c1 text, c2 text, c3 text);
 SELECT create_hypertable('sample_table','time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (17,public,sample_table,t)
@@ -1308,7 +1303,6 @@ DROP TABLE sample_table;
 -- test filtering with ORDER BY columns
 CREATE TABLE sample_table(time timestamptz, c1 int, c2 int, c3 int, c4 int);
 SELECT create_hypertable('sample_table','time',chunk_time_interval=>'1 day'::interval);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (19,public,sample_table,t)
@@ -2515,7 +2509,6 @@ DROP DATABASE test5586;
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  create_hypertable 
 -------------------
  (31,public,t,t)

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -640,7 +640,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
              9 | public      | sample_table | t
@@ -750,7 +749,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             11 | public      | sample_table | t
@@ -812,7 +810,6 @@ CREATE TABLE sample_table(
     device_id INT,
     val INT);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             13 | public      | sample_table | t
@@ -996,7 +993,6 @@ CREATE TABLE sample_table(
     d INT,
     e INT default 13);
 SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 5);
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             15 | public      | sample_table | t
@@ -1222,7 +1218,6 @@ DROP TABLE sample_table;
 -- test with different physical layout
 CREATE TABLE sample_table(time timestamptz, c1 text, c2 text, c3 text);
 SELECT create_hypertable('sample_table','time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (17,public,sample_table,t)
@@ -1308,7 +1303,6 @@ DROP TABLE sample_table;
 -- test filtering with ORDER BY columns
 CREATE TABLE sample_table(time timestamptz, c1 int, c2 int, c3 int, c4 int);
 SELECT create_hypertable('sample_table','time',chunk_time_interval=>'1 day'::interval);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (19,public,sample_table,t)
@@ -2515,7 +2509,6 @@ DROP DATABASE test5586;
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  create_hypertable 
 -------------------
  (31,public,t,t)

--- a/tsl/test/expected/compression_uuid.out
+++ b/tsl/test/expected/compression_uuid.out
@@ -12,7 +12,6 @@
 SET timescaledb.enable_uuid_compression = on;
 CREATE TABLE t (ts int, u uuid);
 SELECT create_hypertable('t', 'ts', chunk_time_interval => 500);
-NOTICE:  adding not-null constraint to column "ts"
  create_hypertable 
 -------------------
  (1,public,t,t)
@@ -96,7 +95,6 @@ SELECT compress_chunk(show_chunks('t'));
 
 CREATE TABLE mixed_compressed (ts int, u uuid);
 SELECT create_hypertable('mixed_compressed', 'ts', chunk_time_interval => 500);
-NOTICE:  adding not-null constraint to column "ts"
        create_hypertable       
 -------------------------------
  (3,public,mixed_compressed,t)

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -22,7 +22,6 @@ SELECT * FROM _timescaledb_config.bgw_job;
 --basic test with count
 create table foo (a integer, b integer, c integer);
 select table_name from create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo
@@ -973,7 +972,6 @@ SELECT create_hypertable(
     chunk_time_interval => 10,
     partitioning_column => 'dev',
     number_partitions => 3);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (24,public,space_table,t)
@@ -1397,7 +1395,6 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_37_75_chunk
 --- github issue 2655 ---
 create table raw_data(time timestamptz, search_query text, cnt integer, cnt2 integer);
 select create_hypertable('raw_data','time', chunk_time_interval=>'15 days'::interval);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (38,public,raw_data,t)
@@ -1717,7 +1714,6 @@ symbol int,
 value numeric
 );
 select create_hypertable('test_group_idx', 'time');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (48,public,test_group_idx,t)

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -22,7 +22,6 @@ SELECT * FROM _timescaledb_config.bgw_job;
 --basic test with count
 create table foo (a integer, b integer, c integer);
 select table_name from create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo
@@ -973,7 +972,6 @@ SELECT create_hypertable(
     chunk_time_interval => 10,
     partitioning_column => 'dev',
     number_partitions => 3);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (24,public,space_table,t)
@@ -1397,7 +1395,6 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_37_75_chunk
 --- github issue 2655 ---
 create table raw_data(time timestamptz, search_query text, cnt integer, cnt2 integer);
 select create_hypertable('raw_data','time', chunk_time_interval=>'15 days'::interval);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (38,public,raw_data,t)
@@ -1717,7 +1714,6 @@ symbol int,
 value numeric
 );
 select create_hypertable('test_group_idx', 'time');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (48,public,test_group_idx,t)

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -22,7 +22,6 @@ SELECT * FROM _timescaledb_config.bgw_job;
 --basic test with count
 create table foo (a integer, b integer, c integer);
 select table_name from create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo
@@ -973,7 +972,6 @@ SELECT create_hypertable(
     chunk_time_interval => 10,
     partitioning_column => 'dev',
     number_partitions => 3);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (24,public,space_table,t)
@@ -1397,7 +1395,6 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_37_75_chunk
 --- github issue 2655 ---
 create table raw_data(time timestamptz, search_query text, cnt integer, cnt2 integer);
 select create_hypertable('raw_data','time', chunk_time_interval=>'15 days'::interval);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (38,public,raw_data,t)
@@ -1717,7 +1714,6 @@ symbol int,
 value numeric
 );
 select create_hypertable('test_group_idx', 'time');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (48,public,test_group_idx,t)

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -38,9 +38,7 @@ ERROR:  invalid value for tsdb.create_default_indexes '-1'
 BEGIN;
 CREATE TABLE t3(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
 CREATE TABLE t4(time timestamp, device text, value float) WITH (tsdb.hypertable,timescaledb.partitioning_column='time');
-NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE t5(time date, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',autovacuum_enabled);
-NOTICE:  adding not-null constraint to column "time"
 CREATE TABLE t6(time timestamptz NOT NULL, device text, value float) WITH (timescaledb.hypertable,tsdb.partition_column='time');
 SELECT hypertable_name FROM timescaledb_information.hypertables ORDER BY 1;
  hypertable_name 

--- a/tsl/test/expected/custom_hashagg.out
+++ b/tsl/test/expected/custom_hashagg.out
@@ -3,7 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 create table foo( a integer, b timestamptz);
 select count(*) from create_hypertable('foo', 'b');
-NOTICE:  adding not-null constraint to column "b"
  count 
 -------
      1

--- a/tsl/test/expected/decompress_index.out
+++ b/tsl/test/expected/decompress_index.out
@@ -5,7 +5,6 @@
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float, tag text);
 ALTER TABLE ht_metrics_compressed SET (autovacuum_enabled = false);
 SELECT create_hypertable('ht_metrics_compressed','time',create_default_indexes:=false, chunk_time_interval => interval '100 day');
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
  (1,public,ht_metrics_compressed,t)

--- a/tsl/test/expected/decompress_memory.out
+++ b/tsl/test/expected/decompress_memory.out
@@ -5,7 +5,6 @@
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float, tag text);
 ALTER TABLE ht_metrics_compressed SET (autovacuum_enabled = false);
 SELECT create_hypertable('ht_metrics_compressed','time',create_default_indexes:=false);
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
  (1,public,ht_metrics_compressed,t)

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -6,7 +6,6 @@ create function stable_abs(x int4) returns int4 as 'int4abs' language internal s
 create table vectorqual(metric1 int8, ts timestamp, metric2 int8, device int8);
 select create_hypertable('vectorqual', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
-NOTICE:  adding not-null constraint to column "ts"
     create_hypertable    
 -------------------------
  (1,public,vectorqual,t)
@@ -138,7 +137,6 @@ select count(*) from vectorqual where device = 1 /* can't apply vector ops to th
 create table arithmetic(ts int, a int2, b int4, c int8, d float4, e float8,
     ax int2, bx int4, cx int8, dx float4, ex float8);
 select create_hypertable('arithmetic', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
     create_hypertable    
 -------------------------
  (3,public,arithmetic,t)
@@ -1176,7 +1174,6 @@ ERROR:  debug: encountered non-vector quals when they are disabled
 -- Date columns
 create table date_table(ts date);
 select create_hypertable('date_table', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
     create_hypertable    
 -------------------------
  (7,public,date_table,t)
@@ -1235,7 +1232,6 @@ select * from date_table where ts <  CURRENT_DATE;
 -- Text columns.
 create table text_table(ts int, d int);
 select create_hypertable('text_table', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
     create_hypertable    
 -------------------------
  (9,public,text_table,t)
@@ -1601,7 +1597,6 @@ reset timescaledb.enable_bulk_decompression;
 -- Test the nonstandard Postgres NaN comparison that doesn't match the IEEE floats.
 create table nans(t int, cfloat4 float4, cfloat8 float8);
 select create_hypertable('nans', 't', chunk_time_interval => 1024 * 1024 * 1024);
-NOTICE:  adding not-null constraint to column "t"
  create_hypertable  
 --------------------
  (11,public,nans,t)
@@ -2936,7 +2931,6 @@ set timescaledb.enable_uuid_compression = off;
 -- set timescaledb.debug_require_vector_qual to 'forbid';
 create table uuid_table(ts int, u uuid);
 select count(*) from create_hypertable('uuid_table', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  count 
 -------
      1
@@ -3217,7 +3211,6 @@ set timescaledb.enable_bulk_decompression to on;
 set timescaledb.enable_bool_compression = on;
 create table bool_table(ts int, b bool);
 select count(*) from create_hypertable('bool_table', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  count 
 -------
      1
@@ -4004,7 +3997,6 @@ select * from bool_table where b is not unknown order by 1;
 -- Verify that NULL compression with ints is vectorized
 create table int_table(ts int, b int);
 select count(*) from create_hypertable('int_table', 'ts');
-NOTICE:  adding not-null constraint to column "ts"
  count 
 -------
      1

--- a/tsl/test/expected/feature_flags.out
+++ b/tsl/test/expected/feature_flags.out
@@ -18,7 +18,6 @@ ERROR:  You are using a PostgreSQL service. This feature is only available on Ti
 \set ON_ERROR_STOP 1
 SET timescaledb.enable_hypertable_create TO on;
 SELECT * FROM create_hypertable('test', 'time');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | test       | t

--- a/tsl/test/expected/foreign_keys_test.out
+++ b/tsl/test/expected/foreign_keys_test.out
@@ -337,7 +337,6 @@ CREATE TABLE metrics(time timestamptz primary key, device text, value float);
 SELECT table_name FROM create_hypertable('metrics', 'time');
 CREATE TABLE event(time timestamptz, info text);
 SELECT table_name FROM create_hypertable('event', 'time');
-psql:include/foreign_keys.sql:384: NOTICE:  adding not-null constraint to column "time"
 \set ON_ERROR_STOP 0
 ALTER TABLE event ADD CONSTRAINT event_time_fkey FOREIGN KEY (time) REFERENCES metrics(time);
 psql:include/foreign_keys.sql:387: ERROR:  hypertables cannot be used as foreign key references of hypertables
@@ -667,7 +666,6 @@ INSERT INTO i7226 VALUES ('2024-08-29 12:00:00+00', 1);
 create table converted_pk(time timestamptz, id int, unique(time, id));
 create table converted_fk(time timestamptz, id int, foreign key (time, id) references converted_pk(time, id));
 select table_name FROM create_hypertable ('converted_pk', 'time');
-psql:include/foreign_keys.sql:748: NOTICE:  adding not-null constraint to column "time"
 \set ON_ERROR_STOP 0
 -- should fail
 INSERT INTO converted_fk SELECT '2020-01-01', 1;
@@ -1027,7 +1025,6 @@ CREATE TABLE metrics(time timestamptz primary key, device text, value float);
 SELECT table_name FROM create_hypertable('metrics', 'time');
 CREATE TABLE event(time timestamptz, info text);
 SELECT table_name FROM create_hypertable('event', 'time');
-psql:include/foreign_keys.sql:384: NOTICE:  adding not-null constraint to column "time"
 \set ON_ERROR_STOP 0
 ALTER TABLE event ADD CONSTRAINT event_time_fkey FOREIGN KEY (time) REFERENCES metrics(time);
 psql:include/foreign_keys.sql:387: ERROR:  hypertables cannot be used as foreign key references of hypertables
@@ -1357,7 +1354,6 @@ INSERT INTO i7226 VALUES ('2024-08-29 12:00:00+00', 1);
 create table converted_pk(time timestamptz, id int, unique(time, id));
 create table converted_fk(time timestamptz, id int, foreign key (time, id) references converted_pk(time, id));
 select table_name FROM create_hypertable ('converted_pk', 'time');
-psql:include/foreign_keys.sql:748: NOTICE:  adding not-null constraint to column "time"
 \set ON_ERROR_STOP 0
 -- should fail
 INSERT INTO converted_fk SELECT '2020-01-01', 1;

--- a/tsl/test/expected/hypertable_generalization.out
+++ b/tsl/test/expected/hypertable_generalization.out
@@ -91,7 +91,6 @@ ERROR:  column_name cannot be NULL
 -- Validate generalized hypertable for smallint
 CREATE TABLE test_table_smallint(id SMALLINT, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_smallint', by_range('id'));
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (1,t)
@@ -119,7 +118,6 @@ SELECT count(*) FROM timescaledb_information.chunks WHERE hypertable_name='test_
 -- Validate generalized hypertable for int
 CREATE TABLE test_table_int(id INTEGER, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_int', by_range('id'));
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (2,t)
@@ -147,7 +145,6 @@ SELECT count(*) FROM timescaledb_information.chunks WHERE hypertable_name='test_
 -- Validate generalized hypertable for bigint
 CREATE TABLE test_table_bigint(id BIGINT, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_bigint', by_range('id'));
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (3,t)
@@ -366,7 +363,6 @@ DROP TABLE jobs_big_serial;
 -- Verify partition function
 CREATE TABLE test_table_int(id TEXT, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_int', by_range('id', 10, partition_func => 'part_func'));
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (6,t)
@@ -387,7 +383,6 @@ DROP FUNCTION part_func;
 CREATE TABLE test_table_int(id INTEGER, device INTEGER, time TIMESTAMPTZ);
 INSERT INTO test_table_int SELECT t, t%10, '01-01-2023 11:00'::TIMESTAMPTZ FROM generate_series(1, 50, 1) t;
 SELECT create_hypertable('test_table_int', by_range('id', 10), migrate_data => true);
-NOTICE:  adding not-null constraint to column "id"
 NOTICE:  migrating data to chunks
  create_hypertable 
 -------------------
@@ -411,7 +406,6 @@ DROP TABLE test_table_int;
 -- create_hypertable without default indexes
 CREATE TABLE test_table_int(id INTEGER, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_int', by_range('id', 10), create_default_indexes => false);
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (8,t)
@@ -426,7 +420,6 @@ DROP TABLE test_table_int;
 -- if_not_exists
 CREATE TABLE test_table_int(id INTEGER, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_int', by_range('id', 10));
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (9,t)
@@ -458,7 +451,6 @@ DROP TABLE test_table_int;
 -- Add dimension
 CREATE TABLE test_table_int(id INTEGER, device INTEGER, time TIMESTAMPTZ);
 SELECT create_hypertable('test_table_int', by_range('id', 10), migrate_data => true);
-NOTICE:  adding not-null constraint to column "id"
  create_hypertable 
 -------------------
  (10,t)
@@ -531,7 +523,6 @@ SELECT count(*) FROM timescaledb_information.chunks WHERE hypertable_name='test_
 (1 row)
 
 SELECT add_dimension('test_time', by_range('device', partition_interval => 2));
-NOTICE:  adding not-null constraint to column "device"
  add_dimension 
 ---------------
  (13,t)

--- a/tsl/test/expected/insert_memory_usage.out
+++ b/tsl/test/expected/insert_memory_usage.out
@@ -8,7 +8,6 @@
 create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);
 -- Aim to about 100 partitions, the data is from 1995 to 2022.
 select create_hypertable('uk_price_paid', 'date', chunk_time_interval => interval '90 day');
-NOTICE:  adding not-null constraint to column "date"
      create_hypertable      
 ----------------------------
  (1,public,uk_price_paid,t)

--- a/tsl/test/expected/merge_append_partially_compressed.out
+++ b/tsl/test/expected/merge_append_partially_compressed.out
@@ -10,7 +10,6 @@ set timescaledb.enable_decompression_sorted_merge = off;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float);
 SELECT create_hypertable('ht_metrics_compressed','time');
-NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
  (1,public,ht_metrics_compressed,t)

--- a/tsl/test/expected/move.out
+++ b/tsl/test/expected/move.out
@@ -19,7 +19,6 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER_2 LOCATION :TEST_TAB
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE cluster_test(time INTEGER, temp float, location int, value TEXT);
 SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => 5);
-psql:include/cluster_test_setup.sql:7: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (1,public,cluster_test,t)

--- a/tsl/test/expected/partialize_finalize.out
+++ b/tsl/test/expected/partialize_finalize.out
@@ -216,7 +216,6 @@ create table foo( a integer, b timestamptz, toastval TEXT);
 -- easily compressable string and instead store it with TOAST
 ALTER TABLE foo ALTER COLUMN toastval SET STORAGE EXTERNAL;
 SELECT count(*) FROM create_hypertable('foo', 'b');
-NOTICE:  adding not-null constraint to column "b"
  count 
 -------
      1

--- a/tsl/test/expected/policy_generalization.out
+++ b/tsl/test/expected/policy_generalization.out
@@ -8,7 +8,6 @@ DROP TABLE IF EXISTS test;
 NOTICE:  table "test" does not exist, skipping
 CREATE TABLE test(time INTEGER, device INTEGER, temp FLOAT);
 SELECT create_hypertable('test', 'time', chunk_time_interval => 10);
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (1,public,test,t)

--- a/tsl/test/expected/privilege_maintain.out
+++ b/tsl/test/expected/privilege_maintain.out
@@ -5,7 +5,6 @@
 CREATE ROLE r_maintain;
 CREATE TABLE metrics(time timestamptz, device text, value float);
 SELECT create_hypertable('metrics', 'time');
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------
  (1,public,metrics,t)

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -327,7 +327,6 @@ select * from compression_rowcnt_view where chunk_name = :'compressed_chunk';
 -- PREPRE A SELECT before recompress and perform it after recompress
 CREATE TABLE mytab_prep (time timestamptz, a int, b int, c int);
 SELECT create_hypertable('mytab_prep', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (9,public,mytab_prep,t)
@@ -402,7 +401,6 @@ EXECUTE p1;
 -- in the second case, a new compressed chunk is created
 CREATE TABLE mytab (time timestamptz, a int, b int, c int);
 SELECT create_hypertable('mytab', 'time');
-NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------
  (11,public,mytab,t)
@@ -504,7 +502,6 @@ select :'compressed_chunk_name_before_recompression' as before_recompression, :'
 select '2022-01-01 09:00:00+00' as start_time \gset
 create table nullseg_one (time timestamptz, a int, b int);
 select create_hypertable('nullseg_one', 'time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (14,public,nullseg_one,t)
@@ -557,7 +554,6 @@ select * from :compressed_chunk_name;
 -- test multiple NULL segmentby columns
 create table nullseg_many (time timestamptz, a int, b int, c int);
 select create_hypertable('nullseg_many', 'time');
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (16,public,nullseg_many,t)
@@ -616,7 +612,6 @@ select * from :compressed_chunk_name;
 -- Test behaviour when no segmentby columns are present
 CREATE TABLE noseg(time timestamptz, a int, b int, c int);
 SELECT create_hypertable('noseg', by_range('time', INTERVAL '1 day'));
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (18,t)
@@ -644,7 +639,6 @@ INFO:  Using index "compress_hyper_19_20_chunk__ts_meta_min_1__ts_meta_max_1_idx
 -- Test behaviour when default order by is empty: should not segmentwise-recompress in this case
 CREATE TABLE no_oby(ts int, c1 int);
 SELECT create_hypertable('no_oby','ts');
-NOTICE:  adding not-null constraint to column "ts"
   create_hypertable   
 ----------------------
  (20,public,no_oby,t)

--- a/tsl/test/expected/reorder.out
+++ b/tsl/test/expected/reorder.out
@@ -7,7 +7,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE cluster_test(time INTEGER, temp float, location int, value TEXT);
 SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => 5);
-psql:include/cluster_test_setup.sql:7: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (1,public,cluster_test,t)
@@ -1214,7 +1213,6 @@ FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY time;
 
 CREATE TABLE ct2(time INTEGER, val BIGINT);
 SELECT create_hypertable('ct2', 'time', chunk_time_interval => 5);
-NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
  (2,public,ct2,t)

--- a/tsl/test/expected/size_utils_tsl.out
+++ b/tsl/test/expected/size_utils_tsl.out
@@ -5,7 +5,6 @@ SET timezone TO 'America/Los_Angeles';
 -- Prepare test data for continuous aggregate size function tests
 CREATE TABLE hypersize(time timestamptz, device int);
 SELECT * FROM create_hypertable('hypersize', 'time');
-NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | hypersize  | t

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -1173,7 +1173,6 @@ and provolatile = 'i'
 and n.nspname = 'pg_catalog' \gset
 create table time_part_func (time float8, temp float);
 select create_hypertable('time_part_func', 'time', time_partitioning_func => :'time_funcid', create_default_indexes => false, chunk_time_interval => interval '1 month');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (5,public,time_part_func,t)

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -7866,7 +7866,6 @@ CREATE TABLE readings (time timestamptz, tags_id integer, fuel_consumption DOUBL
 CREATE INDEX ON readings(tags_id, "time" DESC);
 CREATE INDEX ON readings("time" DESC);
 SELECT create_hypertable('readings', 'time', partitioning_column => 'tags_id', number_partitions => 1, chunk_time_interval => 43200000000, create_default_indexes=>false);
-psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (13,public,readings,t)
@@ -9479,7 +9478,6 @@ motion_table_t2_datalogger_id_idx on motion_table (datalogger_id);
 CREATE INDEX motion_table_t2_dataloggertime_idx on motion_table(dataloggertime DESC);
 CREATE INDEX motion_table_t2_vessel_id_idx on motion_table(vessel_id);
 SELECT create_hypertable( 'motion_table', 'dataloggertime', chunk_time_interval=> '7 days'::interval);
-NOTICE:  adding not-null constraint to column "dataloggertime"
      create_hypertable      
 ----------------------------
  (15,public,motion_table,t)

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -7866,7 +7866,6 @@ CREATE TABLE readings (time timestamptz, tags_id integer, fuel_consumption DOUBL
 CREATE INDEX ON readings(tags_id, "time" DESC);
 CREATE INDEX ON readings("time" DESC);
 SELECT create_hypertable('readings', 'time', partitioning_column => 'tags_id', number_partitions => 1, chunk_time_interval => 43200000000, create_default_indexes=>false);
-psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (13,public,readings,t)
@@ -9479,7 +9478,6 @@ motion_table_t2_datalogger_id_idx on motion_table (datalogger_id);
 CREATE INDEX motion_table_t2_dataloggertime_idx on motion_table(dataloggertime DESC);
 CREATE INDEX motion_table_t2_vessel_id_idx on motion_table(vessel_id);
 SELECT create_hypertable( 'motion_table', 'dataloggertime', chunk_time_interval=> '7 days'::interval);
-NOTICE:  adding not-null constraint to column "dataloggertime"
      create_hypertable      
 ----------------------------
  (15,public,motion_table,t)

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -7881,7 +7881,6 @@ CREATE TABLE readings (time timestamptz, tags_id integer, fuel_consumption DOUBL
 CREATE INDEX ON readings(tags_id, "time" DESC);
 CREATE INDEX ON readings("time" DESC);
 SELECT create_hypertable('readings', 'time', partitioning_column => 'tags_id', number_partitions => 1, chunk_time_interval => 43200000000, create_default_indexes=>false);
-psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (13,public,readings,t)
@@ -9494,7 +9493,6 @@ motion_table_t2_datalogger_id_idx on motion_table (datalogger_id);
 CREATE INDEX motion_table_t2_dataloggertime_idx on motion_table(dataloggertime DESC);
 CREATE INDEX motion_table_t2_vessel_id_idx on motion_table(vessel_id);
 SELECT create_hypertable( 'motion_table', 'dataloggertime', chunk_time_interval=> '7 days'::interval);
-NOTICE:  adding not-null constraint to column "dataloggertime"
      create_hypertable      
 ----------------------------
  (15,public,motion_table,t)

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -1070,7 +1070,6 @@ timec         timestamp with time zone  ,
  utilization   double precision
 );
 SELECT create_hypertable('entity_m1', 'timec', chunk_time_interval=>'30 days'::interval);
-NOTICE:  adding not-null constraint to column "timec"
    create_hypertable    
 ------------------------
  (7,public,entity_m1,t)

--- a/tsl/test/expected/transparent_decompression_ordered_index-16.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-16.out
@@ -1081,7 +1081,6 @@ timec         timestamp with time zone  ,
  utilization   double precision
 );
 SELECT create_hypertable('entity_m1', 'timec', chunk_time_interval=>'30 days'::interval);
-NOTICE:  adding not-null constraint to column "timec"
    create_hypertable    
 ------------------------
  (7,public,entity_m1,t)

--- a/tsl/test/expected/transparent_decompression_ordered_index-17.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-17.out
@@ -1081,7 +1081,6 @@ timec         timestamp with time zone  ,
  utilization   double precision
 );
 SELECT create_hypertable('entity_m1', 'timec', chunk_time_interval=>'30 days'::interval);
-NOTICE:  adding not-null constraint to column "timec"
    create_hypertable    
 ------------------------
  (7,public,entity_m1,t)

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -14,14 +14,12 @@ SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
 CREATE TABLE test_table(time timestamptz, junk int);
 CREATE TABLE test_table_int(time bigint, junk int);
 SELECT create_hypertable('test_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,test_table,t)
 (1 row)
 
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (2,public,test_table_int,t)
@@ -83,7 +81,6 @@ select * from _timescaledb_config.bgw_job where id=:job_id;
 -- Should be 1/2 default chunk interval length
 CREATE TABLE test_table2(time timestamptz, junk int);
 SELECT create_hypertable('test_table2', 'time', chunk_time_interval=>INTERVAL '1 day');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (3,public,test_table2,t)
@@ -408,7 +405,6 @@ ERROR:  table "non_hypertable" is not a hypertable
 -- Now make sure things work with multiple policies on multiple hypertables
 CREATE TABLE test_table(time timestamptz, junk int);
 SELECT create_hypertable('test_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (4,public,test_table,t)
@@ -417,7 +413,6 @@ NOTICE:  adding not-null constraint to column "time"
 CREATE INDEX second_index on test_table (time);
 CREATE TABLE test_table2(time timestamptz, junk int);
 SELECT create_hypertable('test_table2', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (5,public,test_table2,t)
@@ -481,7 +476,6 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 
 CREATE TABLE test_table(time timestamptz, junk int);
 SELECT create_hypertable('test_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (6,public,test_table,t)
@@ -549,7 +543,6 @@ SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
 -- Now check dropping a job will drop the chunk_stat row
 CREATE TABLE test_table(time timestamptz, junk int);
 SELECT create_hypertable('test_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (7,public,test_table,t)

--- a/tsl/test/expected/vector_agg_default.out
+++ b/tsl/test/expected/vector_agg_default.out
@@ -8,7 +8,6 @@
 create function stable_abs(x int4) returns int4 as 'int4abs' language internal stable;
 create table dvagg(a int, b int);
 select create_hypertable('dvagg', 'a', chunk_time_interval => 1000);
-NOTICE:  adding not-null constraint to column "a"
  create_hypertable  
 --------------------
  (1,public,dvagg,t)

--- a/tsl/test/expected/vector_agg_filter.out
+++ b/tsl/test/expected/vector_agg_filter.out
@@ -16,7 +16,6 @@ create function stable_abs(x int4) returns int4 as 'int4abs' language internal s
 create table aggfilter(t int, s int,
     cint2 int2, dropped int4, cint4 int4);
 select create_hypertable('aggfilter', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
-NOTICE:  adding not-null constraint to column "s"
    create_hypertable    
 ------------------------
  (1,public,aggfilter,t)

--- a/tsl/test/expected/vector_agg_functions.out
+++ b/tsl/test/expected/vector_agg_functions.out
@@ -16,7 +16,6 @@ create table aggfns(t int, s int,
     cdate date);
 select create_hypertable('aggfns', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
 WARNING:  column type "timestamp without time zone" used for "cts" does not follow best practices
-NOTICE:  adding not-null constraint to column "s"
   create_hypertable  
 ---------------------
  (1,public,aggfns,t)
@@ -132,7 +131,6 @@ select count(compress_chunk(x)) from show_chunks('aggfns') x;
 vacuum freeze analyze aggfns;
 create table edges(t int, s int, ss int, f1 int);
 select create_hypertable('edges', 't', chunk_time_interval => 100000);
-NOTICE:  adding not-null constraint to column "t"
  create_hypertable  
 --------------------
  (3,public,edges,t)

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -10,7 +10,6 @@ set enable_hashagg to off;
 --set timescaledb.debug_require_vector_agg to 'forbid';
 create table groupagg(t int, s int, value int);
 select create_hypertable('groupagg', 't', chunk_time_interval => 10000);
-NOTICE:  adding not-null constraint to column "t"
    create_hypertable   
 -----------------------
  (1,public,groupagg,t)
@@ -104,7 +103,6 @@ reset timescaledb.debug_require_vector_agg;
 -- More tests for dictionary encoding.
 create table text_table(ts int);
 select create_hypertable('text_table', 'ts', chunk_time_interval => 3);
-NOTICE:  adding not-null constraint to column "ts"
     create_hypertable    
 -------------------------
  (3,public,text_table,t)

--- a/tsl/test/expected/vector_agg_grouping.out
+++ b/tsl/test/expected/vector_agg_grouping.out
@@ -14,7 +14,6 @@ $$ LANGUAGE SQL;
 create table agggroup(t int, s int,
     cint2 int2, cint4 int4, cint8 int8);
 select create_hypertable('agggroup', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
-NOTICE:  adding not-null constraint to column "s"
    create_hypertable   
 -----------------------
  (1,public,agggroup,t)
@@ -1907,7 +1906,6 @@ reset timescaledb.debug_require_vector_agg;
 -- test the long scalar values.
 create table long(t int, a text, b text, c text, d text);
 select create_hypertable('long', 't');
-NOTICE:  adding not-null constraint to column "t"
  create_hypertable 
 -------------------
  (3,public,long,t)
@@ -2005,7 +2003,6 @@ reset timescaledb.debug_require_vector_agg;
 -- to long varlena header for the serialized key.
 create table keylength(t int, a text, b text);
 select create_hypertable('keylength', 't');
-NOTICE:  adding not-null constraint to column "t"
    create_hypertable    
 ------------------------
  (5,public,keylength,t)
@@ -2059,7 +2056,6 @@ reset timescaledb.debug_require_vector_agg;
 -- grouping test above.
 create table groupnull(t int, a text, b text);
 select create_hypertable('groupnull', 't');
-NOTICE:  adding not-null constraint to column "t"
    create_hypertable    
 ------------------------
  (7,public,groupnull,t)

--- a/tsl/test/expected/vector_agg_memory.out
+++ b/tsl/test/expected/vector_agg_memory.out
@@ -10,7 +10,6 @@ create or replace function ts_debug_allocated_bytes(text = 'PortalContext') retu
     language c strict volatile;
 create table mvagg (t int, s0 int, s1 int);
 select create_hypertable('mvagg', 't', chunk_time_interval => pow(10, 9)::int);
-NOTICE:  adding not-null constraint to column "t"
  create_hypertable  
 --------------------
  (1,public,mvagg,t)

--- a/tsl/test/expected/vector_agg_param.out
+++ b/tsl/test/expected/vector_agg_param.out
@@ -4,7 +4,6 @@
 -- Test parameterized vector aggregation plans.
 create table pvagg(s int, a int);
 select create_hypertable('pvagg', 'a', chunk_time_interval => 1000);
-NOTICE:  adding not-null constraint to column "a"
  create_hypertable  
 --------------------
  (1,public,pvagg,t)

--- a/tsl/test/expected/vector_agg_segmentby.out
+++ b/tsl/test/expected/vector_agg_segmentby.out
@@ -6,7 +6,6 @@
 \set GROUPING_CARDINALITY 10::int
 create table svagg(t int, f int, s int);
 select create_hypertable('svagg', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
-NOTICE:  adding not-null constraint to column "s"
  create_hypertable  
 --------------------
  (1,public,svagg,t)

--- a/tsl/test/expected/vector_agg_text.out
+++ b/tsl/test/expected/vector_agg_text.out
@@ -12,7 +12,6 @@ $$ LANGUAGE SQL;
 create table agggroup(t int, s int,
     cint2 int2, cint4 int4, cint8 int8);
 select create_hypertable('agggroup', 's', chunk_time_interval => :GROUPING_CARDINALITY / :CHUNKS);
-NOTICE:  adding not-null constraint to column "s"
    create_hypertable   
 -----------------------
  (1,public,agggroup,t)
@@ -147,7 +146,6 @@ vacuum freeze analyze agggroup;
 -- Long strings
 create table long(t int, a text, b text, c text, d text);
 select create_hypertable('long', 't');
-NOTICE:  adding not-null constraint to column "t"
  create_hypertable 
 -------------------
  (3,public,long,t)

--- a/tsl/test/expected/vector_agg_uuid.out
+++ b/tsl/test/expected/vector_agg_uuid.out
@@ -106,7 +106,6 @@ SELECT count(*) FROM (SELECT device, field FROM plan_plus GROUP BY device, field
 -- UUID groupping
 create table uuid_table(ts int, u uuid);
 select count(*) from create_hypertable('uuid_table', 'ts', chunk_time_interval => 6);
-NOTICE:  adding not-null constraint to column "ts"
  count 
 -------
      1

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -3632,7 +3632,6 @@ SELECT sum(float_value), int_value FROM testtable2 WHERE int_value = 1 GROUP BY 
 --
 CREATE TABLE testtable3 (time timestamptz, location_id int, device_id int, sensor_id int);
 SELECT create_hypertable('testtable3', 'time');
-NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (5,public,testtable3,t)

--- a/tsl/test/shared/expected/cagg_compression.out
+++ b/tsl/test/shared/expected/cagg_compression.out
@@ -342,7 +342,6 @@ DROP TABLE extra_devices;
 -- test enabling compression on cagg after column rename
 CREATE TABLE comp_rename(time timestamptz);
 SELECT table_name FROM create_hypertable('comp_rename', 'time');
-NOTICE:  adding not-null constraint to column "time"
  table_name  
  comp_rename
 (1 row)

--- a/tsl/test/shared/expected/constify_now.out
+++ b/tsl/test/shared/expected/constify_now.out
@@ -11,7 +11,6 @@ SET timezone TO PST8PDT;
 -- others will have 2 chunks in plan
 CREATE TABLE const_now(time timestamptz, time2 timestamptz, device_id int, value float);
 SELECT table_name FROM create_hypertable('const_now','time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
  const_now
 (1 row)
@@ -397,7 +396,6 @@ DROP TABLE const_now;
 -- test prepared statements
 CREATE TABLE prep_const_now(time timestamptz, device int, value float);
 SELECT table_name FROM create_hypertable('prep_const_now', 'time');
-NOTICE:  adding not-null constraint to column "time"
    table_name   
  prep_const_now
 (1 row)
@@ -578,7 +576,6 @@ DROP TABLE const_now_dst;
 SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
 CREATE TABLE now_view_test(time timestamptz,device text, value float);
 SELECT table_name FROM create_hypertable('now_view_test','time');
-NOTICE:  adding not-null constraint to column "time"
   table_name   
  now_view_test
 (1 row)

--- a/tsl/test/shared/expected/constraint_aware_append.out
+++ b/tsl/test/shared/expected/constraint_aware_append.out
@@ -5,7 +5,6 @@
 -- issue 5739
 CREATE TABLE ca_append_result(time timestamptz NULL, device text, value float);
 SELECT table_name FROM create_hypertable('ca_append_result', 'time');
-NOTICE:  adding not-null constraint to column "time"
     table_name    
  ca_append_result
 (1 row)

--- a/tsl/test/shared/expected/decompress_join.out
+++ b/tsl/test/shared/expected/decompress_join.out
@@ -31,7 +31,6 @@ DROP TABLE compressed_join_temp;
 -- test join with partially compressed chunks
 CREATE TABLE partial_join(time timestamptz,device text);
 SELECT table_name FROM create_hypertable('partial_join','time');
-NOTICE:  adding not-null constraint to column "time"
   table_name  
  partial_join
 (1 row)

--- a/tsl/test/shared/expected/decompress_placeholdervar.out
+++ b/tsl/test/shared/expected/decompress_placeholdervar.out
@@ -88,7 +88,6 @@ SELECT
   table_name
 FROM
   create_hypertable('tickers', 'time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
  tickers
 (1 row)

--- a/tsl/test/shared/expected/space_constraint.out
+++ b/tsl/test/shared/expected/space_constraint.out
@@ -657,7 +657,6 @@ QUERY PLAN
 -- test multiple space dimensions and different datatypes
 CREATE TABLE space_constraint(time timestamptz, s1 text, s2 numeric, s3 int, v float);
 SELECT table_name FROM create_hypertable('space_constraint','time');
-NOTICE:  adding not-null constraint to column "time"
     table_name    
  space_constraint
 (1 row)

--- a/tsl/test/shared/expected/timestamp_limits.out
+++ b/tsl/test/shared/expected/timestamp_limits.out
@@ -104,7 +104,6 @@ end_ts_internal_date        | 294247-01-02
 --Suitable constraints should be created on chunks
 CREATE TABLE smallint_table(time smallint);
 SELECT table_name FROM create_hypertable('smallint_table', 'time', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]--------------
 table_name | smallint_table
 
@@ -120,7 +119,6 @@ pg_get_constraintdef | CHECK (("time" >= '32760'::smallint))
 
 CREATE TABLE int_table(time int);
 SELECT table_name FROM create_hypertable('int_table', 'time', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]---------
 table_name | int_table
 
@@ -136,7 +134,6 @@ pg_get_constraintdef | CHECK (("time" >= 2147483640))
 
 CREATE TABLE bigint_table(time bigint);
 SELECT table_name FROM create_hypertable('bigint_table', 'time', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]------------
 table_name | bigint_table
 
@@ -152,7 +149,6 @@ pg_get_constraintdef | CHECK (("time" >= '9223372036854775800'::bigint))
 
 CREATE TABLE date_table(time date);
 SELECT table_name FROM create_hypertable('date_table', 'time');
-NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]----------
 table_name | date_table
 
@@ -176,7 +172,6 @@ pg_get_constraintdef | CHECK (("time" >= '294246-12-31'::date))
 CREATE TABLE timestamp_table(time timestamp);
 SELECT table_name FROM create_hypertable('timestamp_table', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]---------------
 table_name | timestamp_table
 
@@ -201,7 +196,6 @@ pg_get_constraintdef | CHECK (("time" >= '294246-12-31 00:00:00'::timestamp with
 CREATE TABLE timestamptz_table(time timestamp);
 SELECT table_name FROM create_hypertable('timestamptz_table', 'time');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
-NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]-----------------
 table_name | timestamptz_table
 


### PR DESCRIPTION
This message is not actionable and just adds unnecessary output
to hypertable creation.
