### PR TITLE
Fix UNION queries on compressed chunks

### DIFF
--- a/.unreleased/pr_8735
+++ b/.unreleased/pr_8735
@@ -1,0 +1,1 @@
+Fixes: #8735 Fix ColumnarScan for UNION queries

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -566,8 +566,20 @@ build_compressioninfo(PlannerInfo *root, const Hypertable *ht, const Chunk *chun
 	if (chunk_rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
 	{
 		appinfo = ts_get_appendrelinfo(root, chunk_rel->relid, false);
-		info->ht_rte = planner_rt_fetch(appinfo->parent_relid, root);
-		info->ht_rel = root->simple_rel_array[appinfo->parent_relid];
+		RangeTblEntry *rte = planner_rt_fetch(appinfo->parent_relid, root);
+		if (rte->rtekind == RTE_RELATION)
+		{
+			info->ht_rte = rte;
+			info->ht_rel = root->simple_rel_array[appinfo->parent_relid];
+		}
+		else
+		{
+			/* In UNION queries referencing chunks directly, the parent rel can be a subquery */
+			Assert(rte->rtekind == RTE_SUBQUERY);
+			info->single_chunk = true;
+			info->ht_rte = info->chunk_rte;
+			info->ht_rel = info->chunk_rel;
+		}
 	}
 	else
 	{
@@ -1027,7 +1039,6 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, con
 		 * estimate.
 		 */
 		AppendRelInfo *chunk_info = ts_get_appendrelinfo(root, chunk_rel->relid, false);
-		Assert(chunk_info->parent_reloid == ht->main_table_relid);
 		const Index ht_relid = chunk_info->parent_relid;
 		RelOptInfo *hypertable_rel = root->simple_rel_array[ht_relid];
 		hypertable_rel->rows += (new_row_estimate - chunk_rel->rows);
@@ -1941,6 +1952,7 @@ add_segmentby_to_equivalence_class(PlannerInfo *root, EquivalenceClass *cur_ec,
 		/* given that the em is a var of the uncompressed chunk, the relid of the chunk should
 		 * be set on the em */
 		Assert(bms_is_member(info->ht_rel->relid, cur_em->em_relids));
+		Assert(OidIsValid(info->ht_rte->relid));
 
 		const char *attname = get_attname(info->ht_rte->relid, var->varattno, false);
 

--- a/tsl/test/expected/merge_append_partially_compressed.out
+++ b/tsl/test/expected/merge_append_partially_compressed.out
@@ -42,6 +42,75 @@ SELECT tableoid::regclass, min(time), max(time) from ht_metrics_compressed group
  _timescaledb_internal._hyper_1_3_chunk | Wed Jan 15 16:00:00 2020 PST | Fri Jan 17 16:00:00 2020 PST
 (3 rows)
 
+SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
+-- test UNION with partially compressed chunks
+:PREFIX SELECT * FROM :CHUNK UNION ALL SELECT * FROM :CHUNK;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Append (actual rows=282.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=84.00 loops=1)
+         ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3.00 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk (actual rows=57.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=84.00 loops=1)
+         ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=3.00 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=57.00 loops=1)
+(7 rows)
+
+:PREFIX SELECT * FROM :CHUNK UNION ALL SELECT * FROM :CHUNK ORDER BY time DESC;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Sort (actual rows=282.00 loops=1)
+   Sort Key: _hyper_1_1_chunk."time" DESC
+   Sort Method: quicksort 
+   ->  Append (actual rows=282.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=84.00 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3.00 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=57.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=84.00 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=3.00 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=57.00 loops=1)
+(10 rows)
+
+:PREFIX SELECT device FROM :CHUNK UNION ALL SELECT device FROM :CHUNK ORDER BY device DESC;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Merge Append (actual rows=282.00 loops=1)
+   Sort Key: _hyper_1_1_chunk.device DESC
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=84.00 loops=1)
+         ->  Sort (actual rows=3.00 loops=1)
+               Sort Key: compress_hyper_2_4_chunk.device DESC
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=57.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.device DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=57.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=84.00 loops=1)
+         ->  Sort (actual rows=3.00 loops=1)
+               Sort Key: compress_hyper_2_4_chunk_1.device DESC
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=57.00 loops=1)
+         Sort Key: _hyper_1_1_chunk_1.device DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=57.00 loops=1)
+(20 rows)
+
+:PREFIX SELECT value FROM :CHUNK UNION ALL SELECT value FROM :CHUNK ORDER BY value DESC;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Sort (actual rows=282.00 loops=1)
+   Sort Key: _hyper_1_1_chunk.value DESC
+   Sort Method: quicksort 
+   ->  Append (actual rows=282.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=84.00 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3.00 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=57.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=84.00 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=3.00 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=57.00 loops=1)
+(10 rows)
+
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time DESC, device LIMIT 1;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -10,7 +10,7 @@ SET parallel_leader_participation TO off;
 SET min_parallel_table_scan_size TO '0';
 SET enable_incremental_sort TO off;
 SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
