### PR TITLE
Implement multikey skipscan in not-null mode

### DIFF
--- a/.unreleased/pr_8513
+++ b/.unreleased/pr_8513
@@ -1,0 +1,1 @@
+Implements: #8513 Support multikey SkipScan when all keys are guaranteed to be non-null

--- a/src/guc.c
+++ b/src/guc.c
@@ -132,6 +132,7 @@ TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates = true;
 #endif
 TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan = true;
+TSDLLEXPORT bool ts_guc_enable_multikey_skip_scan = true;
 TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier = 1.0;
 static char *ts_guc_default_segmentby_fn = NULL;
 static char *ts_guc_default_orderby_fn = NULL;
@@ -672,6 +673,17 @@ _guc_init(void)
 							 "Enable SkipScan for compressed chunks",
 							 "Enable SkipScan for distinct inputs over compressed chunks",
 							 &ts_guc_enable_compressed_skip_scan,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_multikey_skipscan"),
+							 "Enable SkipScan for multiple distinct keys",
+							 "Enable SkipScan for multiple distinct inputs",
+							 &ts_guc_enable_multikey_skip_scan,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -71,6 +71,7 @@ extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif
 extern bool ts_guc_enable_event_triggers;
 extern TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan;
+extern TSDLLEXPORT bool ts_guc_enable_multikey_skip_scan;
 extern TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier;
 extern TSDLLEXPORT bool ts_guc_debug_skip_scan_info;
 

--- a/tsl/src/nodes/skip_scan/exec.c
+++ b/tsl/src/nodes/skip_scan/exec.c
@@ -38,6 +38,53 @@
  *                    |   DONE    |
  *                    \===========/
  *
+ *
+ *
+ * N-key SkipScan needs to do 2^N null check stages when using the above scheme,
+ * made even more complicated with having to change searches for previous keys.
+ *
+ * So we made a decision to support multikey SkipScan in NOT NULL mode only.
+ *
+ * For N-key SkipScan we search with these predicates when current key = K:
+ * (key_1 = prev_1),...,(key_K > prev_K),(key_K+1 IS NOT NULL)...(key_N IS NOT NULL)
+ *
+ * As all skip keys are NOT NULL, "IS NOT NULL" fetches the tuple with no previous value.
+ *
+ * We start the search with K=1 i.e. with these predicates:
+ * (key_1 IS NOT NULL),...,(key_N IS NOT NULL).
+ *
+ * When a tuple is fetched we set  K=N as we can fill all previous values, search is now:
+ * (key_1 = prev_1),...,(key_N > prev_N)
+ *
+ * When no tuple is fetched and K>1 we can relax the search and move to previous key (K-1):
+ * (key_1 = prev_1),...,(key_K-1 > prev_K-1),(key_K IS NOT NULL)...(key_N IS NOT NULL)
+ *
+ * When no tuple is fetched and K=1, we are done.
+ *
+ * Multikey SkipScan flowchart:
+ *                   start (K=1)
+ *                      |         +---------+
+ *                      |         |         |
+ *                      v         v         |
+ *      +=================================+ |
+ *      |   search for NOT NULL after K   | |
+ *      +=================================+ |
+ *            |                          |  |
+ *            | found value              |  |
+ *            v                          |  |
+ *  +==============================+     |  |
+ *  | search for values after prev |     |  |
+ *  +==============================+     |  |
+ *                       |               |  |
+ *                       |   no value    |  |
+ *                       v               v  |
+ *                 +======================+ |
+ *                 | K=1         | K>1      |
+ *                 v             v          |
+ *            /===========\   +=========+   |
+ *            |   DONE    |   | K = K-1 |---+
+ *            \===========/   +=========+
+ *
  */
 
 #include <postgres.h>
@@ -58,6 +105,7 @@ typedef enum SkipScanStage
 	SS_NOT_NULL,
 	SS_VALUES,
 	SS_NULLS_LAST,
+	SS_PREV_KEY,
 	SS_END,
 } SkipScanStage;
 
@@ -92,6 +140,17 @@ typedef struct SkipScanState
 
 	int num_skip_keys;
 	SkipKeyData *skip_keys;
+
+	/* Skip key with ">" qual, coming after "=" skip quals for multikey SkipScan */
+	int current_key;
+
+	/* For Multikey SkipScan we keep copies of "sk_func" for "=" and ">" for keys 1..N-1
+	 * to be swapped during execution.
+	 */
+	FmgrInfo *eq_funcs;
+	/* Will be filled after IndexScan scankeys have been initialized */
+	FmgrInfo *comp_funcs;
+	StrategyNumber *comp_strategies;
 
 	SkipScanStage stage;
 
@@ -157,31 +216,44 @@ skip_scan_begin(CustomScanState *node, EState *estate, int eflags)
 	/* find position of our skip key
 	 * skip key is put as first key for the respective column in sort_indexquals
 	 */
-	ScanKey data = *state->scan_keys;
+	ScanKey scankeydata = *state->scan_keys;
 	int j = 0;
 	for (int i = 0; i < *state->num_scan_keys; i++)
 	{
-		if (data[i].sk_flags == SK_ISNULL && data[i].sk_attno == state->skip_keys[j].sk_attno)
+		if (scankeydata[i].sk_flags == SK_ISNULL &&
+			scankeydata[i].sk_attno == state->skip_keys[j].sk_attno)
 		{
-			state->skip_keys[j++].skip_key = &data[i];
+			SkipKeyData *skipkeydata = &state->skip_keys[j++];
+			skipkeydata->skip_key = &scankeydata[i];
+			/* Set up ">" sk_func swaps for skip keys 1..N-1 */
+			if (j < state->num_skip_keys)
+			{
+				state->comp_strategies[j - 1] = scankeydata[i].sk_strategy;
+				fmgr_info_copy(&state->comp_funcs[j - 1],
+							   &scankeydata[i].sk_func,
+							   CurrentMemoryContext);
+			}
 			if (j == state->num_skip_keys)
 				break;
 		}
 	}
 	if (j < state->num_skip_keys)
 		elog(ERROR, "ScanKey for skip qual not found");
+
+	/* when we fetch the 1st tuple we update all skip keys from 0 to N */
+	state->current_key = 0;
 }
 
 static bool
 has_nulls_first(SkipScanState *state)
 {
-	return state->skip_keys[0].nulls == SKIPKEY_NULLS_FIRST;
+	return state->skip_keys[0].nulls == SK_NULLS_FIRST;
 }
 
 static bool
 has_nulls_last(SkipScanState *state)
 {
-	return state->skip_keys[0].nulls == SKIPKEY_NULLS_LAST;
+	return state->skip_keys[0].nulls == SK_NULLS_LAST;
 }
 
 static void
