### PR TITLE
Concurrent CAgg refresh improvements

### DIFF
--- a/.unreleased/pr_8514
+++ b/.unreleased/pr_8514
@@ -1,0 +1,1 @@
+Implements: #8514 Concurrent Continuous Aggregates improvements

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -442,6 +442,18 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs
 
 CREATE INDEX continuous_aggs_materialization_invalidation_log_idx ON _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value ASC);
 
+-- cagg materialization ranges
+CREATE TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges (
+  materialization_id integer,
+  lowest_modified_value bigint NOT NULL,
+  greatest_modified_value bigint NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_materialization_ranges_materialization_id_fkey FOREIGN KEY (materialization_id) REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_materialization_ranges', '');
+
+CREATE INDEX continuous_aggs_materialization_ranges_idx ON _timescaledb_catalog.continuous_aggs_materialization_ranges (materialization_id, lowest_modified_value ASC);
 
 /* the source of this data is the enum from the source code that lists
  *  the algorithms. This table is NOT dumped.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -244,3 +244,18 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.indexes_local_size;
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk_index;
 DROP TABLE IF EXISTS _timescaledb_catalog.chunk_index;
 
+-- cagg materialization ranges
+CREATE TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges (
+  materialization_id integer,
+  lowest_modified_value bigint NOT NULL,
+  greatest_modified_value bigint NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_materialization_ranges_materialization_id_fkey FOREIGN KEY (materialization_id) REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_materialization_ranges', '');
+
+CREATE INDEX continuous_aggs_materialization_ranges_idx ON _timescaledb_catalog.continuous_aggs_materialization_ranges (materialization_id, lowest_modified_value ASC);
+
+GRANT SELECT ON TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges TO PUBLIC;
+

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -845,3 +845,19 @@ initReadOnlyStringInfo(StringInfo str, char *data, int len)
 						 tmfd,                                                                     \
 						 is_merge_delete)
 #endif
+
+/* PG16 consolidates ItemPointer to datum functions so backported it to PG15
+ * https://github.com/postgres/postgres/commit/bd944884e92a */
+#if PG16_LT
+static inline ItemPointer
+DatumGetItemPointer(Datum X)
+{
+	return (ItemPointer) DatumGetPointer(X);
+}
+
+static inline Datum
+ItemPointerGetDatum(const ItemPointerData *X)
+{
+	return PointerGetDatum(X);
+}
+#endif

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -85,6 +85,10 @@ static const TableInfoDef catalog_table_names[_MAX_CATALOG_TABLES + 1] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_TABLE_NAME,
 	},
+	[CONTINUOUS_AGGS_MATERIALIZATION_RANGES] = {
+		.schema_name = CATALOG_SCHEMA_NAME,
+		.table_name = CONTINUOUS_AGGS_MATERIALIZATION_RANGES_TABLE_NAME,
+	},
 	[COMPRESSION_SETTINGS] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = COMPRESSION_SETTINGS_TABLE_NAME,
@@ -225,6 +229,12 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_INDEX,
 		.names = (char *[]) {
 			[CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_IDX] = "continuous_aggs_materialization_invalidation_log_idx",
+		},
+	},
+	[CONTINUOUS_AGGS_MATERIALIZATION_RANGES] = {
+		.length = _MAX_CONTINUOUS_AGGS_MATERIALIZATION_RANGES_INDEX,
+		.names = (char *[]) {
+			[CONTINUOUS_AGGS_MATERIALIZATION_RANGES_IDX] = "continuous_aggs_materialization_ranges_idx",
 		},
 	},
 	[CONTINUOUS_AGGS_WATERMARK] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -47,6 +47,7 @@ typedef enum CatalogTable
 	CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG,
 	CONTINUOUS_AGGS_INVALIDATION_THRESHOLD,
 	CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
+	CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
 	COMPRESSION_SETTINGS,
 	COMPRESSION_CHUNK_SIZE,
 	CONTINUOUS_AGGS_BUCKET_FUNCTION,
@@ -1071,6 +1072,44 @@ typedef enum Anum_continuous_aggs_materialization_invalidation_log_idx
 
 #define Natts_continuous_aggs_materialization_invalidation_log_idx                                 \
 	(_Anum_continuous_aggs_materialization_invalidation_log_idx_max - 1)
