### PR TITLE
Fix unit tests after postgresql-17 update

### DIFF
--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -14,7 +14,7 @@ SET timescaledb.enable_now_constify TO false;
 SET enable_memoize TO 'off';
 -- disable index only scans to avoid some flaky results
 SET enable_indexonlyscan TO FALSE;
-\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -22,7 +22,7 @@ SET enable_indexonlyscan TO FALSE;
 -- create a now() function for repeatable testing that always returns
 -- the same timestamp. It needs to be marked STABLE
 CREATE OR REPLACE FUNCTION now_s()
-RETURNS timestamptz LANGUAGE PLPGSQL STABLE PARALLEL SAFE AS
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
 $BODY$
 BEGIN
     RAISE NOTICE 'Stable function now_s() called!';
@@ -45,27 +45,9 @@ BEGIN
     RETURN '2017-08-22T10:00:00'::timestamptz;
 END;
 $BODY$;
-CREATE OR REPLACE PROCEDURE force_parallel(on_or_off bool)
-LANGUAGE PLPGSQL AS
-$$
-BEGIN
-    IF current_setting('server_version_num')::int < 160000 THEN
-        IF on_or_off THEN
-            set force_parallel_mode = 'on';
-        ELSE
-            set force_parallel_mode = 'off';
-        END IF;
-    ELSE
-        IF on_or_off THEN
-            set debug_parallel_query = 'on';
-        ELSE
-            set debug_parallel_query = 'off';
-        END IF;
-    END IF;
-END;
-$$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
+psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,append_test,t)
@@ -81,6 +63,7 @@ VACUUM (ANALYZE) append_test;
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
+psql:include/append_load.sql:47: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -109,7 +92,7 @@ VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:91: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:70: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -152,7 +135,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:123: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:102: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)
@@ -442,9 +425,11 @@ psql:include/append_query.sql:102: NOTICE:  Stable function now_s() called!
          Hash Cond: (time_bucket('@ 30 days'::interval, "time"."time") = data.btime)
          ->  Function Scan on generate_series "time" (actual rows=6 loops=1)
          ->  Hash (actual rows=3 loops=1)
+               Buckets: 1024  Batches: 1 
                ->  Subquery Scan on data (actual rows=3 loops=1)
                      ->  HashAggregate (actual rows=3 loops=1)
                            Group Key: time_bucket('@ 30 days'::interval, append_test."time")
+                           Batches: 1 
                            ->  Result (actual rows=5 loops=1)
                                  ->  Custom Scan (ChunkAppend) on append_test (actual rows=5 loops=1)
                                        Chunks excluded during startup: 0
