### PR TITLE
Ignore the merge_append_partially_compressed test with sanitizer

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -48,7 +48,12 @@ env:
     print_stacktrace=1 halt_on_error=1 log_path=${{ github.workspace }}/sanitizer_logs/sanitizer
     log_exe_name=true print_suppressions=false exitcode=27
 
-  IGNORES: "bgw_db_scheduler bgw_db_scheduler_fixed net telemetry"
+  IGNORES: >-
+    bgw_db_scheduler
+    bgw_db_scheduler_fixed
+    merge_append_partially_compressed
+    net
+    telemetry
 
   EXTENSIONS: "postgres_fdw test_decoding"
 jobs:


### PR DESCRIPTION
It has different plan on PG < 17 due to a cost estimation bug there. We're already ignoring it for old versions in our standard build matrix.