### PR TITLE
Use custom COPY code for direct COPY in chunk

### DIFF
--- a/.unreleased/pr_8734
+++ b/.unreleased/pr_8734
@@ -1,0 +1,1 @@
+Implements: #8734 Support direct compress when inserting into chunk

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1609,17 +1609,14 @@ replace_modify_hypertable_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 					continue;
 				}
 
-				if (ts_chunk_is_frozen(chunk))
-					ereport(ERROR,
-							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-							 errmsg("cannot modify frozen chunk")));
-
 				ht = ts_hypertable_get_by_id(chunk->fd.hypertable_id);
 				if (ht->fd.compression_state == HypertableInternalCompressionTable)
 				{
 					/*
 					 * For operations on internal compressed chunks we block modifications
 					 * if the chunk belongs to a frozen chunk.
+					 * Direct modifications of uncompressed chunks is intercepted by chunk
+					 * tuple routing.
 					 * In all other cases of direct modification of chunks we dont interfere
 					 * and do not add a ModifyHypertable node.
 					 */

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1879,6 +1879,7 @@ INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
 BEGIN;
 UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM dml_blocks WHERE device = 'dev2';
+COPY dml_blocks FROM STDIN;
 ROLLBACK;
 SELECT show_chunks('dml_blocks') AS "CHUNK" \gset
 -- DML on chunk before freezing should work
@@ -1886,6 +1887,7 @@ BEGIN;
 INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
 UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM :CHUNK WHERE device = 'dev2';
+COPY :CHUNK FROM STDIN;
 ROLLBACK;
 SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
  freeze_chunk 
@@ -1901,15 +1903,19 @@ UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
 ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
 DELETE FROM dml_blocks WHERE device = 'dev2';
 ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+COPY dml_blocks FROM STDIN;
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
 \set ON_ERROR_STOP 1
 -- DML on chunk after freezing should be blocked
 \set ON_ERROR_STOP 0
 INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
-ERROR:  cannot modify frozen chunk
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
 UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
-ERROR:  cannot modify frozen chunk
+ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
 DELETE FROM :CHUNK WHERE device = 'dev2';
-ERROR:  cannot modify frozen chunk
+ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+COPY :CHUNK FROM STDIN;
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
 \set ON_ERROR_STOP 1
 -- repeat tests with compressed chunk
 SELECT _timescaledb_functions.unfreeze_chunk(:'CHUNK');
@@ -1939,15 +1945,19 @@ UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
 ERROR:  cannot modify frozen chunk status
 DELETE FROM dml_blocks WHERE device = 'dev2';
 ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+COPY dml_blocks FROM STDIN;
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
 \set ON_ERROR_STOP 1
 -- DML on chunk after freezing should be blocked
 \set ON_ERROR_STOP 0
 INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
-ERROR:  cannot modify frozen chunk
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
 UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
-ERROR:  cannot modify frozen chunk
+ERROR:  cannot modify frozen chunk status
 DELETE FROM :CHUNK WHERE device = 'dev2';
-ERROR:  cannot modify frozen chunk
+ERROR:  cannot update/delete rows from chunk "_hyper_27_44_chunk" as it is frozen
+COPY :CHUNK FROM STDIN;
+ERROR:  cannot INSERT into frozen chunk "_hyper_27_44_chunk"
 \set ON_ERROR_STOP 1
 -- DML on chunk after freezing should be blocked
 \set ON_ERROR_STOP 0
@@ -1957,6 +1967,8 @@ UPDATE :COMPRESSED_CHUNK SET device = 'dev3' WHERE device = 'dev1';
 ERROR:  cannot modify compressed chunk belonging to a frozen chunk
 DELETE FROM :COMPRESSED_CHUNK WHERE device = 'dev1';
 ERROR:  cannot modify compressed chunk belonging to a frozen chunk
+COPY :COMPRESSED_CHUNK FROM STDIN;
+ERROR:  cannot COPY into chunk belonging to a frozen chunk
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- clean up databases created

--- a/tsl/test/expected/compressed_copy.out
+++ b/tsl/test/expected/compressed_copy.out
@@ -343,3 +343,29 @@ SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics
 (1 row)
 
 ROLLBACK;
+SELECT tableoid::regclass AS "CHUNK" FROM metrics_status WHERE time = '2025-01-01' LIMIT 1 \gset
+-- repeat tests with direct reference to chunk
+BEGIN;
+-- compressed copy into fully compressed chunk should result in chunk status 3 (compressed,unordered)
+SET timescaledb.enable_direct_compress_copy = true;
+SET timescaledb.enable_direct_compress_copy_client_sorted = false;
+COPY :CHUNK FROM STDIN;
+SELECT _timescaledb_functions.chunk_status_text(:'CHUNK'::regclass);
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+(1 row)
+
+ROLLBACK;
+BEGIN;
+-- compressed copy new chunk should result in chunk status 1 (compressed)
+SET timescaledb.enable_direct_compress_copy = true;
+SET timescaledb.enable_direct_compress_copy_client_sorted = true;
+COPY :CHUNK FROM STDIN;
+SELECT _timescaledb_functions.chunk_status_text(:'CHUNK'::regclass);
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+(1 row)
+
+ROLLBACK;

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -868,6 +868,9 @@ INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
 BEGIN;
 UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM dml_blocks WHERE device = 'dev2';
+COPY dml_blocks FROM STDIN;
+2025-01-01	dev1	1.0
+\.
 ROLLBACK;
 SELECT show_chunks('dml_blocks') AS "CHUNK" \gset
 
@@ -876,6 +879,9 @@ BEGIN;
 INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
 UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM :CHUNK WHERE device = 'dev2';
+COPY :CHUNK FROM STDIN;
+2025-01-01	dev1	1.0
+\.
 ROLLBACK;
 
 SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
@@ -885,6 +891,9 @@ SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
 INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
 UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM dml_blocks WHERE device = 'dev2';
+COPY dml_blocks FROM STDIN;
+2025-01-01	dev1	1.0
+\.
 \set ON_ERROR_STOP 1
 
 -- DML on chunk after freezing should be blocked
@@ -892,6 +901,9 @@ DELETE FROM dml_blocks WHERE device = 'dev2';
 INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
 UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM :CHUNK WHERE device = 'dev2';
+COPY :CHUNK FROM STDIN;
+2025-01-01	dev1	1.0
+\.
 \set ON_ERROR_STOP 1
 
 -- repeat tests with compressed chunk
@@ -905,6 +917,9 @@ SELECT format('%I.%I', schema_name, table_name) AS "COMPRESSED_CHUNK" FROM _time
 INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);
 UPDATE dml_blocks SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM dml_blocks WHERE device = 'dev2';
