### PR TITLE
Don't run libfuzzer in release branches

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -6,7 +6,6 @@ name: Libfuzzer
   push:
     branches:
       - main
-      - ?.*.x
       - trigger/libfuzzer
   pull_request:
     paths:


### PR DESCRIPTION
They use a different cache prefix from the main branch, so the new cases we found there will not be preserved.