+
+/****** CONTINUOUS_AGGS_MATERIALIZATION_RANGES_TABLE definitions*/
+#define CONTINUOUS_AGGS_MATERIALIZATION_RANGES_TABLE_NAME "continuous_aggs_materialization_ranges"
+typedef enum Anum_continuous_aggs_materialization_ranges
+{
+	Anum_continuous_aggs_materialization_ranges_materialization_id = 1,
+	Anum_continuous_aggs_materialization_ranges_lowest_modified_value,
+	Anum_continuous_aggs_materialization_ranges_greatest_modified_value,
+	_Anum_continuous_aggs_materialization_ranges_max,
+} Anum_continuous_aggs_materialization_ranges;
+
+#define Natts_continuous_aggs_materialization_ranges                                               \
+	(_Anum_continuous_aggs_materialization_ranges_max - 1)
+
+typedef struct FormData_continuous_aggs_materialization_ranges
+{
+	int32 materialization_id;
+	int64 lowest_modified_value;
+	int64 greatest_modified_value;
+} FormData_continuous_aggs_materialization_ranges;
+
+typedef FormData_continuous_aggs_materialization_ranges
+	*Form_continuous_aggs_materialization_ranges;
+
+enum
+{
+	CONTINUOUS_AGGS_MATERIALIZATION_RANGES_IDX = 0,
+	_MAX_CONTINUOUS_AGGS_MATERIALIZATION_RANGES_INDEX,
+};
+typedef enum Anum_continuous_aggs_materialization_ranges_idx
+{
+	Anum_continuous_aggs_materialization_ranges_idx_materialization_id = 1,
+	Anum_continuous_aggs_materialization_ranges_idx_lowest_modified_value,
+	_Anum_continuous_aggs_materialization_ranges_idx_max,
+} Anum_continuous_aggs_materialization_ranges_idx;
+
+#define Natts_continuous_aggs_materialization_ranges_idx                                           \
+	(_Anum_continuous_aggs_materialization_ranges_idx_max - 1)
 
 /****** CONTINUOUS_AGGS_WATERMARK_TABLE definitions*/
 #define CONTINUOUS_AGGS_WATERMARK_TABLE_NAME "continuous_aggs_watermark"

--- a/src/ts_catalog/continuous_aggs_watermark.c
+++ b/src/ts_catalog/continuous_aggs_watermark.c
@@ -243,6 +243,16 @@ cagg_watermark_update_scan_internal(TupleInfo *ti, void *data)
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
 	Form_continuous_aggs_watermark form = (Form_continuous_aggs_watermark) GETSTRUCT(tuple);
 