--- this should use DecompressChunk node
+-- this should use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
@@ -25,7 +25,7 @@ QUERY PLAN
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
 (9 rows)
 
--- must not use DecompressChunk node
+-- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
@@ -38,6 +38,33 @@ QUERY PLAN
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
                Output: "time", device_id, v0, v1, v2, v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- this should use ColumnarScan node
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE;
+QUERY PLAN
+ Gather
+   Workers Planned: 2
+   ->  Parallel Append
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(7 rows)
+
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
+QUERY PLAN
+ Sort
+   Sort Key: _hyper_X_X_chunk."time"
+   ->  Gather
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (9 rows)
 
 -- test expressions

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -10,7 +10,7 @@ SET parallel_leader_participation TO off;
 SET min_parallel_table_scan_size TO '0';
 SET enable_incremental_sort TO off;
 SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
--- this should use DecompressChunk node
+-- this should use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
@@ -25,7 +25,7 @@ QUERY PLAN
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
 (9 rows)
 
--- must not use DecompressChunk node
+-- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
@@ -38,6 +38,33 @@ QUERY PLAN
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
                Output: "time", device_id, v0, v1, v2, v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- this should use ColumnarScan node
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE;
+QUERY PLAN
+ Gather
+   Workers Planned: 2
+   ->  Parallel Append
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(7 rows)
+
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
+QUERY PLAN
+ Sort
+   Sort Key: _hyper_X_X_chunk."time"
+   ->  Gather
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (9 rows)
 
 -- test expressions

--- a/tsl/test/shared/expected/transparent_decompress_chunk-17.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-17.out
@@ -10,7 +10,7 @@ SET parallel_leader_participation TO off;
 SET min_parallel_table_scan_size TO '0';
 SET enable_incremental_sort TO off;
 SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
--- this should use DecompressChunk node
+-- this should use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
@@ -25,7 +25,7 @@ QUERY PLAN
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
 (9 rows)
 
--- must not use DecompressChunk node
+-- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
@@ -38,6 +38,33 @@ QUERY PLAN
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
                Output: "time", device_id, v0, v1, v2, v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- this should use ColumnarScan node
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE;
+QUERY PLAN
+ Gather
+   Workers Planned: 2
+   ->  Parallel Append
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(7 rows)
+
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
+QUERY PLAN
+ Sort
+   Sort Key: _hyper_X_X_chunk."time"
+   ->  Gather
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (9 rows)
 
 -- test expressions

--- a/tsl/test/shared/expected/transparent_decompress_chunk-18.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-18.out
@@ -1,43 +1,71 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
-\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
-\set PREFIX_NO_VERBOSE 'EXPLAIN (costs off)'
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, buffers off, costs off)'
+\set PREFIX_NO_VERBOSE 'EXPLAIN (buffers off, costs off)'
 -- Some tweaks to get less flaky test
 SET parallel_leader_participation TO off;
 SET min_parallel_table_scan_size TO '0';
 SET enable_incremental_sort TO off;
 SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
