### PR TITLE
Fix permissions for `policy_job_stat_history_retention`

### DIFF
--- a/sql/job_stat_history_log_retention.sql
+++ b/sql/job_stat_history_log_retention.sql
@@ -73,7 +73,7 @@ $$
 LANGUAGE plpgsql SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_functions.policy_job_stat_history_retention(job_id integer, config JSONB) RETURNS integer
-LANGUAGE PLPGSQL AS
+LANGUAGE PLPGSQL SECURITY DEFINER AS
 $BODY$
 DECLARE
     numrows INTEGER;


### PR DESCRIPTION
PR #8494 introduces changes to the history retention job, notably it does a TRUNCATE instead of a DELETE. When the job is run on Tiger Cloud it doesn't have the necessary permissions to do this, so we need to use SECURITY DEFINER to ensure the policy can perform the TRUNCATE.

Disable-check: force-changelog-file