+	/* If the tuple was modified concurrently, retry the operation and use a new snapshot
+	 * to see the updated tuple. */
+	if (ti->lockresult == TM_Updated)
+		return SCAN_RESTART_WITH_NEW_SNAPSHOT;
+
+	Ensure(ti->lockresult == TM_Ok,
+		   "unable to lock watermark tuple for cagg %d (lock result %d)",
+		   watermark_update->ht_relid,
+		   ti->lockresult);
+
 	if (watermark_update->watermark > form->watermark || watermark_update->force_update)
 	{
 		HeapTuple new_tuple = heap_copytuple(tuple);
@@ -284,27 +294,27 @@ static void
 cagg_watermark_update_internal(int32 mat_hypertable_id, Oid ht_relid, int64 new_watermark,
 							   bool force_update, bool invalidate_rel_cache)
 {
-	bool watermark_updated;
-	ScanKeyData scankey[1];
 	WatermarkUpdate data = { .watermark = new_watermark,
 							 .force_update = force_update,
 							 .invalidate_rel_cache = invalidate_rel_cache,
 							 .ht_relid = ht_relid };
+	ScanIterator iterator =
+		ts_scan_iterator_create(CONTINUOUS_AGGS_WATERMARK, RowExclusiveLock, CurrentMemoryContext);
 
-	ScanKeyInit(&scankey[0],
-				Anum_continuous_aggs_watermark_mat_hypertable_id,
-				BTEqualStrategyNumber,
-				F_INT4EQ,
-				Int32GetDatum(mat_hypertable_id));
+	cagg_watermark_init_scan_by_mat_hypertable_id(&iterator, mat_hypertable_id);
+	iterator.ctx.tuple_found = cagg_watermark_update_scan_internal;
+	iterator.ctx.data = &data;
+	iterator.ctx.snapshot = GetLatestSnapshot();
+	ScanTupLock scantuplock = {
+		.waitpolicy = LockWaitBlock,
+		.lockmode = LockTupleExclusive,
+		.lockflags = TUPLE_LOCK_FLAG_FIND_LAST_VERSION,
+	};
+	iterator.ctx.tuplock = &scantuplock;
+	iterator.ctx.flags = SCANNER_F_KEEPLOCK;
 
-	watermark_updated = ts_catalog_scan_one(CONTINUOUS_AGGS_WATERMARK /*=table*/,
-											CONTINUOUS_AGGS_WATERMARK_PKEY /*=indexid*/,
-											scankey /*=scankey*/,
-											1 /*=num_keys*/,
-											cagg_watermark_update_scan_internal /*=tuple_found*/,
-											RowExclusiveLock /*=lockmode*/,
-											CONTINUOUS_AGGS_WATERMARK_TABLE_NAME /*=table_name*/,
-											&data /*=data*/);
+	bool watermark_updated =
+		ts_scanner_scan_one(&iterator.ctx, false, "continuous aggregate watermark");
 
 	if (!watermark_updated)
 	{

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -200,6 +200,7 @@ SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_
  _timescaledb_catalog  | continuous_aggs_hypertable_invalidation_log
  _timescaledb_catalog  | continuous_aggs_invalidation_threshold
  _timescaledb_catalog  | continuous_aggs_materialization_invalidation_log
+ _timescaledb_catalog  | continuous_aggs_materialization_ranges
  _timescaledb_catalog  | continuous_aggs_watermark
  _timescaledb_catalog  | dimension
  _timescaledb_catalog  | dimension_slice
@@ -212,7 +213,7 @@ SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_
  _timescaledb_internal | bgw_policy_chunk_stats
  _timescaledb_internal | compressed_chunk_stats
  _timescaledb_internal | hypertable_chunk_local_size
-(25 rows)
+(26 rows)
 
 -- Test that renaming ordinary table works
 CREATE TABLE renametable (foo int);

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -32,7 +32,6 @@
 #include "continuous_aggs/invalidation_multi.h"
 #include "continuous_aggs/invalidation_threshold.h"
 #include "continuous_aggs/materialize.h"
-#include "debug_point.h"
 #include "guc.h"
 #include "invalidation.h"
 #include "refresh.h"
@@ -99,6 +98,7 @@ typedef struct ContinuousAggInvalidationState
 	const ContinuousAgg *cagg;
 	MemoryContext per_tuple_mctx;
 	Relation cagg_log_rel;
+	Relation cagg_queue_rel;
 	Snapshot snapshot;
 	Tuplestorestate *invalidations;
 } ContinuousAggInvalidationState;
@@ -117,15 +117,21 @@ typedef struct HypertableInvalidationState
 	Snapshot snapshot;
 } HypertableInvalidationState;
 
-typedef enum LogType
+typedef enum ContinuousAggTableType
 {
-	LOG_HYPER,
-	LOG_CAGG,
-} LogType;
+	HYPER_INVALIDATION_LOG,
+	CAGG_INVALIDATION_LOG,
+	CAGG_MATERIALIZATION_RANGES,
+} ContinuousAggTableType;
 
-static Relation open_invalidation_log(LogType type, LOCKMODE lockmode);
+static Relation open_cagg_table(ContinuousAggTableType type, LOCKMODE lockmode);
 static void hypertable_invalidation_scan_init(ScanIterator *iterator, int32 hyper_id,
 											  LOCKMODE lockmode);
