### PR TITLE
Handle NULL and NOT NULL constraints for PG18

### DIFF
--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -715,7 +715,14 @@ ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkCo
 static bool
 chunk_constraint_need_on_chunk(Form_pg_constraint conform)
 {
-	if (conform->contype == CONSTRAINT_CHECK)
+	if (conform->contype == CONSTRAINT_CHECK
+#if PG18_GE
+		/* Avoid NOT NULL constraints
+		 * https://github.com/postgres/postgres/commit/b0e96f31
+		 */
+		|| conform->contype == CONSTRAINT_NOTNULL
+#endif
+	)
 	{
 		/*
 		 * check and not null constraints handled by regular inheritance (from

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2676,6 +2676,17 @@ process_add_constraint_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 					 */
 				case CONSTR_FOREIGN:
 					break;
+#if PG18_GE
+					/* NULL and NOT NULL constraints have been added to
+					 * pg_constraints in PG18, we can safely ignore them at end
+					 * just like at beginning.
+					 *
+					 * https://github.com/postgres/postgres/commit/b0e96f31
+					 */
+				case CONSTR_NULL:
+				case CONSTR_NOTNULL:
+					break;
+#endif
 				case CONSTR_CHECK:
 				{
 					validate_check_constraint(chunk, con);


### PR DESCRIPTION
[NOT] NULL constraints are added to pg_constraints catalog table and handled differently in PG18.

https://github.com/postgres/postgres/commit/b0e96f31

Disable-check: force-changelog-file
Disable-check: approval-count