### PR TITLE
Allow set-returning functions in continuous aggregates

### DIFF
--- a/.unreleased/pr_8703
+++ b/.unreleased/pr_8703
@@ -1,0 +1,2 @@
+Implements: #8703 Allow set-returning functions in continuous aggregates
+Thanks: @ruideyllot for reporting set-returning functions not working in continuous aggregates

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -573,10 +573,10 @@ cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail, con
 		return false;
 	}
 
-	if (query->hasRecursive || query->hasSubLinks || query->hasTargetSRFs || query->cteList)
+	if (query->hasRecursive || query->hasSubLinks || query->cteList)
 	{
 		appendStringInfoString(detail,
-							   "CTEs, subqueries and set-returning functions are not supported by "
+							   "CTEs and subqueries are not supported by "
 							   "continuous aggregates.");
 		return false;
 	}

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2249,3 +2249,27 @@ SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension
  time_bucket |             345600000000
 (1 row)
 
+-- test set returning functions in caggs
+CREATE TABLE kpis_raw (time TIMESTAMP NOT NULL, value INTEGER, groups TEXT[]) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO kpis_raw (time, value, groups) VALUES
+  ('2025-01-01', 10, '{group1,group2,group3}'),
+  ('2025-01-02', 20, '{group1,group4}'),
+  ('2025-02-01', 10, '{group1,group3}'),
+  ('2025-02-01', 20, '{group1,group4}');
+CREATE MATERIALIZED VIEW kpis_cagg WITH (tsdb.continuous) AS
+SELECT time_bucket('7 day', time) AS bucket, count(*) AS number_of_records, avg(value) AS average, unnest(groups) AS kpi_group
+FROM kpis_raw GROUP BY bucket, kpi_group;
+NOTICE:  refreshing continuous aggregate "kpis_cagg"
+SELECT * FROM kpis_cagg ORDER BY bucket, kpi_group;
+          bucket          | number_of_records |       average       | kpi_group 
+--------------------------+-------------------+---------------------+-----------
+ Mon Dec 30 00:00:00 2024 |                 2 | 15.0000000000000000 | group1
+ Mon Dec 30 00:00:00 2024 |                 1 | 10.0000000000000000 | group2
+ Mon Dec 30 00:00:00 2024 |                 1 | 10.0000000000000000 | group3
+ Mon Dec 30 00:00:00 2024 |                 1 | 20.0000000000000000 | group4
+ Mon Jan 27 00:00:00 2025 |                 2 | 15.0000000000000000 | group1
+ Mon Jan 27 00:00:00 2025 |                 1 | 10.0000000000000000 | group3
+ Mon Jan 27 00:00:00 2025 |                 1 | 20.0000000000000000 | group4
+(7 rows)
+

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2249,3 +2249,27 @@ SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension
  time_bucket |             345600000000
 (1 row)
 
+-- test set returning functions in caggs
+CREATE TABLE kpis_raw (time TIMESTAMP NOT NULL, value INTEGER, groups TEXT[]) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO kpis_raw (time, value, groups) VALUES
+  ('2025-01-01', 10, '{group1,group2,group3}'),
+  ('2025-01-02', 20, '{group1,group4}'),
+  ('2025-02-01', 10, '{group1,group3}'),
+  ('2025-02-01', 20, '{group1,group4}');
+CREATE MATERIALIZED VIEW kpis_cagg WITH (tsdb.continuous) AS
+SELECT time_bucket('7 day', time) AS bucket, count(*) AS number_of_records, avg(value) AS average, unnest(groups) AS kpi_group
+FROM kpis_raw GROUP BY bucket, kpi_group;
+NOTICE:  refreshing continuous aggregate "kpis_cagg"
+SELECT * FROM kpis_cagg ORDER BY bucket, kpi_group;
+          bucket          | number_of_records |       average       | kpi_group 
+--------------------------+-------------------+---------------------+-----------
+ Mon Dec 30 00:00:00 2024 |                 2 | 15.0000000000000000 | group1
+ Mon Dec 30 00:00:00 2024 |                 1 | 10.0000000000000000 | group2
+ Mon Dec 30 00:00:00 2024 |                 1 | 10.0000000000000000 | group3
+ Mon Dec 30 00:00:00 2024 |                 1 | 20.0000000000000000 | group4
+ Mon Jan 27 00:00:00 2025 |                 2 | 15.0000000000000000 | group1
+ Mon Jan 27 00:00:00 2025 |                 1 | 10.0000000000000000 | group3
+ Mon Jan 27 00:00:00 2025 |                 1 | 20.0000000000000000 | group4
+(7 rows)
+

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -2249,3 +2249,27 @@ SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension
  time_bucket |             345600000000
 (1 row)
 