+static HeapTuple create_materialization_ranges_tup(TupleDesc tupdesc, int32 cagg_hyper_id,
+												   int64 start, int64 end);
+static void insert_new_cagg_materialization_ranges(const ContinuousAggInvalidationState *state,
+												   const InternalTimeRange refresh_window,
+												   int32 cagg_hyper_id);
 static bool save_invalidation_for_refresh(const ContinuousAggInvalidationState *state,
 										  const Invalidation *invalidation);
 static void set_remainder_after_cut(Invalidation *remainder, int32 hyper_id,
@@ -140,8 +146,8 @@ invalidation_entry_set_from_cagg_invalidation(Invalidation *entry, const TupleIn
 											  const ContinuousAggBucketFunction *bucket_function);
 static bool invalidations_can_be_merged(const Invalidation *a, const Invalidation *b);
 static bool invalidation_entry_try_merge(Invalidation *entry, const Invalidation *newentry);
-static void cut_and_insert_new_cagg_invalidation(const HypertableInvalidationState *state,
-												 const Invalidation *entry, int32 cagg_hyper_id);
+static void insert_new_cagg_invalidation(const HypertableInvalidationState *state,
+										 const Invalidation *entry, int32 cagg_hyper_id);
 static void move_invalidations_from_hyper_to_cagg_log(const HypertableInvalidationState *state);
 static void cagg_invalidations_scan_by_hypertable_init(ScanIterator *iterator, int32 cagg_hyper_id,
 													   LOCKMODE lockmode);
@@ -161,11 +167,12 @@ static void continuous_agg_process_hypertable_invalidations_single(Oid hypertabl
 static void continuous_agg_process_hypertable_invalidations_multi(ArrayType *hypertable_array);
 
 static Relation
-open_invalidation_log(LogType type, LOCKMODE lockmode)
+open_cagg_table(ContinuousAggTableType type, LOCKMODE lockmode)
 {
 	static const CatalogTable logmappings[] = {
-		[LOG_HYPER] = CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG,
-		[LOG_CAGG] = CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
+		[HYPER_INVALIDATION_LOG] = CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG,
+		[CAGG_INVALIDATION_LOG] = CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
+		[CAGG_MATERIALIZATION_RANGES] = CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
 	};
 	Catalog *catalog = ts_catalog_get();
 	Oid relid = catalog_get_table_id(catalog, logmappings[type]);
@@ -215,7 +222,7 @@ create_invalidation_tup(const TupleDesc tupdesc, int32 cagg_hyper_id, int64 star
 void
 invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 start, int64 end)
 {
-	Relation rel = open_invalidation_log(LOG_CAGG, RowExclusiveLock);
+	Relation rel = open_cagg_table(CAGG_INVALIDATION_LOG, RowExclusiveLock);
 	CatalogSecurityContext sec_ctx;
 	HeapTuple tuple;
 
@@ -231,7 +238,7 @@ invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 start, int64 end)
 void
 invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 end)
 {
-	Relation rel = open_invalidation_log(LOG_HYPER, RowExclusiveLock);
+	Relation rel = open_cagg_table(HYPER_INVALIDATION_LOG, RowExclusiveLock);
 	CatalogSecurityContext sec_ctx;
 	Datum values[Natts_continuous_aggs_hypertable_invalidation_log];
 	bool nulls[Natts_continuous_aggs_hypertable_invalidation_log] = { false };
@@ -287,6 +294,40 @@ continuous_agg_invalidate_mat_ht(const Hypertable *raw_ht, const Hypertable *mat
 	invalidation_cagg_log_add_entry(mat_ht->fd.id, start, end);
 }
 
+static HeapTuple
+create_materialization_ranges_tup(TupleDesc tupdesc, int32 cagg_hyper_id, int64 start, int64 end)
+{
+	Datum values[Natts_continuous_aggs_materialization_ranges] = { 0 };
+	bool isnull[Natts_continuous_aggs_materialization_ranges] = { false };
+
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_ranges_materialization_id)] =
+		Int32GetDatum(cagg_hyper_id);
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_ranges_lowest_modified_value)] = Int64GetDatum(start);
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_ranges_greatest_modified_value)] = Int64GetDatum(end);
+
+	return heap_form_tuple(tupdesc, values, isnull);
+}
+
+static void
+insert_new_cagg_materialization_ranges(const ContinuousAggInvalidationState *state,
+									   const InternalTimeRange refresh_window, int32 cagg_hyper_id)
+{
+	CatalogSecurityContext sec_ctx;
+	TupleDesc tupdesc = RelationGetDescr(state->cagg_queue_rel);
+	HeapTuple tuple = create_materialization_ranges_tup(tupdesc,
+														cagg_hyper_id,
+														refresh_window.start,
+														refresh_window.end);
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_insert_only(state->cagg_queue_rel, tuple);
+	ts_catalog_restore_user(&sec_ctx);
+	heap_freetuple(tuple);
+}
+
 typedef enum InvalidationResult
 {
 	INVAL_NOMATCH,
@@ -300,19 +341,34 @@ static bool
 save_invalidation_for_refresh(const ContinuousAggInvalidationState *state,
 							  const Invalidation *invalidation)
 {
-	int32 cagg_hyper_id = state->cagg->data.mat_hypertable_id;
-	TupleDesc tupdesc = RelationGetDescr(state->cagg_log_rel);
-	HeapTuple refresh_tup;
-
 	if (!IS_VALID_INVALIDATION(invalidation))
 		return false;
 
-	refresh_tup = create_invalidation_tup(tupdesc,
-										  cagg_hyper_id,
-										  invalidation->lowest_modified_value,
-										  invalidation->greatest_modified_value);
+	int32 cagg_hyper_id = state->cagg->data.mat_hypertable_id;
+	TupleDesc tupdesc = RelationGetDescr(state->cagg_log_rel);
+	HeapTuple refresh_tup = create_invalidation_tup(tupdesc,
+													cagg_hyper_id,
+													invalidation->lowest_modified_value,
+													invalidation->greatest_modified_value);
 	tuplestore_puttuple(state->invalidations, refresh_tup);
 	heap_freetuple(refresh_tup);
+
+	InternalTimeRange refresh_window = {
+		.type = state->cagg->partition_type,
+		.start = invalidation->lowest_modified_value,
+		/* Invalidations are inclusive at the end, while refresh windows aren't, so add one to the
+		   end of the invalidated region */
+		.end = ts_time_saturating_add(invalidation->greatest_modified_value,
+									  1,
+									  state->cagg->partition_type),
+	};
+
+	InternalTimeRange bucketed_refresh_window =
+		compute_circumscribed_bucketed_refresh_window(state->cagg,
+													  &refresh_window,
+													  state->cagg->bucket_function);
+
+	insert_new_cagg_materialization_ranges(state, bucketed_refresh_window, cagg_hyper_id);
 
 	return true;
 }
@@ -674,21 +730,20 @@ invalidation_entry_try_merge(Invalidation *entry, const Invalidation *newentry)
 }
 
 static void
