### PR TITLE
Don't block ALTER TABLE ONLY when setting reloptions

### DIFF
--- a/.unreleased/pr_8661
+++ b/.unreleased/pr_8661
@@ -1,0 +1,1 @@
+Implements: #8661 Don't block ALTER TABLE ONLY when settings reloptions

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -604,3 +604,18 @@ SELECT i4489('a'), i4489('a');
      0 |     0
 (1 row)
 
+-- test ALTER TABLE ONLY for hypertables
+CREATE TABLE at_test(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- adding column only on the parent table should be blocked
+\set ON_ERROR_STOP 0
+ALTER TABLE ONLY at_test ADD COLUMN value INT;
+ERROR:  ONLY option not supported on hypertable operations
+\set ON_ERROR_STOP 1
+ALTER TABLE ONLY at_test SET (autovacuum_enabled = false);
+ALTER TABLE ONLY at_test RESET (autovacuum_enabled);
+-- test again after creating some chunks
+INSERT INTO at_test VALUES ('2025-01-01');
+INSERT INTO at_test VALUES ('2025-02-01');
+ALTER TABLE ONLY at_test SET (autovacuum_enabled = false);
+ALTER TABLE ONLY at_test RESET (autovacuum_enabled);

--- a/test/sql/ddl.sql
+++ b/test/sql/ddl.sql
@@ -134,3 +134,22 @@ SELECT i4489('1'), i4489('1');
 -- should return 0 (zero) in all cases handled by the exception
 SELECT i4489(), i4489();
 SELECT i4489('a'), i4489('a');
+
+-- test ALTER TABLE ONLY for hypertables
+CREATE TABLE at_test(time timestamptz) WITH (tsdb.hypertable);
+
+-- adding column only on the parent table should be blocked
+\set ON_ERROR_STOP 0
+ALTER TABLE ONLY at_test ADD COLUMN value INT;
+\set ON_ERROR_STOP 1
+
+ALTER TABLE ONLY at_test SET (autovacuum_enabled = false);
+ALTER TABLE ONLY at_test RESET (autovacuum_enabled);
+
+-- test again after creating some chunks
+INSERT INTO at_test VALUES ('2025-01-01');
+INSERT INTO at_test VALUES ('2025-02-01');
+
+ALTER TABLE ONLY at_test SET (autovacuum_enabled = false);
+ALTER TABLE ONLY at_test RESET (autovacuum_enabled);
+


### PR DESCRIPTION
Allowing ALTER TABLE ONLY when setting/removing reloptions can
be useful to apply settings changes only to future chunks.
