### PR TITLE
Fixed bug for ALTER TABLE RESET for orderby settings

### DIFF
--- a/.unreleased/pr_8638
+++ b/.unreleased/pr_8638
@@ -1,0 +1,1 @@
+Fixes: #8638 ALTER TABLE RESET for orderby settings

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4978,7 +4978,7 @@ process_altertable_reset_options(AlterTableCmd *cmd, Hypertable *ht)
 
 	if (!parse_results[AlterTableFlagOrderBy].is_default)
 	{
-		ts_remove_orderby_sparse_index(settings);
+		settings->fd.index = ts_remove_orderby_sparse_index(settings);
 		settings->fd.orderby = NULL;
 		settings->fd.orderby_desc = NULL;
 		settings->fd.orderby_nullsfirst = NULL;

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -202,16 +202,16 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
 
 ALTER TABLE foo RESET (timescaledb.compress_orderby);
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                      index                                                       
--------+----------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------
- foo   |                | {c}       |         |              |                    | [{"type": "minmax", "column": "a", "source": "orderby"}, {"type": "minmax", "column": "b", "source": "orderby"}]
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+-------+----------------+-----------+---------+--------------+--------------------+-------
+ foo   |                | {c}       |         |              |                    | 
 (1 row)
 
 ALTER TABLE foo RESET (timescaledb.compress_segmentby);
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                      index                                                       
--------+----------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------
- foo   |                |           |         |              |                    | [{"type": "minmax", "column": "a", "source": "orderby"}, {"type": "minmax", "column": "b", "source": "orderby"}]
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+-------+----------------+-----------+---------+--------------+--------------------+-------
+ foo   |                |           |         |              |                    | 
 (1 row)
 
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_index = 'bloom(c)');


### PR DESCRIPTION
Previously only the orderby column was being without changing the index setting.