-cut_and_insert_new_cagg_invalidation(const HypertableInvalidationState *state,
-									 const Invalidation *entry, int32 cagg_hyper_id)
+insert_new_cagg_invalidation(const HypertableInvalidationState *state, const Invalidation *entry,
+							 int32 cagg_hyper_id)
 {
 	CatalogSecurityContext sec_ctx;
 	TupleDesc tupdesc = RelationGetDescr(state->cagg_log_rel);
-	HeapTuple newtup;
-
-	newtup = create_invalidation_tup(tupdesc,
-									 cagg_hyper_id,
-									 entry->lowest_modified_value,
-									 entry->greatest_modified_value);
+	HeapTuple tuple = create_invalidation_tup(tupdesc,
+											  cagg_hyper_id,
+											  entry->lowest_modified_value,
+											  entry->greatest_modified_value);
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	ts_catalog_insert_only(state->cagg_log_rel, newtup);
+	ts_catalog_insert_only(state->cagg_log_rel, tuple);
 	ts_catalog_restore_user(&sec_ctx);
+	heap_freetuple(tuple);
 }
 
 /*
@@ -760,7 +815,7 @@ move_invalidations_from_hyper_to_cagg_log(const HypertableInvalidationState *sta
 			}
 			else if (!invalidation_entry_try_merge(&mergedentry, &logentry))
 			{
-				cut_and_insert_new_cagg_invalidation(state, &mergedentry, cagg_hyper_id);
+				insert_new_cagg_invalidation(state, &mergedentry, cagg_hyper_id);
 				mergedentry = logentry;
 			}
 
@@ -784,7 +839,7 @@ move_invalidations_from_hyper_to_cagg_log(const HypertableInvalidationState *sta
 
 		/* Handle the last merged invalidation */
 		if (IS_VALID_INVALIDATION(&mergedentry))
-			cut_and_insert_new_cagg_invalidation(state, &mergedentry, cagg_hyper_id);
+			insert_new_cagg_invalidation(state, &mergedentry, cagg_hyper_id);
 	}
 }
 
