### PR TITLE
Allow mixing timescaledb options with postgres options in ALTER TABLE SET

### DIFF
--- a/.unreleased/pr_8581
+++ b/.unreleased/pr_8581
@@ -1,0 +1,1 @@
+Implements: #8581 Allow mixing postgres and timescaledb options in ALTER TABLE SET

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -2788,3 +2788,44 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('alias') ch;
      1
 (1 row)
 
+-- test mixing postgres and timescaledb options
+CREATE TABLE mix_pg_ts(time timestamptz, device text) WITH (tsdb.hypertable,tsdb.partition_column='time',fillfactor=90);
+SELECT reloptions FROM pg_class WHERE relname='mix_pg_ts';
+   reloptions    
+-----------------
+ {fillfactor=90}
+(1 row)
+
+SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hypertable='mix_pg_ts'::regclass;
+ hypertable | segmentby | orderby | compress_interval_length | index 
+------------+-----------+---------+--------------------------+-------
+ mix_pg_ts  |           |         |                          | 
+(1 row)
+
+ALTER TABLE mix_pg_ts SET (timescaledb.compress, fillfactor=70, tsdb.orderby='time', timescaledb.compress_segmentby='device', autovacuum_enabled=true);
+SELECT reloptions FROM pg_class WHERE relname='mix_pg_ts';
+               reloptions                
+-----------------------------------------
+ {fillfactor=70,autovacuum_enabled=true}
+(1 row)
+
+SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hypertable='mix_pg_ts'::regclass;
+ hypertable | segmentby | orderby | compress_interval_length |                            index                            
+------------+-----------+---------+--------------------------+-------------------------------------------------------------
+ mix_pg_ts  | device    | "time"  |                          | [{"type": "minmax", "column": "time", "source": "orderby"}]
+(1 row)
+
+-- test resetting options
+ALTER TABLE mix_pg_ts RESET (fillfactor, tsdb.segmentby);
+SELECT reloptions FROM pg_class WHERE relname='mix_pg_ts';
+        reloptions         
+---------------------------
+ {autovacuum_enabled=true}
+(1 row)
+
+SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hypertable='mix_pg_ts'::regclass;
+ hypertable | segmentby | orderby | compress_interval_length |                            index                            
+------------+-----------+---------+--------------------------+-------------------------------------------------------------
+ mix_pg_ts  |           | "time"  |                          | [{"type": "minmax", "column": "time", "source": "orderby"}]
+(1 row)
+

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -1224,6 +1224,16 @@ ALTER TABLE alias SET (tsdb.compress, tsdb.compress_orderby='time DESC',tsdb.com
 INSERT INTO alias SELECT '2025-01-01';
 SELECT count(compress_chunk(ch)) FROM show_chunks('alias') ch;
 
+-- test mixing postgres and timescaledb options
+CREATE TABLE mix_pg_ts(time timestamptz, device text) WITH (tsdb.hypertable,tsdb.partition_column='time',fillfactor=90);
+SELECT reloptions FROM pg_class WHERE relname='mix_pg_ts';
+SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hypertable='mix_pg_ts'::regclass;
+ALTER TABLE mix_pg_ts SET (timescaledb.compress, fillfactor=70, tsdb.orderby='time', timescaledb.compress_segmentby='device', autovacuum_enabled=true);
+SELECT reloptions FROM pg_class WHERE relname='mix_pg_ts';
+SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hypertable='mix_pg_ts'::regclass;
 
-
+-- test resetting options
+ALTER TABLE mix_pg_ts RESET (fillfactor, tsdb.segmentby);
+SELECT reloptions FROM pg_class WHERE relname='mix_pg_ts';
+SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hypertable='mix_pg_ts'::regclass;
 


### PR DESCRIPTION
This patch allows setting postgres options and timescaledb options
in one command instead of having to them separately. Previously
trying to do them in the same command resulted in an error.

The following now works:
ALTER TABLE metrics SET (tsdb.segmentby='device',autovacuum_enabled=true);
