### PR TITLE
Adjust test for ANALYZE changes in PG18

### DIFF
--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -189,13 +189,11 @@ DROP TABLE approx_count;
 -- Regular table with basic inheritance
 --
 CREATE TABLE approx_count(id int);
-CREATE TABLE approx_count_child(id2 int) INHERITS (approx_count);
-INSERT INTO approx_count_child VALUES(0);
 INSERT INTO approx_count VALUES(1);
 SELECT count(*) FROM approx_count;
  count 
 -------
-     2
+     1
 (1 row)
 
 SELECT * FROM approximate_row_count('approx_count');
@@ -205,6 +203,20 @@ SELECT * FROM approximate_row_count('approx_count');
 (1 row)
 
 ANALYZE approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     1
+(1 row)
+
+CREATE TABLE approx_count_child(id2 int) INHERITS (approx_count);
+INSERT INTO approx_count_child VALUES(0);
+SELECT count(*) FROM approx_count;
+ count 
+-------
+     2
+(1 row)
+
 SELECT * FROM approximate_row_count('approx_count');
  approximate_row_count 
 -----------------------

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -62,12 +62,14 @@ DROP TABLE approx_count;
 -- Regular table with basic inheritance
 --
 CREATE TABLE approx_count(id int);
-CREATE TABLE approx_count_child(id2 int) INHERITS (approx_count);
-INSERT INTO approx_count_child VALUES(0);
 INSERT INTO approx_count VALUES(1);
 SELECT count(*) FROM approx_count;
 SELECT * FROM approximate_row_count('approx_count');
 ANALYZE approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+CREATE TABLE approx_count_child(id2 int) INHERITS (approx_count);
+INSERT INTO approx_count_child VALUES(0);
+SELECT count(*) FROM approx_count;
 SELECT * FROM approximate_row_count('approx_count');
 ANALYZE approx_count_child;
 SELECT * FROM approximate_row_count('approx_count');


### PR DESCRIPTION
With PG18, ANALYZE gets propagated to inheritance children relations where as before it only applied to declarative partitioning children. Adjusting the test so we run ANALYZE before attaching the child relation so its consistent across versions.

https://github.com/postgres/postgres/commit/62ddf7ee

Disable-check: force-changelog-file
Disable-check: approval-count