@@ -897,17 +952,18 @@ clear_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *state
 									 const InternalTimeRange *refresh_window, bool force)
 {
 	ScanIterator iterator;
-	int32 cagg_hyper_id = state->cagg->data.mat_hypertable_id;
 	Invalidation mergedentry;
 	Invalidation remainder;
 
 	invalidation_entry_reset(&mergedentry);
 	invalidation_entry_reset(&remainder);
-	cagg_invalidations_scan_by_hypertable_init(&iterator, cagg_hyper_id, RowExclusiveLock);
+	cagg_invalidations_scan_by_hypertable_init(&iterator,
+											   state->cagg->data.mat_hypertable_id,
+											   RowExclusiveLock);
+	iterator.ctx.data = &state;
 	iterator.ctx.snapshot = state->snapshot;
-	/* Skip locked tuples */
 	ScanTupLock scantuplock = {
-		.waitpolicy = LockWaitSkip,
+		.waitpolicy = LockWaitBlock,
 		.lockmode = LockTupleExclusive,
 		.lockflags = TUPLE_LOCK_FLAG_FIND_LAST_VERSION,
 	};
@@ -919,7 +975,7 @@ clear_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *state
 	/* Force refresh within the entire window */
 	if (force)
 	{
-		mergedentry.hyper_id = cagg_hyper_id;
+		mergedentry.hyper_id = state->cagg->data.mat_hypertable_id;
 		mergedentry.lowest_modified_value = refresh_window->start;
 		mergedentry.greatest_modified_value = refresh_window->end;
 		mergedentry.is_modified = false;
@@ -929,13 +985,10 @@ clear_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *state
 		goto process_remainder;
 	}
 
-	DEBUG_WAITPOINT("clear_cagg_invalidations_for_refresh_lock");
-
 	/* Process all invalidations for the continuous aggregate */
 	ts_scanner_foreach(&iterator)
 	{
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-
 		MemoryContext oldmctx;
 		Invalidation logentry;
 
@@ -944,32 +997,6 @@ clear_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *state
 													  ti,
 													  state->cagg->partition_type,
 													  state->cagg->bucket_function);
-
-		/* If the tuple was not locked, we cannot process it. */
-		if (ti->lockresult != TM_Ok)
-		{
-			Datum start_ts, end_ts;
-			Oid outfuncid = InvalidOid;
-			bool isvarlena;
-
-			start_ts = ts_internal_to_time_value(logentry.lowest_modified_value,
-												 state->cagg->partition_type);
-			end_ts = ts_internal_to_time_value((logentry.greatest_modified_value ==
-														CAGG_INVALIDATION_WRONG_GREATEST_VALUE ?
-													logentry.greatest_modified_value + 1 :
-													logentry.greatest_modified_value),
-											   state->cagg->partition_type);
-			getTypeOutputInfo(state->cagg->partition_type, &outfuncid, &isvarlena);
-			Assert(!isvarlena);
-
-			elog(DEBUG1,
-				 "cannot lock \"%s\" materialization invalidation log [ %s, %s ], skipping",
-				 NameStr(state->cagg->data.user_view_name),
-				 DatumGetCString(OidFunctionCall1(outfuncid, start_ts)),
-				 DatumGetCString(OidFunctionCall1(outfuncid, end_ts)));
-			MemoryContextSwitchTo(oldmctx);
-			continue;
-		}
 
 		if (!IS_VALID_INVALIDATION(&mergedentry))
 			mergedentry = logentry;
@@ -1012,7 +1039,8 @@ static void
 cagg_invalidation_state_init(ContinuousAggInvalidationState *state, const ContinuousAgg *cagg)
 {
 	state->cagg = cagg;
-	state->cagg_log_rel = open_invalidation_log(LOG_CAGG, RowExclusiveLock);
+	state->cagg_log_rel = open_cagg_table(CAGG_INVALIDATION_LOG, RowExclusiveLock);
+	state->cagg_queue_rel = open_cagg_table(CAGG_MATERIALIZATION_RANGES, RowExclusiveLock);
 	state->per_tuple_mctx = AllocSetContextCreate(CurrentMemoryContext,
 												  "Materialization invalidations",
 												  ALLOCSET_DEFAULT_SIZES);
@@ -1023,6 +1051,7 @@ static void
 cagg_invalidation_state_cleanup(const ContinuousAggInvalidationState *state)
 {
 	table_close(state->cagg_log_rel, NoLock);
+	table_close(state->cagg_queue_rel, NoLock);
 	UnregisterSnapshot(state->snapshot);
 	MemoryContextDelete(state->per_tuple_mctx);
 }
@@ -1034,7 +1063,7 @@ hypertable_invalidation_state_init(HypertableInvalidationState *state, int32 hyp
 	state->hypertable_id = hypertable_id;
 	state->dimtype = dimtype;
 	state->all_caggs = all_caggs;
-	state->cagg_log_rel = open_invalidation_log(LOG_CAGG, RowExclusiveLock);
+	state->cagg_log_rel = open_cagg_table(CAGG_INVALIDATION_LOG, RowExclusiveLock);
 	state->per_tuple_mctx = AllocSetContextCreate(CurrentMemoryContext,
 												  "Hypertable invalidations",
 												  ALLOCSET_DEFAULT_SIZES);

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -12,10 +12,6 @@
 #include "materialize.h"
 
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
-extern void continuous_agg_calculate_merged_refresh_window(
-	const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
-	const InvalidationStore *invalidations, InternalTimeRange *merged_refresh_window,
-	const ContinuousAggRefreshContext context);
 extern void
 continuous_agg_refresh_internal(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
 								const ContinuousAggRefreshContext context, const bool start_isnull,
@@ -25,3 +21,7 @@ extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,
 												 InternalTimeRange *original_refresh_window,
 												 int32 buckets_per_batch,
 												 bool refresh_newest_first);
+InternalTimeRange
+compute_circumscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
+											  const InternalTimeRange *const refresh_window,
+											  const ContinuousAggBucketFunction *bucket_function);

--- a/tsl/test/isolation/expected/cagg_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_refresh.out
@@ -1,4 +1,4 @@
-Parsed test spec with 11 sessions
+Parsed test spec with 12 sessions
 
 starting permutation: R1_refresh S1_select R3_refresh S1_select L2_read_unlock_threshold_table L3_unlock_cagg_table L1_unlock_threshold_table
 step R1_refresh: 
@@ -286,10 +286,11 @@ lock_cagg
 
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
-
+ <waiting ...>
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
+step R1_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -347,14 +348,16 @@ lock_cagg
 
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
-
-R2: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+ <waiting ...>
 step R2_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 35, 62);
-
+ <waiting ...>
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
+step R1_refresh: <... completed>
+R2: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+step R2_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -412,13 +415,15 @@ lock_cagg
 
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
-
+ <waiting ...>
 step R3_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
-
+ <waiting ...>
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
+step R1_refresh: <... completed>
+step R3_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -479,13 +484,14 @@ lock_cagg
 
 step R3_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
-
+ <waiting ...>
 step R4_refresh: 
     CALL refresh_continuous_aggregate('cond_20', 39, 84);
 
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
+step R3_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
     FROM cond_10
@@ -539,7 +545,7 @@ step R12_refresh:
     CALL refresh_continuous_aggregate('cond2_10', 25, 70);
 
 
-starting permutation: WP_enable R1_refresh R5_refresh WP_release S1_select R3_refresh S1_select
+starting permutation: WP_enable R1_refresh R6_materialization_ranges R5_refresh R6_materialization_ranges WP_release R6_materialization_ranges S1_select
 R5: LOG:  statement: 
     SET SESSION lock_timeout = '500ms';
     SET SESSION deadlock_timeout = '500ms';
@@ -549,7 +555,7 @@ L1: WARNING:  there is already a transaction in progress
 L2: WARNING:  there is already a transaction in progress
 L3: WARNING:  there is already a transaction in progress
 step WP_enable: 
-    SELECT debug_waitpoint_enable('clear_cagg_invalidations_for_refresh_lock');
+    SELECT debug_waitpoint_enable('after_process_cagg_invalidations_for_refresh_lock');
 
 debug_waitpoint_enable
 ----------------------
@@ -559,14 +565,51 @@ debug_waitpoint_enable
 step R1_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 25, 70);
  <waiting ...>
