### PR TITLE
Check grouping set RTEs for time_bucket in PG18

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2236,6 +2236,11 @@ tsl_compressed_data_in(PG_FUNCTION_ARGS)
 	size_t input_len = strlen(input);
 	int decoded_len;
 #if PG18_GE
+	/* With version 18 pointer type changed to uint8
+	 * for better readability.
+	 *
+	 * https://github.com/postgres/postgres/commit/b28c59a6
+	 */
 	uint8 *decoded;
 #else
 	char *decoded;
@@ -2272,6 +2277,11 @@ tsl_compressed_data_out(PG_FUNCTION_ARGS)
 	bytea *bytes = DatumGetByteaP(bytes_data);
 	int raw_len = VARSIZE_ANY_EXHDR(bytes);
 #if PG18_GE
+	/* With version 18 pointer type changed to uint8
+	 * for better readability.
+	 *
+	 * https://github.com/postgres/postgres/commit/b28c59a6
+	 */
 	const uint8 *raw_data = (uint8 *) VARDATA(bytes);
 #else
 	const char *raw_data = VARDATA(bytes);

--- a/tsl/src/continuous_aggs/finalize.c
+++ b/tsl/src/continuous_aggs/finalize.c
@@ -18,7 +18,7 @@
 
 /* Static function prototypes */
 static Var *mattablecolumninfo_addentry(MaterializationHypertableColumnInfo *out, Node *input,
-										int original_query_resno, bool finalized,
+										List *rtable, int original_query_resno, bool finalized,
 										bool *skip_adding);
 static inline void makeMaterializeColumnName(char *colbuf, const char *type,
 											 int original_query_resno, int colno);
@@ -81,6 +81,7 @@ finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query,
 			bool skip_adding = false;
 			var = mattablecolumninfo_addentry(mattblinfo,
 											  (Node *) tle,
+											  orig_query->rtable,
 											  resno,
 											  inp->finalized,
 											  &skip_adding);
@@ -224,7 +225,7 @@ finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
  *
  */
 static Var *
-mattablecolumninfo_addentry(MaterializationHypertableColumnInfo *out, Node *input,
+mattablecolumninfo_addentry(MaterializationHypertableColumnInfo *out, Node *input, List *rtable,
 							int original_query_resno, bool finalized, bool *skip_adding)
 {
 	int matcolno = list_length(out->matcollist) + 1;
@@ -254,6 +255,35 @@ mattablecolumninfo_addentry(MaterializationHypertableColumnInfo *out, Node *inpu
 
 			if (IsA(tle->expr, FuncExpr))
 				timebkt_chk = function_allowed_in_cagg_definition(((FuncExpr *) tle->expr)->funcid);
+
+#if PG18_GE
+			/* PG18 introduced RTEs for group clauses so
+			 * we use rtable to look up GROUP BY expressions.
+			 *
+			 * https://github.com/postgres/postgres/commit/247dea89
+			 */
+			if (IsA(tle->expr, Var))
+			{
+				Var *var = castNode(Var, tle->expr);
+				Assert((int) var->varno <= list_length(rtable));
+				RangeTblEntry *rte = list_nth(rtable, var->varno - 1);
+				Assert(rte->rtekind == RTE_GROUP);
+				Assert(var->varattno > 0);
+				Node *node = list_nth(rte->groupexprs, var->varattno - 1);
+				if (IsA(node, FuncExpr))
+				{
+					if (contain_mutable_functions(node))
+					{
+						ereport(WARNING,
+								(errmsg("using non-immutable functions in continuous aggregate "
+										"view may lead to "
+										"inconsistent results on rematerialization")));
+					}
+					FuncExpr *expr = (FuncExpr *) node;
+					timebkt_chk = function_allowed_in_cagg_definition(((FuncExpr *) expr)->funcid);
+				}
+			}
+#endif
 
 			if (tle->resname)
 				colname = pstrdup(tle->resname);

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -421,7 +421,7 @@ ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO NOTICE;
-SELECT * FROM new_name;
+SELECT * FROM new_name ORDER BY 1;
  time_bucket | count 
 -------------+-------
            0 |     3

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -421,7 +421,7 @@ ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO NOTICE;
-SELECT * FROM new_name;
+SELECT * FROM new_name ORDER BY 1;
  time_bucket | count 
 -------------+-------
            0 |     3

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -421,7 +421,7 @@ ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO NOTICE;
-SELECT * FROM new_name;
+SELECT * FROM new_name ORDER BY 1;
  time_bucket | count 
 -------------+-------
            0 |     3

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -421,7 +421,7 @@ ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO NOTICE;
-SELECT * FROM new_name;
+SELECT * FROM new_name ORDER BY 1;
  time_bucket | count 
 -------------+-------
            0 |     3
@@ -2107,8 +2107,8 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
- relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+----------------+-----------+---------+--------------+--------------------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+-------+----------------+-----------+---------+--------------+--------------------+-------
 (0 rows)
 
 -- test WITH namespace alias

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -295,7 +295,7 @@ ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO NOTICE;
 
-SELECT * FROM new_name;
+SELECT * FROM new_name ORDER BY 1;
 
 SELECT * FROM drop_chunks_view ORDER BY 1;
 


### PR DESCRIPTION
With PG18, RTEs are now used for group clauses
which need to be taken into account when looking
for time_bucket during validation and finalization stages of cagg operations.

https://github.com/postgres/postgres/commit/247dea89

Disable-check: force-changelog-file
