### PR TITLE
Cancel the pending old workflow runs on force push

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -21,6 +21,11 @@ name: Regression Windows
       - NOTICE
       - 'bootstrap*'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.event.forced }}
+
 jobs:
   config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I'd keep the pending runs on the commits that are still accessible, because I often use this when fixing and debugging the tests.