### PR TITLE
Do not require job to have executed to show status

### DIFF
--- a/.unreleased/pr_8567
+++ b/.unreleased/pr_8567
@@ -1,0 +1,2 @@
+Fixes: #8567 Do not require job to have executed to show status
+Thanks: @moodgorning for reporting issue with timescaledb_information.job_stats view

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -95,6 +95,8 @@ DROP VIEW IF EXISTS timescaledb_information.chunk_columnstore_settings;
 DROP VIEW IF EXISTS timescaledb_information.hypertable_compression_settings;
 DROP VIEW IF EXISTS timescaledb_information.chunk_compression_settings;
 DROP VIEW IF EXISTS timescaledb_information.compression_settings;
+DROP VIEW IF EXISTS timescaledb_information.job_stats;
+
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.compression_settings;
 DROP TABLE _timescaledb_catalog.compression_settings;
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -116,6 +116,8 @@ DROP VIEW timescaledb_information.chunk_columnstore_settings;
 DROP VIEW timescaledb_information.hypertable_compression_settings;
 DROP VIEW timescaledb_information.chunk_compression_settings;
 DROP VIEW timescaledb_information.compression_settings;
+DROP VIEW IF EXISTS timescaledb_information.job_stats;
+
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.compression_settings;
 DROP TABLE _timescaledb_catalog.compression_settings;
 

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -43,6 +43,12 @@ WHERE ht.compression_state != 2 --> no internal compression tables
   AND ht.interval_length IS NOT NULL
   AND ht.dimension_num = 1;
 
+-- Get status of existing jobs.
+--
+-- Note that we will always list all jobs that are available in the
+-- database, but some fields might be null if, for example, the job
+-- has not yet executed, or there is no hypertable associated with the
+-- job.
 CREATE OR REPLACE VIEW timescaledb_information.job_stats AS
 SELECT ht.schema_name AS hypertable_schema,
   ht.table_name AS hypertable_name,
@@ -75,7 +81,7 @@ SELECT ht.schema_name AS hypertable_schema,
   js.total_successes,
   js.total_failures
 FROM _timescaledb_config.bgw_job j
-  INNER JOIN _timescaledb_internal.bgw_job_stat js ON j.id = js.job_id
+  LEFT JOIN _timescaledb_internal.bgw_job_stat js ON j.id = js.job_id
   LEFT JOIN _timescaledb_catalog.hypertable ht ON j.hypertable_id = ht.id
   LEFT JOIN pg_stat_activity pgs ON pgs.datname = current_database()
     AND pgs.application_name = j.application_name

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -164,7 +164,8 @@ SELECT * FROM _timescaledb_internal.bgw_job_stat;
 SELECT * FROM timescaledb_information.job_stats;
  hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_start | total_runs | total_successes | total_failures 
 -------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+------------+------------+-----------------+----------------
-(0 rows)
+                   |                 |   1000 |                     |                        |                 | Paused     |                   |            |            |                 |               
+(1 row)
 
 SELECT test_toggle_scheduled(1000);
  test_toggle_scheduled 

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -171,7 +171,8 @@ SELECT * FROM _timescaledb_internal.bgw_job_stat;
 SELECT * FROM timescaledb_information.job_stats;
  hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_start | total_runs | total_successes | total_failures 
 -------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+------------+------------+-----------------+----------------
-(0 rows)
+                   |                 |   1000 |                     |                        |                 | Paused     |                   |            |            |                 |               
+(1 row)
 
 SELECT test_toggle_scheduled(1000);
  test_toggle_scheduled 


### PR DESCRIPTION
The `timescaledb_information.job_stats` view show status information for each job, but if the job has not executed, it will not show that job in the view, which can be confusing.

Instead, show all jobs in the `timescaledb_information.job_stats` view, but use NULL for attributes that do not have any value, e.g., `next_start`. This is consistent with how other information is shown, e.g., if the job has no associated hypertable, the `hypertable` field is NULL.

It is also similar to how `pg_stat_all_tables` work, which show all  tables but use NULL for fields that are undefined.