### PR TITLE
Delay initial run of compression jobs on new hypertable by 1 day

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1710,7 +1710,7 @@ tsl_columnstore_setup(Hypertable *ht, WithClauseResult *with_clause_options)
 			true,								   /* user_defined_schedule_interval */
 			true,								   /* if_not_exists */
 			false,								   /* fixed_schedule */
-			0,									   /* initial_start */
+			GetCurrentTimestamp() + USECS_PER_DAY, /* initial_start */
 			NULL /* timezone */);
 	}
 }


### PR DESCRIPTION
This change only affects the initial start of compression policies
created as part of CREATE TABLE WITH. These would previously run
immediately after creation potentially interfering with initial
data load into the table.

Disable-check: force-changelog-file