### PR TITLE
Remove jobs from compression_hypertable test

### DIFF
--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -60,6 +60,12 @@ CREATE OPERATOR CLASS customtype_ops
   DEFAULT
   FOR TYPE customtype
   USING hash AS OPERATOR 1 =;
+SELECT count(delete_job(job_id)) from timescaledb_information.jobs ;
+ count 
+-------
+     2
+(1 row)
+
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');

--- a/tsl/test/sql/compression_hypertable.sql
+++ b/tsl/test/sql/compression_hypertable.sql
@@ -41,6 +41,8 @@ CREATE OPERATOR CLASS customtype_ops
   FOR TYPE customtype
   USING hash AS OPERATOR 1 =;
 
+SELECT count(delete_job(job_id)) from timescaledb_information.jobs ;
+
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);


### PR DESCRIPTION
Jobs could be the culprit for causing flakiness
when we attempt to drop and recreate the DB in this test so removing them should help reduce the issue.

Disable-check: force-changelog-file
Disable-check: approval-count