### PR TITLE
Ignore result of compression_bgw test on macos

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -150,6 +150,7 @@ def macos_config(overrides):
     macos_ignored_tests = {
         "bgw_launcher",
         "pg_dump",
+        "compression_bgw",
         "compressed_collation",
     }
     base_config = dict(


### PR DESCRIPTION
On disk sizes of the resulting chunks are different on macos