+COPY dml_blocks FROM STDIN;
+2025-01-01	dev1	1.0
+\.
 \set ON_ERROR_STOP 1
 
 -- DML on chunk after freezing should be blocked
@@ -912,6 +927,9 @@ DELETE FROM dml_blocks WHERE device = 'dev2';
 INSERT INTO :CHUNK VALUES ('2025-01-01','dev1',1.0);
 UPDATE :CHUNK SET value = 2.0 WHERE device = 'dev1';
 DELETE FROM :CHUNK WHERE device = 'dev2';
+COPY :CHUNK FROM STDIN;
+2025-01-01	dev1	1.0
+\.
 \set ON_ERROR_STOP 1
 
 -- DML on chunk after freezing should be blocked
@@ -919,6 +937,7 @@ DELETE FROM :CHUNK WHERE device = 'dev2';
 INSERT INTO :COMPRESSED_CHUNK SELECT;
 UPDATE :COMPRESSED_CHUNK SET device = 'dev3' WHERE device = 'dev1';
 DELETE FROM :COMPRESSED_CHUNK WHERE device = 'dev1';
+COPY :COMPRESSED_CHUNK FROM STDIN;
 \set ON_ERROR_STOP 1
 
 \c :TEST_DBNAME :ROLE_SUPERUSER


### PR DESCRIPTION
Previously only COPY targetting hypertable would result in our
custom COPY code being used. COPY targetting chunk directly would
instead use postgres COPY code. This means DML into frozen chunks
would not be prevented and direct compress would not be used.
