### PR TITLE
Error on change of invalidation method for continuous aggregate

### DIFF
--- a/.unreleased/pr_8593
+++ b/.unreleased/pr_8593
@@ -1,0 +1,1 @@
+Fixes: #8593 Error on change of invalidation method for continuous aggregate

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -179,6 +179,7 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		cagg_update_materialized_only(agg, materialized_only);
 		ts_cache_release(&hcache);
 	}
+
 	if (!with_clause_options[CreateMaterializedViewFlagChunkTimeInterval].is_default)
 	{
 		Cache *hcache = ts_hypertable_cache_pin();
@@ -192,6 +193,21 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		ts_dimension_set_chunk_interval(dim, interval);
 		ts_cache_release(&hcache);
 	}
+
+	/*
+	 * We do not support changing the invalidation method on a continuous
+	 * aggregate. We will add support for this using a dedicated function
+	 * since it needs to be changed for the hypertable.
+	 */
+	if (!with_clause_options[CreateMaterializedViewFlagInvalidateUsing].is_default)
+	{
+		ereport(ERROR,
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("cannot change invalidation method for continuous aggregate"),
+				errdetail("All continuous aggregates for a hypertable need to use the same "
+						  "invalidation collection method."));
+	}
+
 	List *compression_options = ts_continuous_agg_get_compression_defelems(with_clause_options);
 
 	if (list_length(compression_options) > 0)
@@ -204,12 +220,14 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		cagg_alter_compression(agg, mat_ht, compression_options);
 		ts_cache_release(&hcache);
 	}
+
 	if (!with_clause_options[CreateMaterializedViewFlagCreateGroupIndexes].is_default)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot alter create_group_indexes option for continuous aggregates")));
 	}
