### PR TITLE
Install PG contrib extensions

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -158,7 +158,7 @@ def macos_config(overrides):
             "ignored_tests": default_ignored_tests.union(macos_ignored_tests),
             "os": "macos-13",
             "pg_extra_args": "--enable-debug --with-libraries=/usr/local/opt/openssl@3/lib --with-includes=/usr/local/opt/openssl@3/include --without-icu",
-            "pg_extensions": "postgres_fdw test_decoding",
+            "pg_extensions": "postgres_fdw test_decoding pageinspect pgstattuple",
             "pginstallcheck": True,
             "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3",
         }


### PR DESCRIPTION
Install `pgstattuple` to retrieve tuple-level statistics and `pageinspect` to look into index pages.

(cherry picked from commit af861f3e228d4b8e52bd0cbb863b33968c4d51fa)