@@ -907,7 +892,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -915,7 +900,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -923,7 +908,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -938,7 +923,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -946,7 +931,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -954,7 +939,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -969,7 +954,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -977,7 +962,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -994,7 +979,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1002,7 +987,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -1010,7 +995,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > '01-10-2000'::date)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -1025,7 +1010,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1033,7 +1018,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -1041,7 +1026,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -1056,7 +1041,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -1064,7 +1049,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -1081,7 +1066,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1089,7 +1074,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -1097,7 +1082,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > '01-10-2000'::date) AND ("time" < '01-15-2000'::date))
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -1112,7 +1097,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1120,7 +1105,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -1128,7 +1113,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000'::timestamp without time zone))
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -1143,7 +1128,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=11520 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=7670 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=3068 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=3068 loops=1)
@@ -1151,7 +1136,7 @@ reset enable_material;
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=1534 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
    ->  Merge Append (actual rows=3850 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=1540 loops=1)
                Index Cond: (("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone))
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=1540 loops=1)
@@ -1178,7 +1163,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=2304 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=1534 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (device_id = ANY ('{1,2}'::integer[]))
@@ -1188,7 +1173,7 @@ reset enable_material;
                Filter: (device_id = ANY ('{1,2}'::integer[]))
                Rows Removed by Filter: 2301
    ->  Merge Append (actual rows=770 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (device_id = ANY ('{1,2}'::integer[]))
@@ -1216,7 +1201,7 @@ reset enable_material;
  Custom Scan (ChunkAppend) on metrics_space (actual rows=1152 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=767 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=767 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (v3 = '1'::text)
@@ -1230,7 +1215,7 @@ reset enable_material;
                Filter: (v3 = '1'::text)
                Rows Removed by Filter: 1534
    ->  Merge Append (actual rows=385 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=385 loops=1)
                Index Cond: ("time" > 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (v3 = '1'::text)
@@ -1318,7 +1303,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1326,7 +1311,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
@@ -1334,7 +1319,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_DATE)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
@@ -1375,7 +1360,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1383,7 +1368,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
@@ -1391,7 +1376,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > CURRENT_TIMESTAMP)
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
@@ -1432,7 +1417,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
    Order: metrics_space."time"
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_22_chunk."time"
          ->  Index Scan Backward using _hyper_6_22_chunk_metrics_space_time_idx on _hyper_6_22_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
          ->  Index Scan Backward using _hyper_6_23_chunk_metrics_space_time_idx on _hyper_6_23_chunk (actual rows=0 loops=1)
@@ -1440,7 +1425,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          ->  Index Scan Backward using _hyper_6_24_chunk_metrics_space_time_idx on _hyper_6_24_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_25_chunk."time"
          ->  Index Scan Backward using _hyper_6_25_chunk_metrics_space_time_idx on _hyper_6_25_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
          ->  Index Scan Backward using _hyper_6_26_chunk_metrics_space_time_idx on _hyper_6_26_chunk (actual rows=0 loops=1)
@@ -1448,7 +1433,7 @@ WHERE time = (VALUES ('2019-12-24' at time zone 'UTC'))
          ->  Index Scan Backward using _hyper_6_27_chunk_metrics_space_time_idx on _hyper_6_27_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
    ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: metrics_space."time"
+         Sort Key: _hyper_6_28_chunk."time"
          ->  Index Scan Backward using _hyper_6_28_chunk_metrics_space_time_idx on _hyper_6_28_chunk (actual rows=0 loops=1)
                Index Cond: ("time" > now())
          ->  Index Scan Backward using _hyper_6_29_chunk_metrics_space_time_idx on _hyper_6_29_chunk (actual rows=0 loops=1)
@@ -1465,7 +1450,7 @@ ORDER BY time DESC;
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
  Sort (actual rows=217 loops=1)
-   Sort Key: metrics_date."time" DESC
+   Sort Key: _hyper_3_11_chunk."time" DESC
    Sort Method: quicksort 
    ->  Append (actual rows=217 loops=1)
          ->  Sample Scan on _hyper_3_11_chunk (actual rows=72 loops=1)
@@ -1512,7 +1497,7 @@ ORDER BY time DESC, device_id;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Sort (actual rows=522 loops=1)
-   Sort Key: metrics_space."time" DESC, metrics_space.device_id
+   Sort Key: _hyper_6_30_chunk."time" DESC, _hyper_6_30_chunk.device_id
    Sort Method: quicksort 
    ->  Append (actual rows=522 loops=1)
          ->  Sample Scan on _hyper_6_30_chunk (actual rows=35 loops=1)
@@ -1640,9 +1625,10 @@ ORDER BY time DESC, device_id;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Hash Join (actual rows=96 loops=1)
-   Hash Cond: (g."time" = m."time")
+   Hash Cond: (g."time" = m_1."time")
    ->  Function Scan on generate_series g (actual rows=32 loops=1)
    ->  Hash (actual rows=26787 loops=1)
+         Buckets: 32768  Batches: 1 
          ->  Append (actual rows=26787 loops=1)
                ->  Seq Scan on _hyper_5_17_chunk m_1 (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_5_18_chunk m_2 (actual rows=6048 loops=1)
@@ -1798,7 +1784,7 @@ ORDER BY time DESC, device_id;
    Hypertable: metrics_timestamptz
    Chunks excluded during startup: 3
    ->  Merge Append (actual rows=7776 loops=1)
-         Sort Key: metrics_timestamptz.device_id, metrics_timestamptz."time"
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
          ->  Index Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=4032 loops=1)
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Index Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=3744 loops=1)
@@ -1892,7 +1878,7 @@ SET enable_hashagg TO false;
  Limit (actual rows=3 loops=1)
    ->  Unique (actual rows=3 loops=1)
          ->  Merge Append (actual rows=17859 loops=1)
-               Sort Key: metrics_timestamptz.device_id
+               Sort Key: _hyper_5_17_chunk.device_id
                ->  Index Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=2689 loops=1)
                ->  Index Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=4033 loops=1)
                ->  Index Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=4033 loops=1)
