### PR TITLE
Add chunk_status_text helper function

### DIFF
--- a/.unreleased/pr_8528
+++ b/.unreleased/pr_8528
@@ -1,0 +1,1 @@
+Implements: #8528 Add _timescaledb_functions.chunk_status_text helper function

--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -25,6 +25,13 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.calculate_chunk_interval(
 CREATE OR REPLACE FUNCTION _timescaledb_functions.chunk_status(REGCLASS) RETURNS INT
 AS '@MODULE_PATHNAME@', 'ts_chunk_status' LANGUAGE C;
 
+-- Get the status of the chunk as text array
+CREATE OR REPLACE FUNCTION _timescaledb_functions.chunk_status_text(chunk_status int) RETURNS TEXT[]
+AS '@MODULE_PATHNAME@', 'ts_chunk_status_text' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_functions.chunk_status_text(chunk regclass) RETURNS TEXT[]
+AS $$ SELECT _timescaledb_functions.chunk_status_text(_timescaledb_functions.chunk_status($1)); $$ LANGUAGE SQL STRICT IMMUTABLE PARALLEL SAFE SET search_path TO pg_catalog, pg_temp;;
+
 --given a chunk's relid, return the id. Error out if not a chunk relid.
 CREATE OR REPLACE FUNCTION _timescaledb_functions.chunk_id_from_relid(relid OID) RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_chunk_id_from_relid' LANGUAGE C STABLE STRICT PARALLEL SAFE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -226,3 +226,6 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.temp_index_keycolumns(oid);
 
 GRANT SELECT ON TABLE _timescaledb_catalog.chunk_index TO PUBLIC;
 
+DROP FUNCTION IF EXISTS _timescaledb_functions.chunk_status_text(regclass);
+DROP FUNCTION IF EXISTS _timescaledb_functions.chunk_status_text(int);
+

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4564,6 +4564,7 @@ ts_chunk_create(PG_FUNCTION_ARGS)
  * @see CHUNK_STATUS_COMPRESSED
  * @see CHUNK_STATUS_COMPRESSED_UNORDERED
  * @see CHUNK_STATUS_FROZEN
+ * @see CHUNK_STATUS_COMPRESSED_PARTIAL
  */
 Datum
 ts_chunk_status(PG_FUNCTION_ARGS)
@@ -4571,6 +4572,52 @@ ts_chunk_status(PG_FUNCTION_ARGS)
 	Oid chunk_relid = PG_GETARG_OID(0);
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, /* fail_if_not_found */ true);
 	PG_RETURN_INT32(chunk->fd.status);