--- this should use DecompressChunk node
+-- this should use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
- Limit (actual rows=5 loops=1)
+ Limit (actual rows=5.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Reverse: true
          Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+               Index Searches: 1
+(10 rows)
 
--- must not use DecompressChunk node
+-- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
    Output: "time", device_id, v0, v1, v2, v3
-   ->  Sort (actual rows=0 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
          Output: "time", device_id, v0, v1, v2, v3
          Sort Key: _hyper_X_X_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
                Output: "time", device_id, v0, v1, v2, v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- this should use ColumnarScan node
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE;
+QUERY PLAN
+ Gather
+   Workers Planned: 2
+   ->  Parallel Append
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+               ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(7 rows)
+
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
+QUERY PLAN
+ Sort
+   Sort Key: _hyper_X_X_chunk."time"
+   ->  Gather
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (9 rows)
 
 -- test expressions
@@ -52,94 +80,100 @@ FROM :TEST_TABLE t
 WHERE device_id IN (1, 2)
 ORDER BY time, device_id;
 QUERY PLAN
- Sort (actual rows=7196 loops=1)
+ Sort (actual rows=7196.00 loops=1)
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
-   ->  Result (actual rows=7196 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+   ->  Result (actual rows=7196.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=7196.00 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+                     Index Searches: 1
+(8 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
 (2 rows)
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
-(3 rows)
+         Index Searches: 1
+(4 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
 QUERY PLAN
- Result (actual rows=17990 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+ Result (actual rows=17990.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
 (3 rows)
 
 -- test constraints not present in targetlist
 :PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
 QUERY PLAN
- Sort (actual rows=3598 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+               Index Searches: 1
+(7 rows)
 
 -- test order not present in targetlist
 :PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
 QUERY PLAN
- Sort (actual rows=3598 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+               Index Searches: 1
+(7 rows)
 
 -- test column with all NULL
 :PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Index Cond: (device_id = 1)
-(3 rows)
+         Index Searches: 1
+(4 rows)
 
 -- test qual pushdown
 -- v3 is not segment by or order by column so should not be pushed down
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
 QUERY PLAN
- Sort (actual rows=0 loops=1)
+ Sort (actual rows=0.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
          Rows Removed by Filter: 17990
          Batches Removed by Filter: 20
          Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20 loops=1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
                Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
 (12 rows)
 
 -- device_id constraint should be pushed down
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+               Index Searches: 1
+(5 rows)
 
 -- test IS NULL / IS NOT NULL
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
@@ -149,42 +183,45 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
 (8 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
-(7 rows)
+                     Index Searches: 1
+(8 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Sort (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=7196.00 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+                     Index Searches: 1
+(8 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+               Index Searches: 1
+(5 rows)
 
 --test var op var
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
@@ -194,7 +231,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Filter: (device_id = v0)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (8 rows)
@@ -206,7 +243,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Filter: (device_id < v1)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (8 rows)
@@ -214,17 +251,18 @@ QUERY PLAN
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 3)
-(4 rows)
+               Index Searches: 1
+(5 rows)
 
 -- test function calls
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
          ->  Sort
                Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
@@ -236,7 +274,7 @@ QUERY PLAN
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
          Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
                Index Cond: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
@@ -249,7 +287,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -262,7 +300,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -275,7 +313,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -288,7 +326,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -301,7 +339,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -315,7 +353,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: (v0 < 1)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (8 rows)
@@ -327,7 +365,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Filter: (v0 < device_id)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (8 rows)
@@ -339,7 +377,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Filter: (device_id < v0)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (8 rows)
@@ -351,7 +389,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Filter: (v1 = device_id)
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (8 rows)
@@ -359,35 +397,36 @@ QUERY PLAN
 --pushdown between two order by column (not pushed down)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
-   ->  Gather Merge (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
+   ->  Gather Merge (actual rows=0.00 loops=1)
          Workers Planned: 2
          Workers Launched: 2
-         ->  Sort (actual rows=0 loops=2)
+         ->  Sort (actual rows=0.00 loops=2)
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Worker 0:  Sort Method: quicksort 
                Worker 1:  Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=2)
                      Filter: (v0 = v1)
                      Rows Removed by Filter: 8995
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
 (12 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
+ Limit (actual rows=10.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 31
          Reverse: true
          Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
                Index Cond: ((compress_hyper_X_X_chunk.device_id = 1) AND (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(11 rows)
+               Index Searches: 1
+(12 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -397,7 +436,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
@@ -411,7 +450,7 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" < now())
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                            Filter: (_ts_meta_min_1 < now())
@@ -421,7 +460,7 @@ QUERY PLAN
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
          ->  Sort
                Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                ->  Seq Scan on compress_hyper_X_X_chunk
@@ -434,63 +473,65 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
 (7 rows)
 
 :PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
 (3 rows)
 
 -- test aggregate
 :PREFIX SELECT count(*) FROM :TEST_TABLE;
 QUERY PLAN
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=1 loops=1)
+ Finalize Aggregate (actual rows=1.00 loops=1)
+   ->  Gather (actual rows=1.00 loops=1)
          Workers Planned: 2
          Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=0 loops=2)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (VectorAgg) (actual rows=0.50 loops=2)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
 (7 rows)
 
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Finalize GroupAggregate (actual rows=5 loops=1)
+ Finalize GroupAggregate (actual rows=5.00 loops=1)
    Group Key: _hyper_X_X_chunk.device_id
-   ->  Gather Merge (actual rows=20 loops=1)
+   ->  Gather Merge (actual rows=20.00 loops=1)
          Workers Planned: 2
          Workers Launched: 2
-         ->  Sort (actual rows=10 loops=2)
-               Sort Key: _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: quicksort 
-               Worker 1:  Sort Method: quicksort 
-               ->  Custom Scan (VectorAgg) (actual rows=10 loops=2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
+                     ->  Sort (actual rows=10.00 loops=2)
+                           Sort Key: compress_hyper_X_X_chunk.device_id
+                           Worker 0:  Sort Method: quicksort 
+                           Worker 1:  Sort Method: quicksort 
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
 (12 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- WindowAgg (actual rows=5 loops=1)
-   ->  Finalize GroupAggregate (actual rows=5 loops=1)
+ WindowAgg (actual rows=5.00 loops=1)
+   Window: w1 AS ()
+   Storage: Memory  Maximum Storage: 17kB
+   ->  Finalize GroupAggregate (actual rows=5.00 loops=1)
          Group Key: _hyper_X_X_chunk.device_id
-         ->  Gather Merge (actual rows=20 loops=1)
+         ->  Gather Merge (actual rows=20.00 loops=1)
                Workers Planned: 2
                Workers Launched: 2
-               ->  Sort (actual rows=10 loops=2)
-                     Sort Key: _hyper_X_X_chunk.device_id
-                     Worker 0:  Sort Method: quicksort 
-                     Worker 1:  Sort Method: quicksort 
-                     ->  Custom Scan (VectorAgg) (actual rows=10 loops=2)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
-(13 rows)
+               ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
+                           ->  Sort (actual rows=10.00 loops=2)
+                                 Sort Key: compress_hyper_X_X_chunk.device_id
+                                 Worker 0:  Sort Method: quicksort 
+                                 Worker 1:  Sort Method: quicksort 
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
+(15 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -498,15 +539,15 @@ QUERY PLAN
 )
 SELECT * FROM q ORDER BY v1;
 QUERY PLAN
- Sort (actual rows=17990 loops=1)
+ Sort (actual rows=17990.00 loops=1)
    Sort Key: q.v1
    Sort Method: quicksort 
-   ->  Subquery Scan on q (actual rows=17990 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Sort (actual rows=20 loops=1)
+   ->  Subquery Scan on q (actual rows=17990.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
+               ->  Sort (actual rows=20.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
 (9 rows)
 
 -- test CTE join
@@ -518,173 +559,157 @@ q2 AS (
 )
 SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
 QUERY PLAN
- Merge Join (actual rows=3598 loops=1)
+ Merge Join (actual rows=3598.00 loops=1)
    Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                Index Cond: (device_id = 1)
-   ->  Materialize (actual rows=3598 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+               Index Searches: 1
+   ->  Materialize (actual rows=3598.00 loops=1)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
                      Index Cond: (device_id = 2)
-(9 rows)
+                     Index Searches: 1
+(12 rows)
 
 -- test indexes
 SET enable_seqscan TO FALSE;
 -- IndexScans should work
 :PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    Reverse: true
    Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+         Index Searches: 1
+(8 rows)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    Reverse: true
    Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+         Index Searches: 1
+(8 rows)
 
 -- whole row reference should work
 :PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598.00 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
    Reverse: true
    Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+         Index Searches: 1
+(8 rows)
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
 QUERY PLAN
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk.device_id
    Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+         Index Searches: 1
+(7 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
- Aggregate (actual rows=1 loops=1)
+ Aggregate (actual rows=1.00 loops=1)
    Output: count(*)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+               Index Searches: 1
+(8 rows)
 
 --ensure that we can get a nested loop
 SET enable_seqscan TO TRUE;
 SET enable_hashjoin TO FALSE;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
 QUERY PLAN
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk.device_id
    Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+         Index Searches: 1
+(7 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
 QUERY PLAN
- Nested Loop (actual rows=7196 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=7196.00 loops=1)
    Output: _hyper_X_X_chunk.device_id
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   Bulk Decompression: false
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Index Searches: 1
+(7 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
 QUERY PLAN
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk.device_id
    Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
          Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+         Index Searches: 1
+(7 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
 QUERY PLAN
- Nested Loop (actual rows=7196 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=7196.00 loops=1)
    Output: _hyper_X_X_chunk.device_id
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   Bulk Decompression: false
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Index Searches: 1
+(7 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
 :PREFIX_NO_ANALYZE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
 QUERY PLAN
- Nested Loop
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
    Output: _hyper_X_X_chunk.device_id
-   ->  Unique
-         Output: "*VALUES*".column1
-         ->  Sort
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               ->  Values Scan on "*VALUES*"
-                     Output: "*VALUES*".column1
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk
-         Output: _hyper_X_X_chunk.device_id
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(14 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+(5 rows)
 
 RESET seq_page_cost;
 -- test view
 CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
 :PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+               Index Searches: 1
+(5 rows)
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
@@ -701,10 +726,10 @@ QUERY PLAN
    ->  Nested Loop
          ->  Sort
                Sort Key: m1."time", m1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
                      ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               Filter: ("time" = m1."time")
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+               Filter: (m1."time" = "time")
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
                      Index Cond: (device_id = m1.device_id)
 (10 rows)
@@ -721,23 +746,26 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Merge Join
-         Merge Cond: (m1."time" = m3."time")
-         ->  Nested Loop
+   ->  Nested Loop
+         ->  Gather Merge
+               Workers Planned: 1
                ->  Sort
                      Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     Filter: ("time" = m1."time")
-                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                           Index Cond: (device_id = m1.device_id)
-         ->  Sort
-               Sort Key: m3."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                           Filter: (device_id = 3)
-(17 rows)
+                     ->  Parallel Hash Join
+                           Hash Cond: (m3."time" = m1."time")
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
+                                 ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                                       Recheck Cond: (device_id = 3)
+                                       ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
+                                             Index Cond: (device_id = 3)
+                           ->  Parallel Hash
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+               Filter: (m1."time" = "time")
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(20 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -755,11 +783,11 @@ QUERY PLAN
  Limit
    ->  Merge Join
          Merge Cond: (m1."time" = m2."time")
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
                      Index Cond: (device_id = 1)
          ->  Materialize
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
                            Index Cond: (device_id = 2)
 (10 rows)
@@ -817,15 +845,18 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop Left Join
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Gather Merge
+         Workers Planned: 2
          ->  Sort
                Sort Key: m1."time", m1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(9 rows)
+               ->  Parallel Hash Left Join
+                     Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Hash
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(12 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -843,15 +874,15 @@ QUERY PLAN
  Limit
    ->  Sort
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         ->  Hash Left Join
-               Hash Cond: (m1."time" = m2."time")
+         ->  Hash Right Join
+               Hash Cond: (m2."time" = m1."time")
                Join Filter: (m1.device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = 2)
                ->  Hash
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                                 Index Cond: (device_id = 2)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
 (12 rows)
 
 -- test implicit self-join
@@ -871,10 +902,10 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
                      ->  Seq Scan on compress_hyper_X_X_chunk
                ->  Hash
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (10 rows)
 
@@ -897,10 +928,10 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
                      ->  Seq Scan on compress_hyper_X_X_chunk
                ->  Hash
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (10 rows)
 
@@ -915,13 +946,13 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
             WHERE m1.time = g.time
             LIMIT 1) m1 ON TRUE;
 QUERY PLAN
- Nested Loop (actual rows=5 loops=1)
-   ->  Function Scan on generate_series g (actual rows=32 loops=1)
-   ->  Limit (actual rows=0 loops=32)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+ Nested Loop (actual rows=5.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
+   ->  Limit (actual rows=0.16 loops=32)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
                Filter: ("time" = g."time")
                Rows Removed by Filter: 81
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
                      Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                      Rows Removed by Filter: 17
 (9 rows)
@@ -931,11 +962,12 @@ SET plan_cache_mode TO force_generic_plan;
 PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
 :PREFIX EXECUTE prep;
 QUERY PLAN
- Aggregate (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+               Index Searches: 1
+(5 rows)
 
 EXECUTE prep;
  count 
@@ -980,27 +1012,29 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
             LIMIT 1) m1 ON TRUE;
 :PREFIX EXECUTE param_prep (1);
 QUERY PLAN
- Nested Loop (actual rows=5 loops=1)
-   ->  Function Scan on generate_series g (actual rows=32 loops=1)
-   ->  Limit (actual rows=0 loops=32)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+ Nested Loop (actual rows=5.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
+   ->  Limit (actual rows=0.16 loops=32)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
                Filter: ("time" = g."time")
                Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
                      Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+                     Index Searches: 32
+(9 rows)
 
 :PREFIX EXECUTE param_prep (2);
 QUERY PLAN
- Nested Loop (actual rows=5 loops=1)
-   ->  Function Scan on generate_series g (actual rows=32 loops=1)
-   ->  Limit (actual rows=0 loops=32)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+ Nested Loop (actual rows=5.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
+   ->  Limit (actual rows=0.16 loops=32)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
                Filter: ("time" = g."time")
                Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
                      Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+                     Index Searches: 32
+(9 rows)
 
 EXECUTE param_prep (1);
              time             |             time             
@@ -1063,7 +1097,6 @@ SELECT table_name FROM create_hypertable('i6925_t1', 'observed');
 (1 row)
 
 ALTER TABLE i6925_t1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'queryid');
-NOTICE:  default order by for hypertable "i6925_t1" is set to "observed DESC"
 INSERT INTO i6925_t1 SELECT '2020-01-01', 1, 1;
 SELECT count(compress_chunk(chunk_name)) FROM show_chunks('i6925_t1') chunk_name;
  count 

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -14,13 +14,20 @@ SET enable_incremental_sort TO off;
 
 SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
 
--- this should use DecompressChunk node
+-- this should use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 
--- must not use DecompressChunk node
+-- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+
+-- this should use ColumnarScan node
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE;
+
+:PREFIX_NO_VERBOSE
+SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
 
 -- test expressions
 :PREFIX

--- a/tsl/test/sql/merge_append_partially_compressed.sql
+++ b/tsl/test/sql/merge_append_partially_compressed.sql
@@ -31,6 +31,13 @@ generate_series(1,3) device;
 VACUUM ANALYZE ht_metrics_compressed;
 
 SELECT tableoid::regclass, min(time), max(time) from ht_metrics_compressed group by 1 order by 2;
+SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
+
+-- test UNION with partially compressed chunks
+:PREFIX SELECT * FROM :CHUNK UNION ALL SELECT * FROM :CHUNK;
+:PREFIX SELECT * FROM :CHUNK UNION ALL SELECT * FROM :CHUNK ORDER BY time DESC;
+:PREFIX SELECT device FROM :CHUNK UNION ALL SELECT device FROM :CHUNK ORDER BY device DESC;
+:PREFIX SELECT value FROM :CHUNK UNION ALL SELECT value FROM :CHUNK ORDER BY value DESC;
 
 -- chunkAppend eligible queries (from tsbench)
 -- sort is not pushed down


### PR DESCRIPTION
In UNION queries with compressed chunks the chunks would not be
classified correctly leading to ColumnarScans not working.

An entry of reloptkind RELOPT_OTHER_MEMBER_REL might still
be a hypertable chunk here if it was pulled up from a subquery
as happens with UNION ALL for example.

Fixes #7821