+-- test set returning functions in caggs
+CREATE TABLE kpis_raw (time TIMESTAMP NOT NULL, value INTEGER, groups TEXT[]) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO kpis_raw (time, value, groups) VALUES
+  ('2025-01-01', 10, '{group1,group2,group3}'),
+  ('2025-01-02', 20, '{group1,group4}'),
+  ('2025-02-01', 10, '{group1,group3}'),
+  ('2025-02-01', 20, '{group1,group4}');
+CREATE MATERIALIZED VIEW kpis_cagg WITH (tsdb.continuous) AS
+SELECT time_bucket('7 day', time) AS bucket, count(*) AS number_of_records, avg(value) AS average, unnest(groups) AS kpi_group
+FROM kpis_raw GROUP BY bucket, kpi_group;
+NOTICE:  refreshing continuous aggregate "kpis_cagg"
+SELECT * FROM kpis_cagg ORDER BY bucket, kpi_group;
+          bucket          | number_of_records |       average       | kpi_group 
+--------------------------+-------------------+---------------------+-----------
+ Mon Dec 30 00:00:00 2024 |                 2 | 15.0000000000000000 | group1
+ Mon Dec 30 00:00:00 2024 |                 1 | 10.0000000000000000 | group2
+ Mon Dec 30 00:00:00 2024 |                 1 | 10.0000000000000000 | group3
+ Mon Dec 30 00:00:00 2024 |                 1 | 20.0000000000000000 | group4
+ Mon Jan 27 00:00:00 2025 |                 2 | 15.0000000000000000 | group1
+ Mon Jan 27 00:00:00 2025 |                 1 | 10.0000000000000000 | group3
+ Mon Jan 27 00:00:00 2025 |                 1 | 20.0000000000000000 | group4
+(7 rows)
+

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -60,7 +60,7 @@ Select location, count(*) from conditions
  group by time_bucket('1week', timec) , location)
 select * from m1 WITH NO DATA;
 ERROR:  invalid continuous aggregate query
-DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
+DETAIL:  CTEs and subqueries are not supported by continuous aggregates.
 --with DISTINCT ON
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -1017,7 +1017,7 @@ WHERE conditions.city IN (
 AND conditions.device_id = devices.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate query
-DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
+DETAIL:  CTEs and subqueries are not supported by continuous aggregates.
 CREATE MATERIALIZED VIEW conditions_summary_subselect
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -1033,7 +1033,7 @@ WHERE conditions.city IN (
       WHERE currency = 'EUR'))
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate query
-DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
+DETAIL:  CTEs and subqueries are not supported by continuous aggregates.
 CREATE MATERIALIZED VIEW conditions_summary_subselect
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -1049,7 +1049,7 @@ WHERE conditions.city IN (
       WHERE currency = 'EUR'))
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate query
-DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
+DETAIL:  CTEs and subqueries are not supported by continuous aggregates.
 DROP TABLE cities CASCADE;
 --Error out when join is between two hypertables
 CREATE MATERIALIZED VIEW cagg_ht

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1437,3 +1437,15 @@ SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension
 ALTER MATERIALIZED VIEW columnstore_options SET (tsdb.compress_chunk_time_interval='4 day');
 SELECT column_name, compress_interval_length from _timescaledb_catalog.dimension where column_name='time_bucket' ORDER BY id DESC LIMIT 1;
 
+-- test set returning functions in caggs
+CREATE TABLE kpis_raw (time TIMESTAMP NOT NULL, value INTEGER, groups TEXT[]) WITH (tsdb.hypertable);
+INSERT INTO kpis_raw (time, value, groups) VALUES
+  ('2025-01-01', 10, '{group1,group2,group3}'),
+  ('2025-01-02', 20, '{group1,group4}'),
+  ('2025-02-01', 10, '{group1,group3}'),
+  ('2025-02-01', 20, '{group1,group4}');
+
+CREATE MATERIALIZED VIEW kpis_cagg WITH (tsdb.continuous) AS
+SELECT time_bucket('7 day', time) AS bucket, count(*) AS number_of_records, avg(value) AS average, unnest(groups) AS kpi_group
+FROM kpis_raw GROUP BY bucket, kpi_group;
+SELECT * FROM kpis_cagg ORDER BY bucket, kpi_group;


### PR DESCRIPTION
Remove the blocker for set-returning functions from continuous
aggregate definitions

Fixes #1717 
