### PR TITLE
Adjust packaging test names

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -1,5 +1,5 @@
 # Test installing our ubuntu and debian ARM64 packages for the latest version.
-name: APT ARM64 packages
+name: "Packaging tests: APT ARM64"
 "on":
   schedule:
     # run daily 0:00 on main branch

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -1,5 +1,5 @@
 # Test installing our ubuntu and debian packages for the latest version.
-name: APT packages
+name: "Packaging tests: APT"
 "on":
   schedule:
     # run daily 0:00 on main branch

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -2,7 +2,7 @@
 # The main purpose of this test is to check the image is working
 # and the latest tag points to an image with the most recent
 # release.
-name: Test Docker images
+name: "Packaging tests: Docker images"
 "on":
   schedule:
     # run daily 0:00 on main branch

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -1,5 +1,5 @@
 # Test installation of our homebrew tap for latest version
-name: Homebrew
+name: "Packaging tests: Homebrew"
 "on":
   schedule:
     # run daily 20:00 on main branch

--- a/.github/workflows/release_build_packages.yml
+++ b/.github/workflows/release_build_packages.yml
@@ -1,4 +1,4 @@
-name: "Build distribution packages"
+name: "Packaging: Build distributions"
 
 "on":
   release:

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -1,5 +1,5 @@
 # Test rpm package installation for latest version
-name: RPM packages
+name: "Packaging tests: RPM"
 "on":
   schedule:
     # run daily 0:00 on main branch

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -1,5 +1,5 @@
 # Test installation of windows package for latest version
-name: Windows Packages
+name: "Packaging tests: Windows"
 "on":
   schedule:
     # run daily 0:00 on main branch


### PR DESCRIPTION
prefixes the packaging workflows with same prefix to have them co-located as it's quite cumbersome to jump up and down between the tests, plus easy to miss one.

Disable-check: approval-count
Disable-check: force-changelog-file