@@ -223,18 +295,48 @@ skip_scan_rescan_index(SkipScanState *state)
 static void
 skip_scan_switch_stage(SkipScanState *state, SkipScanStage new_stage)
 {
-	Assert(new_stage > state->stage);
+	Assert(new_stage > state->stage || state->num_skip_keys > 1);
 
 	switch (new_stage)
 	{
 		case SS_NOT_NULL:
-			state->skip_keys[0].skip_key->sk_flags = SK_ISNULL | SK_SEARCHNOTNULL;
-			state->skip_keys[0].skip_key->sk_argument = 0;
+			for (int i = 0; i < state->num_skip_keys; i++)
+			{
+				state->skip_keys[i].skip_key->sk_flags = SK_ISNULL | SK_SEARCHNOTNULL;
+				state->skip_keys[i].skip_key->sk_argument = 0;
+			}
+			state->needs_rescan = true;
+			break;
+
+		case SS_PREV_KEY:
+			/* Done searching with ">" for this key: set this key to NOT NULL i.e. any value,
+			 * set previous "=" key to search with ">".
+			 */
+			state->skip_keys[state->current_key].skip_key->sk_flags = SK_ISNULL | SK_SEARCHNOTNULL;
+			state->current_key--;
+			state->skip_keys[state->current_key].skip_key->sk_flags = 0;
+			fmgr_info_copy(&state->skip_keys[state->current_key].skip_key->sk_func,
+						   &state->comp_funcs[state->current_key],
+						   CurrentMemoryContext);
+			state->skip_keys[state->current_key].skip_key->sk_strategy =
+				state->comp_strategies[state->current_key];
 			state->needs_rescan = true;
 			break;
 
 		case SS_VALUES:
-			state->skip_keys[0].skip_key->sk_flags = 0;
+			for (int i = 0; i < state->num_skip_keys; i++)
+			{
+				state->skip_keys[i].skip_key->sk_flags = 0;
+				/* reset all ">" back to "=" from the current key to N-1 */
+				if (i >= state->current_key && i < state->num_skip_keys - 1)
+				{
+					fmgr_info_copy(&state->skip_keys[i].skip_key->sk_func,
+								   &state->eq_funcs[i],
+								   CurrentMemoryContext);
+					state->skip_keys[i].skip_key->sk_strategy = BTEqualStrategyNumber;
+				}
+			}
+			state->current_key = state->num_skip_keys - 1;
 			state->needs_rescan = true;
 			break;
 
@@ -256,31 +358,32 @@ skip_scan_switch_stage(SkipScanState *state, SkipScanStage new_stage)
 static void
 skip_scan_update_key(SkipScanState *state, TupleTableSlot *slot)
 {
-	if (!state->skip_keys[0].prev_is_null && !state->skip_keys[0].distinct_by_val)
+	for (int i = state->current_key; i < state->num_skip_keys; i++)
 	{
-		Assert(state->stage == SS_VALUES);
-		pfree(DatumGetPointer(state->skip_keys[0].prev_datum));
-	}
+		if (!state->skip_keys[i].prev_is_null && !state->skip_keys[i].distinct_by_val)
+		{
+			Assert(state->stage == SS_VALUES || state->num_skip_keys > 1);
+			pfree(DatumGetPointer(state->skip_keys[i].prev_datum));
+		}
 
-	MemoryContext old_ctx = MemoryContextSwitchTo(state->ctx);
-	state->skip_keys[0].prev_datum = slot_getattr(slot,
-												  state->skip_keys[0].distinct_col_attnum,
-												  &state->skip_keys[0].prev_is_null);
-	if (state->skip_keys[0].prev_is_null)
-	{
-		state->skip_keys[0].skip_key->sk_flags = SK_ISNULL;
-		state->skip_keys[0].skip_key->sk_argument = 0;
+		MemoryContext old_ctx = MemoryContextSwitchTo(state->ctx);
+		state->skip_keys[i].prev_datum = slot_getattr(slot,
+													  state->skip_keys[i].distinct_col_attnum,
+													  &state->skip_keys[i].prev_is_null);
+		if (state->skip_keys[i].prev_is_null)
+		{
+			state->skip_keys[i].skip_key->sk_flags = SK_ISNULL;
+			state->skip_keys[i].skip_key->sk_argument = 0;
+		}
+		else
+		{
+			state->skip_keys[i].prev_datum = datumCopy(state->skip_keys[i].prev_datum,
+													   state->skip_keys[i].distinct_by_val,
+													   state->skip_keys[i].distinct_typ_len);
+			state->skip_keys[i].skip_key->sk_argument = state->skip_keys[i].prev_datum;
+		}
+		MemoryContextSwitchTo(old_ctx);
 	}
-	else
-	{
-		state->skip_keys[0].prev_datum = datumCopy(state->skip_keys[0].prev_datum,
-												   state->skip_keys[0].distinct_by_val,
-												   state->skip_keys[0].distinct_typ_len);
-		state->skip_keys[0].skip_key->sk_argument = state->skip_keys[0].prev_datum;
-	}
-
-	MemoryContextSwitchTo(old_ctx);
-
 	/* we need to do a rescan whenever we modify the ScanKey */
 	state->needs_rescan = true;
 }
@@ -330,6 +433,7 @@ skip_scan_exec(CustomScanState *node)
 				break;
 
 			case SS_NOT_NULL:
+			case SS_PREV_KEY:
 			case SS_VALUES:
 				child_state = linitial(state->cscan_state.custom_ps);
 				result = child_state->ps.ExecProcNode(&child_state->ps);
@@ -343,10 +447,10 @@ skip_scan_exec(CustomScanState *node)
 					 * also switch stage to look for values greater than
 					 * that in subsequent calls.
 					 */
-					if (state->stage == SS_NOT_NULL)
+					skip_scan_update_key(state, result);
+					if (state->stage == SS_NOT_NULL || state->stage == SS_PREV_KEY)
 						skip_scan_switch_stage(state, SS_VALUES);
 
-					skip_scan_update_key(state, result);
 					return result;
 				}
 				else
@@ -356,9 +460,15 @@ skip_scan_exec(CustomScanState *node)
 					 * the skip constraint we are either done
 					 * for NULLS FIRST ordering or need to check
 					 * for NULLs if we have NULLS LAST ordering
+					 *
+					 * Or we can move back one key for multikey SkipScan to relax the search,
+					 * i.e. make current key NOT NULL (any value) and change previous search from
+					 * "=" to ">"
 					 */
 					if (has_nulls_last(state))
 						skip_scan_switch_stage(state, SS_NULLS_LAST);
+					else if (state->current_key > 0)
+						skip_scan_switch_stage(state, SS_PREV_KEY);
 					else
 						skip_scan_switch_stage(state, SS_END);
 				}
@@ -401,8 +511,11 @@ skip_scan_rescan(CustomScanState *node)
 	else
 		skip_scan_switch_stage(state, SS_NOT_NULL);
 
