### PR TITLE
Add BR delete and update triggers for PG18 compat

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -740,3 +740,108 @@ initReadOnlyStringInfo(StringInfo str, char *data, int len)
 #define COMPARE_GT BTGreaterStrategyNumber
 #define pk_cmptype pk_strategy
 #endif
+
+/* PG18 adds is_merge_delete param to ExecBR{Delete|Update}Triggers function.
+ * This has been backported to 17.6 but with a new name (ExecBR{Delete|Update}TriggersNew)j
+ * Add compat function to cover 3 versions (pre 17.6, 17.6 - 18, post 18)
+ * https://github.com/postgres/postgres/commit/5022ff25
+ */
+#if PG_VERSION_NUM < 170006
+#define ExecBRDeleteTriggersCompat(estate,                                                         \
+								   epqstate,                                                       \
+								   relinfo,                                                        \
+								   tupleid,                                                        \
+								   fdw_trigtuple,                                                  \
+								   epqslot,                                                        \
+								   tmresult,                                                       \
+								   tmfd,                                                           \
+								   is_merge_delete)                                                \
+	ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, epqslot, tmresult, tmfd)
+#define ExecBRUpdateTriggersCompat(estate,                                                         \
+								   epqstate,                                                       \
+								   relinfo,                                                        \
+								   tupleid,                                                        \
+								   fdw_trigtuple,                                                  \
+								   epqslot,                                                        \
+								   tmresult,                                                       \
+								   tmfd,                                                           \
+								   is_merge_delete)                                                \
+	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, epqslot, tmresult, tmfd)
+#endif
+
+#if PG_VERSION_NUM >= 170006 && PG_VERSION_NUM < 180000
+#define ExecBRDeleteTriggersCompat(estate,                                                         \
+								   epqstate,                                                       \
+								   relinfo,                                                        \
+								   tupleid,                                                        \
+								   fdw_trigtuple,                                                  \
+								   epqslot,                                                        \
+								   tmresult,                                                       \
+								   tmfd,                                                           \
+								   is_merge_delete)                                                \
+	ExecBRDeleteTriggersNew(estate,                                                                \
+							epqstate,                                                              \
+							relinfo,                                                               \
+							tupleid,                                                               \
+							fdw_trigtuple,                                                         \
+							epqslot,                                                               \
+							tmresult,                                                              \
+							tmfd,                                                                  \
+							is_merge_delete)
+#define ExecBRUpdateTriggersCompat(estate,                                                         \
+								   epqstate,                                                       \
+								   relinfo,                                                        \
+								   tupleid,                                                        \
+								   fdw_trigtuple,                                                  \
+								   epqslot,                                                        \
+								   tmresult,                                                       \
+								   tmfd,                                                           \
+								   is_merge_delete)                                                \
+	ExecBRUpdateTriggersNew(estate,                                                                \
+							epqstate,                                                              \
+							relinfo,                                                               \
+							tupleid,                                                               \
+							fdw_trigtuple,                                                         \
+							epqslot,                                                               \
+							tmresult,                                                              \
+							tmfd,                                                                  \
+							is_merge_delete)
+#endif
+#if PG18_GE
+#define ExecBRDeleteTriggersCompat(estate,                                                         \
+								   epqstate,                                                       \
+								   relinfo,                                                        \
+								   tupleid,                                                        \
+								   fdw_trigtuple,                                                  \
+								   epqslot,                                                        \
+								   tmresult,                                                       \
+								   tmfd,                                                           \
+								   is_merge_delete)                                                \
+	ExecBRDeleteTriggers(estate,                                                                   \
+						 epqstate,                                                                 \
+						 relinfo,                                                                  \
+						 tupleid,                                                                  \
+						 fdw_trigtuple,                                                            \
+						 epqslot,                                                                  \
+						 tmresult,                                                                 \
+						 tmfd,                                                                     \
+						 is_merge_delete)
+#define ExecBRUpdateTriggersCompat(estate,                                                         \
+								   epqstate,                                                       \
+								   relinfo,                                                        \
+								   tupleid,                                                        \
+								   fdw_trigtuple,                                                  \
+								   epqslot,                                                        \
+								   tmresult,                                                       \
+								   tmfd,                                                           \
+								   is_merge_delete)                                                \
+	ExecBRUpdateTriggers(estate,                                                                   \
+						 epqstate,                                                                 \
+						 relinfo,                                                                  \
+						 tupleid,                                                                  \
+						 fdw_trigtuple,                                                            \
+						 epqslot,                                                                  \
+						 tmresult,                                                                 \
+						 tmfd,                                                                     \
+						 is_merge_delete)
+#endif

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -1155,9 +1155,10 @@ ExecDeletePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 		if (context->estate->es_insert_pending_result_relations != NIL)
 			ExecPendingInserts(context->estate);
 
-		return ExecBRDeleteTriggers(context->estate, context->epqstate,
+		return ExecBRDeleteTriggersCompat(context->estate, context->epqstate,
 									resultRelInfo, tupleid, oldtuple,
-									epqreturnslot, result, &context->tmfd);
+									epqreturnslot, result, &context->tmfd,
+									context->mtstate->operation == CMD_MERGE);
 	}
 
 	return true;
@@ -1580,9 +1581,10 @@ ExecUpdatePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 		if (context->estate->es_insert_pending_result_relations != NIL)
 			ExecPendingInserts(context->estate);
 
-		return ExecBRUpdateTriggers(context->estate, context->epqstate,
+		return ExecBRUpdateTriggersCompat(context->estate, context->epqstate,
 									resultRelInfo, tupleid, oldtuple, slot,
-									result, &context->tmfd);
+									result, &context->tmfd,
+									context->mtstate->operation == CMD_MERGE);
 	}
 
 	return true;


### PR DESCRIPTION
In version 18, we got a breaking change in the before row delete and update triggers by adding a new parameter to the function signature. This change has been backported with 17.6 hence we need to keep track of 3 versions of these functions.

https://github.com/postgres/postgres/commit/5022ff25

Disable-check: force-changelog-file