### PR TITLE
Add chunk support for ModifyHypertable

### DIFF
--- a/.unreleased/pr_8704
+++ b/.unreleased/pr_8704
@@ -1,0 +1,1 @@
+Fixes: #8704 Fix direct DELETE on compressed chunk

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -321,21 +321,6 @@ setup_on_conflict_state(ResultRelInfo *ht_rri, ModifyTableState *mtstate, ChunkI
 	}
 }
 
-static void
-destroy_on_conflict_state(ChunkInsertState *state)
-{
-	/*
-	 * Clean up per-chunk tuple table slots created for ON CONFLICT handling.
-	 */
-	if (NULL != state->existing_slot)
-		ExecDropSingleTupleTableSlot(state->existing_slot);
-
-	/* The ON CONFLICT projection slot is only chunk specific in case the
-	 * tuple descriptor didn't match the hypertable */
-	if (NULL != state->hyper_to_chunk_map && NULL != state->conflproj_slot)
-		ExecDropSingleTupleTableSlot(state->conflproj_slot);
-}
-
 /* Translate hypertable indexes to chunk indexes in the arbiter clause */
 static void
 set_arbiter_indexes(ChunkInsertState *state, List *ht_arbiter_indexes)
@@ -428,12 +413,6 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkTupleRouting *ctr)
 	ResultRelInfo *relinfo;
 	const Chunk *chunk;
 
-	/* permissions NOT checked here; were checked at hypertable level */
-	if (check_enable_rls(chunk_relid, InvalidOid, false) == RLS_ENABLED)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("hypertables do not support row-level security")));
-
 	MemoryContext old_mcxt =
 		MemoryContextSwitchTo(ctr->estate->es_per_tuple_exprcontext->ecxt_per_tuple_memory);
 	/*
@@ -457,7 +436,11 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkTupleRouting *ctr)
 	ts_chunk_validate_chunk_status_for_operation(chunk, CHUNK_INSERT, true);
 
 	MemoryContextSwitchTo(cis_context);
-	relinfo = create_chunk_result_relation_info(ctr->hypertable_rri, rel, ctr->estate);
+	if (ctr->single_chunk_insert)
+		relinfo = ctr->root_rri;
+	else
+		relinfo = create_chunk_result_relation_info(ctr->root_rri, rel, ctr->estate);
+
 	if (ctr->mht_state)
 		CheckValidResultRelCompat(relinfo,
 								  ctr->mht_state->mt->operation,
@@ -497,20 +480,23 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkTupleRouting *ctr)
 			elog(ERROR, "statement trigger on chunk table not supported");
 	}
 
-	parent_rel = table_open(ctr->hypertable->main_table_relid, AccessShareLock);
+	if (!ctr->single_chunk_insert)
+	{
+		parent_rel = table_open(ctr->hypertable->main_table_relid, AccessShareLock);
 
-	/* Set tuple conversion map, if tuple needs conversion. We don't want to
-	 * convert tuples going into foreign tables since these are actually sent to
-	 * data nodes for insert on that node's local hypertable. */
-	if (chunk->relkind != RELKIND_FOREIGN_TABLE)
+		/* Set tuple conversion map, if tuple needs conversion. */
 		state->hyper_to_chunk_map =
 			convert_tuples_by_name(RelationGetDescr(parent_rel), RelationGetDescr(rel));
 
-	if (ctr->mht_state)
-		adjust_projections(ctr->hypertable_rri,
-						   linitial_node(ModifyTableState, ctr->mht_state->cscan_state.custom_ps),
-						   state,
-						   RelationGetForm(rel)->reltype);
+		if (ctr->mht_state)
+			adjust_projections(ctr->root_rri,
+							   linitial_node(ModifyTableState,
+											 ctr->mht_state->cscan_state.custom_ps),
+							   state,
+							   RelationGetForm(rel)->reltype);
+
+		table_close(parent_rel, AccessShareLock);
+	}
 
 	/* Need a tuple table slot to store tuples going into this chunk. We don't
 	 * want this slot tied to the executor's tuple table, since that would tie
@@ -521,23 +507,9 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkTupleRouting *ctr)
 	 * the chunk insert state. */
 	state->slot = MakeSingleTupleTableSlot(RelationGetDescr(relinfo->ri_RelationDesc),
 										   table_slot_callbacks(relinfo->ri_RelationDesc));
-	table_close(parent_rel, AccessShareLock);
 
 	state->hypertable_relid = chunk->hypertable_relid;
 	state->chunk_id = chunk->fd.id;
