### PR TITLE
Don't close the scanner iterator after update watermark

### DIFF
--- a/src/ts_catalog/continuous_aggs_watermark.c
+++ b/src/ts_catalog/continuous_aggs_watermark.c
@@ -317,7 +317,6 @@ cagg_watermark_update_internal(int32 mat_hypertable_id, Oid ht_relid, int64 new_
 
 	bool watermark_updated =
 		ts_scanner_scan_one(&iterator.ctx, false, "continuous aggregate watermark");
-	ts_scan_iterator_close(&iterator);
 	UnregisterSnapshot(iterator.ctx.snapshot);
 
 	if (!watermark_updated)


### PR DESCRIPTION
In #8542 we made a change to use active and registered snapshots only due to some Postgres upstream changes but we unnecessary also closed the iterator that will be a Noop since the iterator is already closed after execute the callback function `cagg_watermark_update_scan_internal` that returns `SCAN_DONE`.

Disable-check: force-changelog-file
Disable-check: approval-count
