### PR TITLE
Add version to invalidation plugin name

### DIFF
--- a/sql/pre_install/types.functions.sql
+++ b/sql/pre_install/types.functions.sql
@@ -59,6 +59,11 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.dimension_info_out(_timescaled
 CREATE OR REPLACE FUNCTION _timescaledb_functions.bloom1in(cstring) RETURNS _timescaledb_internal.bloom1 AS 'byteain' LANGUAGE INTERNAL STRICT IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_functions.bloom1out(_timescaledb_internal.bloom1) RETURNS cstring AS 'byteaout' LANGUAGE INTERNAL STRICT IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.invalidation_plugin_name()
+   RETURNS text
+   LANGUAGE C STRICT PARALLEL SAFE
+   AS '@MODULE_PATHNAME@', 'ts_invalidation_plugin_name';
+
 CREATE OR REPLACE FUNCTION _timescaledb_functions.has_invalidation_trigger(regclass)
    RETURNS bool
    LANGUAGE C STRICT PARALLEL SAFE

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -6,6 +6,7 @@ DROP PROCEDURE _timescaledb_functions.process_hypertable_invalidations(REGCLASS[
 DROP PROCEDURE _timescaledb_functions.process_hypertable_invalidations(NAME);
 DROP FUNCTION _timescaledb_functions.cagg_parse_invalidation_record(BYTEA);
 DROP FUNCTION _timescaledb_functions.has_invalidation_trigger(regclass);
+DROP FUNCTION _timescaledb_functions.invalidation_plugin_name();
 
 CREATE FUNCTION ts_hypercore_handler(internal) RETURNS table_am_handler
 AS '@MODULE_PATHNAME@', 'ts_hypercore_handler' LANGUAGE C;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,7 +109,7 @@ if(USE_OPENSSL)
 endif(USE_OPENSSL)
 
 set(TSL_CAGG_INVALIDATION_PLUGIN_NAME
-    "${PROJECT_NAME}-invalidations"
+    "${PROJECT_NAME}-invalidations-${PROJECT_VERSION_MOD}"
     CACHE STRING "Continuous aggregates invalidation plugin name")
 
 configure_file(config.h.in config.h)

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -50,7 +50,17 @@
 #define BUCKET_FUNCTION_SERIALIZE_VERSION 1
 #define CHECK_NAME_MATCH(name1, name2) (namestrcmp(name1, name2) == 0)
 
+TS_FUNCTION_INFO_V1(ts_invalidation_plugin_name);
 TS_FUNCTION_INFO_V1(ts_has_invalidation_trigger);
+
+/*
+ * Return the full name of the invalidation plugin, with version and all.
+ */
+Datum
+ts_invalidation_plugin_name(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TEXT_P(cstring_to_text(CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_PLUGIN_NAME));
+}
 
 Datum
 ts_has_invalidation_trigger(PG_FUNCTION_ARGS)

--- a/tsl/test/expected/cagg_invalidation_multi.out
+++ b/tsl/test/expected/cagg_invalidation_multi.out
@@ -11,6 +11,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 
 SET datestyle TO 'ISO, YMD';
 SET timezone TO 'UTC';
+SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
 CREATE VIEW hypertable_invalidation_thresholds AS
 SELECT format('%I.%I', ht.schema_name, ht.table_name)::regclass AS hypertable,
        watermark AS threshold
@@ -29,12 +30,11 @@ SELECT ca.user_view_name AS aggregate_name,
     ON materialization_id = ht.id;
 CREATE VIEW invalidation_slots AS
 SELECT replace(slot_name::text, dboid::text, 'DBOID') AS slot_name,
-       plugin,
        slot_type,
        database
  FROM pg_replication_slots,
       (select oid from pg_database where current_database() = datname) t(dboid)
-WHERE plugin = 'timescaledb-invalidations';
+WHERE plugin = :'plugin_name';
 CREATE TABLE conditions (time bigint NOT NULL, device int, temp float);
 SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
     create_hypertable    
@@ -88,8 +88,8 @@ SELECT * FROM conditions ORDER BY time DESC, device LIMIT 10;
 (10 rows)
 
 SELECT * FROM invalidation_slots;
- slot_name | plugin | slot_type | database 
------------+--------+-----------+----------
+ slot_name | slot_type | database 
+-----------+-----------+----------
 (0 rows)
 
 -- Create two continuous aggregates on the same hypertable to test
@@ -156,9 +156,9 @@ INSERT INTO measurements VALUES
 INSERT INTO measurements VALUES
        (20, 4, 23.7), (140, 5, 23.8), (200, 3, 23.6);
 SELECT * FROM invalidation_slots;
-   slot_name   |          plugin           | slot_type |          database          
----------------+---------------------------+-----------+----------------------------
- ts_DBOID_cagg | timescaledb-invalidations | logical   | db_cagg_invalidation_multi
+   slot_name   | slot_type |          database          
+---------------+-----------+----------------------------
+ ts_DBOID_cagg | logical   | db_cagg_invalidation_multi
 (1 row)
 
 CALL _timescaledb_functions.process_hypertable_invalidations(

--- a/tsl/test/expected/cagg_plugin.out
+++ b/tsl/test/expected/cagg_plugin.out
@@ -28,6 +28,7 @@ SELECT hypertable_relid,
   FROM changes
 ORDER BY 1,2,3;
 $$ LANGUAGE sql;
+select _timescaledb_functions.invalidation_plugin_name() as plugin_name \gset
 -- Creating a table with a primary key since we need a replica
 -- identity to use logical decoding.
 CREATE TABLE conditions (
@@ -53,7 +54,7 @@ SELECT recorded_at, (random()*3 + 1)::int, random()*80 - 40
   FROM generate_series('2025-02-01'::timestamptz,
   	               '2025-03-31'::timestamptz,
 		       '1 minute'::interval) AS recorded_at;
-select from pg_create_logical_replication_slot('my_slot', 'timescaledb-invalidations', false, true);
+select from pg_create_logical_replication_slot('my_slot', :'plugin_name', false, true);
 --
 (1 row)
 

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -6,8 +6,10 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
 CREATE VIEW invalidation_slots AS
-SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
+SELECT * FROM pg_replication_slots
+ WHERE plugin = :'plugin_name';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -755,7 +757,7 @@ SELECT hypertable_name, view_name, invalidate_using
 (3 rows)
 
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -767,7 +769,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -779,7 +781,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -791,7 +793,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -6,8 +6,10 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
 CREATE VIEW invalidation_slots AS
-SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
+SELECT * FROM pg_replication_slots
+ WHERE plugin = :'plugin_name';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -755,7 +757,7 @@ SELECT hypertable_name, view_name, invalidate_using
 (3 rows)
 
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -767,7 +769,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -779,7 +781,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -791,7 +793,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -6,8 +6,10 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
 CREATE VIEW invalidation_slots AS
-SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
+SELECT * FROM pg_replication_slots
+ WHERE plugin = :'plugin_name';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -755,7 +757,7 @@ SELECT hypertable_name, view_name, invalidate_using
 (3 rows)
 
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -767,7 +769,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -779,7 +781,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------
@@ -791,7 +793,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
  count 
 -------

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -110,6 +110,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.index_matches(regclass,regclass)
  _timescaledb_functions.insert_blocker()
  _timescaledb_functions.interval_to_usec(interval)
+ _timescaledb_functions.invalidation_plugin_name()
  _timescaledb_functions.job_history_bsearch(timestamp with time zone)
  _timescaledb_functions.jsonb_get_matching_index_entry(jsonb,text,text)
  _timescaledb_functions.last_combinefunc(internal,internal)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -220,8 +220,7 @@ set(SOLO_TESTS
     # https://github.com/postgres/postgres/commit/d87d07b7ad3b782cb74566cd771ecdb2823adf6a
     cagg_invalidation
     cagg_invalidation_multi
-    cagg_plugin
-    cagg_invalidation_multi)
+    cagg_plugin)
 
 # Check if PostgreSQL was compiled with JIT support
 set(PG_CONFIG_H "${PG_INCLUDEDIR}/pg_config.h")

--- a/tsl/test/sql/cagg_plugin.sql
+++ b/tsl/test/sql/cagg_plugin.sql
@@ -28,6 +28,8 @@ SELECT hypertable_relid,
 ORDER BY 1,2,3;
 $$ LANGUAGE sql;
 
+select _timescaledb_functions.invalidation_plugin_name() as plugin_name \gset
+
 -- Creating a table with a primary key since we need a replica
 -- identity to use logical decoding.
 CREATE TABLE conditions (
@@ -46,7 +48,7 @@ SELECT recorded_at, (random()*3 + 1)::int, random()*80 - 40
   	               '2025-03-31'::timestamptz,
 		       '1 minute'::interval) AS recorded_at;
 
-select from pg_create_logical_replication_slot('my_slot', 'timescaledb-invalidations', false, true);
+select from pg_create_logical_replication_slot('my_slot', :'plugin_name', false, true);
 
 -- Generate a few entries in one go. This caused some problems
 -- initially, so check this first.

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -8,8 +8,11 @@ SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
 
+SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
+
 CREATE VIEW invalidation_slots AS
-SELECT * FROM pg_replication_slots WHERE plugin = 'timescaledb-invalidations';
+SELECT * FROM pg_replication_slots
+ WHERE plugin = :'plugin_name';
 
 -- START OF USAGE TEST --
 
@@ -492,7 +495,7 @@ SELECT hypertable_name, view_name, invalidate_using
  WHERE view_name like 'magic_\_summary%';
 
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
 
 DROP MATERIALIZED VIEW magic2_summary1_wal;
@@ -500,7 +503,7 @@ DROP MATERIALIZED VIEW magic2_summary1_wal;
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
@@ -508,7 +511,7 @@ DROP MATERIALIZED VIEW magic1_summary1_wal;
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
@@ -516,7 +519,7 @@ DROP MATERIALIZED VIEW magic1_summary2_wal;
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
- WHERE plugin = 'timescaledb-invalidations'
+ WHERE plugin = :'plugin_name'
    AND database = current_database();
 
 SELECT hypertable_name, view_name, invalidate_using


### PR DESCRIPTION
To be able to package the invalidation plugin it is necessary for it to have a version number that matches the version number of the TimescaleDB extension in use.

The plugin is versioned on protocol level and will be ABI compatible going forward so the versioning is only needed for the packaging.

Disable-check: force-changelog-file