### PR TITLE
Ignore timescaledb-toolkit availability on rockylinux 9 for PG17

### DIFF
--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -109,10 +109,12 @@ jobs:
         fi
 
     - name: Install toolkit
+      if: matrix.pg != 17 && matrix.image != 'rockylinux:9' # timescaledb-toolkit currently not available for PG17 and Rocky9
       run: |
         yum install -y timescaledb-toolkit-postgresql-${{ matrix.pg }}
 
     - name: List available toolkit versions
+      if: matrix.pg != 17 && matrix.image != 'rockylinux:9' # timescaledb-toolkit currently not available for PG17 and Rocky9
       run: |
         yum --showduplicates list timescaledb-toolkit-postgresql-${{ matrix.pg }}
 


### PR DESCRIPTION
We havent yet published timescaledb-toolkit on rockylinux:9 for
PG17 due to build problems.
