### PR TITLE
Improve job stat history retention job

### DIFF
--- a/.unreleased/pr_8494
+++ b/.unreleased/pr_8494
@@ -1,0 +1,1 @@
+Implements: #8494 Improve job stat history retention policy

--- a/sql/job_stat_history_log_retention.sql
+++ b/sql/job_stat_history_log_retention.sql
@@ -4,23 +4,110 @@
 
 -- A retention policy is set up for the table _timescaledb_internal.job_errors (Error Log Retention Policy [2])
 -- By default, it will run once a month and and drop rows older than a month.
+
+-- We use binary search on the id column to figure out which rows should be retained from the job history table
+-- Doing it this way allows us to use the index on the `id` column, which (empirically) we found is faster than querying on the `execution_finish` column directly without an index
+-- This works because `execution_finish` is always ordered.
+-- We can consider alternative approaches to simplify this in the future.
+CREATE OR REPLACE FUNCTION _timescaledb_functions.job_history_bsearch(search_point TIMESTAMPTZ) RETURNS BIGINT
+AS
+$$
+DECLARE
+  id_lower BIGINT;
+  id_upper BIGINT;
+  id_middle BIGINT DEFAULT 0;
+  target_tz TIMESTAMPTZ;
+BEGIN
+
+  SELECT COALESCE(min(id), 0), COALESCE(max(id), 0)
+  INTO id_lower, id_upper
+  FROM _timescaledb_internal.bgw_job_stat_history;
+
+  IF id_lower = 0 AND id_upper = 0 THEN
+    RETURN NULL;
+  END IF;
+
+  -- We want the first entry in the table where execution_finish is >= search_point
+  WHILE id_lower < id_upper LOOP
+    id_middle := id_lower + (id_upper - id_lower) / 2;
+
+    SELECT execution_finish
+    INTO target_tz
+    FROM _timescaledb_internal.bgw_job_stat_history
+    WHERE id = id_middle;
+
+    -- If the id_middle is not found, shift to a previous id that's still in the search space
+    IF NOT FOUND THEN
+      SELECT execution_finish, id
+      INTO target_tz, id_middle
+      FROM _timescaledb_internal.bgw_job_stat_history
+      WHERE id <= id_middle AND id >= id_lower
+      ORDER BY id LIMIT 1;
+
+      IF NOT FOUND THEN
+        id_middle := id_lower;
+      END IF;
+
+    END IF;
+
+    IF target_tz >= search_point THEN
+      id_upper := id_middle;
+    ELSE
+      id_lower := id_middle + 1;
+    END IF;
+  END LOOP;
+
+  -- Handle the case where no ids need to be deleted and return NULL instead
+  SELECT execution_finish
+  INTO target_tz
+  FROM _timescaledb_internal.bgw_job_stat_history
+  WHERE id = id_lower;
+
+  IF target_tz < search_point THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN id_lower;
+END
+$$
+LANGUAGE plpgsql SET search_path TO pg_catalog, pg_temp;
+
 CREATE OR REPLACE FUNCTION _timescaledb_functions.policy_job_stat_history_retention(job_id integer, config JSONB) RETURNS integer
 LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
-    drop_after INTERVAL;
     numrows INTEGER;
+    search_point TIMESTAMPTZ;
+    id_found BIGINT;
 BEGIN
-    drop_after := config->>'drop_after';
+  PERFORM set_config('lock_timeout', coalesce(config->>'lock_timeout', '5s'), true /* is local */);
 
-    DELETE
-    FROM _timescaledb_internal.bgw_job_stat_history
-    WHERE execution_finish < (now() - drop_after);
+  -- We need to prevent concurrent changes on this table when running this retention job
+  -- We take an AccessExclusiveLock at the start since we TRUNCATE later
+  LOCK TABLE _timescaledb_internal.bgw_job_stat_history IN ACCESS EXCLUSIVE MODE;
 
-    GET DIAGNOSTICS numrows = ROW_COUNT;
+  search_point := now() - (config->>'drop_after')::interval;
 