-
-	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
-	{
-#if PG16_LT
-		RangeTblEntry *rte = rt_fetch(relinfo->ri_RangeTableIndex, ctr->estate->es_range_table);
-
-		Assert(rte != NULL);
-
-		state->user_id = OidIsValid(rte->checkAsUser) ? rte->checkAsUser : GetUserId();
-#else
-		state->user_id = ExecGetResultRelCheckAsUser(relinfo, ctr->estate);
-#endif
-	}
 
 	MemoryContextSwitchTo(old_mcxt);
 
@@ -555,10 +527,8 @@ ts_set_compression_status(ChunkInsertState *state, const Chunk *chunk)
 }
 
 extern void
-ts_chunk_insert_state_destroy(ChunkInsertState *state)
+ts_chunk_insert_state_destroy(ChunkInsertState *state, bool single_chunk_insert)
 {
-	ResultRelInfo *rri = state->result_relation_info;
-
 	/*
 	 * Check if we need to mark the chunk as partial.
 	 * We need to change chunk status to partial in the following cases:
@@ -574,15 +544,24 @@ ts_chunk_insert_state_destroy(ChunkInsertState *state)
 		ts_chunk_set_partial(chunk);
 	}
 
-	if (rri->ri_FdwRoutine && !rri->ri_usesFdwDirectModify && rri->ri_FdwRoutine->EndForeignModify)
-		rri->ri_FdwRoutine->EndForeignModify(state->estate, rri);
-
-	destroy_on_conflict_state(state);
-	ExecCloseIndices(state->result_relation_info);
-
 	table_close(state->rel, NoLock);
 	if (state->slot)
 		ExecDropSingleTupleTableSlot(state->slot);
 
-	MemoryContextDelete(state->mctx);
+	/*
+	 * Clean up per-chunk tuple table slots created for ON CONFLICT handling.
+	 */
+	if (NULL != state->existing_slot)
+		ExecDropSingleTupleTableSlot(state->existing_slot);
+
+	/* The ON CONFLICT projection slot is only chunk specific in case the
+	 * tuple descriptor didn't match the hypertable */
+	if (NULL != state->hyper_to_chunk_map && NULL != state->conflproj_slot)
+		ExecDropSingleTupleTableSlot(state->conflproj_slot);
+
+	if (!single_chunk_insert)
+	{
+		ExecCloseIndices(state->result_relation_info);
+		MemoryContextDelete(state->mctx);
+	}
 }

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -112,7 +112,7 @@ typedef struct ChunkInsertState
 
 extern ChunkInsertState *ts_chunk_insert_state_create(Oid chunk_relid,
 													  const ChunkTupleRouting *ctr);
-extern void ts_chunk_insert_state_destroy(ChunkInsertState *state);
+extern void ts_chunk_insert_state_destroy(ChunkInsertState *state, bool single_chunk_insert);
 ResultRelInfo *create_chunk_result_relation_info(ResultRelInfo *ht_rri, Relation rel,
 												 EState *estate);
 

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -28,15 +28,28 @@ ts_chunk_tuple_routing_create(EState *estate, ResultRelInfo *rri)
 	 * single tuple into a partitioned table and this must be fast.
 	 */
 	ctr = (ChunkTupleRouting *) palloc0(sizeof(ChunkTupleRouting));
-	ctr->hypertable_rri = rri;
-	ctr->partition_root = rri->ri_RelationDesc;
+	ctr->root_rri = rri;
+	ctr->root_rel = rri->ri_RelationDesc;
 	ctr->estate = estate;
 	ctr->counters = palloc0(sizeof(SharedCounters));
 
 	ctr->hypertable =
 		ts_hypertable_cache_get_cache_and_entry(RelationGetRelid(rri->ri_RelationDesc),
-												CACHE_FLAG_NONE,
+												CACHE_FLAG_MISSING_OK,
 												&ctr->hypertable_cache);
+
+	/*
+	 * If we are inserting into a chunk directly, rri will point to the chunk
+	 * itself, so we need to get the hypertable from the chunk.
+	 */
+	if (!ctr->hypertable)
+	{
+		Chunk *chunk = ts_chunk_get_by_relid(RelationGetRelid(rri->ri_RelationDesc), false);
+		ctr->hypertable = ts_hypertable_cache_get_entry(ctr->hypertable_cache,
+														chunk->hypertable_relid,
+														CACHE_FLAG_NONE);
+		ctr->single_chunk_insert = true;
+	}
 	ctr->subspace = ts_subspace_store_init(ctr->hypertable->space,
 										   estate->es_query_cxt,
 										   ts_guc_max_open_chunks_per_insert);
@@ -56,9 +69,15 @@ ts_chunk_tuple_routing_destroy(ChunkTupleRouting *ctr)
 }
 
 static void
