### PR TITLE
Fix warning message for concurrent policy refreshes

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -62,6 +62,7 @@ BEGIN
             JOIN _timescaledb_config.bgw_job ON bgw_job.hypertable_id = continuous_agg.mat_hypertable_id
         WHERE
             parent_mat_hypertable_id IS NOT NULL
+            AND proc_name = 'policy_refresh_continuous_aggregate'
         GROUP BY
             1
         HAVING


### PR DESCRIPTION
In #8707 we blocked creating multiple concurrent refresh policies for Hierarchical Continuous Aggregate due to potential deadlocks and emit a warning message during the extension update.

But the warning message is not taking in account only refresh policies but all policies associated to the Continuous Aggregate (compression, retention, etc). So fixed it by checking only refresh policies to emit the warning message.