### PR TITLE
Update iterating over ems for PG18

### DIFF
--- a/src/import/planner.h
+++ b/src/import/planner.h
@@ -51,3 +51,14 @@ extern TSDLLEXPORT PathKey *ts_make_pathkey_from_sortop(PlannerInfo *root, Expr 
 extern TSDLLEXPORT List *ts_build_path_tlist(PlannerInfo *root, Path *path);
 
 extern void ts_ExecSetTupleBound(int64 tuples_needed, PlanState *child_node);
+
+#if PG18_GE
+/* In PG18, child ems are not added to ec_members
+ * but need to be maintained in separate Lists.
+ *
+ * https://github.com/postgres/postgres/commit/d69d45a5
+ */
+/* copied from add_child_eq_member */
+extern TSDLLEXPORT void ts_add_child_eq_member(PlannerInfo *root, EquivalenceClass *ec,
+											   EquivalenceMember *em, int child_relid);
+#endif

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -251,16 +251,29 @@ ts_sort_transform_expr(Expr *orig_expr)
  */
 
 static EquivalenceClass *
-sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
+sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig, Relids child_relids)
 {
-	ListCell *lc_member;
 	EquivalenceClass *newec = NULL;
 	bool propagate_to_children = false;
 
 	/* check all members, adding only transformable members to new ec */
+	EquivalenceMember *ec_mem;
+#if PG18_GE
+	/* Use specialized iterator to include child ems.
+	 *
+	 * https://github.com/postgres/postgres/commit/d69d45a5
+	 */
+	EquivalenceMemberIterator it;
+
+	setup_eclass_member_iterator(&it, orig, child_relids);
+	while ((ec_mem = eclass_member_iterator_next(&it)) != NULL)
+	{
+#else
+	ListCell *lc_member;
 	foreach (lc_member, orig->ec_members)
 	{
-		EquivalenceMember *ec_mem = (EquivalenceMember *) lfirst(lc_member);
+		ec_mem = (EquivalenceMember *) lfirst(lc_member);
+#endif
 		Expr *transformed_expr = ts_sort_transform_expr(ec_mem->em_expr);
 
 		if (transformed_expr != ec_mem->em_expr)
@@ -317,6 +330,10 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
 				newec->ec_opfamilies = opfamilies;
 				newec->ec_collation = orig->ec_collation;
 				newec->ec_members = NIL;
+#if PG18_GE
+				newec->ec_childmembers = NULL;
+				newec->ec_childmembers_size = 0;
+#endif
 				newec->ec_sources = list_copy(orig->ec_sources);
 				newec->ec_derives_list = list_copy(orig->ec_derives_list);
 				newec->ec_relids = bms_copy(orig->ec_relids);
@@ -347,7 +364,27 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
 				 */
 				orig->ec_has_volatile = false;
 			}
+#if PG18_LT
 			newec->ec_members = lappend(newec->ec_members, em);
+#else
+			/* Update the child member lists when adding child ems.
+			 *
+			 * https://github.com/postgres/postgres/commit/d69d45a5
+			 */
+			if (em->em_is_child)
+				ts_add_child_eq_member(root, newec, em, it.current_relid);
+			else
+				newec->ec_members = lappend(newec->ec_members, em);
+
+			int i = -1;
+			for (; i >= 0; i = bms_next_member(em->em_relids, i))
+			{
+				RelOptInfo *child_rel = root->simple_rel_array[i];
+
+				child_rel->eclass_indexes =
+					bms_add_member(child_rel->eclass_indexes, root->eq_classes->length);
+			}
+#endif
 		}
 	}
 	/* if any transforms were found return new ec */
@@ -438,15 +475,34 @@ ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry
 		desired_ec_relid = appinfo->parent_relid;
 	}
 
-	if (!bms_is_member(desired_ec_relid, last_pk->pk_eclass->ec_relids))
+	EquivalenceClass *last_pk_eclass = last_pk->pk_eclass;
+
+	if (!bms_is_member(desired_ec_relid, last_pk_eclass->ec_relids))
 	{
 		return NIL;
 	}
 
+	Relids child_relids = NULL;
+#if PG18_GE
+	/* In PG18, iterating over child ems requires you to
+	 * use child relids with a special iterator. Here we gather
+	 * them by collecting them from childmembers array.
+	 *
+	 * https://github.com/postgres/postgres/commit/d69d45a5
+	 */
+	for (int i = 0; i < last_pk_eclass->ec_childmembers_size; i++)
+	{
+		if (list_length(last_pk_eclass->ec_childmembers[i]) > 0)
+		{
+			child_relids = bms_add_member(child_relids, i);
+		}
+	}
+#endif
+
 	/*
 	 * Try to apply the transformation.
 	 */
-	transformed = sort_transform_ec(root, last_pk->pk_eclass);
+	transformed = sort_transform_ec(root, last_pk_eclass, child_relids);
 
 	if (transformed == NULL)
 		return NIL;

--- a/src/sort_transform.h
+++ b/src/sort_transform.h
@@ -8,6 +8,7 @@
 #include <postgres.h>
 
 #include "hypertable.h"
+#include "import/planner.h"
 
 extern Expr *ts_sort_transform_expr(Expr *expr);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,6 +16,7 @@
 #include <foreign/foreign.h>
 #include <nodes/extensible.h>
 #include <nodes/pathnodes.h>
+#include <optimizer/paths.h>
 #include <utils/builtins.h>
 #include <utils/datetime.h>
 #include <utils/jsonb.h>


### PR DESCRIPTION
PG18 introduced an optimization for more efficient iterating over ec_members which no longer include child EMs. In order to include iterating over child members, specialized iterator was created which needs to be used along with child relids.

https://github.com/postgres/postgres/commit/d69d45a5

Disable-check: force-changelog-file
Disable-check: approval-count