+
 	if (!with_clause_options[CreateMaterializedViewFlagFinalized].is_default)
 	{
 		ereport(ERROR,

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -614,6 +614,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 
 CREATE TABLE magic1(time timestamptz not null, device int, value float);
 CREATE TABLE magic2(time timestamptz not null, device int, value float);
+CREATE TABLE magic3(time timestamptz not null, device int, value float);
 SELECT table_name FROM create_hypertable('magic1','time');
  table_name 
 ------------
@@ -626,11 +627,21 @@ SELECT table_name FROM create_hypertable('magic2','time');
  magic2
 (1 row)
 
+SELECT table_name FROM create_hypertable('magic3','time');
+ table_name 
+------------
+ magic3
+(1 row)
+
 INSERT INTO magic1
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
 INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic3
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
@@ -657,7 +668,7 @@ select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
 select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
  setval 
 --------
-     18
+     19
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -744,6 +755,12 @@ CREATE MATERIALIZED VIEW magic_summary1_magic
          FROM magic1
      GROUP BY 1,2;
 ERROR:  unrecognized value "magic" for invalidate_using
+-- This should error out since we cannot add the trigger to the
+-- hypertable when there are multiple caggs connected. Changing
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic1_summary2_wal
+      SET (timescaledb.invalidate_using = 'trigger');
+ERROR:  cannot change invalidation method for continuous aggregate
 \set ON_ERROR_STOP 1
 -- Check that it was actually written to the catalog
 SELECT hypertable_name, view_name, invalidate_using
@@ -765,7 +782,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic2_summary1_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_40_chunk
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -777,7 +794,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -789,7 +806,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -807,3 +824,33 @@ SELECT hypertable_name, view_name, invalidate_using
 -----------------+-----------+------------------
 (0 rows)
 
+-- Check that trigger-based invalidation works as well, and give
+-- proper errors when trying to modify them.
+CREATE MATERIALIZED VIEW magic3_day_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic3_day_summary_trigger"
+CREATE MATERIALIZED VIEW magic3_week_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic3_week_summary_trigger"
+\set ON_ERROR_STOP 0
+-- This should error out since we already are using trigger-based
+-- collection.
+CREATE MATERIALIZED VIEW magic3_week_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
+-- This should error out since we cannot remove the trigger from the
+-- hypertable when there are multiple caggs connected. Switching
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic3_day_summary_trigger
+      SET (timescaledb.invalidate_using = 'wal');
+ERROR:  cannot change invalidation method for continuous aggregate
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -614,6 +614,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 
 CREATE TABLE magic1(time timestamptz not null, device int, value float);
 CREATE TABLE magic2(time timestamptz not null, device int, value float);
+CREATE TABLE magic3(time timestamptz not null, device int, value float);
 SELECT table_name FROM create_hypertable('magic1','time');
  table_name 
 ------------
@@ -626,11 +627,21 @@ SELECT table_name FROM create_hypertable('magic2','time');
  magic2
 (1 row)
 
+SELECT table_name FROM create_hypertable('magic3','time');
+ table_name 
+------------
+ magic3
+(1 row)
+
 INSERT INTO magic1
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
 INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic3
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
@@ -657,7 +668,7 @@ select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
 select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
  setval 
 --------
-     18
+     19
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -744,6 +755,12 @@ CREATE MATERIALIZED VIEW magic_summary1_magic
          FROM magic1
      GROUP BY 1,2;
 ERROR:  unrecognized value "magic" for invalidate_using
+-- This should error out since we cannot add the trigger to the
+-- hypertable when there are multiple caggs connected. Changing
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic1_summary2_wal
+      SET (timescaledb.invalidate_using = 'trigger');
+ERROR:  cannot change invalidation method for continuous aggregate
 \set ON_ERROR_STOP 1
 -- Check that it was actually written to the catalog
 SELECT hypertable_name, view_name, invalidate_using
@@ -765,7 +782,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic2_summary1_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_40_chunk
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -777,7 +794,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -789,7 +806,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -807,3 +824,33 @@ SELECT hypertable_name, view_name, invalidate_using
 -----------------+-----------+------------------
 (0 rows)
 
+-- Check that trigger-based invalidation works as well, and give
+-- proper errors when trying to modify them.
+CREATE MATERIALIZED VIEW magic3_day_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic3_day_summary_trigger"
+CREATE MATERIALIZED VIEW magic3_week_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic3_week_summary_trigger"
+\set ON_ERROR_STOP 0
+-- This should error out since we already are using trigger-based
+-- collection.
+CREATE MATERIALIZED VIEW magic3_week_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
+-- This should error out since we cannot remove the trigger from the
+-- hypertable when there are multiple caggs connected. Switching
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic3_day_summary_trigger
+      SET (timescaledb.invalidate_using = 'wal');
+ERROR:  cannot change invalidation method for continuous aggregate
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -614,6 +614,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 
 CREATE TABLE magic1(time timestamptz not null, device int, value float);
 CREATE TABLE magic2(time timestamptz not null, device int, value float);
+CREATE TABLE magic3(time timestamptz not null, device int, value float);
 SELECT table_name FROM create_hypertable('magic1','time');
  table_name 
 ------------
@@ -626,11 +627,21 @@ SELECT table_name FROM create_hypertable('magic2','time');
  magic2
 (1 row)
 
+SELECT table_name FROM create_hypertable('magic3','time');
+ table_name 
+------------
+ magic3
+(1 row)
+
 INSERT INTO magic1
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
 INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic3
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
@@ -657,7 +668,7 @@ select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
 select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
  setval 
 --------
-     18
+     19
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -744,6 +755,12 @@ CREATE MATERIALIZED VIEW magic_summary1_magic
          FROM magic1
      GROUP BY 1,2;
 ERROR:  unrecognized value "magic" for invalidate_using
+-- This should error out since we cannot add the trigger to the
+-- hypertable when there are multiple caggs connected. Changing
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic1_summary2_wal
+      SET (timescaledb.invalidate_using = 'trigger');
+ERROR:  cannot change invalidation method for continuous aggregate
 \set ON_ERROR_STOP 1
 -- Check that it was actually written to the catalog
 SELECT hypertable_name, view_name, invalidate_using
@@ -765,7 +782,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic2_summary1_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_36_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_40_chunk
 -- Slot should be there. We have another hypertable using WAL-based
 -- invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -777,7 +794,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_34_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
 -- Slot should be there. We have yet another continuous aggregate for
 -- the hypertable using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -789,7 +806,7 @@ SELECT count(*) FROM pg_replication_slots
 (1 row)
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_35_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
 -- Now slot should be gone and we should not have any continuous
 -- aggregates using WAL-based invalidation collection.
 SELECT count(*) FROM pg_replication_slots
@@ -807,3 +824,33 @@ SELECT hypertable_name, view_name, invalidate_using
 -----------------+-----------+------------------
 (0 rows)
 
+-- Check that trigger-based invalidation works as well, and give
+-- proper errors when trying to modify them.
+CREATE MATERIALIZED VIEW magic3_day_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic3_day_summary_trigger"
+CREATE MATERIALIZED VIEW magic3_week_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic3_week_summary_trigger"
+\set ON_ERROR_STOP 0
+-- This should error out since we already are using trigger-based
+-- collection.
+CREATE MATERIALIZED VIEW magic3_week_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
+-- This should error out since we cannot remove the trigger from the
+-- hypertable when there are multiple caggs connected. Switching
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic3_day_summary_trigger
+      SET (timescaledb.invalidate_using = 'wal');
+ERROR:  cannot change invalidation method for continuous aggregate
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -389,9 +389,11 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 
 CREATE TABLE magic1(time timestamptz not null, device int, value float);
 CREATE TABLE magic2(time timestamptz not null, device int, value float);
+CREATE TABLE magic3(time timestamptz not null, device int, value float);
 
 SELECT table_name FROM create_hypertable('magic1','time');
 SELECT table_name FROM create_hypertable('magic2','time');
+SELECT table_name FROM create_hypertable('magic3','time');
 
 INSERT INTO magic1
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
@@ -399,6 +401,11 @@ SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12
        100 * random();
 
 INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+
+INSERT INTO magic3
 SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
        (100 * random())::int,
        100 * random();
@@ -487,6 +494,11 @@ CREATE MATERIALIZED VIEW magic_summary1_magic
          FROM magic1
      GROUP BY 1,2;
 
+-- This should error out since we cannot add the trigger to the
+-- hypertable when there are multiple caggs connected. Changing
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic1_summary2_wal
+      SET (timescaledb.invalidate_using = 'trigger');
 \set ON_ERROR_STOP 1
 
 -- Check that it was actually written to the catalog
@@ -525,3 +537,35 @@ SELECT count(*) FROM pg_replication_slots
 SELECT hypertable_name, view_name, invalidate_using
   FROM timescaledb_information.continuous_aggregates
  WHERE view_name like 'magic_\_summary%';
+
+-- Check that trigger-based invalidation works as well, and give
+-- proper errors when trying to modify them.
+CREATE MATERIALIZED VIEW magic3_day_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+
+CREATE MATERIALIZED VIEW magic3_week_summary_trigger
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+
+\set ON_ERROR_STOP 0
+
+-- This should error out since we already are using trigger-based
+-- collection.
+CREATE MATERIALIZED VIEW magic3_week_summary_wal
+  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+    AS SELECT time_bucket('1 week', time), device, avg(value)
+         FROM magic3
+     GROUP BY 1,2;
+
+-- This should error out since we cannot remove the trigger from the
+-- hypertable when there are multiple caggs connected. Switching
+-- invalidation collection method is more complicated than this.
+ALTER MATERIALIZED VIEW magic3_day_summary_trigger
+      SET (timescaledb.invalidate_using = 'wal');
+
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Using `ALTER MATERIALIZED VIEW` to change the invalidation method for a continuous aggregate does not work since it is necessary to remove or add the trigger on the hypertable and add or remove a slot as well as syncing the hypertable invalidations.