+step R6_materialization_ranges: 
+    SELECT
+        c.user_view_name,
+        m.lowest_modified_value,
+        m.greatest_modified_value
+    FROM
+        _timescaledb_catalog.continuous_aggs_materialization_ranges m
+        JOIN _timescaledb_catalog.continuous_agg c on c.mat_hypertable_id = m.materialization_id
+    WHERE
+        c.user_view_name = 'cond_10'
+    ORDER BY
+        1, 2, 3;
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                     70
+(1 row)
+
 R5: LOG:  statement: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
 
 step R5_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 70, 107);
  <waiting ...>
+step R6_materialization_ranges: 
+    SELECT
+        c.user_view_name,
+        m.lowest_modified_value,
+        m.greatest_modified_value
+    FROM
+        _timescaledb_catalog.continuous_aggs_materialization_ranges m
+        JOIN _timescaledb_catalog.continuous_agg c on c.mat_hypertable_id = m.materialization_id
+    WHERE
+        c.user_view_name = 'cond_10'
+    ORDER BY
+        1, 2, 3;
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                     70
+cond_10       |                   70|                    100
+(2 rows)
+
 step WP_release: 
-    SELECT debug_waitpoint_release('clear_cagg_invalidations_for_refresh_lock');
+    SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock');
 
 debug_waitpoint_release
 -----------------------