+destroy_chunk_insert_state_single_chunk(void *cis)
+{
+	ts_chunk_insert_state_destroy((ChunkInsertState *) cis, true);
+}
+
+static void
 destroy_chunk_insert_state(void *cis)
 {
-	ts_chunk_insert_state_destroy((ChunkInsertState *) cis);
+	ts_chunk_insert_state_destroy((ChunkInsertState *) cis, false);
 }
 
 extern ChunkInsertState *
@@ -90,13 +109,24 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 		chunk = ts_hypertable_find_chunk_for_point(ctr->hypertable, point);
 
 		/*
-		 * Frozen chunks require at least PG14.
+		 * When inserting directly into a chunk, we should always find the chunk and
+		 * the returned chunk should match the relid we are inserting into.
 		 */
+		if (ctr->single_chunk_insert)
+		{
+			if (!chunk || chunk->table_id != RelationGetRelid(ctr->root_rri->ri_RelationDesc))
+				ereport(ERROR,
+						(errcode(ERRCODE_CHECK_VIOLATION),
+						 errmsg("new row for relation \"%s\" violates chunk constraint",
+								RelationGetRelationName(ctr->root_rri->ri_RelationDesc))));
+		}
+
 		if (chunk && ts_chunk_is_frozen(chunk))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot INSERT into frozen chunk \"%s\"",
 							get_rel_name(chunk->table_id))));
+
 		if (chunk && IS_OSM_CHUNK(chunk))
 		{
 			const Dimension *time_dim = hyperspace_get_open_dimension(ctr->hypertable->space, 0);
@@ -151,7 +181,11 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 
 		cis = ts_chunk_insert_state_create(chunk->table_id, ctr);
 		cis->needs_partial = needs_partial;
-		ts_subspace_store_add(ctr->subspace, chunk->cube, cis, destroy_chunk_insert_state);
+		ts_subspace_store_add(ctr->subspace,
+							  chunk->cube,
+							  cis,
+							  ctr->single_chunk_insert ? destroy_chunk_insert_state_single_chunk :
+														 destroy_chunk_insert_state);
 	}
 
 	MemoryContextSwitchTo(old_context);

--- a/src/chunk_tuple_routing.h
+++ b/src/chunk_tuple_routing.h
@@ -15,9 +15,14 @@ typedef struct ModifyHypertableState ModifyHypertableState;
 
 typedef struct ChunkTupleRouting
 {
-	Relation partition_root;
 	Hypertable *hypertable;
-	ResultRelInfo *hypertable_rri;
+	/*
+	 * When single_chunk_insert is true, root_rel and root_rri point to the
+	 * chunk being inserted into. Otherwise, they point to the hypertable.
+	 */
+	Relation root_rel;
+	ResultRelInfo *root_rri;
+	bool single_chunk_insert;
 	Cache *hypertable_cache;
 
 	SubspaceStore *subspace;

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -71,7 +71,7 @@ should_use_direct_compress(ModifyHypertableState *state)
 		return false;
 	}
 