-	state->skip_keys[0].prev_is_null = true;
-	state->skip_keys[0].prev_datum = 0;
+	for (int i = 0; i < state->num_skip_keys; i++)
+	{
+		state->skip_keys[i].prev_is_null = true;
+		state->skip_keys[i].prev_datum = 0;
+	}
 
 	state->needs_rescan = false;
 	ScanState *child_state = linitial(state->cscan_state.custom_ps);
@@ -435,24 +548,54 @@ tsl_skip_scan_state_create(CustomScan *cscan)
 	}
 	state->stage = SS_BEGIN;
 
-	state->num_skip_keys = list_length(cscan->custom_private);
+	/* set up N skipkeyinfos for N skip keys */
+	List *skinfos = (List *) linitial(cscan->custom_private);
+	state->num_skip_keys = list_length(skinfos);
 	state->skip_keys = palloc(sizeof(SkipKeyData) * state->num_skip_keys);
 
 	ListCell *lc;
 	int i = 0;
-	foreach (lc, cscan->custom_private)
+	foreach (lc, skinfos)
 	{
 		List *skipkeyinfo = (List *) lfirst(lc);
 
-		state->skip_keys[i].distinct_col_attnum = linitial_int(skipkeyinfo);
-		state->skip_keys[i].distinct_by_val = lsecond_int(skipkeyinfo);
-		state->skip_keys[i].distinct_typ_len = lthird_int(skipkeyinfo);
-		state->skip_keys[i].nulls = lfourth_int(skipkeyinfo);
-		state->skip_keys[i].sk_attno = list_nth_int(skipkeyinfo, 4);
+		state->skip_keys[i].distinct_col_attnum = list_nth_int(skipkeyinfo, SK_DistinctColAttno);
+		state->skip_keys[i].distinct_by_val = list_nth_int(skipkeyinfo, SK_DistinctByVal);
+		state->skip_keys[i].distinct_typ_len = list_nth_int(skipkeyinfo, SK_DistinctTypeLen);
+		state->skip_keys[i].nulls = list_nth_int(skipkeyinfo, SK_NullStatus);
+		Assert(state->num_skip_keys == 1 || state->skip_keys[i].nulls == SK_NOT_NULL);
+		state->skip_keys[i].sk_attno = list_nth_int(skipkeyinfo, SK_IndexKeyAttno);
 
 		state->skip_keys[i].prev_is_null = true;
 		i++;
 	}
+
+	state->eq_funcs = NULL;
+	state->comp_funcs = NULL;
+	state->comp_strategies = NULL;
+
+	/* set up N-1 equality ops for N skip keys if N>1 */
+	if (state->num_skip_keys > 1)
+	{
+		/* Should have a list of N-1 equality op Oids for N skip keys if N>1 */
+		Assert(list_length(cscan->custom_private) == 2);
+		List *eqoids = (List *) lsecond(cscan->custom_private);
+
+		state->eq_funcs = palloc(sizeof(FmgrInfo) * (state->num_skip_keys - 1));
+		state->comp_funcs = palloc(sizeof(FmgrInfo) * (state->num_skip_keys - 1));
+		state->comp_strategies = palloc(sizeof(StrategyNumber) * (state->num_skip_keys - 1));
+
+		int i = 0;
+		/* Set up "=" sk_funcs for keys 1..N-1 */
+		foreach (lc, eqoids)
+		{
+			Oid eqoid = lfirst_oid(lc);
+			Assert(OidIsValid(eqoid));
+			fmgr_info(eqoid, &state->eq_funcs[i++]);
+		}
+		Assert(i == state->num_skip_keys - 1);
+	}
+
 	state->cscan_state.methods = &skip_scan_state_methods;
 	return (Node *) state;
 }

--- a/tsl/src/nodes/skip_scan/skip_scan.h
+++ b/tsl/src/nodes/skip_scan/skip_scan.h
@@ -10,10 +10,19 @@
 
 typedef enum SkipKeyNullStatus
 {
-	SKIPKEY_NOT_NULL = 0,
-	SKIPKEY_NULLS_FIRST,
-	SKIPKEY_NULLS_LAST
+	SK_NOT_NULL = 0,
+	SK_NULLS_FIRST,
+	SK_NULLS_LAST
 } SkipKeyNullStatus;
