### PR TITLE
Use active and registered snapshots only

### DIFF
--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -1291,8 +1291,9 @@ check_chunk_constraint_violated(Oid chunk_relid, const Dimension *dim, const Dim
 	TableScanDesc scandesc;
 	bool isnull;
 
+	PushActiveSnapshot(GetLatestSnapshot());
 	rel = table_open(chunk_relid, AccessShareLock);
-	scandesc = table_beginscan(rel, GetLatestSnapshot(), 0, NULL);
+	scandesc = table_beginscan(rel, GetActiveSnapshot(), 0, NULL);
 	slot = table_slot_create(rel, NULL);
 
 	while (table_scan_getnextslot(scandesc, ForwardScanDirection, slot))
@@ -1323,6 +1324,7 @@ check_chunk_constraint_violated(Oid chunk_relid, const Dimension *dim, const Dim
 	ExecDropSingleTupleTableSlot(slot);
 	table_endscan(scandesc);
 	table_close(rel, NoLock);
+	PopActiveSnapshot();
 }
 
 /*

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3373,6 +3373,7 @@ process_index_start(ProcessUtilityArgs *args)
 								   &info);
 
 	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
 	MemoryContextSwitchTo(info.mctx);
 
 	if (multitransaction_create_index_mark_valid(info))
@@ -3384,6 +3385,7 @@ process_index_start(ProcessUtilityArgs *args)
 		CacheInvalidateRelcacheByRelid(info.obj.objectId);
 	}
 
+	PopActiveSnapshot();
 	CommitTransactionCommand();
 	StartTransactionCommand();
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -483,8 +483,14 @@ ts_scanner_scan(ScannerCtx *ctx)
 			{
 				ts_scanner_end_scan(ctx);
 				ctx->internal.tinfo.count = 0;
-				ctx->snapshot = GetLatestSnapshot();
+				ctx->snapshot = RegisterSnapshot(GetLatestSnapshot());
 				ts_scanner_start_scan(ctx);
+				/* Since we register the snapshot manually above,
+				 * we need to mark it as registered in the scanner but only after we
+				 * start the scan since the scanner resets this flag and sets it only
+				 * if the snapshot gets registered during scan preparation phase.
+				 */
+				ctx->internal.registered_snapshot = true;
 			}
 		}
 	}

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -863,7 +863,8 @@ delete_tuple_for_recompression(Relation rel, ItemPointer tid, Snapshot snapshot)
 static void
 try_updating_chunk_status(Chunk *uncompressed_chunk, Relation uncompressed_chunk_rel)
 {
-	TableScanDesc scan = table_beginscan(uncompressed_chunk_rel, GetLatestSnapshot(), 0, 0);
+	PushActiveSnapshot(GetLatestSnapshot());
+	TableScanDesc scan = table_beginscan(uncompressed_chunk_rel, GetActiveSnapshot(), 0, 0);
 	ScanDirection scan_dir = BackwardScanDirection;
 	TupleTableSlot *slot = table_slot_create(uncompressed_chunk_rel, NULL);
 
@@ -878,6 +879,7 @@ try_updating_chunk_status(Chunk *uncompressed_chunk, Relation uncompressed_chunk
 
 	ExecDropSingleTupleTableSlot(slot);
 	table_endscan(scan);
+	PopActiveSnapshot();
 
 	if (!has_tuples)
 	{

--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -737,8 +737,9 @@ get_direct_view_oid(int32 mat_hypertable_id)
 						   Int32GetDatum(mat_hypertable_id));
 
 	/* Prepare index scan */
+	PushActiveSnapshot(GetTransactionSnapshot());
 	IndexScanDesc indexscan =
-		index_beginscan_compat(cagg_rel, cagg_idx_rel, GetTransactionSnapshot(), NULL, 1, 0);
+		index_beginscan_compat(cagg_rel, cagg_idx_rel, GetActiveSnapshot(), NULL, 1, 0);
 	index_rescan(indexscan, scankeys, 1, NULL, 0);
 
 	/* Read tuple from relation */
@@ -784,6 +785,7 @@ get_direct_view_oid(int32 mat_hypertable_id)
 	ExecDropSingleTupleTableSlot(slot);
 	relation_close(cagg_rel, AccessShareLock);
 	relation_close(cagg_idx_rel, AccessShareLock);
+	PopActiveSnapshot();
 
 	/* Get Oid of user view */
 	Oid direct_view_oid =


### PR DESCRIPTION
Snapshot being used for scans needs to be active
or registered so that its pinned and cannot be
invalidated from under us.

https://github.com/postgres/postgres/commit/8076c005

Disable-check: force-changelog-file