### PR TITLE
Remove unused EXPLAIN hook

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -313,7 +313,6 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.set_rel_pathlist_query = NULL,
 	.process_altertable_cmd = NULL,
 	.process_rename_cmd = NULL,
-	.process_explain_def = NULL,
 
 	/* gapfill */
 	.gapfill_marker = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -80,7 +80,6 @@ typedef struct CrossModuleFunctions
 	void (*set_rel_pathlist_dml)(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
 	void (*set_rel_pathlist_query)(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *,
 								   Hypertable *);
-	bool (*process_explain_def)(DefElem *def);
 
 	/* gapfill */
 	PGFunction gapfill_marker;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3421,24 +3421,6 @@ chunk_index_mappings_cmp(const void *p1, const void *p2)
 	return 0;
 }
 
-static DDLResult
-process_explain_start(ProcessUtilityArgs *args)
-{
-	ExplainStmt *stmt = castNode(ExplainStmt, args->parsetree);
-	ListCell *lc;
-
-	if (ts_cm_functions->process_explain_def)
-	{
-		foreach (lc, stmt->options)
-		{
-			DefElem *opt = (DefElem *) lfirst(lc);
-			if (ts_cm_functions->process_explain_def(opt))
-				foreach_delete_current(stmt->options, lc);
-		}
-	}
-	return DDL_CONTINUE;
-}
-
 /*
  * Cluster a hypertable.
  *
@@ -5224,10 +5206,6 @@ process_ddl_command_start(ProcessUtilityArgs *args)
 		case T_ExecuteStmt:
 			check_read_only = false;
 			handler = preprocess_execute;
-			break;
-		case T_ExplainStmt:
-			check_read_only = false;
-			handler = process_explain_start;
 			break;
 
 		default:


### PR DESCRIPTION
This was added with the table access method and is no longer used.
