### PR TITLE
Fix attnum mismatch bug in chunk constraint checks

### DIFF
--- a/.unreleased/pr_8599
+++ b/.unreleased/pr_8599
@@ -1,0 +1,1 @@
+Fixes: #8599 Fix attnum mismatch bug in chunk constraint checks

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -1290,6 +1290,8 @@ check_chunk_constraint_violated(Oid chunk_relid, const Dimension *dim, const Dim
 	TupleTableSlot *slot;
 	TableScanDesc scandesc;
 	bool isnull;
+	int attno = get_attnum(chunk_relid, NameStr(dim->fd.column_name));
+	Ensure(attno != InvalidAttrNumber, "invalid attribute number");
 
 	PushActiveSnapshot(GetLatestSnapshot());
 	rel = table_open(chunk_relid, AccessShareLock);
@@ -1301,11 +1303,15 @@ check_chunk_constraint_violated(Oid chunk_relid, const Dimension *dim, const Dim
 		Datum datum;
 		int64 value;
 
-		if (NULL != dim->partitioning)
-			datum = ts_partitioning_func_apply_slot(dim->partitioning, slot, &isnull);
-		else
-			datum = slot_getattr(slot, dim->column_attno, &isnull);
+		datum = slot_getattr(slot, attno, &isnull);
 		Assert(!isnull);
+
+		if (NULL != dim->partitioning)
+		{
+			Oid collation = TupleDescAttr(slot->tts_tupleDescriptor, AttrNumberGetAttrOffset(attno))
+								->attcollation;
+			datum = ts_partitioning_func_apply(dim->partitioning, collation, datum);
+		}
 
 		if (dim->type == DIMENSION_TYPE_OPEN)
 			value = ts_time_value_to_internal(datum, ts_dimension_get_partition_type(dim));

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -319,3 +319,38 @@ SELECT * FROM _timescaledb_internal._hyper_2_12_chunk
 (1 row)
 
 DROP TABLE chunkapi;
+-- Test the fix for Bug #8577
+-- Mismatch in attnum between chunk and hypertable should not fail
+CREATE TABLE chunkapi(col_to_drop int, time timestamptz not null, device int);
+SELECT create_hypertable('chunkapi', 'time', 'device', 2);
+   create_hypertable   
+-----------------------
+ (3,public,chunkapi,t)
+(1 row)
+
+ALTER TABLE chunkapi DROP COLUMN col_to_drop;
+CREATE TABLE new_chunk(time timestamptz not null, device int);
+INSERT INTO new_chunk VALUES ('2018-01-01 05:00:00-8', 1);
+SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1514419200000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'new_chunk');
+ chunk_id | hypertable_id |      schema_name      |    table_name     | relkind |                                            slices                                            | created 
+----------+---------------+-----------------------+-------------------+---------+----------------------------------------------------------------------------------------------+---------
+       13 |             3 | _timescaledb_internal | _hyper_3_13_chunk | r       | {"time": [1514419200000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]} | t
+(1 row)
+
+CREATE TABLE reordered_chunk(device int, time timestamptz not null);
+INSERT INTO reordered_chunk VALUES (1, '2018-01-08 05:00:00-8');
+SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1515024000000000, 1515628800000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'reordered_chunk');
+ chunk_id | hypertable_id |      schema_name      |    table_name     | relkind |                                            slices                                            | created 
+----------+---------------+-----------------------+-------------------+---------+----------------------------------------------------------------------------------------------+---------
+       14 |             3 | _timescaledb_internal | _hyper_3_14_chunk | r       | {"time": [1515024000000000, 1515628800000000], "device": [-9223372036854775808, 1073741823]} | t
+(1 row)
+
+CREATE TABLE new_col_chunk(time timestamptz not null, temp float, device int);
+INSERT INTO new_col_chunk VALUES ('2018-01-15 05:00:00-8', 23.4, 1);
+ALTER TABLE chunkapi ADD COLUMN temp float;
+SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1515628800000000, 1516233600000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'new_col_chunk');
+ chunk_id | hypertable_id |      schema_name      |    table_name     | relkind |                                            slices                                            | created 
+----------+---------------+-----------------------+-------------------+---------+----------------------------------------------------------------------------------------------+---------
+       15 |             3 | _timescaledb_internal | _hyper_3_15_chunk | r       | {"time": [1515628800000000, 1516233600000000], "device": [-9223372036854775808, 1073741823]} | t
+(1 row)
+

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -214,3 +214,22 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'chunkapi'; \gexec
 
 DROP TABLE chunkapi;
+
+-- Test the fix for Bug #8577
+-- Mismatch in attnum between chunk and hypertable should not fail
+CREATE TABLE chunkapi(col_to_drop int, time timestamptz not null, device int);
+SELECT create_hypertable('chunkapi', 'time', 'device', 2);
+ALTER TABLE chunkapi DROP COLUMN col_to_drop;
+
+CREATE TABLE new_chunk(time timestamptz not null, device int);
+INSERT INTO new_chunk VALUES ('2018-01-01 05:00:00-8', 1);
+SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1514419200000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'new_chunk');
+
+CREATE TABLE reordered_chunk(device int, time timestamptz not null);
+INSERT INTO reordered_chunk VALUES (1, '2018-01-08 05:00:00-8');
+SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1515024000000000, 1515628800000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'reordered_chunk');
+
+CREATE TABLE new_col_chunk(time timestamptz not null, temp float, device int);
+INSERT INTO new_col_chunk VALUES ('2018-01-15 05:00:00-8', 23.4, 1);
+ALTER TABLE chunkapi ADD COLUMN temp float;
+SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1515628800000000, 1516233600000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'new_col_chunk');


### PR DESCRIPTION
Operations that creates a new chunk from an existing table (create_chunk() and attach_chunk()) may encounter mismatches in attribute numbers even though names and types match.

Use attnums on chunk instead of hypertable.