+
+typedef enum
+{
+	SK_DistinctColAttno = 0,
+	SK_DistinctByVal = 1,
+	SK_DistinctTypeLen = 2,
+	SK_NullStatus = 3,
+	SK_IndexKeyAttno = 4
+} SkipScanPrivateIndex;
 
 extern void tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel,
 									RelOptInfo *output_rel, UpperRelationKind stage);

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -1402,15 +1402,16 @@ DEALLOCATE prep;
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
 (11 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
-         Index Cond: (dev IS NOT NULL)
-(4 rows)
+         Filter: (COALESCE(dev, '-1'::integer) >= 0)
+         Rows Removed by Filter: 21
+(5 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -1423,7 +1424,8 @@ UNION SELECT b.* FROM
          ->  Append (actual rows=20002 loops=1)
                ->  Unique (actual rows=10001 loops=1)
                      ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
-                           Index Cond: (dev IS NOT NULL)
+                           Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                           Rows Removed by Filter: 21
                ->  Nested Loop (actual rows=10001 loops=1)
                      ->  Unique (actual rows=12 loops=1)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
@@ -1433,7 +1435,7 @@ UNION SELECT b.* FROM
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-(20 rows)
+(21 rows)
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
@@ -3865,23 +3867,27 @@ DEALLOCATE prep;
                            Index Cond: ((dev = skip_scan_ht.dev) AND ("time" > NULL::integer))
 (39 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10000 loops=1)
    ->  Merge Append (actual rows=10000 loops=1)
          Sort Key: skip_scan_ht.dev, skip_scan_ht."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
-(15 rows)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
+(19 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -3896,13 +3902,17 @@ UNION SELECT b.* FROM
                      ->  Merge Append (actual rows=10000 loops=1)
                            Sort Key: skip_scan_ht.dev, skip_scan_ht."time"
                            ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                            ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                            ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                            ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                ->  Nested Loop (actual rows=10000 loops=1)
                      ->  Unique (actual rows=11 loops=1)
                            ->  Merge Append (actual rows=44 loops=1)
@@ -3934,7 +3944,7 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = skip_scan_ht_1.dev) AND ("time" > NULL::integer))
-(59 rows)
+(63 rows)
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -1401,15 +1401,16 @@ DEALLOCATE prep;
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
 (11 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
-         Index Cond: (dev IS NOT NULL)
-(4 rows)
+         Filter: (COALESCE(dev, '-1'::integer) >= 0)
+         Rows Removed by Filter: 21
+(5 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -1422,7 +1423,8 @@ UNION SELECT b.* FROM
          ->  Append (actual rows=20002 loops=1)
                ->  Unique (actual rows=10001 loops=1)
                      ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
-                           Index Cond: (dev IS NOT NULL)
+                           Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                           Rows Removed by Filter: 21
                ->  Nested Loop (actual rows=10001 loops=1)
                      ->  Unique (actual rows=12 loops=1)
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
@@ -1432,7 +1434,7 @@ UNION SELECT b.* FROM
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-(20 rows)
+(21 rows)
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
@@ -3860,23 +3862,27 @@ DEALLOCATE prep;
                            Index Cond: ((dev = skip_scan_ht.dev) AND ("time" > NULL::integer))
 (39 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10000 loops=1)
    ->  Merge Append (actual rows=10000 loops=1)
          Sort Key: skip_scan_ht.dev, skip_scan_ht."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
-(15 rows)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
+(19 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -3891,13 +3897,17 @@ UNION SELECT b.* FROM
                      ->  Merge Append (actual rows=10000 loops=1)
                            Sort Key: skip_scan_ht.dev, skip_scan_ht."time"
                            ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                            ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                            ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                            ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
-                                 Index Cond: (dev IS NOT NULL)
+                                 Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                                 Rows Removed by Filter: 5
                ->  Nested Loop (actual rows=10000 loops=1)
                      ->  Unique (actual rows=11 loops=1)
                            ->  Merge Append (actual rows=44 loops=1)
@@ -3929,7 +3939,7 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = skip_scan_ht_1.dev) AND ("time" > NULL::integer))
-(59 rows)
+(63 rows)
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -1401,15 +1401,16 @@ DEALLOCATE prep;
                      Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
 (11 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Unique (actual rows=10001 loops=1)
    ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
-         Index Cond: (dev IS NOT NULL)
-(4 rows)
+         Filter: (COALESCE(dev, '-1'::integer) >= 0)
+         Rows Removed by Filter: 21
+(5 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -1420,7 +1421,8 @@ UNION SELECT b.* FROM
          Sort Key: skip_scan.dev, skip_scan."time"
          ->  Unique (actual rows=10001 loops=1)
                ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
-                     Index Cond: (dev IS NOT NULL)
+                     Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                     Rows Removed by Filter: 21
          ->  Sort (actual rows=10001 loops=1)
                Sort Key: skip_scan_2.dev, skip_scan_2."time"
                Sort Method: quicksort 
@@ -1433,7 +1435,7 @@ UNION SELECT b.* FROM
                            ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                  ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
                                        Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
-(21 rows)
+(22 rows)
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
@@ -3861,23 +3863,27 @@ DEALLOCATE prep;
                            Index Cond: ((dev = skip_scan_ht.dev) AND ("time" > NULL::integer))
 (39 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10000 loops=1)
    ->  Merge Append (actual rows=10000 loops=1)
          Sort Key: skip_scan_ht.dev, skip_scan_ht."time"
          ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
          ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
-               Index Cond: (dev IS NOT NULL)
-(15 rows)
+               Filter: (COALESCE(dev, '-1'::integer) >= 0)
+               Rows Removed by Filter: 5
+(19 rows)
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -3890,13 +3896,17 @@ UNION SELECT b.* FROM
                ->  Merge Append (actual rows=10000 loops=1)
                      Sort Key: skip_scan_ht.dev, skip_scan_ht."time"
                      ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
-                           Index Cond: (dev IS NOT NULL)
+                           Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                           Rows Removed by Filter: 5
                      ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
-                           Index Cond: (dev IS NOT NULL)
+                           Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                           Rows Removed by Filter: 5
                      ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
-                           Index Cond: (dev IS NOT NULL)
+                           Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                           Rows Removed by Filter: 5
                      ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
-                           Index Cond: (dev IS NOT NULL)
+                           Filter: (COALESCE(dev, '-1'::integer) >= 0)
+                           Rows Removed by Filter: 5
          ->  Sort (actual rows=10000 loops=1)
                Sort Key: skip_scan_ht_2.dev, skip_scan_ht_2."time"
                Sort Method: quicksort 
@@ -3931,7 +3941,7 @@ UNION SELECT b.* FROM
                                  ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                        ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
                                              Index Cond: ((dev = skip_scan_ht_1.dev) AND ("time" > NULL::integer))
-(60 rows)
+(64 rows)
 
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;

--- a/tsl/test/expected/plan_skip_scan_notnull.out
+++ b/tsl/test/expected/plan_skip_scan_notnull.out
@@ -153,7 +153,7 @@ SET timescaledb.debug_skip_scan_info  TO true;
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Base queries with regular NULL mode
 :PREFIX SELECT DISTINCT dev FROM :TABLE;
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Unique (actual rows=12 loops=1)
@@ -163,7 +163,7 @@ psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LA
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS FIRST)
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Unique (actual rows=12 loops=1)
@@ -174,7 +174,7 @@ psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FI
 
 -- Index quals except IS NULL discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -184,7 +184,7 @@ psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NUL
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=8 loops=1)
@@ -194,7 +194,7 @@ psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NUL
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=5 loops=1)
@@ -206,7 +206,7 @@ psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NUL
 -- next two filters produce small output for which we may select seqscan, don't want it
 set enable_seqscan=0;
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
@@ -216,7 +216,7 @@ psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NUL
 (5 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -227,7 +227,7 @@ psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS L
 
 -- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -238,7 +238,7 @@ psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS L
 
 -- Complex expressions over IS NOT NULL are non-strict filters
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -252,7 +252,7 @@ psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS L
 reset enable_seqscan;
 -- Strict Index filters discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=4 loops=1)
@@ -265,7 +265,7 @@ psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NUL
 
 -- OR is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -278,7 +278,7 @@ psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS L
 
 -- Coalesce is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=2 loops=1)
