### PR TITLE
Remove Continuous Aggregate GUC

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -929,25 +929,6 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
-	/*
-	 * Define the limit on number of invalidation-based refreshes we allow per
-	 * refresh call. If this limit is exceeded, fall back to a single refresh that
-	 * covers the range decided by the min and max invalidated time.
-	 */
-	DefineCustomIntVariable(MAKE_EXTOPTION("materializations_per_refresh_window"),
-							"Max number of materializations per cagg refresh window",
-							"The maximal number of individual refreshes per cagg refresh. If more "
-							"refreshes need to be performed, they are merged into a larger "
-							"single refresh.",
-							&ts_guc_cagg_max_individual_materializations,
-							10,
-							0,
-							INT_MAX,
-							PGC_USERSET,
-							0,
-							NULL,
-							NULL,
-							NULL);
 
 	DefineCustomIntVariable(MAKE_EXTOPTION("cagg_processing_wal_batch_size"),
 							"Batch size when processing WAL entries.",

--- a/tsl/test/expected/cagg_bgw-15.out
+++ b/tsl/test/expected/cagg_bgw-15.out
@@ -517,15 +517,6 @@ last_run_duration |
 \x off
 -- test merged refresh (change data in two chunks)
 UPDATE test_continuous_agg_table SET data = 11;
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 --advance time by 1day so that job runs one more time
 SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
  ts_bgw_params_reset_time 
@@ -590,15 +581,6 @@ SELECT * FROM sorted_bgw_log;
      14 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (46 rows)
 
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute

--- a/tsl/test/expected/cagg_bgw-16.out
+++ b/tsl/test/expected/cagg_bgw-16.out
@@ -517,15 +517,6 @@ last_run_duration |
 \x off
 -- test merged refresh (change data in two chunks)
 UPDATE test_continuous_agg_table SET data = 11;
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 --advance time by 1day so that job runs one more time
 SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
  ts_bgw_params_reset_time 
@@ -590,15 +581,6 @@ SELECT * FROM sorted_bgw_log;
      14 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (46 rows)
 
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute

--- a/tsl/test/expected/cagg_bgw-17.out
+++ b/tsl/test/expected/cagg_bgw-17.out
@@ -517,15 +517,6 @@ last_run_duration |
 \x off
 -- test merged refresh (change data in two chunks)
 UPDATE test_continuous_agg_table SET data = 11;
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 --advance time by 1day so that job runs one more time
 SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
  ts_bgw_params_reset_time 
@@ -590,15 +581,6 @@ SELECT * FROM sorted_bgw_log;
      14 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (46 rows)
 
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1195,8 +1195,6 @@ WHERE cagg_id = :cond_10_id;
 
 -- should trigger two individual refreshes
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
--- Allow at most 5 individual invalidations per refresh
-SET timescaledb.materializations_per_refresh_window=5;
 -- Insert into every second bucket
 INSERT INTO conditions VALUES (20, 1, 1.0);
 INSERT INTO conditions VALUES (40, 1, 1.0);
@@ -1206,34 +1204,6 @@ INSERT INTO conditions VALUES (100, 1, 1.0);
 INSERT INTO conditions VALUES (120, 1, 1.0);
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
--- Test acceptable values for materializations per refresh
-SET timescaledb.materializations_per_refresh_window=' 5 ';
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
--- Large value will be treated as LONG_MAX
-SET timescaledb.materializations_per_refresh_window=342239897234023842394249234766923492347;
-ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "342239897234023842394249234766923492347"
-HINT:  Value exceeds integer range.
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
--- Test bad values for materializations per refresh
-SET timescaledb.materializations_per_refresh_window='foo';
-ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "foo"
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-SET timescaledb.materializations_per_refresh_window='2bar';
-ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "2bar"
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-SET timescaledb.materializations_per_refresh_window='-';
-ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "-"
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-\set VERBOSITY terse
-RESET timescaledb.materializations_per_refresh_window;
-\set ON_ERROR_STOP 1
 -- Test refresh with undefined invalidation threshold and variable sized buckets
 CREATE TABLE timestamp_ht (
   time timestamptz NOT NULL,

--- a/tsl/test/expected/exp_cagg_monthly.out
+++ b/tsl/test/expected/exp_cagg_monthly.out
@@ -1001,7 +1001,6 @@ SELECT * FROM conditions_large_1y1m ORDER BY bucket;
 -- Trigger merged refresh to check corresponding code path as well
 DROP MATERIALIZED VIEW conditions_large_1y;
 NOTICE:  drop cascades to 10 other objects
-SET timescaledb.materializations_per_refresh_window = 0;
 SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_1y
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -1048,7 +1047,6 @@ SELECT * FROM conditions_large_1y ORDER BY bucket;
  01-01-2020 | 101 | 1231
 (11 rows)
 
-RESET timescaledb.materializations_per_refresh_window;
 -- Test the specific code path of creating a CAGG on top of empty hypertable.
 CREATE TABLE conditions_empty(
   day DATE NOT NULL,

--- a/tsl/test/sql/cagg_bgw.sql.in
+++ b/tsl/test/sql/cagg_bgw.sql.in
@@ -270,22 +270,12 @@ and cagg.materialization_hypertable_name = ps.hypertable_name;
 -- test merged refresh (change data in two chunks)
 UPDATE test_continuous_agg_table SET data = 11;
 
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
-SELECT pg_reload_conf();
-SET ROLE :ROLE_DEFAULT_PERM_USER;
-
 --advance time by 1day so that job runs one more time
 SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
 
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
 
 SELECT * FROM sorted_bgw_log;
-
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
-SELECT pg_reload_conf();
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 

--- a/tsl/test/sql/cagg_invalidation.sql
+++ b/tsl/test/sql/cagg_invalidation.sql
@@ -691,9 +691,6 @@ WHERE cagg_id = :cond_10_id;
 -- should trigger two individual refreshes
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
 
--- Allow at most 5 individual invalidations per refresh
-SET timescaledb.materializations_per_refresh_window=5;
-
 -- Insert into every second bucket
 INSERT INTO conditions VALUES (20, 1, 1.0);
 INSERT INTO conditions VALUES (40, 1, 1.0);
@@ -704,32 +701,6 @@ INSERT INTO conditions VALUES (120, 1, 1.0);
 INSERT INTO conditions VALUES (140, 1, 1.0);
 
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
--- Test acceptable values for materializations per refresh
-SET timescaledb.materializations_per_refresh_window=' 5 ';
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
--- Large value will be treated as LONG_MAX
-SET timescaledb.materializations_per_refresh_window=342239897234023842394249234766923492347;
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-
--- Test bad values for materializations per refresh
-SET timescaledb.materializations_per_refresh_window='foo';
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-SET timescaledb.materializations_per_refresh_window='2bar';
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-
-SET timescaledb.materializations_per_refresh_window='-';
-INSERT INTO conditions VALUES (140, 1, 1.0);
-CALL refresh_continuous_aggregate('cond_10', 0, 200);
-\set VERBOSITY terse
-RESET timescaledb.materializations_per_refresh_window;
-\set ON_ERROR_STOP 1
 
 -- Test refresh with undefined invalidation threshold and variable sized buckets
 CREATE TABLE timestamp_ht (

--- a/tsl/test/sql/exp_cagg_monthly.sql
+++ b/tsl/test/sql/exp_cagg_monthly.sql
@@ -412,7 +412,6 @@ SELECT * FROM conditions_large_1y1m ORDER BY bucket;
 
 -- Trigger merged refresh to check corresponding code path as well
 DROP MATERIALIZED VIEW conditions_large_1y;
-SET timescaledb.materializations_per_refresh_window = 0;
 
 SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_1y
@@ -434,8 +433,6 @@ FROM generate_series('2020-01-01' :: date, '2021-01-01' :: date - interval '1 da
 CALL refresh_continuous_aggregate('conditions_large_1y', '2020-01-01', '2021-01-01');
 
 SELECT * FROM conditions_large_1y ORDER BY bucket;
-
-RESET timescaledb.materializations_per_refresh_window;
 
 -- Test the specific code path of creating a CAGG on top of empty hypertable.
 


### PR DESCRIPTION
In #8508 we removed the merged Continuous Aggregate materialization making the GUC `timescaledb.materializations_per_refresh_window` completely useless so removed it.

Disable-check: force-changelog-file
