### PR TITLE
Run merge_append_partially_compressed only for PG17GE as MergeAppend was broken in PG16LE

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -59,7 +59,6 @@ set(TEST_FILES
     custom_hashagg.sql
     decompress_index.sql
     foreign_keys_test.sql
-    merge_append_partially_compressed.sql
     merge_chunks.sql
     merge_compress.sql
     modify_exclusion.sql
@@ -187,7 +186,8 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))
-  list(APPEND TEST_FILES privilege_maintain.sql)
+  list(APPEND TEST_FILES privilege_maintain.sql
+       merge_append_partially_compressed.sql)
 endif()
 
 set(SOLO_TESTS


### PR DESCRIPTION
MergeAppend cost model was broken in PG16LE and [was fixed in PG17GE](https://github.com/postgres/postgres/commit/9d1a5354f58cf61d9be6733d5ad0b36936af5af3), making `merge_append_partially_compressed` test unreliable for PG16LE.

Moving it to PG17GE tests only as it keeps popping up in some workflows even after being ignored in most workflows.