-    RETURN numrows;
-END;
+  id_found := _timescaledb_functions.job_history_bsearch(search_point);
+
+  IF id_found IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  CREATE TEMP TABLE __tmp_bgw_job_stat_history ON COMMIT DROP AS
+  SELECT * FROM _timescaledb_internal.bgw_job_stat_history
+  WHERE id >= id_found
+  ORDER BY id;
+
+  TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+
+  INSERT INTO _timescaledb_internal.bgw_job_stat_history
+  SELECT * FROM __tmp_bgw_job_stat_history;
+
+  GET DIAGNOSTICS numrows = ROW_COUNT;
+
+  RETURN numrows;
+END
 $BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_functions.policy_job_stat_history_retention_check(config JSONB) RETURNS VOID
@@ -34,7 +121,7 @@ BEGIN
     IF config->>'drop_after' IS NULL THEN
         RAISE EXCEPTION 'drop_after interval not provided';
     END IF ;
-END;
+END
 $BODY$ SET search_path TO pg_catalog, pg_temp;
 
 INSERT INTO _timescaledb_config.bgw_job (

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -252,3 +252,4 @@ ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_aggs_mate
 
 DROP TABLE IF EXISTS _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
+DROP FUNCTION _timescaledb_functions.job_history_bsearch(TIMESTAMPTZ);

--- a/tsl/test/expected/bgw_job_stat_history.out
+++ b/tsl/test/expected/bgw_job_stat_history.out
@@ -413,3 +413,424 @@ SELECT _timescaledb_functions.stop_background_workers();
  t
 (1 row)
 
+-- Test bgw_job_stat_history retention job
+-- Alter the drop_after interval to be fixed (30 days) to ensure tests are deterministic
+SELECT config AS config FROM _timescaledb_config.bgw_job WHERE id = 3 \gset
+SELECT config FROM alter_job(3, config => jsonb_set(:'config', '{drop_after}', '"30 days"'));
+          config           
+---------------------------
+ {"drop_after": "30 days"}
+(1 row)
+
+-- Test 1
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Insert test data: jobs every 15 minutes from 3 months ago to today
+-- Each job runs for 5 minutes (job_id=100, pid=12345)
+-- Fix NOW to ensure the tests are deterministic
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(job_id, pid, succeeded, execution_start, execution_finish, data)
+SELECT
+    100 as job_id,
+    12345 as pid,
+    true as succeeded,
+    ts as execution_start,
+    ts + interval '5 minutes' as execution_finish,
+    '{}'::jsonb as data
+FROM generate_series(now() - interval '90 days', now(), interval '15 minutes') as ts;
+-- Check data after insertion
+SELECT count(*) as total_records FROM _timescaledb_internal.bgw_job_stat_history;
+ total_records 
+---------------
+          8641
+(1 row)
+
+-- Test the retention job (job id 3)
+CALL run_job(3);
+-- Check data after retention
+SELECT count(*) as total_records FROM _timescaledb_internal.bgw_job_stat_history;
+ total_records 
+---------------
+          2881
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+         2881
+(1 row)
+
+-- Cleanup
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Test 2: Empty table (no job history)
+CALL run_job(3);
+SELECT count(*) as records_after_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_after_retention 
+-------------------------
+                       0
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+            0
+(1 row)
+
+-- Test 3: Odd number of entries (5 entries)
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(301, 3001, true, now() - interval '60 days', now() - interval '60 days' + interval '5 minutes', '{}'),
+(302, 3002, true, now() - interval '6 weeks', now() - interval '6 weeks' + interval '5 minutes', '{}'),
+(303, 3003, true, now() - interval '30 days', now() - interval '30 days' + interval '5 minutes', '{}'),
+(301, 3001, true, now() - interval '2 weeks', now() - interval '2 weeks' + interval '5 minutes', '{}'),
+(304, 3004, true, now() - interval '1 week', now() - interval '1 week' + interval '5 minutes', '{}');
+SELECT count(*) as records_before_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_before_retention 
+--------------------------
+                        5
+(1 row)
+
+CALL run_job(3);
+SELECT count(*) as records_after_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_after_retention 
+-------------------------
+                       3
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+            3
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Test 4: Even number of entries (6 entries)
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(401, 4001, true, now() - interval '90 days', now() - interval '90 days' + interval '5 minutes', '{}'),
+(402, 4002, true, now() - interval '60 days', now() - interval '60 days' + interval '5 minutes', '{}'),
+(403, 4003, true, now() - interval '6 weeks', now() - interval '6 weeks' + interval '5 minutes', '{}'),
+(401, 4001, true, now() - interval '30 days', now() - interval '30 days' + interval '5 minutes', '{}'),
+(404, 4004, true, now() - interval '2 weeks', now() - interval '2 weeks' + interval '5 minutes', '{}'),
+(402, 4002, true, now() - interval '1 week', now() - interval '1 week' + interval '5 minutes', '{}');
+SELECT count(*) as records_before_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_before_retention 
+--------------------------
+                        6
+(1 row)
+
+CALL run_job(3);
+SELECT count(*) as records_after_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_after_retention 
+-------------------------
+                       3
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+            3
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Test 5: Missing middle job id (gaps in sequence)
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(job_id, pid, succeeded, execution_start, execution_finish, data)
+SELECT
+    501 + (row_number() over () % 3) as job_id,
+    5001 + (row_number() over () % 3) as pid,
+    true as succeeded,
+    ts as execution_start,
+    ts + interval '5 minutes' as execution_finish,
+    '{}'::jsonb as data
+FROM generate_series(now() - interval '60 days', now() - interval '1 week', interval '1 week') as ts;
+-- Delete some records to create gaps
+DELETE FROM _timescaledb_internal.bgw_job_stat_history
+WHERE id IN (SELECT id FROM _timescaledb_internal.bgw_job_stat_history ORDER BY id LIMIT 2 OFFSET 2);
+SELECT count(*) as records_before_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_before_retention 
+--------------------------
+                        6
+(1 row)
+
+CALL run_job(3);
+SELECT count(*) as records_after_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_after_retention 
+-------------------------
+                       3
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+            3
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Test 6: All records older than retention period
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(601, 6001, true, now() - interval '90 days', now() - interval '90 days' + interval '5 minutes', '{}'),
+(602, 6002, true, now() - interval '60 days', now() - interval '60 days' + interval '5 minutes', '{}'),
+(601, 6001, true, now() - interval '6 weeks', now() - interval '6 weeks' + interval '5 minutes', '{}');
+SELECT count(*) as records_before_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_before_retention 
+--------------------------
+                        3
+(1 row)
+
+CALL run_job(3);
+SELECT count(*) as records_after_retention FROM _timescaledb_internal.bgw_job_stat_history;
+ records_after_retention 
+-------------------------
+                       3
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+            0
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Test 7: No records older than retention period
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(701, 7001, true, now() - interval '1 week', now() - interval '1 week' + interval '7 minutes', '{}'),
+(702, 7002, true, now() - interval '6 days', now() - interval '6 days' + interval '7 minutes', '{}'),
+(703, 7003, true, now() - interval '7 days', now() - interval '7 days' + interval '7 minutes', '{}'),
+(701, 7001, true, now() - interval '4 days', now() - interval '4 days' + interval '7 minutes', '{}');
+SELECT count(*) as records_before_removal FROM _timescaledb_internal.bgw_job_stat_history;
+ records_before_removal 
+------------------------
+                      4
+(1 row)
+
+CALL run_job(3);
+SELECT count(*) as records_after_removal FROM _timescaledb_internal.bgw_job_stat_history;
+ records_after_removal 
+-----------------------
+                     4
+(1 row)
+
+-- Verify only recent records remain
+SELECT
+count(*) as record_count
+FROM _timescaledb_internal.bgw_job_stat_history
+WHERE
+execution_finish > now() - interval '30 days';
+ record_count 
+--------------
+            4
+(1 row)
+
+-- Cleanup
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Test that lock_timeout can be configured
+SELECT config FROM alter_job(3, config => jsonb_set(:'config', '{lock_timeout}', '"1s"'));
+                     config                      
+-------------------------------------------------
+ {"drop_after": "1 month", "lock_timeout": "1s"}
+(1 row)
+
+CALL run_job(3);
+-- Test the job_history_bsearch function directly as well
+-- It returns the first element where execution_finish >= search_point or NULL if no such element exists
+\set NOW '2025-08-15 12:34:00'
+-- No elements in table
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '1 month');
+ job_history_bsearch 
+---------------------
+                    
+(1 row)
+
+-- Single element
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(id, job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(5, 601, 6001, true, :'NOW'::timestamptz - interval '2 weeks', :'NOW'::timestamptz - interval '2 weeks' + interval '5 minutes', '{}');
+-- Return the single element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '1 month');
+ job_history_bsearch 
+---------------------
+                   5
+(1 row)
+
+-- Return NULL
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '1 week');
+ job_history_bsearch 
+---------------------
+                    
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Two elements
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(id, job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(5, 701, 7001, true, :'NOW'::timestamptz - interval '3 weeks', :'NOW'::timestamptz - interval '3 weeks' + interval '5 minutes', '{}'),
+(6, 702, 7002, true, :'NOW'::timestamptz - interval '1 week', :'NOW'::timestamptz - interval '1 week' + interval '5 minutes', '{}');
+-- Returns the first element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '1 month');
+ job_history_bsearch 
+---------------------
+                   5
+(1 row)
+
+-- Returns the second element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '2 weeks');
+ job_history_bsearch 
+---------------------
+                   6
+(1 row)
+
+-- Returns NULL
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '3 days');
+ job_history_bsearch 
+---------------------
+                    
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Odd number of elements
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(id, job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(5, 801, 8001, true, :'NOW'::timestamptz - interval '5 weeks', :'NOW'::timestamptz - interval '5 weeks' + interval '5 minutes', '{}'),
+(6, 802, 8002, true, :'NOW'::timestamptz - interval '4 weeks', :'NOW'::timestamptz - interval '4 weeks' + interval '5 minutes', '{}'),
+(7, 803, 8003, true, :'NOW'::timestamptz - interval '3 weeks', :'NOW'::timestamptz - interval '3 weeks' + interval '5 minutes', '{}'),
+(8, 804, 8004, true, :'NOW'::timestamptz - interval '2 weeks', :'NOW'::timestamptz - interval '2 weeks' + interval '5 minutes', '{}'),
+(9, 805, 8005, true, :'NOW'::timestamptz - interval '1 week', :'NOW'::timestamptz - interval '1 week' + interval '5 minutes', '{}');
+-- Returns the first element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '6 weeks');
+ job_history_bsearch 
+---------------------
+                   5
+(1 row)
+
+-- Returns the middle element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '3 weeks');
+ job_history_bsearch 
+---------------------
+                   7
+(1 row)
+
+-- Returns one after the middle element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '2 weeks 3 days');
+ job_history_bsearch 
+---------------------
+                   8
+(1 row)
+
+-- Returns NULL
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '2 days');
+ job_history_bsearch 
+---------------------
+                    
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- Even number of elements
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(id, job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(5, 902, 9002, true, :'NOW'::timestamptz - interval '5 weeks', :'NOW'::timestamptz - interval '5 weeks' + interval '5 minutes', '{}'),
+(6, 903, 9003, true, :'NOW'::timestamptz - interval '4 weeks', :'NOW'::timestamptz - interval '4 weeks' + interval '5 minutes', '{}'),
+(7, 904, 9004, true, :'NOW'::timestamptz - interval '3 weeks', :'NOW'::timestamptz - interval '3 weeks' + interval '5 minutes', '{}'),
+(8, 905, 9005, true, :'NOW'::timestamptz - interval '2 weeks', :'NOW'::timestamptz - interval '2 weeks' + interval '5 minutes', '{}'),
+(9, 906, 9006, true, :'NOW'::timestamptz - interval '1 week', :'NOW'::timestamptz - interval '1 week' + interval '5 minutes', '{}'),
+(10, 907, 9007, true, :'NOW'::timestamptz - interval '3 days', :'NOW'::timestamptz - interval '3 days' + interval '5 minutes', '{}');
+-- Returns the first element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '6 weeks');
+ job_history_bsearch 
+---------------------
+                   5
+(1 row)
+
+-- Returns the middle element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '3 weeks');
+ job_history_bsearch 
+---------------------
+                   7
+(1 row)
+
+-- Returns one after the middle element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '2 weeks 3 days');
+ job_history_bsearch 
+---------------------
+                   8
+(1 row)
+
+-- Returns NULL
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '2 days');
+ job_history_bsearch 
+---------------------
+                    
+(1 row)
+
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+-- With gaps in id
+INSERT INTO _timescaledb_internal.bgw_job_stat_history
+(id, job_id, pid, succeeded, execution_start, execution_finish, data)
+VALUES
+(10, 1001, 10001, true, :'NOW'::timestamptz - interval '5 weeks', :'NOW'::timestamptz - interval '5 weeks' + interval '5 minutes', '{}'),
+(11, 1002, 10002, true, :'NOW'::timestamptz - interval '4 weeks', :'NOW'::timestamptz - interval '4 weeks' + interval '5 minutes', '{}'),
+(13, 1003, 10003, true, :'NOW'::timestamptz - interval '3 weeks', :'NOW'::timestamptz - interval '3 weeks' + interval '5 minutes', '{}'),
+(15, 1004, 10004, true, :'NOW'::timestamptz - interval '2 weeks', :'NOW'::timestamptz - interval '2 weeks' + interval '5 minutes', '{}'),
+(16, 1005, 10005, true, :'NOW'::timestamptz - interval '1 week', :'NOW'::timestamptz - interval '1 week' + interval '5 minutes', '{}');
+-- Returns id before the gap
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '3 weeks 3 days') AS result_gap_trigger1;
+ result_gap_trigger1 
+---------------------
+                  13
+(1 row)
+
+-- Returns id after the gap
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '2 weeks 3 days') AS result_gap_trigger2;
+ result_gap_trigger2 
+---------------------
+                  15
+(1 row)
+
+-- Returns second element
+SELECT _timescaledb_functions.job_history_bsearch(:'NOW'::timestamptz - interval '4 weeks 3 days') AS result_gap_trigger3;
+ result_gap_trigger3 
+---------------------
+                  11
+(1 row)
+
+-- Final cleanup
+TRUNCATE _timescaledb_internal.bgw_job_stat_history;