-	if (ts_indexing_relation_has_primary_or_unique_index(state->ctr->partition_root))
+	if (ts_indexing_relation_has_primary_or_unique_index(state->ctr->root_rel))
 	{
 		ereport(WARNING,
 				(errmsg("disabling direct compress because the destination table has unique "

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2456,9 +2456,9 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 				 * for PG >= 17? See PostgreSQL commit 0294df2f1f84
 				 */
 #if PG17_GE
-				List *actionStates = ctr->hypertable_rri->ri_MergeActions[MERGE_WHEN_NOT_MATCHED_BY_TARGET];
+				List *actionStates = ctr->root_rri->ri_MergeActions[MERGE_WHEN_NOT_MATCHED_BY_TARGET];
 #else
-				List *actionStates = ctr->hypertable_rri->ri_notMatchedMergeAction;
+				List *actionStates = ctr->root_rri->ri_notMatchedMergeAction;
 #endif
 				ListCell *l;
 				foreach (l, actionStates)

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -183,3 +183,42 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
 (4 rows)
 
 ROLLBACK;
+-- test update on chunks directly
+CREATE TABLE direct_delete(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_delete VALUES ('2020-01-01');
+SELECT show_chunks('direct_delete') AS "CHUNK" \gset
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) DELETE FROM :CHUNK;
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Delete on _hyper_2_5_chunk
+         ->  Seq Scan on _hyper_2_5_chunk
+(3 rows)
+
+EXPLAIN (costs off, timing off, summary off) DELETE FROM ONLY :CHUNK;
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Delete on _hyper_2_5_chunk
+         ->  Seq Scan on _hyper_2_5_chunk
+(3 rows)
+
+-- DELETE should succeed
+BEGIN;
+DELETE FROM :CHUNK RETURNING *;
+             time             
+------------------------------
+ Wed Jan 01 00:00:00 2020 PST
+(1 row)
+
+ROLLBACK;
+BEGIN;
+DELETE FROM ONLY :CHUNK RETURNING *;
+             time             
+------------------------------
+ Wed Jan 01 00:00:00 2020 PST
+(1 row)
+
+ROLLBACK;

--- a/test/expected/insert-15.out
+++ b/test/expected/insert-15.out
@@ -650,3 +650,83 @@ SELECT create_hypertable('i3037','time');
 ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
 INSERT INTO i3037 VALUES ('2000-01-01');
 INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;
+-- test inserting into chunks directly
+CREATE TABLE direct_insert(time timestamptz, meta text) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_insert VALUES ('2020-01-01');
+SELECT show_chunks('direct_insert') AS "CHUNK" \gset
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) INSERT INTO :CHUNK VALUES ('2020-01-01');
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Insert on _hyper_14_231_chunk
+         ->  Result
+(3 rows)
+
+-- correct time range should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+             time             | meta 
+------------------------------+------
+ Wed Jan 01 00:00:00 2020 PST | 
+(1 row)
+
+-- incorrect time range should fail
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2020-01-01'), ('2021-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+INSERT INTO :CHUNK VALUES ('2025-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+\set ON_ERROR_STOP 1
+-- test that triggers on chunks work
+CREATE FUNCTION test_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'trigger called';
+  NEW.meta = 'triggered';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER test_trigger BEFORE INSERT ON direct_insert FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- test upsert
+DELETE FROM direct_insert;
+ALTER TABLE direct_insert ADD CONSTRAINT direct_insert_pkey PRIMARY KEY (time);
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- DO NOTHING should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT DO NOTHING RETURNING *;
+NOTICE:  trigger called
+ time | meta 
+------+------
+(0 rows)
+
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET meta = 'update' RETURNING *;
+NOTICE:  trigger called
+             time             |  meta  
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | update
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- conflict should fail
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+ERROR:  duplicate key value violates unique constraint "231_205_direct_insert_pkey"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = '2000-01-01' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = EXCLUDED.time + '1 year' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+\set ON_ERROR_STOP 1

--- a/test/expected/insert-16.out
+++ b/test/expected/insert-16.out
@@ -650,3 +650,83 @@ SELECT create_hypertable('i3037','time');
 ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
 INSERT INTO i3037 VALUES ('2000-01-01');
 INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;
+-- test inserting into chunks directly
+CREATE TABLE direct_insert(time timestamptz, meta text) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_insert VALUES ('2020-01-01');
+SELECT show_chunks('direct_insert') AS "CHUNK" \gset
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) INSERT INTO :CHUNK VALUES ('2020-01-01');
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Insert on _hyper_14_231_chunk
+         ->  Result
+(3 rows)
+
+-- correct time range should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+             time             | meta 
+------------------------------+------
+ Wed Jan 01 00:00:00 2020 PST | 
+(1 row)
+
+-- incorrect time range should fail
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2020-01-01'), ('2021-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+INSERT INTO :CHUNK VALUES ('2025-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+\set ON_ERROR_STOP 1
+-- test that triggers on chunks work
+CREATE FUNCTION test_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'trigger called';
+  NEW.meta = 'triggered';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER test_trigger BEFORE INSERT ON direct_insert FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- test upsert
+DELETE FROM direct_insert;
+ALTER TABLE direct_insert ADD CONSTRAINT direct_insert_pkey PRIMARY KEY (time);
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- DO NOTHING should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT DO NOTHING RETURNING *;
+NOTICE:  trigger called
+ time | meta 
+------+------
+(0 rows)
+
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET meta = 'update' RETURNING *;
+NOTICE:  trigger called
+             time             |  meta  
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | update
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- conflict should fail
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+ERROR:  duplicate key value violates unique constraint "231_205_direct_insert_pkey"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = '2000-01-01' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = EXCLUDED.time + '1 year' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+\set ON_ERROR_STOP 1

--- a/test/expected/insert-17.out
+++ b/test/expected/insert-17.out
@@ -650,3 +650,83 @@ SELECT create_hypertable('i3037','time');
 ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
 INSERT INTO i3037 VALUES ('2000-01-01');
 INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;
+-- test inserting into chunks directly
+CREATE TABLE direct_insert(time timestamptz, meta text) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_insert VALUES ('2020-01-01');
+SELECT show_chunks('direct_insert') AS "CHUNK" \gset
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) INSERT INTO :CHUNK VALUES ('2020-01-01');
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Insert on _hyper_14_231_chunk
+         ->  Result
+(3 rows)
+
+-- correct time range should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+             time             | meta 
+------------------------------+------
+ Wed Jan 01 00:00:00 2020 PST | 
+(1 row)
+
+-- incorrect time range should fail
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2020-01-01'), ('2021-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+INSERT INTO :CHUNK VALUES ('2025-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+\set ON_ERROR_STOP 1
+-- test that triggers on chunks work
+CREATE FUNCTION test_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'trigger called';
+  NEW.meta = 'triggered';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER test_trigger BEFORE INSERT ON direct_insert FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- test upsert
+DELETE FROM direct_insert;
+ALTER TABLE direct_insert ADD CONSTRAINT direct_insert_pkey PRIMARY KEY (time);
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- DO NOTHING should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT DO NOTHING RETURNING *;
+NOTICE:  trigger called
+ time | meta 
+------+------
+(0 rows)
+
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET meta = 'update' RETURNING *;
+NOTICE:  trigger called
+             time             |  meta  
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | update
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- conflict should fail
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+ERROR:  duplicate key value violates unique constraint "231_205_direct_insert_pkey"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = '2000-01-01' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = EXCLUDED.time + '1 year' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+\set ON_ERROR_STOP 1

--- a/test/expected/insert-18.out
+++ b/test/expected/insert-18.out
@@ -650,3 +650,83 @@ SELECT create_hypertable('i3037','time');
 ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
 INSERT INTO i3037 VALUES ('2000-01-01');
 INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;
+-- test inserting into chunks directly
+CREATE TABLE direct_insert(time timestamptz, meta text) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_insert VALUES ('2020-01-01');
+SELECT show_chunks('direct_insert') AS "CHUNK" \gset
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) INSERT INTO :CHUNK VALUES ('2020-01-01');
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Insert on _hyper_14_231_chunk
+         ->  Result
+(3 rows)
+
+-- correct time range should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+             time             | meta 
+------------------------------+------
+ Wed Jan 01 00:00:00 2020 PST | 
+(1 row)
+
+-- incorrect time range should fail
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2020-01-01'), ('2021-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+INSERT INTO :CHUNK VALUES ('2025-01-01') RETURNING *;
+ERROR:  new row for relation "_hyper_14_231_chunk" violates chunk constraint
+\set ON_ERROR_STOP 1
+-- test that triggers on chunks work
+CREATE FUNCTION test_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'trigger called';
+  NEW.meta = 'triggered';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER test_trigger BEFORE INSERT ON direct_insert FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- test upsert
+DELETE FROM direct_insert;
+ALTER TABLE direct_insert ADD CONSTRAINT direct_insert_pkey PRIMARY KEY (time);
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+             time             |   meta    
+------------------------------+-----------
+ Wed Jan 01 00:00:00 2020 PST | triggered
+(1 row)
+
+-- DO NOTHING should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT DO NOTHING RETURNING *;
+NOTICE:  trigger called
+ time | meta 
+------+------
+(0 rows)
+
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET meta = 'update' RETURNING *;
+NOTICE:  trigger called
+             time             |  meta  
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | update
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- conflict should fail
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+NOTICE:  trigger called
+ERROR:  duplicate key value violates unique constraint "231_205_direct_insert_pkey"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = '2000-01-01' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = EXCLUDED.time + '1 year' RETURNING *;
+NOTICE:  trigger called
+ERROR:  new row for relation "_hyper_14_231_chunk" violates check constraint "constraint_237"
+\set ON_ERROR_STOP 1

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -162,3 +162,45 @@ SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id, series_0, series
  1257987600000000000 | dev1      |      1.5 |       47 |          | t
 (12 rows)
 
+-- test update on chunks directly
+CREATE TABLE direct_update(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_update VALUES ('2020-01-01');
+SELECT show_chunks('direct_update') AS "CHUNK" \gset
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) UPDATE :CHUNK SET time = time + INTERVAL '1 minute';
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Update on _hyper_2_4_chunk
+         ->  Seq Scan on _hyper_2_4_chunk
+(3 rows)
+
+EXPLAIN (costs off, timing off, summary off) UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 minute';
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (ModifyHypertable)
+   ->  Update on _hyper_2_4_chunk
+         ->  Seq Scan on _hyper_2_4_chunk
+(3 rows)
+
+-- correct time range should succeed
+UPDATE :CHUNK SET time = time + INTERVAL '1 minute' RETURNING *;
+             time             
+------------------------------
+ Wed Jan 01 00:01:00 2020 PST
+(1 row)
+
+UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 minute' RETURNING *;
+             time             
+------------------------------
+ Wed Jan 01 00:02:00 2020 PST
+(1 row)
+
+-- crossing chunk boundary should fail
+\set ON_ERROR_STOP 0
+UPDATE :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
+ERROR:  new row for relation "_hyper_2_4_chunk" violates check constraint "constraint_4"
+UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
+ERROR:  new row for relation "_hyper_2_4_chunk" violates check constraint "constraint_4"
+\set ON_ERROR_STOP 1

--- a/test/sql/delete.sql
+++ b/test/sql/delete.sql
@@ -47,3 +47,23 @@ DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val()) RETURNING "timeCustom";
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 ROLLBACK;
+
+-- test update on chunks directly
+CREATE TABLE direct_delete(time timestamptz) WITH (tsdb.hypertable);
+
+INSERT INTO direct_delete VALUES ('2020-01-01');
+SELECT show_chunks('direct_delete') AS "CHUNK" \gset
+
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) DELETE FROM :CHUNK;
+EXPLAIN (costs off, timing off, summary off) DELETE FROM ONLY :CHUNK;
+
+-- DELETE should succeed
+BEGIN;
+DELETE FROM :CHUNK RETURNING *;
+ROLLBACK;
+
+BEGIN;
+DELETE FROM ONLY :CHUNK RETURNING *;
+ROLLBACK;
+

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -210,3 +210,48 @@ ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
 INSERT INTO i3037 VALUES ('2000-01-01');
 INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;
 
+-- test inserting into chunks directly
+CREATE TABLE direct_insert(time timestamptz, meta text) WITH (tsdb.hypertable);
+
+INSERT INTO direct_insert VALUES ('2020-01-01');
+SELECT show_chunks('direct_insert') AS "CHUNK" \gset
+
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) INSERT INTO :CHUNK VALUES ('2020-01-01');
+
+-- correct time range should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+-- incorrect time range should fail
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2020-01-01'), ('2021-01-01') RETURNING *;
+INSERT INTO :CHUNK VALUES ('2025-01-01') RETURNING *;
+\set ON_ERROR_STOP 1
+
+-- test that triggers on chunks work
+CREATE FUNCTION test_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'trigger called';
+  NEW.meta = 'triggered';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER test_trigger BEFORE INSERT ON direct_insert FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+
+-- test upsert
+DELETE FROM direct_insert;
+ALTER TABLE direct_insert ADD CONSTRAINT direct_insert_pkey PRIMARY KEY (time);
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+
+-- DO NOTHING should succeed
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT DO NOTHING RETURNING *;
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET meta = 'update' RETURNING *;
+
+\set ON_ERROR_STOP 0
+-- conflict should fail
+INSERT INTO :CHUNK VALUES ('2020-01-01') RETURNING *;
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = '2000-01-01' RETURNING *;
+INSERT INTO :CHUNK VALUES ('2020-01-01') ON CONFLICT (time) DO UPDATE SET time = EXCLUDED.time + '1 year' RETURNING *;
+\set ON_ERROR_STOP 1
+