@@ -291,7 +291,7 @@ psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS L
 
 -- Strict non-index filters on relation discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -303,7 +303,7 @@ psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NUL
 
 -- OR is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -315,7 +315,7 @@ psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS L
 
 -- Coalesce is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -327,7 +327,7 @@ psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS L
 
 -- If at least one filter is strict then it filters out NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -339,7 +339,7 @@ psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Index qual on a non-skip key: skip key can be NULL
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -350,7 +350,7 @@ psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS L
 
 -- Index quals on several keys including skip key
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Unique (actual rows=8 loops=1)
@@ -362,7 +362,7 @@ psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NUL
 -- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
 -- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NOT NULL)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -373,7 +373,7 @@ psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Satisfying (dev_name>'device_1') may allow NULLs into dev
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -384,7 +384,7 @@ psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS L
 
 -- Non-index qual row comparison: row comparison in general is not strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev NULLS LAST)
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -397,7 +397,7 @@ psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS L
 
 -- Different SkipScan column
 :PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on skip_scan_dev_devname_idx(dev_name NOT NULL)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -409,7 +409,7 @@ psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NUL
 -- Boolean and NOT NULL constraint tests
 -- Boolean column index qual is strict
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on skip_scan_b_idx(b NOT NULL)
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -419,7 +419,7 @@ psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NUL
 (5 rows)
 
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on skip_scan_b_idx(b NOT NULL)
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -430,7 +430,7 @@ psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Boolean column predicates could be non-strict filters, below filter can accept NULLs
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on skip_scan_b_idx(b NULLS LAST)
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Unique (actual rows=2 loops=1)
@@ -443,7 +443,7 @@ psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS L
 
 -- dev is declared NOT NULL
 :PREFIX SELECT DISTINCT dev FROM skip_scan_nn;
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on skip_scan_nn_idx(dev NOT NULL)
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -475,10 +475,10 @@ NOTICE:  migrating data to chunks
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Base queries with regular NULL mode
 :PREFIX SELECT DISTINCT dev FROM :TABLE;
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -499,10 +499,10 @@ psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LA
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS FIRST)
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS FIRST)
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS FIRST)
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS FIRST)
                                                                  QUERY PLAN                                                                  
 ---------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -524,10 +524,10 @@ psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FI
 
 -- Index quals except IS NULL discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -548,10 +548,10 @@ psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NUL
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=8 loops=1)
@@ -572,10 +572,10 @@ psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NUL
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=5 loops=1)
@@ -598,10 +598,10 @@ psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NUL
 -- next two filters produce small output for which we may select seqscan, don't want it
 set enable_seqscan=0;
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
@@ -622,10 +622,10 @@ psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NUL
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -647,10 +647,10 @@ psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS L
 
 -- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -672,10 +672,10 @@ psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS L
 
 -- Complex expressions over IS NOT NULL are non-strict filters
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -706,10 +706,10 @@ psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS L
 reset enable_seqscan;
 -- Strict Index filters discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
