### PR TITLE
Remove unused ChunkDispatch field from CopyChunkState

### DIFF
--- a/src/copy.h
+++ b/src/copy.h
@@ -15,7 +15,6 @@
 
 #include "chunk_tuple_routing.h"
 
-typedef struct ChunkDispatch ChunkDispatch;
 typedef struct CopyChunkState CopyChunkState;
 typedef struct Hypertable Hypertable;
 
@@ -26,7 +25,6 @@ typedef struct CopyChunkState
 {
 	Relation rel;
 	EState *estate;
-	ChunkDispatch *dispatch;
 	ChunkTupleRouting *ctr;
 	CopyFromFunc next_copy_from;
 	CopyFromState cstate;

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -13,7 +13,6 @@
 #include "chunk.h"
 #include "cross_module_fn.h"
 
-typedef struct TSCopyMultiInsertBuffer TSCopyMultiInsertBuffer;
 typedef struct ChunkDispatchState ChunkDispatchState;
 typedef struct CompressionSettings CompressionSettings;
 typedef struct tuple_filtering_constraints tuple_filtering_constraints;


### PR DESCRIPTION
This was forgotten in an earlier refactoring

Disable-check: force-changelog-file