@@ -1906,7 +1892,7 @@ SET enable_hashagg TO false;
  Limit (actual rows=3 loops=1)
    ->  Unique (actual rows=3 loops=1)
          ->  Merge Append (actual rows=7491 loops=1)
-               Sort Key: metrics_space.device_id
+               Sort Key: _hyper_6_22_chunk.device_id
                ->  Index Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=1345 loops=1)
                ->  Index Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=1345 loops=1)
                ->  Index Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
@@ -1925,6 +1911,7 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
+psql:include/append_query.sql:315: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit
@@ -1989,34 +1976,30 @@ FROM (
 ) ts
 LEFT JOIN i2661 ht ON
   (FLOOR(EXTRACT (EPOCH FROM ht."timestamp") / 300) * 300 = EXTRACT (EPOCH FROM ts.timestamp))
-  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp
-ORDER BY ts.timestamp, ht.timestamp;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=33 loops=1)
-   Sort Key: ts."timestamp", ht."timestamp"
-   Sort Method: quicksort 
-   ->  Merge Left Join (actual rows=33 loops=1)
-         Merge Cond: ((EXTRACT(epoch FROM ts."timestamp")) = ((floor((EXTRACT(epoch FROM ht."timestamp") / '300'::numeric)) * '300'::numeric)))
-         ->  Sort (actual rows=13 loops=1)
-               Sort Key: (EXTRACT(epoch FROM ts."timestamp"))
-               Sort Method: quicksort 
-               ->  Subquery Scan on ts (actual rows=13 loops=1)
-                     ->  ProjectSet (actual rows=13 loops=1)
-                           ->  Result (actual rows=1 loops=1)
-         ->  Sort (actual rows=514 loops=1)
-               Sort Key: ((floor((EXTRACT(epoch FROM ht."timestamp") / '300'::numeric)) * '300'::numeric))
-               Sort Method: quicksort 
-               ->  Result (actual rows=7201 loops=1)
-                     ->  Custom Scan (ChunkAppend) on i2661 ht (actual rows=7201 loops=1)
-                           Chunks excluded during startup: 0
-                           ->  Seq Scan on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
-                                 Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
-                           ->  Seq Scan on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
-                                 Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
-                           ->  Seq Scan on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
-                                 Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
-(23 rows)
+  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Left Join (actual rows=33 loops=1)
+   Merge Cond: ((EXTRACT(epoch FROM ts."timestamp")) = ((floor((EXTRACT(epoch FROM ht."timestamp") / '300'::numeric)) * '300'::numeric)))
+   ->  Sort (actual rows=13 loops=1)
+         Sort Key: (EXTRACT(epoch FROM ts."timestamp"))
+         Sort Method: quicksort 
+         ->  Subquery Scan on ts (actual rows=13 loops=1)
+               ->  ProjectSet (actual rows=13 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+   ->  Sort (actual rows=514 loops=1)
+         Sort Key: ((floor((EXTRACT(epoch FROM ht."timestamp") / '300'::numeric)) * '300'::numeric))
+         Sort Method: quicksort 
+         ->  Result (actual rows=7201 loops=1)
+               ->  Custom Scan (ChunkAppend) on i2661 ht (actual rows=7201 loops=1)
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_7_31_chunk_i2661_timestamp_idx on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
+                           Index Cond: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+                     ->  Index Scan using _hyper_7_32_chunk_i2661_timestamp_idx on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
+                           Index Cond: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+                     ->  Index Scan using _hyper_7_33_chunk_i2661_timestamp_idx on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
+                           Index Cond: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+(20 rows)
 
 -- #3030 test chunkappend keeps pathkeys when subpath is append
 -- on PG11 this will not use ChunkAppend but MergeAppend
@@ -2075,7 +2058,7 @@ WHERE a.attr @> ANY((SELECT attr FROM join_test_plain WHERE temp > 100));
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Nested Loop Semi Join (actual rows=0 loops=1)
-   Join Filter: (a.attr @> join_test_plain.attr)
+   Join Filter: (a_1.attr @> join_test_plain.attr)
    ->  Append (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_1_chunk a_1 (actual rows=2 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk a_2 (actual rows=2 loops=1)
@@ -2161,48 +2144,6 @@ WHERE a.attr @> ANY((SELECT array_agg(attr) FROM join_test_plain WHERE temp > 10
          Rows Removed by Filter: 1
 (16 rows)
 
--- Test that ConstraintAwareAppend properly locks relations in
--- parallel query mode
-set timescaledb.enable_chunk_append=false;
-call force_parallel(true);
-:PREFIX
-select time, avg(temp), colorid from append_test
-where time > now_s() - interval '3 months 20 days'
-group by time, colorid;
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-psql:include/append_query.sql:415: NOTICE:  Stable function now_s() called!
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Gather (actual rows=3 loops=1)
-   Workers Planned: 1
-   Workers Launched: 1
-   Single Copy: true
-   ->  HashAggregate (actual rows=3 loops=1)
-         Group Key: append_test."time", append_test.colorid
-         ->  Custom Scan (ConstraintAwareAppend) (actual rows=3 loops=1)
-               Hypertable: append_test
-               Chunks excluded during startup: 1
-               ->  Append (actual rows=3 loops=1)
-                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2 loops=1)
-                           Filter: ("time" > (now_s() - '@ 3 mons 20 days'::interval))
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
-                           Filter: ("time" > (now_s() - '@ 3 mons 20 days'::interval))
-(15 rows)
-
-reset timescaledb.enable_chunk_append;
-reset max_parallel_workers_per_gather;
-call force_parallel(false);
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results
@@ -2214,6 +2155,44 @@ call force_parallel(false);
 + timescaledb.enable_optimizations | on
   timescaledb.enable_chunk_append  | on
  (2 rows)
+ 
+@@ -359165,30 +359165,30 @@
+  Wed Jan 01 00:10:00 2020 | Tue Dec 31 16:10:00 2019 PST
+  Wed Jan 01 00:10:00 2020 | Tue Dec 31 16:12:00 2019 PST
+  Wed Jan 01 00:10:00 2020 | Tue Dec 31 16:14:00 2019 PST
+- Wed Jan 01 00:15:00 2020 | Tue Dec 31 16:16:00 2019 PST
+  Wed Jan 01 00:15:00 2020 | Tue Dec 31 16:18:00 2019 PST
+- Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:20:00 2019 PST
++ Wed Jan 01 00:15:00 2020 | Tue Dec 31 16:16:00 2019 PST
+  Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:22:00 2019 PST
++ Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:20:00 2019 PST
+  Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:24:00 2019 PST
+- Wed Jan 01 00:25:00 2020 | Tue Dec 31 16:26:00 2019 PST
+  Wed Jan 01 00:25:00 2020 | Tue Dec 31 16:28:00 2019 PST
+- Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:30:00 2019 PST
++ Wed Jan 01 00:25:00 2020 | Tue Dec 31 16:26:00 2019 PST
+  Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:32:00 2019 PST
++ Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:30:00 2019 PST
+  Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:34:00 2019 PST
+  Wed Jan 01 00:35:00 2020 | Tue Dec 31 16:36:00 2019 PST
+  Wed Jan 01 00:35:00 2020 | Tue Dec 31 16:38:00 2019 PST
+- Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:40:00 2019 PST
+  Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:42:00 2019 PST
++ Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:40:00 2019 PST
+  Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:44:00 2019 PST
+  Wed Jan 01 00:45:00 2020 | Tue Dec 31 16:46:00 2019 PST
+  Wed Jan 01 00:45:00 2020 | Tue Dec 31 16:48:00 2019 PST
+- Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:50:00 2019 PST
+  Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:52:00 2019 PST
++ Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:50:00 2019 PST
+  Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:54:00 2019 PST
+  Wed Jan 01 00:55:00 2020 | Tue Dec 31 16:56:00 2019 PST
+  Wed Jan 01 00:55:00 2020 | Tue Dec 31 16:58:00 2019 PST
+- Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:00:00 2019 PST
+  Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:02:00 2019 PST
++ Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:00:00 2019 PST
+  Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:04:00 2019 PST
+ (33 rows)
  
 --- Unoptimized results
 +++ Optimized results
@@ -2227,3 +2206,41 @@ call force_parallel(false);
  (2 rows)
  
   time | temp | colorid | attr 
+@@ -359165,30 +359165,30 @@
+  Wed Jan 01 00:10:00 2020 | Tue Dec 31 16:10:00 2019 PST
+  Wed Jan 01 00:10:00 2020 | Tue Dec 31 16:12:00 2019 PST
+  Wed Jan 01 00:10:00 2020 | Tue Dec 31 16:14:00 2019 PST
+- Wed Jan 01 00:15:00 2020 | Tue Dec 31 16:16:00 2019 PST
+  Wed Jan 01 00:15:00 2020 | Tue Dec 31 16:18:00 2019 PST
+- Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:20:00 2019 PST
++ Wed Jan 01 00:15:00 2020 | Tue Dec 31 16:16:00 2019 PST
+  Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:22:00 2019 PST
++ Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:20:00 2019 PST
+  Wed Jan 01 00:20:00 2020 | Tue Dec 31 16:24:00 2019 PST
+- Wed Jan 01 00:25:00 2020 | Tue Dec 31 16:26:00 2019 PST
+  Wed Jan 01 00:25:00 2020 | Tue Dec 31 16:28:00 2019 PST
+- Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:30:00 2019 PST
++ Wed Jan 01 00:25:00 2020 | Tue Dec 31 16:26:00 2019 PST
+  Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:32:00 2019 PST
++ Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:30:00 2019 PST
+  Wed Jan 01 00:30:00 2020 | Tue Dec 31 16:34:00 2019 PST
+  Wed Jan 01 00:35:00 2020 | Tue Dec 31 16:36:00 2019 PST
+  Wed Jan 01 00:35:00 2020 | Tue Dec 31 16:38:00 2019 PST
+- Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:40:00 2019 PST
+  Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:42:00 2019 PST
++ Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:40:00 2019 PST
+  Wed Jan 01 00:40:00 2020 | Tue Dec 31 16:44:00 2019 PST
+  Wed Jan 01 00:45:00 2020 | Tue Dec 31 16:46:00 2019 PST
+  Wed Jan 01 00:45:00 2020 | Tue Dec 31 16:48:00 2019 PST
+- Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:50:00 2019 PST
+  Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:52:00 2019 PST
++ Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:50:00 2019 PST
+  Wed Jan 01 00:50:00 2020 | Tue Dec 31 16:54:00 2019 PST
+  Wed Jan 01 00:55:00 2020 | Tue Dec 31 16:56:00 2019 PST
+  Wed Jan 01 00:55:00 2020 | Tue Dec 31 16:58:00 2019 PST
+- Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:00:00 2019 PST
+  Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:02:00 2019 PST
++ Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:00:00 2019 PST
+  Wed Jan 01 01:00:00 2020 | Tue Dec 31 17:04:00 2019 PST
+ (33 rows)
+ 


### PR DESCRIPTION
After the latest version of postgresql-17, the postgres engine seems to by default use an Index Scan rather than a Seq Scan, as well as using the following index:
```
_hyper_7_31_chunk_i2661_timestamp_idx
```

This commit amends the expected output data in line with this change.

Running the tests on a system with postgresql-17 has the following error:
```

173s ==> test-17/test/regression.diffs <==
173s diff -u /tmp/autopkgtest.WFGZ2j/build.pJP/src/test/expected/append-17.out /tmp/autopkgtest.WFGZ2j/build.pJP/src/test-17/test/results/append-17.out
173s --- /tmp/autopkgtest.WFGZ2j/build.pJP/src/test/expected/append-17.out      2025-04-15 15:51:18.000000000 +0000
173s +++ /tmp/autopkgtest.WFGZ2j/build.pJP/src/test-17/test/results/append-17.out       2025-08-21 09:30:49.991073257 +0000
173s @@ -1993,12 +1993,12 @@
173s           ->  Result (actual rows=7201 loops=1)
173s                 ->  Custom Scan (ChunkAppend) on i2661 ht (actual rows=7201 loops=1)
173s                       Chunks excluded during startup: 0
173s -                     ->  Seq Scan on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
173s -                           Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
173s -                     ->  Seq Scan on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
173s -                           Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
173s -                     ->  Seq Scan on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
173s -                           Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
173s +                     ->  Index Scan using _hyper_7_31_chunk_i2661_timestamp_idx on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
173s +                           Index Cond: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
173s +                     ->  Index Scan using _hyper_7_32_chunk_i2661_timestamp_idx on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
173s +                           Index Cond: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
173s +                     ->  Index Scan using _hyper_7_33_chunk_i2661_timestamp_idx on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
173s +                           Index Cond: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)

```

Which this diff amends.