### PR TITLE
Bump to next release version

### DIFF
--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
-version = 2.22.0
-previous_version = 2.21.3
+version = 2.22.1
+previous_version = 2.22.0


### PR DESCRIPTION
After the 2.22 tag, we need to bump the release version on the release branch