@@ -739,10 +739,10 @@ psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NUL
 
 -- OR is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -772,10 +772,10 @@ psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS L
 
 -- Coalesce is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -805,10 +805,10 @@ psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS L
 
 -- Strict non-index filters on relation discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -833,10 +833,10 @@ psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NUL
 
 -- OR is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -862,10 +862,10 @@ psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS L
 
 -- Coalesce is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -890,10 +890,10 @@ psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS L
 
 -- If at least one filter is strict then it filters out NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -918,10 +918,10 @@ psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Index qual on a non-skip key: skip key can be NULL
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -943,10 +943,10 @@ psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS L
 
 -- Index quals on several keys including skip key
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=8 loops=1)
@@ -969,10 +969,10 @@ psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NUL
 -- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
 -- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -994,10 +994,10 @@ psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Satisfying (dev_name>'device_1') may allow NULLs into dev
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -1019,10 +1019,10 @@ psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS L
 
 -- Non-index qual row comparison: row comparison in general is not strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev NULLS LAST)
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1052,10 +1052,10 @@ psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS L
 
 -- Different SkipScan column
 :PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on _hyper_1_1_chunk_skip_scan_ht_dev_devname_idx(dev_name NOT NULL)
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on _hyper_1_2_chunk_skip_scan_ht_dev_devname_idx(dev_name NOT NULL)
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on _hyper_1_3_chunk_skip_scan_ht_dev_devname_idx(dev_name NOT NULL)
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on _hyper_1_4_chunk_skip_scan_ht_dev_devname_idx(dev_name NOT NULL)
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1078,9 +1078,9 @@ psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NUL
 -- Boolean and NOT NULL constraint tests
 -- Boolean column index qual is strict
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on _hyper_7_21_chunk_skip_scan_b_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on _hyper_7_22_chunk_skip_scan_b_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on _hyper_7_23_chunk_skip_scan_b_idx(b NOT NULL)
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1098,9 +1098,9 @@ psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NUL
 (15 rows)
 
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on _hyper_7_21_chunk_skip_scan_b_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on _hyper_7_22_chunk_skip_scan_b_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on _hyper_7_23_chunk_skip_scan_b_idx(b NOT NULL)
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1119,9 +1119,9 @@ psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Boolean column predicates could be non-strict filters, below filter can accept NULLs
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on _hyper_7_21_chunk_skip_scan_b_idx(b NULLS LAST)
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on _hyper_7_22_chunk_skip_scan_b_idx(b NULLS LAST)
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on _hyper_7_23_chunk_skip_scan_b_idx(b NULLS LAST)
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=2 loops=1)
@@ -1146,9 +1146,9 @@ psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS L
 
 -- dev is declared NOT NULL
 :PREFIX SELECT DISTINCT dev FROM skip_scan_nn;
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on _hyper_8_24_chunk_skip_scan_nn_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on _hyper_8_25_chunk_skip_scan_nn_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on _hyper_8_26_chunk_skip_scan_nn_idx(dev NOT NULL)
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -1192,10 +1192,10 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_nn') ch;
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Base queries with regular NULL mode
 :PREFIX SELECT DISTINCT dev FROM :TABLE;
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -1216,10 +1216,10 @@ psql:include/skip_scan_notnull.sql:6: INFO:  SkipScan index column 1 is NULLS LA
 (15 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE order by dev DESC;
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
-psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FIRST
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS FIRST)
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS FIRST)
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS FIRST)
+psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS FIRST)
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -1241,10 +1241,10 @@ psql:include/skip_scan_notnull.sql:8: INFO:  SkipScan index column 1 is NULLS FI
 
 -- Index quals except IS NULL discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NOT NULL;
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1269,10 +1269,10 @@ psql:include/skip_scan_notnull.sql:11: INFO:  SkipScan index column 1 is NOT NUL
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev > 2;
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=8 loops=1)
@@ -1297,10 +1297,10 @@ psql:include/skip_scan_notnull.sql:13: INFO:  SkipScan index column 1 is NOT NUL
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev BETWEEN 1 AND 5;
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=5 loops=1)
@@ -1327,10 +1327,10 @@ psql:include/skip_scan_notnull.sql:15: INFO:  SkipScan index column 1 is NOT NUL
 -- next two filters produce small output for which we may select seqscan, don't want it
 set enable_seqscan=0;
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev in (1,2,3);
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
@@ -1355,10 +1355,10 @@ psql:include/skip_scan_notnull.sql:19: INFO:  SkipScan index column 1 is NOT NUL
 (19 rows)
 
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev IS NULL;
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1384,10 +1384,10 @@ psql:include/skip_scan_notnull.sql:21: INFO:  SkipScan index column 1 is NULLS L
 
 -- PG is smart enough to convert negation of IS NOT NULL to IS NULL index condition
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE (dev IS NOT NULL) = false;
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1413,10 +1413,10 @@ psql:include/skip_scan_notnull.sql:24: INFO:  SkipScan index column 1 is NULLS L
 
 -- Complex expressions over IS NOT NULL are non-strict filters
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE ((dev is null) = false)::int + 1 > 1;
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1447,10 +1447,10 @@ psql:include/skip_scan_notnull.sql:27: INFO:  SkipScan index column 1 is NULLS L
 reset enable_seqscan;
 -- Strict Index filters discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev * 2 < 8;
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
@@ -1480,10 +1480,10 @@ psql:include/skip_scan_notnull.sql:31: INFO:  SkipScan index column 1 is NOT NUL
 
 -- OR is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev < 2 OR dev > 0;
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1513,10 +1513,10 @@ psql:include/skip_scan_notnull.sql:34: INFO:  SkipScan index column 1 is NULLS L
 
 -- Coalesce is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,-1) < 1;
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1546,10 +1546,10 @@ psql:include/skip_scan_notnull.sql:36: INFO:  SkipScan index column 1 is NULLS L
 
 -- Strict non-index filters on relation discard NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100;
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1579,10 +1579,10 @@ psql:include/skip_scan_notnull.sql:39: INFO:  SkipScan index column 1 is NOT NUL
 
 -- OR is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev + time < 100 OR dev > 0;
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1612,10 +1612,10 @@ psql:include/skip_scan_notnull.sql:42: INFO:  SkipScan index column 1 is NULLS L
 
 -- Coalesce is non-strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100;
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)
@@ -1645,10 +1645,10 @@ psql:include/skip_scan_notnull.sql:44: INFO:  SkipScan index column 1 is NULLS L
 
 -- If at least one filter is strict then it filters out NULLs
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE coalesce(dev,20) + time < 100 and dev + time < 100;
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1678,10 +1678,10 @@ psql:include/skip_scan_notnull.sql:47: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Index qual on a non-skip key: skip key can be NULL
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1';
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -1707,10 +1707,10 @@ psql:include/skip_scan_notnull.sql:50: INFO:  SkipScan index column 1 is NULLS L
 
 -- Index quals on several keys including skip key
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE dev_name > 'device_1' and dev > 2;
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NOT NULL)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=8 loops=1)
@@ -1737,10 +1737,10 @@ psql:include/skip_scan_notnull.sql:53: INFO:  SkipScan index column 1 is NOT NUL
 -- Index qual row comparison will filter out NULLs in skip key when skip key is a leading column
 -- But for compressed chunks ROW is not pushed into index quals, it is treated as a filter and is not strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev,dev_name) > row(1,'device_1');
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -1770,10 +1770,10 @@ psql:include/skip_scan_notnull.sql:57: INFO:  SkipScan index column 1 is NULLS L
 
 -- Satisfying (dev_name>'device_1') may allow NULLs into dev
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev_name,dev) > row('device_1',1);
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=9 loops=1)
@@ -1803,10 +1803,10 @@ psql:include/skip_scan_notnull.sql:60: INFO:  SkipScan index column 1 is NULLS L
 
 -- Non-index qual row comparison: row comparison in general is not strict
 :PREFIX SELECT DISTINCT dev FROM :TABLE WHERE row(dev+1,dev_name) > row(1,'device_1');
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
+psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev NULLS LAST)
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=10 loops=1)
@@ -1836,10 +1836,10 @@ psql:include/skip_scan_notnull.sql:63: INFO:  SkipScan index column 1 is NULLS L
 
 -- Different SkipScan column
 :PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev=1 and dev_name IS NOT NULL;
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
-psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NULL
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on compress_hyper_4_17_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev_name NOT NULL)
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on compress_hyper_4_18_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev_name NOT NULL)
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on compress_hyper_4_19_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev_name NOT NULL)
+psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan used on compress_hyper_4_20_chunk_dev_dev_name__ts_meta_min_1__ts_m_idx(dev_name NOT NULL)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1866,9 +1866,9 @@ psql:include/skip_scan_notnull.sql:66: INFO:  SkipScan index column 2 is NOT NUL
 -- Boolean and NOT NULL constraint tests
 -- Boolean column index qual is strict
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b;
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on compress_hyper_9_27_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on compress_hyper_9_28_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan used on compress_hyper_9_29_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NOT NULL)
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1889,9 +1889,9 @@ psql:include/skip_scan_notnull.sql:71: INFO:  SkipScan index column 1 is NOT NUL
 (15 rows)
 
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b != true;
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on compress_hyper_9_27_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on compress_hyper_9_28_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NOT NULL)
+psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan used on compress_hyper_9_29_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NOT NULL)
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
@@ -1913,9 +1913,9 @@ psql:include/skip_scan_notnull.sql:72: INFO:  SkipScan index column 1 is NOT NUL
 
 -- Boolean column predicates could be non-strict filters, below filter can accept NULLs
 :PREFIX SELECT DISTINCT b FROM skip_scan_b WHERE b IS NOT true;
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
-psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS LAST
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on compress_hyper_9_27_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NULLS LAST)
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on compress_hyper_9_28_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NULLS LAST)
+psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan used on compress_hyper_9_29_chunk_b__ts_meta_min_1__ts_meta_max_1_idx(b NULLS LAST)
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=2 loops=1)
@@ -1940,9 +1940,9 @@ psql:include/skip_scan_notnull.sql:74: INFO:  SkipScan index column 1 is NULLS L
 
 -- dev is declared NOT NULL
 :PREFIX SELECT DISTINCT dev FROM skip_scan_nn;
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
-psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan index column 1 is NOT NULL
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on compress_hyper_10_30_chunk_dev__ts_meta_min_1__ts_meta_max__idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on compress_hyper_10_31_chunk_dev__ts_meta_min_1__ts_meta_max__idx(dev NOT NULL)
+psql:include/skip_scan_notnull.sql:77: INFO:  SkipScan used on compress_hyper_10_32_chunk_dev__ts_meta_min_1__ts_meta_max__idx(dev NOT NULL)
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=11 loops=1)

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -5,6 +5,7 @@
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 \set TEST_BASE_NAME skip_scan
 SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_multi_load.sql', :'TEST_BASE_NAME') AS "TEST_MULTI_LOAD_NAME",
     format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
     format('%s/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNOPTIMIZED",
     format('%s/results/%s_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_OPTIMIZED" \gset
@@ -337,8 +338,8 @@ DEALLOCATE prep;
 :PREFIX SELECT * FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -580,8 +581,8 @@ DEALLOCATE prep;
 :PREFIX SELECT * FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -838,8 +839,8 @@ DEALLOCATE prep;
 :PREFIX SELECT * FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -1081,8 +1082,8 @@ DEALLOCATE prep;
 :PREFIX SELECT * FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
@@ -1605,7 +1606,7 @@ TRUNCATE skip_scan_insert;
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \o
 RESET timescaledb.enable_compressed_skipscan;
--- compare SkipScan results on hypertable
+-- compare SkipScan results on compressed hypertable
 :DIFF_CMD
 --- Unoptimized results
 +++ Optimized results
@@ -1857,7 +1858,7 @@ RESET max_parallel_workers_per_gather;
 RESET enable_seqscan;
 \o
 RESET timescaledb.enable_compressed_skipscan;
--- compare SkipScan results on hypertable
+-- compare SkipScan results on compressed hypertable
 :DIFF_CMD
 --- Unoptimized results
 +++ Optimized results
@@ -1869,3 +1870,1034 @@ RESET timescaledb.enable_compressed_skipscan;
  (1 row)
  
   dev 
+-- run tests on compressed hypertable with different layouts of compressed chunks
+SELECT format('include/%s_multi_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME" \gset
+-- run multikey SkipScan tests
+\ir :TEST_MULTI_LOAD_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Create tables with 4 not-null index columns (ASC, DESC, ASC, ASC) to test various multikey SkipScan scenarios
+-- Not-null scenarios are tested separately in skip_scan_notnull.sql, here we are testing multi-keys specifically
+CREATE TABLE mskip_scan(time int not null, status int not null, region text not null, dev int not null, dev_name text not null, val int);
+-- Status: (1,2), region: (reg1..reg4), dev: (1..5), dev_name same as dev, 400 timestamps divided into 4 chunks tied to status, 8K rows total
+-- We want to test both (1 distinct, N distinct) and (N distinct, 1 distinct) scenarios,
+-- (status,*) where time<100 will do for the former, (dev, dev_name) will do for the latter
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(0, 99) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(100, 199) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(200, 299) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(300, 399) t, generate_series(1, 4) r, generate_series(1, 5) d;
+CREATE INDEX on mskip_scan(status, region, dev, dev_name);
+-- To test reverse column orders
+CREATE INDEX on mskip_scan(status, region DESC, dev);
+ANALYZE mskip_scan;
+-- Same with a hypertable
+CREATE TABLE mskip_scan_ht(time int not null, status int not null, region text not null, dev int not null, dev_name text not null, val int);
+SELECT create_hypertable('mskip_scan_ht', 'time', chunk_time_interval => 100, create_default_indexes => false);
+     create_hypertable      
+----------------------------
+ (7,public,mskip_scan_ht,t)
+(1 row)
+
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(0, 99) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(100, 199) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(200, 299) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(300, 399) t, generate_series(1, 4) r, generate_series(1, 5) d;
+CREATE INDEX on mskip_scan_ht(status, region, dev, dev_name);
+-- To test reverse column orders
+CREATE INDEX on mskip_scan_ht(status, region DESC, dev);
+ANALYZE mskip_scan_ht;
+-- Same with columnar
+CREATE TABLE mskip_scan_htc(time int not null, status int not null, region text not null, dev int not null, dev_name text not null, val int);
+SELECT create_hypertable('mskip_scan_htc', 'time', chunk_time_interval => 100, create_default_indexes => false);
+      create_hypertable      
+-----------------------------
+ (8,public,mskip_scan_htc,t)
+(1 row)
+
+-- Cannot have reverse orders on segmented columns in columnar index, so it won't be tested for columnar table
+ALTER TABLE mskip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='status,region,dev,dev_name');
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(0, 99) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(100, 199) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(200, 299) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(300, 399) t, generate_series(1, 4) r, generate_series(1, 5) d;
+SELECT compress_chunk(ch) FROM show_chunks('mskip_scan_htc') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_8_69_chunk
+ _timescaledb_internal._hyper_8_70_chunk
+ _timescaledb_internal._hyper_8_71_chunk
+ _timescaledb_internal._hyper_8_72_chunk
+(4 rows)
+
+ANALYZE mskip_scan_htc;
+alter table mskip_scan set (autovacuum_enabled = off);
+alter table mskip_scan_ht set (autovacuum_enabled = off);
+alter table mskip_scan_htc set (autovacuum_enabled = off);
+\set PREFIX ''
+-- make sure multikey SkipScan results are correct
+\set TABLE mskip_scan
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+SET timescaledb.enable_multikey_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+RESET timescaledb.enable_multikey_skipscan;
+-- compare SkipScan results on table
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_multikey_skipscan 
+ --------------------------
+- off
++ on
+ (1 row)
+ 
+  time | status | region | dev | dev_name | val 
+\set TABLE mskip_scan_ht
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+SET timescaledb.enable_multikey_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+RESET timescaledb.enable_multikey_skipscan;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_multikey_skipscan 
+ --------------------------
+- off
++ on
+ (1 row)
+ 
+  time | status | region | dev | dev_name | val  
+\set TABLE mskip_scan_htc
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+SET timescaledb.enable_multikey_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+RESET timescaledb.enable_multikey_skipscan;
+-- compare SkipScan results on compressed hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_multikey_skipscan 
+ --------------------------
+- off
++ on
+ (1 row)
+ 
+  time | status | region | dev | dev_name | val  
+-- make sure multikey SkipScan is applied correctly
+SET timescaledb.debug_skip_scan_info TO true;
+\set TABLE mskip_scan
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+psql:include/skip_scan_multi_query.sql:13: INFO:  SkipScan used on mskip_scan_status_region_dev_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+psql:include/skip_scan_multi_query.sql:14: INFO:  SkipScan used on mskip_scan_status_region_dev_idx(region NOT NULL, dev NOT NULL)
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+psql:include/skip_scan_multi_query.sql:18: INFO:  SkipScan used on mskip_scan_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(dev NOT NULL, dev_name NOT NULL)
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on mskip_scan_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+psql:include/skip_scan_multi_query.sql:51: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+\set TABLE mskip_scan_ht
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+psql:include/skip_scan_multi_query.sql:13: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:13: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:13: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:13: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+psql:include/skip_scan_multi_query.sql:14: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:14: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:14: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:14: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_idx(region NOT NULL, dev NOT NULL)
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+psql:include/skip_scan_multi_query.sql:18: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(dev NOT NULL, dev_name NOT NULL)
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_idx(status NOT NULL, dev NOT NULL)
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+psql:include/skip_scan_multi_query.sql:51: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:51: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:51: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:51: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL)
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_7_65_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_7_66_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_7_67_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_7_68_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+\set TABLE mskip_scan_htc
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:9: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:10: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+psql:include/skip_scan_multi_query.sql:18: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:21: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(dev NOT NULL, dev_name NOT NULL)
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:24: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL, dev_name NOT NULL)
+reset enable_seqscan;
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:28: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:31: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:32: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:33: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:34: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:37: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:40: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:41: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:54: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:64: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:69: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+psql:include/skip_scan_multi_query.sql:73: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL, dev_name NOT NULL)
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+reset enable_seqscan;
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+\o
+RESET timescaledb.debug_skip_scan_info;