+}
+
+TS_FUNCTION_INFO_V1(ts_chunk_status_text);
+
+Datum
+ts_chunk_status_text(PG_FUNCTION_ARGS)
+{
+	int32 status = PG_GETARG_INT32(0);
+
+	ArrayBuildState *astate = initArrayResult(TEXTOID, CurrentMemoryContext, false);
+
+	if (status & CHUNK_STATUS_COMPRESSED)
+		astate = accumArrayResult(astate,
+								  CStringGetTextDatum("COMPRESSED"),
+								  false,
+								  TEXTOID,
+								  CurrentMemoryContext);
+
+	if (status & CHUNK_STATUS_COMPRESSED_UNORDERED)
+		astate = accumArrayResult(astate,
+								  CStringGetTextDatum("UNORDERED"),
+								  false,
+								  TEXTOID,
+								  CurrentMemoryContext);
+
+	if (status & CHUNK_STATUS_FROZEN)
+		astate = accumArrayResult(astate,
+								  CStringGetTextDatum("FROZEN"),
+								  false,
+								  TEXTOID,
+								  CurrentMemoryContext);
+
+	if (status & CHUNK_STATUS_COMPRESSED_PARTIAL)
+		astate = accumArrayResult(astate,
+								  CStringGetTextDatum("PARTIAL"),
+								  false,
+								  TEXTOID,
+								  CurrentMemoryContext);
+
+	if (status < 0 || status > (CHUNK_STATUS_COMPRESSED | CHUNK_STATUS_COMPRESSED_UNORDERED |
+								CHUNK_STATUS_FROZEN | CHUNK_STATUS_COMPRESSED_PARTIAL))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid chunk status %d", status)));
+
+	PG_RETURN_DATUM(makeArrayResult(astate, CurrentMemoryContext));
 }
 
 /*

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -229,6 +229,7 @@ extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(const Chunk
 extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(const Chunk *chunk);
 extern TSDLLEXPORT ChunkCompressionStatus ts_chunk_get_compression_status(int32 chunk_id);
 extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);
+extern TSDLLEXPORT Datum ts_chunk_status_text(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT List *ts_chunk_get_chunk_ids_by_hypertable_id(int32 hypertable_id);
 extern TSDLLEXPORT List *ts_chunk_get_by_hypertable_id(int32 hypertable_id);
 

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1572,3 +1572,66 @@ SELECT * FROM test_view_part_few WHERE ts BETWEEN '2024-01-04 00:00:00+00'AND '2
          15 | Thu Jan 04 21:55:12 2024 PST
 (14 rows)
 
+-- Test chunk_status_text function
+CREATE TABLE chunk_status_test(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.columnstore=false);
+INSERT INTO chunk_status_test VALUES ('2025-01-01'),('2025-02-01'),('2025-03-01');
+SELECT _timescaledb_functions.chunk_status_text(i) FROM generate_series(0,15) i;
+           chunk_status_text           
+---------------------------------------
+ {}
+ {COMPRESSED}
+ {UNORDERED}
+ {COMPRESSED,UNORDERED}
+ {FROZEN}
+ {COMPRESSED,FROZEN}
+ {UNORDERED,FROZEN}
+ {COMPRESSED,UNORDERED,FROZEN}
+ {PARTIAL}
+ {COMPRESSED,PARTIAL}
+ {UNORDERED,PARTIAL}
+ {COMPRESSED,UNORDERED,PARTIAL}
+ {FROZEN,PARTIAL}
+ {COMPRESSED,FROZEN,PARTIAL}
+ {UNORDERED,FROZEN,PARTIAL}
+ {COMPRESSED,UNORDERED,FROZEN,PARTIAL}
+(16 rows)
+
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('chunk_status_test') chunk;
+                   chunk                   | chunk_status_text 
+-------------------------------------------+-------------------
+ _timescaledb_internal._hyper_18_218_chunk | {}
+ _timescaledb_internal._hyper_18_219_chunk | {}
+ _timescaledb_internal._hyper_18_220_chunk | {}
+(3 rows)
+
+SELECT _timescaledb_functions.chunk_status_text(NULL::int);
+ chunk_status_text 
+-------------------
+ 
+(1 row)
+
+SELECT _timescaledb_functions.chunk_status_text(NULL::regclass);
+ chunk_status_text 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.chunk_status_text(-1);
+ERROR:  invalid chunk status -1
+SELECT _timescaledb_functions.chunk_status_text(16);
+ERROR:  invalid chunk status 16
+SELECT _timescaledb_functions.chunk_status_text(1000);
+ERROR:  invalid chunk status 1000
+SELECT _timescaledb_functions.chunk_status_text(0::regclass);
+ERROR:  invalid Oid
+SELECT _timescaledb_functions.chunk_status_text('pg_class'::regclass);
+ERROR:  chunk not found
+\set ON_ERROR_STOP 1
+-- Test that function exists and returns an array type
+SELECT pg_typeof(_timescaledb_functions.chunk_status_text(0));
+ pg_typeof 
+-----------
+ text[]
+(1 row)
+

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -672,3 +672,24 @@ CREATE VIEW test_view_part_few AS SELECT project_id,
   WHERE project_id = ANY (ARRAY[5, 10, 15]);
 -- Complicated query on a view involving a range check and a sort
 SELECT * FROM test_view_part_few WHERE ts BETWEEN '2024-01-04 00:00:00+00'AND '2024-01-05 00:00:00' ORDER BY ts LIMIT 1000;
+
+-- Test chunk_status_text function
+CREATE TABLE chunk_status_test(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.columnstore=false);
+INSERT INTO chunk_status_test VALUES ('2025-01-01'),('2025-02-01'),('2025-03-01');
+SELECT _timescaledb_functions.chunk_status_text(i) FROM generate_series(0,15) i;
+
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('chunk_status_test') chunk;
+
+SELECT _timescaledb_functions.chunk_status_text(NULL::int);
+SELECT _timescaledb_functions.chunk_status_text(NULL::regclass);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.chunk_status_text(-1);
+SELECT _timescaledb_functions.chunk_status_text(16);
+SELECT _timescaledb_functions.chunk_status_text(1000);
+SELECT _timescaledb_functions.chunk_status_text(0::regclass);
+SELECT _timescaledb_functions.chunk_status_text('pg_class'::regclass);
+\set ON_ERROR_STOP 1
+
+-- Test that function exists and returns an array type
+SELECT pg_typeof(_timescaledb_functions.chunk_status_text(0));
+

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -55,6 +55,8 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.chunk_constraint_add_table_constraint(_timescaledb_catalog.chunk_constraint)
  _timescaledb_functions.chunk_id_from_relid(oid)
  _timescaledb_functions.chunk_status(regclass)
+ _timescaledb_functions.chunk_status_text(integer)
+ _timescaledb_functions.chunk_status_text(regclass)
  _timescaledb_functions.chunks_local_size(name,name)
  _timescaledb_functions.compressed_chunk_local_stats(name,name)
  _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data)


### PR DESCRIPTION
Add helper function to decode chunk status bit field into text.

SELECT chunk,
  _timescaledb_functions.chunk_status(chunk),
  _timescaledb_functions.chunk_status_text(chunk)
FROM show_chunks('metrics') chunk;
                 chunk                  | chunk_status |  chunk_status_text
----------------------------------------+--------------+----------------------
 _timescaledb_internal._hyper_1_1_chunk |            9 | {COMPRESSED,PARTIAL}
(1 row)