--- a/test/sql/update.sql
+++ b/test/sql/update.sql
@@ -38,3 +38,23 @@ SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id, series_0, series
 UPDATE "one_Partition" SET series_1 = 47;
 UPDATE "one_Partition" SET series_bool = true;
 SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id, series_0, series_1, series_2;
+
+-- test update on chunks directly
+CREATE TABLE direct_update(time timestamptz) WITH (tsdb.hypertable);
+
+INSERT INTO direct_update VALUES ('2020-01-01');
+SELECT show_chunks('direct_update') AS "CHUNK" \gset
+
+--should have ModifyHyperable node
+EXPLAIN (costs off, timing off, summary off) UPDATE :CHUNK SET time = time + INTERVAL '1 minute';
+EXPLAIN (costs off, timing off, summary off) UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 minute';
+
+-- correct time range should succeed
+UPDATE :CHUNK SET time = time + INTERVAL '1 minute' RETURNING *;
+UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 minute' RETURNING *;
+-- crossing chunk boundary should fail
+\set ON_ERROR_STOP 0
+UPDATE :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
+UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
+\set ON_ERROR_STOP 1
+

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -169,7 +169,7 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 	}
 	/*
 	 * We do not support MERGE command with UPDATE/DELETE merge actions on
-	 * compressed hypertables, because Custom Scan (HypertableModify) node is
+	 * compressed hypertables, because Custom Scan (ModifyHypertable) node is
 	 * not generated in the plan for MERGE command on compressed hypertables
 	 */
 	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1871,6 +1871,93 @@ SELECT _timescaledb_functions.attach_osm_table_chunk('ht_alter', 'child_ht_alter
 
 ALTER TABLE ht_alter SET (autovacuum_enabled = false);
 ALTER TABLE ht_alter RESET (autovacuum_enabled);
+-- test DML blocker on frozen chunks
+CREATE TABLE dml_blocks (time timestamptz, device text, value float) WITH (tsdb.hypertable, tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- DML on hypertable before freezing should work
+INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
+BEGIN;
+UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
+DELETE FROM dml_blocks WHERE device = 'dev2';
+ROLLBACK;
+SELECT show_chunks('dml_blocks') AS "CHUNK" \gset
+-- DML on chunk before freezing should work
+BEGIN;
+INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
+UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
+DELETE FROM :CHUNK WHERE device = 'dev2';
+ROLLBACK;
+SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
+ freeze_chunk 
+--------------
+ t
+(1 row)
+
+-- DML on hypertable after freezing should be blocked
+\set ON_ERROR_STOP 0
+INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
+UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
+ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+DELETE FROM dml_blocks WHERE device = 'dev2';
+ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+\set ON_ERROR_STOP 1
+-- DML on chunk after freezing should be blocked
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
+ERROR:  cannot modify frozen chunk
+UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
+ERROR:  cannot modify frozen chunk
+DELETE FROM :CHUNK WHERE device = 'dev2';
+ERROR:  cannot modify frozen chunk
+\set ON_ERROR_STOP 1
+-- repeat tests with compressed chunk
+SELECT _timescaledb_functions.unfreeze_chunk(:'CHUNK');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
+SELECT compress_chunk(:'CHUNK');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_27_44_chunk
+(1 row)
+
+SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
+ freeze_chunk 
+--------------
+ t
+(1 row)
+
+SELECT format('%I.%I', schema_name, table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk ORDER BY id DESC LIMIT 1 \gset
+-- DML on hypertable after freezing should be blocked
+\set ON_ERROR_STOP 0
+INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
+UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
+ERROR:  cannot modify frozen chunk status
+DELETE FROM dml_blocks WHERE device = 'dev2';
+ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+\set ON_ERROR_STOP 1
+-- DML on chunk after freezing should be blocked
+\set ON_ERROR_STOP 0
+INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
+ERROR:  cannot modify frozen chunk
+UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
+ERROR:  cannot modify frozen chunk
+DELETE FROM :CHUNK WHERE device = 'dev2';
+ERROR:  cannot modify frozen chunk
+\set ON_ERROR_STOP 1
+-- DML on chunk after freezing should be blocked
+\set ON_ERROR_STOP 0
+INSERT INTO :COMPRESSED_CHUNK SELECT;
+ERROR:  cannot modify compressed chunk belonging to a frozen chunk
+UPDATE :COMPRESSED_CHUNK SET device = 'dev3' WHERE device = 'dev1';
+ERROR:  cannot modify compressed chunk belonging to a frozen chunk
+DELETE FROM :COMPRESSED_CHUNK WHERE device = 'dev1';
+ERROR:  cannot modify compressed chunk belonging to a frozen chunk
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- clean up databases created
 DROP DATABASE postgres_fdw_db WITH (FORCE);

--- a/tsl/test/expected/compressed_insert.out
+++ b/tsl/test/expected/compressed_insert.out
@@ -450,3 +450,71 @@ SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics
 (1 row)
 
 ROLLBACK;
+-- test direct compress into chunk directly
+CREATE TABLE metrics_chunk(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time');
+SET timescaledb.enable_direct_compress_insert = true;
+-- create uncompressed chunk
+INSERT INTO metrics_chunk SELECT '2025-01-01';
+WARNING:  disabling direct compress because of too small batch size
+-- status should be normal uncompressed chunk since it was single tuple insert
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_chunk') chunk;
+ chunk_status_text 
+-------------------
+ {}
+(1 row)
+
+SELECT show_chunks('metrics_chunk') AS "CHUNK" \gset
+EXPLAIN (costs off,summary off,timing off) INSERT INTO :CHUNK SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval FROM generate_series(0,100) i;
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ModifyHypertable)
+   Direct Compress: true
+   ->  Insert on _hyper_6_41_chunk
+         ->  Function Scan on generate_series i
+(4 rows)
+
+BEGIN;
+INSERT INTO :CHUNK SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval FROM generate_series(0,100) i;
+-- status should be COMPRESSED, UNORDERED, PARTIAL
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_chunk') chunk;
+       chunk_status_text        
+--------------------------------
+ {COMPRESSED,UNORDERED,PARTIAL}
+(1 row)
+
+-- delete should propagate to compressed chunk
+SELECT count(*) FROM :CHUNK;
+ count 
+-------
+   102
+(1 row)
+
+EXPLAIN (analyze,buffers off,costs off,summary off,timing off) DELETE FROM :CHUNK WHERE time > '2025-01-01'::timestamptz;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 101
+   ->  Delete on _hyper_6_41_chunk (actual rows=0.00 loops=1)
+         ->  Index Scan using _hyper_6_41_chunk_metrics_chunk_time_idx on _hyper_6_41_chunk (actual rows=100.00 loops=1)
+               Index Cond: ("time" > 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
+(6 rows)
+
+SELECT count(*) FROM :CHUNK;
+ count 
+-------
+     2
+(1 row)
+
+ROLLBACK;
+BEGIN;
+SET timescaledb.enable_direct_compress_insert_client_sorted = true;
+INSERT INTO :CHUNK SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval FROM generate_series(0,100) i;
+-- status should be COMPRESSED, PARTIAL
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_chunk') chunk;
+  chunk_status_text   
+----------------------
+ {COMPRESSED,PARTIAL}
+(1 row)
+
+ROLLBACK;

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1569,3 +1569,41 @@ ORDER BY 1;
 (3 rows)
 
 DROP TABLE gen_column;
+-- test insert into compressed chunk directly works
+-- to ensure maintenance operations work unhindered we dont
+-- want to block direct inserts into compressed chunks
+CREATE TABLE direct_compressed_insert (time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+HINT:  Use "timescaledb.partition_column" to specify a different column to use as partitioning column.
+INSERT INTO direct_compressed_insert SELECT generate_series('2024-01-01'::timestamptz, '2024-01-01 1:00:00'::timestamptz, '1 second');
+SELECT count(compress_chunk(c)) FROM show_chunks('direct_compressed_insert') c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk ORDER BY id DESC LIMIT 1 \gset
+CREATE TABLE compressed_batches AS SELECT * FROM :CHUNK;
+SELECT _ts_meta_count, count(*) FROM :CHUNK GROUP BY _ts_meta_count ORDER BY 1 DESC;
+ _ts_meta_count | count 
+----------------+-------
+           1000 |     3
+            601 |     1
+(2 rows)
+
+-- should have not ModifyHypertable node
+EXPLAIN (costs off,timing off, summary off) INSERT INTO :CHUNK SELECT * FROM compressed_batches;
+              QUERY PLAN              
+--------------------------------------
+ Insert on compress_hyper_43_95_chunk
+   ->  Seq Scan on compressed_batches
+(2 rows)
+
+INSERT INTO :CHUNK SELECT * FROM compressed_batches;
+SELECT _ts_meta_count, count(*) FROM :CHUNK GROUP BY _ts_meta_count ORDER BY 1 DESC;
+ _ts_meta_count | count 
+----------------+-------
+           1000 |     6
+            601 |     2
+(2 rows)
+

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -749,7 +749,7 @@ select table_name, dropped, status, compressed_chunk_id
 from _timescaledb_catalog.chunk where table_name = '_hyper_1_3_chunk';
     table_name    | dropped | status | compressed_chunk_id 
 ------------------+---------+--------+---------------------
- _hyper_1_3_chunk | f       |      1 |                  15
+ _hyper_1_3_chunk | f       |      9 |                  15
 (1 row)
 
 truncate chunk_summary_before_split;
@@ -763,7 +763,7 @@ select
 select * from chunk_summary_before_split;
  count | device_sum | location_sum |   temp_sum   
 -------+------------+--------------+--------------
- 29523 |     162731 |       169458 | 603967.96562
+ 29525 |     162733 |       169511 | 604005.96562
 (1 row)
 
 select * from chunk_info;
@@ -833,7 +833,7 @@ select
 select * from chunk_summary_before_split;
  count | device_sum | location_sum |   temp_sum   
 -------+------------+--------------+--------------
- 29523 |     162731 |       169458 | 603967.96562
+ 29525 |     162733 |       169511 | 604005.96562
 (1 row)
 
 select * from chunk_summary_after_split;

--- a/tsl/test/isolation/expected/attach_chunk_isolation.out
+++ b/tsl/test/isolation/expected/attach_chunk_isolation.out
@@ -101,7 +101,7 @@ step s1_attach: CALL attach_chunk('attach_test', 'chunk_to_attach', jsonb_build_
 step s4_violate: INSERT INTO chunk_to_attach VALUES ('2025-08-01 20:00', 1, 34); <waiting ...>
 step s1c: COMMIT;
 step s4_violate: <... completed>
-ERROR:  new row for relation "chunk_to_attach" violates check constraint "constraint_X"
+ERROR:  new row for relation "chunk_to_attach" violates chunk constraint
 step s3_show_num_chunks: SELECT count(*) FROM show_chunks('attach_test');
 count
 -----


### PR DESCRIPTION
When doing DML operations on a hypertable the postgres ModifyTable
node would be wrapped into ModifyHypertable node. This patch makes
DML operations work the same when working with chunks directly.
Previously we would not intercept DML on chunks directly leading
to some features not working correctly when operating on a chunk
directly.

Fixes #5873
Fixes #6241 
Fixes #6250
Fixes #7026