--- a/tsl/test/isolation/expected/bgw_job_stat_history_retention_isolation.out
+++ b/tsl/test/isolation/expected/bgw_job_stat_history_retention_isolation.out
@@ -1,0 +1,62 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2_begin s2_insert s2_count s1_retention s2_commit
+expected_count
+--------------
+             4
+(1 row)
+
+step s2_begin: 
+    BEGIN;
+
+step s2_insert: 
+    INSERT INTO _timescaledb_internal.bgw_job_stat_history
+    (job_id, pid, succeeded, execution_start, execution_finish)
+    VALUES
+    (201, 2001, true, now() - interval '1 week', now() - interval '1 week' + interval '5 minutes');
+
+step s2_count: 
+    SELECT count(*) as s2_count FROM _timescaledb_internal.bgw_job_stat_history;
+
+s2_count
+--------
+      10
+(1 row)
+
+step s1_retention: 
+    CALL run_job(3);
+    SELECT count(*) as s1_count FROM _timescaledb_internal.bgw_job_stat_history;
+ <waiting ...>
+step s2_commit: 
+    COMMIT;
+
+step s1_retention: <... completed>
+s1_count
+--------
+       5
+(1 row)
+
+
+starting permutation: s2_lock_table s1_retention s2_unlock_table
+expected_count
+--------------
+             4
+(1 row)
+
+step s2_lock_table: 
+    BEGIN;
+    LOCK TABLE _timescaledb_internal.bgw_job_stat_history IN ACCESS SHARE MODE;
+
+step s1_retention: 
+    CALL run_job(3);
+    SELECT count(*) as s1_count FROM _timescaledb_internal.bgw_job_stat_history;
+ <waiting ...>
+step s2_unlock_table: 
+    ROLLBACK;
+
+step s1_retention: <... completed>
+s1_count
+--------
+       4
+(1 row)
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -23,7 +23,8 @@ list(
   deadlock_drop_index_vacuum.spec
   parallel_compression.spec
   osm_range_updates_iso.spec
-  concurrent_decompress_update.spec)
+  concurrent_decompress_update.spec
+  bgw_job_stat_history_retention_isolation.spec)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_TEMPLATES_MODULE ${TEST_TEMPLATES_MODULE_DEBUG})

