### PR TITLE
Use force option to drop database in compression_null_dump_restore

### DIFF
--- a/tsl/test/expected/compression_null_dump_restore.out
+++ b/tsl/test/expected/compression_null_dump_restore.out
@@ -76,5 +76,5 @@ select * from public.null_dump order by 1;
   4 |  
 (4 rows)
 
-drop database db_compression_null_dump_restore_2;
-drop database db_compression_null_dump_restore_3;
+drop database db_compression_null_dump_restore_2 WITH (FORCE);
+drop database db_compression_null_dump_restore_3 WITH (FORCE);

--- a/tsl/test/sql/compression_null_dump_restore.sql
+++ b/tsl/test/sql/compression_null_dump_restore.sql
@@ -47,5 +47,5 @@ select public.timescaledb_post_restore();
 select * from public.null_dump order by 1;
 
 \c postgres :ROLE_SUPERUSER
-drop database :TEST_DBNAME_2;
-drop database :TEST_DBNAME_3;
+drop database :TEST_DBNAME_2 WITH (FORCE);
+drop database :TEST_DBNAME_3 WITH (FORCE);


### PR DESCRIPTION
Try to make this test less flaky by forcefully dropping database

Disable-check: force-changelog-file
Disable-check: approval-count