@@ -574,47 +617,26 @@ debug_waitpoint_release
 (1 row)
 
 step R1_refresh: <... completed>
-R5: DEBUG:  cannot lock "cond_10" materialization invalidation log [ 0, -1 ], skipping
-R5: DEBUG:  cannot lock "cond_10" materialization invalidation log [ 0, 49 ], skipping
-R5: DEBUG:  cannot lock "cond_10" materialization invalidation log [ 30, -1 ], skipping
-R5: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+R5: DEBUG:  continuous aggregate refresh (individual invalidation) on "cond_10" in window [ 70, 100 ]
+R5: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R5: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
 step R5_refresh: <... completed>
-step S1_select: 
-    SELECT bucket, avg_temp
-    FROM cond_10
-    ORDER BY 1;
+step R6_materialization_ranges: 
+    SELECT
+        c.user_view_name,
+        m.lowest_modified_value,
+        m.greatest_modified_value
+    FROM
+        _timescaledb_catalog.continuous_aggs_materialization_ranges m
+        JOIN _timescaledb_catalog.continuous_agg c on c.mat_hypertable_id = m.materialization_id
+    WHERE
+        c.user_view_name = 'cond_10'
+    ORDER BY
+        1, 2, 3;
 
-    SELECT * FROM cagg_bucket_count('cond_10');
-    SELECT h.table_name AS hypertable, it.watermark AS threshold
-    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
-    _timescaledb_catalog.hypertable h
-    WHERE it.hypertable_id = h.id
-    ORDER BY 1;
-
-bucket|        avg_temp
-------+----------------
-     0|15.8888888888889
-    10|            14.2
-    20|            13.4
-    30|            18.3
-    40|16.0909090909091
-    50|            26.9
-    60|            18.9
-(7 rows)
-
-cagg_bucket_count
------------------
-                7
-(1 row)
-
-hypertable |  threshold
------------+-----------
-conditions |        100
-conditions2|-2147483648
-(2 rows)
-
-step R3_refresh: 
-    CALL refresh_continuous_aggregate('cond_10', 70, 107);
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+(0 rows)
 
 step S1_select: 
     SELECT bucket, avg_temp


### PR DESCRIPTION
In #8117 we allowed concurrent CAgg refreshes by relaxing the strong lock when processing the invalidation by locking those rows and skipping the lock when the lock was already taken. The problem was when we had only one invalidation log to either expand or contract that the first session take the lock and the second skip the lock and return to the user that the CAgg is up-to-date and this is wrong.

So in order to improve and fix this wrong behavior we've splitted the second transaction (data materialization) into two transactions:
1. process the cagg invalidation logs (expand/contract) and insert the ranges to be materialized into a new metadata table named `_timescaledb_catalog.continuous_aggs_materialization_ranges` to process the materialization in the next transaction
2. process the materialization by reading ranges using FOR UPDATE SKIP LOCK from the new metadata table, execute the materialization and at the end remove the row from the new metadata table.

This new approach is like a producer/consumer pattern where the first transaction produce items in the queue to be consumed and processed by the next transaction.

Closes #8372 #8490

Disable-check: commit-count
