### PR TITLE
Update copy memory usage test to prepare for PG18

### DIFF
--- a/test/expected/copy_memory_usage.out
+++ b/test/expected/copy_memory_usage.out
@@ -28,6 +28,27 @@ create function log_memory() returns trigger as $$
         return new;
     end;
 $$ language plpgsql;
+-- Prepare version dependent TopTransactionContext total memory usage query.
+-- Using prepared statements to avoid contaminating memory usage numbers.
+-- PG18 removed parent column so we have to use path to get TopTransactionContext child entries.
+-- https://github.com/postgres/postgres/commit/f0d11275
+create or replace function prepare_transaction_total_memory_usage_stmt() returns void
+language plpgsql as
+$$
+begin
+    if current_setting('server_version_num')::int < 180000 then
+        prepare total_stmt as select sum(total_bytes)
+        from pg_backend_memory_contexts
+		where parent = 'TopTransactionContext';
+    else
+        prepare total_stmt as select sum(m.total_bytes)
+        from pg_backend_memory_contexts m
+        inner join pg_backend_memory_contexts p
+            on (m.path[m.level-1] = p.path[p.level])
+        where p.name = 'TopTransactionContext';
+    end if;
+end;
+$$;
 -- Add a trigger that runs after completion of each INSERT/COPY and logs the
 -- current memory usage.
 create trigger check_update after insert on uk_price_paid
@@ -78,16 +99,22 @@ END;
 $$;
 -- TopTransactionContext usage needs to remain the same after every insert
 -- There was a leak earlier in the child CurTransactionContext
+SELECT prepare_transaction_total_memory_usage_stmt();
+ prepare_transaction_total_memory_usage_stmt 
+---------------------------------------------
+ 
+(1 row)
+
 BEGIN;
 INSERT INTO test_ht VALUES ('1980-01-01 00:00:00-00', to_double('23.11', 0));
-SELECT sum(total_bytes) from pg_backend_memory_contexts where parent = 'TopTransactionContext';
+EXECUTE total_stmt;
   sum  
 -------
  16384
 (1 row)
 
 INSERT INTO test_ht VALUES ('1980-02-01 00:00:00-00', to_double('24.11', 0));
-SELECT sum(total_bytes) from pg_backend_memory_contexts where parent = 'TopTransactionContext';
+EXECUTE total_stmt;
   sum  
 -------
  16384

--- a/test/sql/copy_memory_usage.sql
+++ b/test/sql/copy_memory_usage.sql
@@ -30,6 +30,28 @@ create function log_memory() returns trigger as $$
     end;
 $$ language plpgsql;
 
+-- Prepare version dependent TopTransactionContext total memory usage query.
+-- Using prepared statements to avoid contaminating memory usage numbers.
+-- PG18 removed parent column so we have to use path to get TopTransactionContext child entries.
+-- https://github.com/postgres/postgres/commit/f0d11275
+create or replace function prepare_transaction_total_memory_usage_stmt() returns void
+language plpgsql as
+$$
+begin
+    if current_setting('server_version_num')::int < 180000 then
+        prepare total_stmt as select sum(total_bytes)
+        from pg_backend_memory_contexts
+		where parent = 'TopTransactionContext';
+    else
+        prepare total_stmt as select sum(m.total_bytes)
+        from pg_backend_memory_contexts m
+        inner join pg_backend_memory_contexts p
+            on (m.path[m.level-1] = p.path[p.level])
+        where p.name = 'TopTransactionContext';
+    end if;
+end;
+$$;
+
 -- Add a trigger that runs after completion of each INSERT/COPY and logs the
 -- current memory usage.
 create trigger check_update after insert on uk_price_paid
@@ -72,9 +94,11 @@ $$;
 
 -- TopTransactionContext usage needs to remain the same after every insert
 -- There was a leak earlier in the child CurTransactionContext
+
+SELECT prepare_transaction_total_memory_usage_stmt();
 BEGIN;
 INSERT INTO test_ht VALUES ('1980-01-01 00:00:00-00', to_double('23.11', 0));
-SELECT sum(total_bytes) from pg_backend_memory_contexts where parent = 'TopTransactionContext';
+EXECUTE total_stmt;
 INSERT INTO test_ht VALUES ('1980-02-01 00:00:00-00', to_double('24.11', 0));
-SELECT sum(total_bytes) from pg_backend_memory_contexts where parent = 'TopTransactionContext';
+EXECUTE total_stmt;
 COMMIT;


### PR DESCRIPTION
View pg_backend_memory_contexts removed column parent in PG18 so we need to account for the change in our memory test.

https://github.com/postgres/postgres/commit/f0d11275

Disable-check: force-changelog-file
Disable-check: approval-count