### PR TITLE
Serialize WAL-based invalidation processing

### DIFF
--- a/tsl/test/isolation/expected/cagg_concurrent_process_wal.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_process_wal.out
@@ -1,0 +1,27 @@
+Parsed test spec with 3 sessions
+
+starting permutation: lock_enable s1_refresh s2_refresh lock_show lock_release
+step lock_enable: SELECT debug_waitpoint_enable('multi_invalidation_process_invalidations');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_refresh: CALL _timescaledb_functions.process_hypertable_invalidations(ARRAY['temperature']); <waiting ...>
+step s2_refresh: CALL _timescaledb_functions.process_hypertable_invalidations(ARRAY['temperature']); <waiting ...>
+step lock_show: SELECT locktype, granted, application_name, objtyp, objid FROM my_locks WHERE locktype in ('object', 'advisory');
+locktype|granted|application_name|objtyp  |objid                                                                
+--------+-------+----------------+--------+---------------------------------------------------------------------
+advisory|f      |s1              |-       |1465306080                                                           
+object  |t      |s1              |pg_class|_timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+object  |f      |s2              |pg_class|_timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+(3 rows)
+
+step lock_release: SELECT debug_waitpoint_release('multi_invalidation_process_invalidations');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_refresh: <... completed>
+step s2_refresh: <... completed>

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -32,6 +32,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     APPEND
     TEST_FILES
     cagg_concurrent_move.spec
+    cagg_concurrent_process_wal.spec
     cagg_concurrent_invalidation.spec
     cagg_concurrent_refresh.spec
     compression_chunk_race.spec

--- a/tsl/test/isolation/specs/cagg_concurrent_process_wal.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_process_wal.spec
@@ -1,0 +1,94 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# Test concurrent hypertable invalidation processing when using
+# WAL-based hypertable invalidations.
+#
+# If two refresh procedures are executing at the same time, the second
+# one should wait for the first one to complete before dealing with
+# materializations.
+
+setup
+{
+  SET timezone TO PST8PDT;
+
+  CREATE TABLE temperature (
+    time timestamptz NOT NULL,
+    value float
+  );
+
+  CREATE VIEW my_locks AS
+  SELECT locktype, relation::regclass AS relname,
+         classid::regclass AS objtyp,
+         objid::regclass, 
+         mode, granted, application_name
+    FROM pg_locks JOIN pg_stat_activity USING (pid)
+   WHERE database = (SELECT oid FROM pg_database WHERE current_database() = datname)
+     AND pid != pg_backend_pid()
+   ORDER BY locktype, application_name, objtyp, objid;
+
+  SELECT create_hypertable('temperature', 'time');
+
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
+                          '2020-01-01 23:59:59+0','1m') time;
+}
+
+# All the below need to be in separate transactions.
+setup {
+  CREATE MATERIALIZED VIEW cagg_1
+    WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal') AS
+    SELECT time_bucket('4 hour', time), avg(value)
+      FROM temperature
+      GROUP BY 1 ORDER BY 1
+    WITH NO DATA;
+}
+
+setup {
+  CREATE MATERIALIZED VIEW cagg_2
+    WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal') AS
+    SELECT time_bucket('4 hour', time), avg(value)
+      FROM temperature
+      GROUP BY 1 ORDER BY 1
+    WITH NO DATA;
+}
+
+setup {
+    CALL refresh_continuous_aggregate('cagg_1', '2020-01-01'::timestamptz, '2025-01-01');
+}
+setup {
+    CALL refresh_continuous_aggregate('cagg_2', '2020-01-01'::timestamptz, '2025-01-01');
+}
+
+# Create some invalidations
+setup
+{
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2023-01-01'::timestamptz, '2023-01-02', '1m') time;
+}
+
+teardown {
+    DROP VIEW my_locks;
+    DROP MATERIALIZED VIEW cagg_2;
+    DROP MATERIALIZED VIEW cagg_1;
+    DROP TABLE temperature CASCADE;
+}
+
+session "s1"
+setup { set application_name = 's1'; }
+step s1_refresh {CALL _timescaledb_functions.process_hypertable_invalidations(ARRAY['temperature']);}
+
+session "s2"
+setup { set application_name = 's2'; }
+step s2_refresh {CALL _timescaledb_functions.process_hypertable_invalidations(ARRAY['temperature']);}
+
+session "locking"
+step lock_enable {SELECT debug_waitpoint_enable('multi_invalidation_process_invalidations');}
+step lock_show {SELECT locktype, granted, application_name, objtyp, objid FROM my_locks WHERE locktype in ('object', 'advisory');}
+step lock_release {SELECT debug_waitpoint_release('multi_invalidation_process_invalidations');}
+
+permutation lock_enable s1_refresh s2_refresh lock_show lock_release
+


### PR DESCRIPTION
If two sessions using WAL-based invalidation processing starts processing the WAL at the same time, the second one will get an error rather than waiting.

This is solved by adding a database object lock on the materialization table. This will not conflict with relation locks on the same table, but will allow concurrent refresh to serialize on the invalidation processing.

Disable-check: force-changelog-file