--- a/tsl/test/isolation/specs/bgw_job_stat_history_retention_isolation.spec
+++ b/tsl/test/isolation/specs/bgw_job_stat_history_retention_isolation.spec
@@ -1,0 +1,63 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+#
+# This test verifies the behavior of the job stat history retention policy
+# when there are concurrent inserts into the job stat history table.
+#
+
+setup {
+    INSERT INTO _timescaledb_internal.bgw_job_stat_history(job_id, pid, succeeded, execution_start, execution_finish)
+        SELECT 100 as job_id, 12345 as pid, true as succeeded, ts as execution_start, ts + interval '5 minutes' as execution_finish
+        FROM generate_series(now() - interval '2 months', now(), interval '1 week') as ts;
+
+    -- Verify # of rows that should be kept
+    SELECT count(*) as expected_count FROM _timescaledb_internal.bgw_job_stat_history WHERE execution_finish > now() - interval '1 month';
+}
+
+teardown {
+    TRUNCATE _timescaledb_internal.bgw_job_stat_history;
+}
+
+session "s1"
+step "s1_retention" {
+    CALL run_job(3);
+    SELECT count(*) as s1_count FROM _timescaledb_internal.bgw_job_stat_history;
+}
+
+session "s2"
+step "s2_insert" {
+    INSERT INTO _timescaledb_internal.bgw_job_stat_history
+    (job_id, pid, succeeded, execution_start, execution_finish)
+    VALUES
+    (201, 2001, true, now() - interval '1 week', now() - interval '1 week' + interval '5 minutes');
+}
+
+step "s2_begin" {
+    BEGIN;
+}
+
+step "s2_commit" {
+    COMMIT;
+}
+
+
+step "s2_count" {
+    SELECT count(*) as s2_count FROM _timescaledb_internal.bgw_job_stat_history;
+}
+
+step "s2_lock_table" {
+    BEGIN;
+    LOCK TABLE _timescaledb_internal.bgw_job_stat_history IN ACCESS SHARE MODE;
+}
+
+step "s2_unlock_table" {
+    ROLLBACK;
+}
+
+# Retention policy blocked by insert, inserted data shuold not be deleted
+permutation "s2_begin" "s2_insert" "s2_count" "s1_retention" "s2_commit"
+
+# Retention policy blocked by table lock
+permutation "s2_lock_table" "s1_retention" "s2_unlock_table"

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -110,6 +110,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.index_matches(regclass,regclass)
  _timescaledb_functions.insert_blocker()
  _timescaledb_functions.interval_to_usec(interval)
+ _timescaledb_functions.job_history_bsearch(timestamp with time zone)
  _timescaledb_functions.jsonb_get_matching_index_entry(jsonb,text,text)
  _timescaledb_functions.last_combinefunc(internal,internal)
  _timescaledb_functions.last_sfunc(internal,anyelement,"any")


### PR DESCRIPTION
Previously a delete query was run on the `bgw_job_stat_history` table to
remove job history. This could be slow once the job history table became
very large. We now use a temporary table to keep recent history and
truncate the job history table instead. We also introduce a
`job_history_bsearch` function which finds the ids of the jobs that need
to be deleted using binary search.

This PR is based on experiments done
previously (https://github.com/timescale/timescaledb-extras/pull/47).

Disable-check: approval-count