--- a/tsl/test/sql/include/skip_scan_multi_load.sql
+++ b/tsl/test/sql/include/skip_scan_multi_load.sql
@@ -1,0 +1,58 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Create tables with 4 not-null index columns (ASC, DESC, ASC, ASC) to test various multikey SkipScan scenarios
+-- Not-null scenarios are tested separately in skip_scan_notnull.sql, here we are testing multi-keys specifically
+
+CREATE TABLE mskip_scan(time int not null, status int not null, region text not null, dev int not null, dev_name text not null, val int);
+
+-- Status: (1,2), region: (reg1..reg4), dev: (1..5), dev_name same as dev, 400 timestamps divided into 4 chunks tied to status, 8K rows total
+-- We want to test both (1 distinct, N distinct) and (N distinct, 1 distinct) scenarios,
+-- (status,*) where time<100 will do for the former, (dev, dev_name) will do for the latter
+
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(0, 99) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(100, 199) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(200, 299) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(300, 399) t, generate_series(1, 4) r, generate_series(1, 5) d;
+
+CREATE INDEX on mskip_scan(status, region, dev, dev_name);
+-- To test reverse column orders
+CREATE INDEX on mskip_scan(status, region DESC, dev);
+
+ANALYZE mskip_scan;
+
+-- Same with a hypertable
+CREATE TABLE mskip_scan_ht(time int not null, status int not null, region text not null, dev int not null, dev_name text not null, val int);
+SELECT create_hypertable('mskip_scan_ht', 'time', chunk_time_interval => 100, create_default_indexes => false);
+
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(0, 99) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(100, 199) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(200, 299) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_ht SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(300, 399) t, generate_series(1, 4) r, generate_series(1, 5) d;
+
+CREATE INDEX on mskip_scan_ht(status, region, dev, dev_name);
+-- To test reverse column orders
+CREATE INDEX on mskip_scan_ht(status, region DESC, dev);
+
+ANALYZE mskip_scan_ht;
+
+-- Same with columnar
+CREATE TABLE mskip_scan_htc(time int not null, status int not null, region text not null, dev int not null, dev_name text not null, val int);
+SELECT create_hypertable('mskip_scan_htc', 'time', chunk_time_interval => 100, create_default_indexes => false);
+
+-- Cannot have reverse orders on segmented columns in columnar index, so it won't be tested for columnar table
+ALTER TABLE mskip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='status,region,dev,dev_name');
+
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(0, 99) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(100, 199) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(200, 299) t, generate_series(1, 4) r, generate_series(1, 5) d;
+INSERT INTO mskip_scan_htc SELECT t, 1, 'reg_' || r::text, d, 'device_' || d::text, t*d FROM generate_series(300, 399) t, generate_series(1, 4) r, generate_series(1, 5) d;
+
+SELECT compress_chunk(ch) FROM show_chunks('mskip_scan_htc') ch;
+
+ANALYZE mskip_scan_htc;
+
+alter table mskip_scan set (autovacuum_enabled = off);
+alter table mskip_scan_ht set (autovacuum_enabled = off);
+alter table mskip_scan_htc set (autovacuum_enabled = off);

