### PR TITLE
Add WITH (FORCE) to DML compression test

### DIFF
--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -2505,7 +2505,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE tab1;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test5586;
+DROP DATABASE test5586 WITH (FORCE);
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
@@ -2732,7 +2732,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE t6367;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test6367;
+DROP DATABASE test6367 WITH (FORCE);
 -- Text limitting decompressed tuple during an UPDATE or DELETE
 CREATE TABLE test_limit (
     timestamp int not null,

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -2505,7 +2505,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE tab1;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test5586;
+DROP DATABASE test5586 WITH (FORCE);
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
@@ -2732,7 +2732,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE t6367;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test6367;
+DROP DATABASE test6367 WITH (FORCE);
 -- Text limitting decompressed tuple during an UPDATE or DELETE
 CREATE TABLE test_limit (
     timestamp int not null,

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -2505,7 +2505,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE tab1;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test5586;
+DROP DATABASE test5586 WITH (FORCE);
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
@@ -2732,7 +2732,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE t6367;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test6367;
+DROP DATABASE test6367 WITH (FORCE);
 -- Text limitting decompressed tuple during an UPDATE or DELETE
 CREATE TABLE test_limit (
     timestamp int not null,

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1331,7 +1331,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE tab1;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test5586;
+DROP DATABASE test5586 WITH (FORCE);
 
 
 --issue: #6024
@@ -1443,7 +1443,7 @@ ROLLBACK;
 RESET timescaledb.debug_compression_path_info;
 DROP TABLE t6367;
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test6367;
+DROP DATABASE test6367 WITH (FORCE);
 
 -- Text limitting decompressed tuple during an UPDATE or DELETE
 CREATE TABLE test_limit (


### PR DESCRIPTION
This is to reduce the chance of tests failing due to stray bgw running during the drop.

Disable-check: force-changelog-file
Disable-check: approval-count