--- a/tsl/test/sql/include/skip_scan_multi_query.sql
+++ b/tsl/test/sql/include/skip_scan_multi_query.sql
@@ -1,0 +1,97 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_multikey_skipscan') AS enable_multikey_skipscan;
+
+-- multicolumn index with uniform order
+:PREFIX SELECT DISTINCT ON(status, region, dev, dev_name) * FROM :TABLE ORDER BY status, region, dev, dev_name;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region DESC, dev DESC;
+
+-- index with reverse column orders (applied to non-columnstore ony)
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE ORDER BY status, region DESC, dev;
+:PREFIX SELECT DISTINCT ON(region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev DESC;
+
+set enable_seqscan=0;
+-- (1,N) distinct scenario
+:PREFIX SELECT DISTINCT status, dev FROM :TABLE WHERE time < 100 AND region = 'reg_1' ORDER BY 1,2;
+
+-- (N,1) distinct scenario
+:PREFIX SELECT DISTINCT dev, dev_name FROM :TABLE WHERE status = 1 AND region = 'reg_1' ORDER BY 1,2;
+
+-- SELECT list order of distinct columns shouldn't matter if OBY matches index order
+:PREFIX SELECT DISTINCT dev, status, dev_name FROM :TABLE WHERE region = 'reg_2' ORDER BY status, dev, dev_name;
+reset enable_seqscan;
+
+-- Basic queries
+:PREFIX SELECT DISTINCT region, dev, 'q1_3', NULL FROM :TABLE WHERE status = 1 ORDER BY region, dev;
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, tableoid::regclass, 'q2_11' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_immutable(), 'q2_12' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_stable(), 'q2_13' FROM :TABLE WHERE status = 1;
+:PREFIX SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name, int_func_volatile(), 'q2_14' FROM :TABLE WHERE status = 1;
+
+\qecho ordered append on :TABLE
+:PREFIX SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1 AND time BETWEEN 0 AND 5000;
+
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, region, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1) a;
+:PREFIX SELECT NULL, region, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1) a;
+
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (region, dev) * FROM :TABLE WHERE status = 1 ORDER BY region, dev) a;
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
+-- no tuples matching
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > 20;
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE status = 1 ORDER BY status, region;
+
+-- test distinct PathKey with sortref = 0 in PG15 due to FALSE filter not pushed into relation (should not crash in PG15)
+:PREFIX SELECT DISTINCT sq.dev FROM (SELECT status, region, dev FROM :TABLE) sq JOIN :TABLE ref
+ON (sq.dev = ref.dev) AND (sq.status = ref.status) AND (sq.region = ref.region) WHERE 1 > 2;
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices;
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (region, dev) region, dev FROM :TABLE WHERE status = 1
+)
+SELECT * FROM devices ORDER BY region, dev;
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (region, dev, dev_name) region, dev, dev_name FROM :TABLE WHERE status = 1;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+
+-- ReScan tests
+:PREFIX SELECT time, status, region, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (status, region, dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+
+set enable_seqscan=0;
+:PREFIX SELECT time, status, region, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev != a.v) b) a;
+
+-- RuntimeKeys
+:PREFIX SELECT time, status, region, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+reset enable_seqscan;
+
+-- parallel query
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+:PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -250,9 +250,9 @@ DEALLOCATE prep;
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0;
 
-:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE coalesce(dev, -1) >= 0
 UNION SELECT b.* FROM
    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;


### PR DESCRIPTION
Implement multikey SkipScan when all distinct keys are guaranteed to be not null.
Fixes https://github.com/timescale/timescaledb/issues/3094.
Not-null mode is implemented in https://github.com/timescale/timescaledb/issues/8479.

Added unit tests based on a multikey table.