### PR TITLE
Add a partial chunk to the shared database setup

### DIFF
--- a/tsl/test/shared/expected/constify_timestamptz_op_interval.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval.out
@@ -121,11 +121,14 @@ SELECT time
 FROM metrics_compressed
 WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-   Vectorized Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
-   ->  Seq Scan on compress_hyper_X_X_chunk
-         Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
-(4 rows)
+ Append
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+         Vectorized Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+         ->  Seq Scan on compress_hyper_X_X_chunk
+               Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(7 rows)
 
 -- test on space-partitioned compressed hypertable
 :PREFIX

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -477,28 +477,37 @@ DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 -- test prepared statement with params and generic plan
 SET plan_cache_mode TO force_generic_plan;
-PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1;
+PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1 ORDER BY device_id, time;
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 2
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Index Cond: ("time" = $1)
-(4 rows)
+ Sort (actual rows=5.00 loops=1)
+   Sort Key: metrics.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=5.00 loops=1)
+         Chunks excluded during startup: 2
+         ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5.00 loops=1)
+               Index Cond: ("time" = $1)
+(7 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 2
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Index Cond: ("time" = $1)
-(4 rows)
+ Sort (actual rows=5.00 loops=1)
+   Sort Key: metrics.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=5.00 loops=1)
+         Chunks excluded during startup: 2
+         ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5.00 loops=1)
+               Index Cond: ("time" = $1)
+(7 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics (actual rows=0.00 loops=1)
-   Chunks excluded during startup: 3
-(2 rows)
+ Sort (actual rows=0.00 loops=1)
+   Sort Key: metrics.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=0.00 loops=1)
+         Chunks excluded during startup: 3
+(5 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
@@ -1164,36 +1173,45 @@ DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 -- test prepared statement with params and generic plan
 SET plan_cache_mode TO force_generic_plan;
-PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1;
+PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1 ORDER BY device_id, time;
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_space (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 6
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3.00 loops=1)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-         Index Cond: ("time" = $1)
-(8 rows)
+ Sort (actual rows=5.00 loops=1)
+   Sort Key: metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5.00 loops=1)
+         Chunks excluded during startup: 6
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Index Cond: ("time" = $1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3.00 loops=1)
+               Index Cond: ("time" = $1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Index Cond: ("time" = $1)
+(11 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_space (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 6
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3.00 loops=1)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-         Index Cond: ("time" = $1)
-(8 rows)
+ Sort (actual rows=5.00 loops=1)
+   Sort Key: metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5.00 loops=1)
+         Chunks excluded during startup: 6
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Index Cond: ("time" = $1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3.00 loops=1)
+               Index Cond: ("time" = $1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Index Cond: ("time" = $1)
+(11 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_space (actual rows=0.00 loops=1)
-   Chunks excluded during startup: 9
-(2 rows)
+ Sort (actual rows=0.00 loops=1)
+   Sort Key: metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0.00 loops=1)
+         Chunks excluded during startup: 9
+(5 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
@@ -1217,10 +1235,19 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < now())
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1229,7 +1256,7 @@ QUERY PLAN
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
-(16 rows)
+(26 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1237,10 +1264,19 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < now())
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1249,7 +1285,7 @@ QUERY PLAN
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
-(16 rows)
+(26 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1257,10 +1293,19 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < now())
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1269,7 +1314,7 @@ QUERY PLAN
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
-(16 rows)
+(26 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1277,10 +1322,19 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < now())
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1289,7 +1343,7 @@ QUERY PLAN
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
-(16 rows)
+(26 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1297,10 +1351,19 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < now())
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < now()))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1309,7 +1372,7 @@ QUERY PLAN
                Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < now()))
-(16 rows)
+(26 rows)
 
 DEALLOCATE prep;
 -- executor startup exclusion with chunks excluded
@@ -1326,15 +1389,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(12 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1342,15 +1414,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(12 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1358,15 +1439,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(12 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1374,15 +1464,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(12 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1390,15 +1489,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     ->  Sort (actual rows=1.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                 Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(12 rows)
+(22 rows)
 
 DEALLOCATE prep;
 -- runtime exclusion with LATERAL and 2 hypertables
@@ -1421,8 +1529,13 @@ QUERY PLAN
    ->  Nested Loop Left Join (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed m1 (actual rows=100.00 loops=1)
                Order: m1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: m1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 2)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1438,6 +1551,8 @@ QUERY PLAN
                            Rows Removed by Filter: 548
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=100)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2_1 (never executed)
+                           Index Cond: ("time" = m1."time")
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2_2 (never executed)
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -1446,7 +1561,7 @@ QUERY PLAN
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
-(29 rows)
+(38 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1454,8 +1569,13 @@ QUERY PLAN
    ->  Nested Loop Left Join (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed m1 (actual rows=100.00 loops=1)
                Order: m1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: m1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 2)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1471,6 +1591,8 @@ QUERY PLAN
                            Rows Removed by Filter: 548
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=100)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2_1 (never executed)
+                           Index Cond: ("time" = m1."time")
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2_2 (never executed)
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -1479,7 +1601,7 @@ QUERY PLAN
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
-(29 rows)
+(38 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1487,8 +1609,13 @@ QUERY PLAN
    ->  Nested Loop Left Join (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed m1 (actual rows=100.00 loops=1)
                Order: m1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: m1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 2)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1504,6 +1631,8 @@ QUERY PLAN
                            Rows Removed by Filter: 548
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=100)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2_1 (never executed)
+                           Index Cond: ("time" = m1."time")
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2_2 (never executed)
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -1512,7 +1641,7 @@ QUERY PLAN
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
-(29 rows)
+(38 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1520,8 +1649,13 @@ QUERY PLAN
    ->  Nested Loop Left Join (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed m1 (actual rows=100.00 loops=1)
                Order: m1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: m1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 2)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1537,6 +1671,8 @@ QUERY PLAN
                            Rows Removed by Filter: 548
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=100)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2_1 (never executed)
+                           Index Cond: ("time" = m1."time")
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2_2 (never executed)
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -1545,7 +1681,7 @@ QUERY PLAN
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
-(29 rows)
+(38 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1553,8 +1689,13 @@ QUERY PLAN
    ->  Nested Loop Left Join (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed m1 (actual rows=100.00 loops=1)
                Order: m1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: m1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 2)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -1570,6 +1711,8 @@ QUERY PLAN
                            Rows Removed by Filter: 548
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=100)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2_1 (never executed)
+                           Index Cond: ("time" = m1."time")
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2_2 (never executed)
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -1578,7 +1721,7 @@ QUERY PLAN
                            Filter: (m1."time" = "time")
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
-(29 rows)
+(38 rows)
 
 DEALLOCATE prep;
 RESET enable_seqscan;
@@ -1597,20 +1740,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Sort (actual rows=100.00 loops=1)
-               Sort Key: _hyper_X_X_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Sort (actual rows=80.00 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(17 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1618,20 +1765,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Sort (actual rows=100.00 loops=1)
-               Sort Key: _hyper_X_X_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Sort (actual rows=80.00 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(17 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1639,20 +1790,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Sort (actual rows=100.00 loops=1)
-               Sort Key: _hyper_X_X_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Sort (actual rows=80.00 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(17 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1660,20 +1815,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Sort (actual rows=100.00 loops=1)
-               Sort Key: _hyper_X_X_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Sort (actual rows=80.00 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(17 rows)
+(22 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1681,20 +1840,24 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
-         ->  Sort (actual rows=100.00 loops=1)
-               Sort Key: _hyper_X_X_chunk."time"
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Sort (actual rows=80.00 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(17 rows)
+(22 rows)
 
 DEALLOCATE prep;
 -- test constraint exclusion for subqueries with ConstraintAwareAppend
@@ -1718,13 +1881,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Merge Append (actual rows=100.00 loops=1)
                Sort Key: metrics_compressed.device_id, metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
@@ -1732,7 +1897,7 @@ QUERY PLAN
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=25.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(20 rows)
+(23 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1742,13 +1907,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Merge Append (actual rows=100.00 loops=1)
                Sort Key: metrics_compressed.device_id, metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
@@ -1756,7 +1923,7 @@ QUERY PLAN
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=25.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(20 rows)
+(23 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1766,13 +1933,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Merge Append (actual rows=100.00 loops=1)
                Sort Key: metrics_compressed.device_id, metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
@@ -1780,7 +1949,7 @@ QUERY PLAN
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=25.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(20 rows)
+(23 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1790,13 +1959,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Merge Append (actual rows=100.00 loops=1)
                Sort Key: metrics_compressed.device_id, metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
@@ -1804,7 +1975,7 @@ QUERY PLAN
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=25.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(20 rows)
+(23 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1814,13 +1985,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Merge Append (actual rows=100.00 loops=1)
                Sort Key: metrics_compressed.device_id, metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1.00 loops=1)
@@ -1828,42 +2001,110 @@ QUERY PLAN
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=25.00 loops=1)
                                  Index Cond: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
-(20 rows)
+(23 rows)
 
 DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 -- test prepared statement with params and generic plan
 SET plan_cache_mode TO force_generic_plan;
-PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1;
+PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1 ORDER BY device_id, time;
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 2
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5.00 loops=1)
+ Merge Append (actual rows=5.00 loops=1)
+   Sort Key: metrics_compressed.device_id
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=4.00 loops=1)
          Vectorized Filter: ("time" = $1)
-         Rows Removed by Filter: 4995
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 15
-(8 rows)
+         Rows Removed by Filter: 3996
+         ->  Sort (actual rows=4.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 14
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+         Index Cond: ("time" = $1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 30
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 30
+(30 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 2
+ Merge Append (actual rows=5.00 loops=1)
+   Sort Key: metrics_compressed.device_id
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 4995
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 25
-(8 rows)
+         ->  Sort (actual rows=5.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 25
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 30
+(30 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_compressed (actual rows=0.00 loops=1)
-   Chunks excluded during startup: 3
-(2 rows)
+ Merge Append (actual rows=0.00 loops=1)
+   Sort Key: metrics_compressed.device_id
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Index Cond: ("time" = $1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 30
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 30
+(29 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
@@ -3009,60 +3250,246 @@ DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 -- test prepared statement with params and generic plan
 SET plan_cache_mode TO force_generic_plan;
-PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1;
+PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1 ORDER BY device_id, time;
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 6
+ Merge Append (actual rows=5.00 loops=1)
+   Sort Key: metrics_space_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 999
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 3
+         ->  Sort (actual rows=1.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 3
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 2997
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 9
+         ->  Sort (actual rows=3.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 9
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 999
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 3
-(20 rows)
+         ->  Sort (actual rows=1.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 3
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+(77 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=5.00 loops=1)
-   Chunks excluded during startup: 6
+ Merge Append (actual rows=5.00 loops=1)
+   Sort Key: metrics_space_compressed.device_id
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 4
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 12
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 4
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 999
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 5
+         ->  Sort (actual rows=1.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 5
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 2997
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 15
+         ->  Sort (actual rows=3.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 15
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 999
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-               Rows Removed by Filter: 5
-(20 rows)
+         ->  Sort (actual rows=1.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 5
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+(77 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
- Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=0.00 loops=1)
-   Chunks excluded during startup: 9
-(2 rows)
+ Merge Append (actual rows=0.00 loops=1)
+   Sort Key: metrics_space_compressed.device_id
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 4
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 12
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 4
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 18
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ("time" = $1)
+         ->  Sort (actual rows=0.00 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+                     Rows Removed by Filter: 6
+(74 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;

--- a/tsl/test/shared/expected/decompress_join.out
+++ b/tsl/test/shared/expected/decompress_join.out
@@ -17,15 +17,16 @@ QUERY PLAN
    ->  Hash Join (actual rows=1.00 loops=1)
          Hash Cond: ((m."time" = t."time") AND (m.device_id = t.device_id))
          ->  Append (actual rows=43181.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m_1 (actual rows=17990.00 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m_1 (actual rows=16392.00 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk m_1 (actual rows=1598.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m_2 (actual rows=25190.00 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m_3 (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
          ->  Hash (actual rows=10.00 loops=1)
                ->  Seq Scan on compressed_join_temp t (actual rows=10.00 loops=1)
-(13 rows)
+(14 rows)
 
 DROP TABLE compressed_join_temp;
 -- test join with partially compressed chunks

--- a/tsl/test/shared/expected/memoize.out
+++ b/tsl/test/shared/expected/memoize.out
@@ -129,11 +129,14 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=68370.00 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_compressed m1 (actual rows=68370.00 loops=1)
          Order: m1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=17990.00 loops=1)
-               ->  Sort (actual rows=20.00 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+         ->  Merge Append (actual rows=17990.00 loops=1)
+               Sort Key: m1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=16392.00 loops=1)
+                     ->  Sort (actual rows=18.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m1_1 (actual rows=1598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_2 (actual rows=25190.00 loops=1)
                ->  Sort (actual rows=30.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
@@ -156,7 +159,9 @@ QUERY PLAN
                            Rows Removed by Filter: 466
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=3598)
                                  Filter: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
-                                 Rows Removed by Filter: 1
+                                 Rows Removed by Filter: 2
+                     ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2_1 (never executed)
+                           Index Cond: ("time" = m1."time")
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2_2 (actual rows=1.00 loops=5038)
                            Filter: (m1."time" = "time")
                            Rows Removed by Filter: 496
@@ -169,7 +174,7 @@ QUERY PLAN
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=5038)
                                  Filter: ((_ts_meta_min_1 <= m1."time") AND (_ts_meta_max_1 >= m1."time"))
                                  Rows Removed by Filter: 2
-(43 rows)
+(50 rows)
 
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -1666,13 +1666,16 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: metrics_compressed."time" DESC
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
          ->  Materialize (actual rows=2.00 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
-(19 rows)
+(22 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -1704,11 +1707,14 @@ QUERY PLAN
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(21 rows)
+                                 ->  Merge Append (never executed)
+                                       Sort Key: metrics_compressed."time" DESC
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(24 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -1730,10 +1736,17 @@ QUERY PLAN
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                     Filter: (device_id = 1)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+(19 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -1755,11 +1768,14 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-         ->  Sort (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(16 rows)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(19 rows)
 
 SET enable_nestloop TO on;
 -- test LATERAL with correlated query
@@ -1796,16 +1812,20 @@ QUERY PLAN
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1.00 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3600.00 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                       Rows Removed by Filter: 12
-(29 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+(33 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -1824,33 +1844,30 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=2.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=2.00 loops=1)
    ->  Limit (actual rows=1.00 loops=2)
-         ->  Result (actual rows=1.00 loops=2)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1.00 loops=2)
-                     Order: o."time"
-                     Chunks excluded during startup: 0
-                     Chunks excluded during runtime: 2
-                     ->  Sort (never executed)
-                           Sort Key: o_1."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (never executed)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1.00 loops=2)
-                           Sort Key: o_2."time"
-                           Sort Method: top-N heapsort 
+         ->  Sort (actual rows=1.00 loops=2)
+               Sort Key: o."time"
+               Sort Method: top-N heapsort 
+               ->  Result (actual rows=3600.00 loops=2)
+                     ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=3600.00 loops=2)
+                           Chunks excluded during startup: 0
+                           Chunks excluded during runtime: 1
+                           ->  Merge Append (actual rows=0.00 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
+                                             Index Cond: ((_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 >= g."time"))
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                       Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=3600.00 loops=2)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 3900
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=2)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                       Rows Removed by Filter: 22
-                     ->  Sort (never executed)
-                           Sort Key: o_3."time"
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=2)
+                                       Index Cond: ((_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 >= g."time"))
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-(29 rows)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       Index Cond: ((_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 >= g."time"))
+(26 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -1888,17 +1905,21 @@ QUERY PLAN
                                  Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                     ->  Sort (actual rows=1.00 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3600.00 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 Vectorized Filter: ("time" < now())
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                                       Rows Removed by Filter: 12
-(32 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       Vectorized Filter: ("time" < now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+(36 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -1921,8 +1942,22 @@ QUERY PLAN
          ->  Result (actual rows=0.00 loops=3)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
-                     Chunks excluded during startup: 3
-(7 rows)
+                     Chunks excluded during startup: 2
+                     Chunks excluded during runtime: 0
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
+                                             Rows Removed by Filter: 18
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+(21 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -1942,10 +1977,15 @@ QUERY PLAN
    Merge Cond: (o1."time" = o2."time")
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
-               Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -1957,10 +1997,15 @@ QUERY PLAN
    ->  Materialize (actual rows=13674.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                           Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Merge Append (actual rows=3598.00 loops=1)
+                     Sort Key: o2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
+                           Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
@@ -1969,7 +2014,7 @@ QUERY PLAN
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(31 rows)
+(41 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -1988,30 +2033,34 @@ QUERY PLAN
  Limit (actual rows=10.00 loops=1)
    ->  Merge Join (actual rows=10.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=2.00 loops=1)
-               Order: o1."time"
-               ->  Sort (actual rows=2.00 loops=1)
-                     Sort Key: o1_1."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=17990.00 loops=1)
+         ->  Sort (actual rows=2.00 loops=1)
+               Sort Key: o1."time"
+               Sort Method: quicksort 
+               ->  Append (actual rows=26390.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: o1_2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
+                     ->  Seq Scan on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                           Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=8400.00 loops=1)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                           Rows Removed by Filter: 1790
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15.00 loops=1)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 Rows Removed by Filter: 15
          ->  Materialize (actual rows=10.00 loops=1)
                ->  Result (actual rows=6.00 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Sort (actual rows=6.00 loops=1)
-                                 Sort Key: o2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=17990.00 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20.00 loops=1)
+                           ->  Merge Append (actual rows=6.00 loops=1)
+                                 Sort Key: o2."time"
+                                 ->  Sort (actual rows=5.00 loops=1)
+                                       Sort Key: o2_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2.00 loops=1)
                            ->  Sort (never executed)
                                  Sort Key: o2_2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
@@ -2020,7 +2069,7 @@ QUERY PLAN
                                  Sort Key: o2_3."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(35 rows)
+(39 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -2040,8 +2089,13 @@ QUERY PLAN
    Merge Cond: (o1."time" = ($0))
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -2068,12 +2122,16 @@ QUERY PLAN
                                    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                          Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                             ->  Sort (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
-                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-(37 rows)
+                             ->  Merge Append (never executed)
+                                   Sort Key: metrics_compressed."time" DESC
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                               Vectorized Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Cond: ("time" IS NOT NULL)
+(46 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -2094,8 +2152,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2106,8 +2169,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2115,7 +2183,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -2133,8 +2201,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2145,8 +2218,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2154,7 +2232,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -2191,8 +2269,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2203,8 +2286,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2212,7 +2300,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -2230,8 +2318,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2242,8 +2335,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2251,7 +2349,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -2269,8 +2367,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2281,8 +2384,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2290,7 +2398,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -2309,8 +2417,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2321,8 +2434,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2330,7 +2448,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -2348,8 +2466,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2360,8 +2483,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2369,7 +2497,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -2388,21 +2516,23 @@ QUERY PLAN
          ->  Hash Join (actual rows=68370.00 loops=1)
                Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
                ->  Append (actual rows=68370.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=17990.00 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=25190.00 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=25190.00 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                ->  Hash (actual rows=68370.00 loops=1)
                      ->  Append (actual rows=68370.00 loops=1)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=17990.00 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20.00 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=1598.00 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=25190.00 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=25190.00 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
-(22 rows)
+(24 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2418,8 +2548,13 @@ QUERY PLAN
    ->  Nested Loop (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=1.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2430,15 +2565,18 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
+                           Index Cond: (device_id = 1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 1)
-(24 rows)
+(32 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -2457,8 +2595,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2469,8 +2612,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2478,7 +2626,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -2498,8 +2646,13 @@ QUERY PLAN
          Merge Cond: (o3."time" = o1."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o3."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 3)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 3)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
@@ -2512,8 +2665,13 @@ QUERY PLAN
                      Merge Cond: (o1."time" = o2."time")
                      ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                           ->  Merge Append (actual rows=100.00 loops=1)
+                                 Sort Key: o1."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                                       Filter: (device_id = 1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             Index Cond: (device_id = 1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2524,8 +2682,13 @@ QUERY PLAN
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                 ->  Merge Append (actual rows=100.00 loops=1)
+                                       Sort Key: o2."time"
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                             Filter: (device_id = 2)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                                   Index Cond: (device_id = 2)
+                                       ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2533,7 +2696,7 @@ QUERY PLAN
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 2)
-(40 rows)
+(55 rows)
 
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -1666,13 +1666,16 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: metrics_compressed."time" DESC
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
          ->  Materialize (actual rows=2.00 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
-(19 rows)
+(22 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -1704,11 +1707,14 @@ QUERY PLAN
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(21 rows)
+                                 ->  Merge Append (never executed)
+                                       Sort Key: metrics_compressed."time" DESC
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(24 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -1730,10 +1736,17 @@ QUERY PLAN
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                     Filter: (device_id = 1)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+(19 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -1755,11 +1768,14 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-         ->  Sort (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(16 rows)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(19 rows)
 
 SET enable_nestloop TO on;
 -- test LATERAL with correlated query
@@ -1796,16 +1812,20 @@ QUERY PLAN
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1.00 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3600.00 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                       Rows Removed by Filter: 12
-(29 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+(33 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -1824,33 +1844,30 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=2.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=2.00 loops=1)
    ->  Limit (actual rows=1.00 loops=2)
-         ->  Result (actual rows=1.00 loops=2)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1.00 loops=2)
-                     Order: o."time"
-                     Chunks excluded during startup: 0
-                     Chunks excluded during runtime: 2
-                     ->  Sort (never executed)
-                           Sort Key: o_1."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (never executed)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1.00 loops=2)
-                           Sort Key: o_2."time"
-                           Sort Method: top-N heapsort 
+         ->  Sort (actual rows=1.00 loops=2)
+               Sort Key: o."time"
+               Sort Method: top-N heapsort 
+               ->  Result (actual rows=3600.00 loops=2)
+                     ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=3600.00 loops=2)
+                           Chunks excluded during startup: 0
+                           Chunks excluded during runtime: 1
+                           ->  Merge Append (actual rows=0.00 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
+                                             Index Cond: ((_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 >= g."time"))
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                       Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=3600.00 loops=2)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 3900
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=2)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                       Rows Removed by Filter: 22
-                     ->  Sort (never executed)
-                           Sort Key: o_3."time"
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=2)
+                                       Index Cond: ((_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 >= g."time"))
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-(29 rows)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       Index Cond: ((_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 >= g."time"))
+(26 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -1888,17 +1905,21 @@ QUERY PLAN
                                  Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                     ->  Sort (actual rows=1.00 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3600.00 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 Vectorized Filter: ("time" < now())
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                                       Rows Removed by Filter: 12
-(32 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       Vectorized Filter: ("time" < now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+(36 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -1921,8 +1942,22 @@ QUERY PLAN
          ->  Result (actual rows=0.00 loops=3)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
-                     Chunks excluded during startup: 3
-(7 rows)
+                     Chunks excluded during startup: 2
+                     Chunks excluded during runtime: 0
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
+                                             Rows Removed by Filter: 18
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+(21 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -1942,10 +1977,15 @@ QUERY PLAN
    Merge Cond: (o1."time" = o2."time")
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
-               Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -1957,10 +1997,15 @@ QUERY PLAN
    ->  Materialize (actual rows=13674.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                           Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Merge Append (actual rows=3598.00 loops=1)
+                     Sort Key: o2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
+                           Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
@@ -1969,7 +2014,7 @@ QUERY PLAN
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(31 rows)
+(41 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -1988,30 +2033,34 @@ QUERY PLAN
  Limit (actual rows=10.00 loops=1)
    ->  Merge Join (actual rows=10.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=2.00 loops=1)
-               Order: o1."time"
-               ->  Sort (actual rows=2.00 loops=1)
-                     Sort Key: o1_1."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=17990.00 loops=1)
+         ->  Sort (actual rows=2.00 loops=1)
+               Sort Key: o1."time"
+               Sort Method: quicksort 
+               ->  Append (actual rows=26390.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: o1_2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
+                     ->  Seq Scan on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                           Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=8400.00 loops=1)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                           Rows Removed by Filter: 1790
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15.00 loops=1)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 Rows Removed by Filter: 15
          ->  Materialize (actual rows=10.00 loops=1)
                ->  Result (actual rows=6.00 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Sort (actual rows=6.00 loops=1)
-                                 Sort Key: o2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=17990.00 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20.00 loops=1)
+                           ->  Merge Append (actual rows=6.00 loops=1)
+                                 Sort Key: o2."time"
+                                 ->  Sort (actual rows=5.00 loops=1)
+                                       Sort Key: o2_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2.00 loops=1)
                            ->  Sort (never executed)
                                  Sort Key: o2_2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
@@ -2020,7 +2069,7 @@ QUERY PLAN
                                  Sort Key: o2_3."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(35 rows)
+(39 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -2040,8 +2089,13 @@ QUERY PLAN
    Merge Cond: (o1."time" = ($0))
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -2068,12 +2122,16 @@ QUERY PLAN
                                    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                          Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                             ->  Sort (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
-                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-(37 rows)
+                             ->  Merge Append (never executed)
+                                   Sort Key: metrics_compressed."time" DESC
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                               Vectorized Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Cond: ("time" IS NOT NULL)
+(46 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -2094,8 +2152,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2106,8 +2169,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2115,7 +2183,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -2133,8 +2201,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2145,8 +2218,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2154,7 +2232,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -2191,8 +2269,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2203,8 +2286,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2212,7 +2300,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -2230,8 +2318,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2242,8 +2335,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2251,7 +2349,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -2269,8 +2367,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2281,8 +2384,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2290,7 +2398,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -2309,8 +2417,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2321,8 +2434,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2330,7 +2448,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -2348,8 +2466,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2360,8 +2483,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2369,7 +2497,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -2388,21 +2516,23 @@ QUERY PLAN
          ->  Hash Join (actual rows=68370.00 loops=1)
                Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
                ->  Append (actual rows=68370.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=17990.00 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=25190.00 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=25190.00 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                ->  Hash (actual rows=68370.00 loops=1)
                      ->  Append (actual rows=68370.00 loops=1)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=17990.00 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20.00 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=1598.00 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=25190.00 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=25190.00 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
-(22 rows)
+(24 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2418,8 +2548,13 @@ QUERY PLAN
    ->  Nested Loop (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=1.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2430,15 +2565,18 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
+                           Index Cond: (device_id = 1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 1)
-(24 rows)
+(32 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -2457,8 +2595,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2469,8 +2612,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2478,7 +2626,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -2498,8 +2646,13 @@ QUERY PLAN
          Merge Cond: (o3."time" = o1."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o3."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 3)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 3)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
@@ -2512,8 +2665,13 @@ QUERY PLAN
                      Merge Cond: (o1."time" = o2."time")
                      ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                           ->  Merge Append (actual rows=100.00 loops=1)
+                                 Sort Key: o1."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                                       Filter: (device_id = 1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             Index Cond: (device_id = 1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2524,8 +2682,13 @@ QUERY PLAN
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                 ->  Merge Append (actual rows=100.00 loops=1)
+                                       Sort Key: o2."time"
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                             Filter: (device_id = 2)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                                   Index Cond: (device_id = 2)
+                                       ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2533,7 +2696,7 @@ QUERY PLAN
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 2)
-(40 rows)
+(55 rows)
 
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'

--- a/tsl/test/shared/expected/ordered_append_join-17.out
+++ b/tsl/test/shared/expected/ordered_append_join-17.out
@@ -1654,13 +1654,16 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: metrics_compressed."time" DESC
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
          ->  Materialize (actual rows=2.00 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
-(19 rows)
+(22 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -1692,11 +1695,14 @@ QUERY PLAN
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(21 rows)
+                                 ->  Merge Append (never executed)
+                                       Sort Key: metrics_compressed."time" DESC
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(24 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -1718,10 +1724,17 @@ QUERY PLAN
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                     Filter: (device_id = 1)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+(19 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -1743,11 +1756,14 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-         ->  Sort (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(16 rows)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(19 rows)
 
 SET enable_nestloop TO on;
 -- test LATERAL with correlated query
@@ -1784,16 +1800,20 @@ QUERY PLAN
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1.00 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3600.00 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                       Rows Removed by Filter: 12
-(29 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+(33 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -1816,13 +1836,19 @@ QUERY PLAN
                ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1.00 loops=2)
                      Order: o."time"
                      Chunks excluded during startup: 0
-                     Chunks excluded during runtime: 2
-                     ->  Sort (never executed)
-                           Sort Key: o_1."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (never executed)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                     Chunks excluded during runtime: 1
+                     ->  Merge Append (actual rows=0.00 loops=2)
+                           Sort Key: o."time"
+                           ->  Sort (actual rows=0.00 loops=2)
+                                 Sort Key: o_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                                             Rows Removed by Filter: 18
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                      ->  Sort (actual rows=1.00 loops=2)
                            Sort Key: o_2."time"
                            Sort Method: top-N heapsort 
@@ -1838,7 +1864,7 @@ QUERY PLAN
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-(29 rows)
+(35 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -1876,17 +1902,21 @@ QUERY PLAN
                                  Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                     ->  Sort (actual rows=1.00 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3600.00 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 Vectorized Filter: ("time" < now())
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8.00 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                                       Rows Removed by Filter: 12
-(32 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       Vectorized Filter: ("time" < now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+(36 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -1909,8 +1939,22 @@ QUERY PLAN
          ->  Result (actual rows=0.00 loops=3)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
-                     Chunks excluded during startup: 3
-(7 rows)
+                     Chunks excluded during startup: 2
+                     Chunks excluded during runtime: 0
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
+                                             Rows Removed by Filter: 18
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+(21 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -1930,10 +1974,15 @@ QUERY PLAN
    Merge Cond: (o1."time" = o2."time")
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
-               Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -1945,10 +1994,15 @@ QUERY PLAN
    ->  Materialize (actual rows=13674.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                           Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Merge Append (actual rows=3598.00 loops=1)
+                     Sort Key: o2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
+                           Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
@@ -1957,7 +2011,7 @@ QUERY PLAN
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(31 rows)
+(41 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -1978,13 +2032,17 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=2.00 loops=1)
                Order: o1."time"
-               ->  Sort (actual rows=2.00 loops=1)
-                     Sort Key: o1_1."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=17990.00 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Merge Append (actual rows=2.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Sort Key: o1_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: o1_2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
@@ -1995,11 +2053,14 @@ QUERY PLAN
                ->  Result (actual rows=6.00 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Sort (actual rows=6.00 loops=1)
-                                 Sort Key: o2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=17990.00 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20.00 loops=1)
+                           ->  Merge Append (actual rows=6.00 loops=1)
+                                 Sort Key: o2."time"
+                                 ->  Sort (actual rows=5.00 loops=1)
+                                       Sort Key: o2_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2.00 loops=1)
                            ->  Sort (never executed)
                                  Sort Key: o2_2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
@@ -2008,7 +2069,7 @@ QUERY PLAN
                                  Sort Key: o2_3."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(35 rows)
+(42 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -2028,8 +2089,13 @@ QUERY PLAN
    Merge Cond: (o1."time" = ((InitPlan 1).col1))
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -2054,11 +2120,14 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                             ->  Sort (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-(34 rows)
+                             ->  Merge Append (never executed)
+                                   Sort Key: metrics_compressed."time" DESC
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+(42 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -2079,8 +2148,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2091,8 +2165,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2100,7 +2179,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -2118,8 +2197,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2130,8 +2214,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2139,7 +2228,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -2176,8 +2265,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2188,8 +2282,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2197,7 +2296,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -2215,8 +2314,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2227,8 +2331,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2236,7 +2345,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -2254,8 +2363,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2266,8 +2380,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2275,7 +2394,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -2294,8 +2413,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2306,8 +2430,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2315,7 +2444,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -2333,8 +2462,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2345,8 +2479,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2354,7 +2493,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -2373,21 +2512,23 @@ QUERY PLAN
          ->  Hash Join (actual rows=68370.00 loops=1)
                Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
                ->  Append (actual rows=68370.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=17990.00 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=25190.00 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=25190.00 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                ->  Hash (actual rows=68370.00 loops=1)
                      ->  Append (actual rows=68370.00 loops=1)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=17990.00 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20.00 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=1598.00 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=25190.00 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=25190.00 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
-(22 rows)
+(24 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2403,8 +2544,13 @@ QUERY PLAN
    ->  Nested Loop (actual rows=100.00 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=1.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2415,15 +2561,18 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
+                           Index Cond: (device_id = 1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 1)
-(24 rows)
+(32 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -2442,8 +2591,13 @@ QUERY PLAN
          Merge Cond: (o1."time" = o2."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2454,8 +2608,13 @@ QUERY PLAN
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2463,7 +2622,7 @@ QUERY PLAN
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+(36 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -2483,8 +2642,13 @@ QUERY PLAN
          Merge Cond: (o3."time" = o1."time")
          ->  Custom Scan (ChunkAppend) on metrics_compressed o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o3."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 3)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 3)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
@@ -2497,8 +2661,13 @@ QUERY PLAN
                      Merge Cond: (o1."time" = o2."time")
                      ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                           ->  Merge Append (actual rows=100.00 loops=1)
+                                 Sort Key: o1."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                                       Filter: (device_id = 1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             Index Cond: (device_id = 1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
@@ -2509,8 +2678,13 @@ QUERY PLAN
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                 ->  Merge Append (actual rows=100.00 loops=1)
+                                       Sort Key: o2."time"
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                             Filter: (device_id = 2)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                                   Index Cond: (device_id = 2)
+                                       ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
@@ -2518,7 +2692,7 @@ QUERY PLAN
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 2)
-(40 rows)
+(55 rows)
 
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'

--- a/tsl/test/shared/expected/ordered_append_join-18.out
+++ b/tsl/test/shared/expected/ordered_append_join-18.out
@@ -14,8 +14,8 @@ SELECT
 SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed results" %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
 \gset
 -- get EXPLAIN output for all variations
-\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
-\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 set enable_nestloop to off;
@@ -45,16 +45,20 @@ FROM :TEST_TABLE,
 ORDER BY time DESC
 LIMIT 2;
 QUERY PLAN
- Limit (actual rows=2 loops=1)
-   ->  Nested Loop (actual rows=2 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
+ Limit (actual rows=2.00 loops=1)
+   ->  Nested Loop (actual rows=2.00 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=1.00 loops=1)
                Order: metrics."time" DESC
-               ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         ->  Materialize (actual rows=2 loops=1)
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(9 rows)
+                     Index Searches: 0
+         ->  Materialize (actual rows=2.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+(13 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -69,18 +73,22 @@ FROM (
     ORDER BY time DESC
     LIMIT 2) l;
 QUERY PLAN
- Nested Loop (actual rows=4 loops=1)
-   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Materialize (actual rows=2 loops=2)
-         ->  Subquery Scan on l (actual rows=2 loops=1)
-               ->  Limit (actual rows=2 loops=1)
-                     ->  Result (actual rows=2 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics (actual rows=2 loops=1)
+ Nested Loop (actual rows=4.00 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+   ->  Materialize (actual rows=2.00 loops=2)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Subquery Scan on l (actual rows=2.00 loops=1)
+               ->  Limit (actual rows=2.00 loops=1)
+                     ->  Result (actual rows=2.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics (actual rows=2.00 loops=1)
                                  Order: metrics."time" DESC
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                       Index Searches: 1
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
+                                       Index Searches: 0
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-(11 rows)
+                                       Index Searches: 0
+(15 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -93,16 +101,19 @@ WHERE device_id = 1
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=1.00 loops=1)
          Order: metrics."time" DESC
-         ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
+               Index Searches: 1
          ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
+               Index Searches: 0
          ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk (never executed)
                Index Cond: (device_id = 1)
-(9 rows)
+               Index Searches: 0
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -112,13 +123,16 @@ FROM :TEST_TABLE
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=1.00 loops=1)
          Order: metrics."time" DESC
-         ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Index Searches: 1
          ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
+               Index Searches: 0
          ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-(6 rows)
+               Index Searches: 0
+(9 rows)
 
 SET enable_nestloop TO on;
 -- test LATERAL with correlated query
@@ -135,21 +149,24 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
                      Chunks excluded during startup: 0
                      Chunks excluded during runtime: 2
                      ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
+                           Index Searches: 0
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-(14 rows)
+                           Index Searches: 3
+(17 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -165,21 +182,24 @@ FROM generate_series('2000-01-10'::timestamptz, '2000-01-11', '1d') AS g (time)
   ORDER BY time
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=2 loops=1)
-   ->  Function Scan on generate_series g (actual rows=2 loops=1)
-   ->  Limit (actual rows=1 loops=2)
-         ->  Result (actual rows=1 loops=2)
-               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=1 loops=2)
+ Nested Loop Left Join (actual rows=2.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=2.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=2)
+         ->  Result (actual rows=1.00 loops=2)
+               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=1.00 loops=2)
                      Order: o."time"
                      Chunks excluded during startup: 0
                      Chunks excluded during runtime: 2
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (actual rows=1 loops=2)
+                           Index Searches: 0
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (actual rows=1.00 loops=2)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                           Index Searches: 2
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-(14 rows)
+                           Index Searches: 0
+(17 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -195,21 +215,24 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
                      Chunks excluded during startup: 0
                      Chunks excluded during runtime: 2
                      ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_1 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_2 (never executed)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1 loops=3)
+                           Index Searches: 0
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o_3 (actual rows=1.00 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-(14 rows)
+                           Index Searches: 3
+(17 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -226,11 +249,11 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=0 loops=3)
-         ->  Result (actual rows=0 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=0 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=0.00 loops=3)
+         ->  Result (actual rows=0.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
                      Chunks excluded during startup: 3
 (7 rows)
@@ -249,26 +272,33 @@ WHERE o1.time < '2000-02-01'
   AND o2.device_id = 2
 ORDER BY o1.time;
 QUERY PLAN
- Merge Join (actual rows=13674 loops=1)
+ Merge Join (actual rows=13674.00 loops=1)
    Merge Cond: (o1."time" = o2."time")
-   ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
                Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-   ->  Materialize (actual rows=13674 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=13674 loops=1)
+               Index Searches: 1
+   ->  Materialize (actual rows=13674.00 loops=1)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
+                     Index Searches: 1
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
+                     Index Searches: 1
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038.00 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(19 rows)
+                     Index Searches: 1
+(26 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -284,23 +314,29 @@ WHERE o1.time < '2000-01-08'
 ORDER BY o1.time
 LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Merge Join (actual rows=10 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Merge Join (actual rows=10.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=2 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=2.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2.00 loops=1)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Materialize (actual rows=10 loops=1)
-               ->  Result (actual rows=6 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=6 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=10.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Result (actual rows=6.00 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=6 loops=1)
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=6.00 loops=1)
+                                 Index Searches: 1
                            ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 0
                            ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-(16 rows)
+                                 Index Searches: 0
+(22 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -316,28 +352,34 @@ FROM :TEST_TABLE o1
 WHERE o1.device_id = 1
 ORDER BY time;
 QUERY PLAN
- Merge Join (actual rows=1 loops=1)
+ Merge Join (actual rows=1.00 loops=1)
    Merge Cond: (o1."time" = ((InitPlan 1).col1))
-   ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
                Index Cond: (device_id = 1)
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Index Cond: (device_id = 1)
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
                Index Cond: (device_id = 1)
-   ->  Sort (actual rows=1 loops=1)
+               Index Searches: 1
+   ->  Sort (actual rows=1.00 loops=1)
          Sort Key: ((InitPlan 1).col1)
          Sort Method: quicksort 
-         ->  Result (actual rows=1 loops=1)
+         ->  Result (actual rows=1.00 loops=1)
                InitPlan 1
-                 ->  Limit (actual rows=1 loops=1)
-                       ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
+                 ->  Limit (actual rows=1.00 loops=1)
+                       ->  Custom Scan (ChunkAppend) on metrics (actual rows=1.00 loops=1)
                              Order: metrics."time" DESC
-                             ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+                             ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                   Index Searches: 1
                              ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
+                                   Index Searches: 0
                              ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-(21 rows)
+                                   Index Searches: 0
+(27 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -353,27 +395,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -386,27 +435,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -419,11 +475,11 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
          Sort Key: o1."time"
          Sort Method: quicksort 
-         ->  Result (actual rows=0 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                One-Time Filter: false
 (6 rows)
 
@@ -438,27 +494,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -471,27 +534,34 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -504,27 +574,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -538,27 +615,34 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -571,27 +655,34 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -603,23 +694,30 @@ FROM :TEST_TABLE o1
   ORDER BY o1.time
   LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
          Join Filter: (o1.device_id = o2.device_id)
          Rows Removed by Join Filter: 400
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_2 (never executed)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o1_3 (never executed)
-         ->  Materialize (actual rows=500 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=101 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=500.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=101.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=101 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_1 (actual rows=101.00 loops=1)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_2 (never executed)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-(16 rows)
+                           Index Searches: 0
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -631,25 +729,33 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Nested Loop (actual rows=100 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=1 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Nested Loop (actual rows=100.00 loops=1)
+         Disabled: true
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Append (actual rows=100 loops=1)
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           Index Cond: ((device_id = 1) AND (device_id = 1))
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 20kB
+               ->  Append (actual rows=100.00 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                           Index Cond: ((device_id = 1) AND (device_id = 1))
+                           Index Cond: (device_id = 1)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                           Index Cond: ((device_id = 1) AND (device_id = 1))
-(18 rows)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 0
+(26 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -663,27 +769,34 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Index Cond: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -698,38 +811,49 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o3."time" = o1."time")
-         ->  Custom Scan (ChunkAppend) on metrics o3 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                      Index Cond: (device_id = 3)
+                     Index Searches: 1
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_2 (never executed)
                      Index Cond: (device_id = 3)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o3_3 (never executed)
                      Index Cond: (device_id = 3)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Merge Join (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Merge Join (actual rows=100.00 loops=1)
                      Merge Cond: (o1."time" = o2."time")
-                     ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                  Index Cond: (device_id = 1)
+                                 Index Searches: 1
                            ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                                  Index Cond: (device_id = 1)
+                                 Index Searches: 0
                            ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                                  Index Cond: (device_id = 1)
-                     ->  Materialize (actual rows=100 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100 loops=1)
+                                 Index Searches: 0
+                     ->  Materialize (actual rows=100.00 loops=1)
+                           Storage: Memory  Maximum Storage: 17kB
+                           ->  Custom Scan (ChunkAppend) on metrics o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                                 ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        Index Cond: (device_id = 2)
+                                       Index Searches: 1
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
+                                       Index Searches: 0
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-(31 rows)
+                                       Index Searches: 0
+(42 rows)
 
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space'
@@ -758,28 +882,38 @@ FROM :TEST_TABLE,
 ORDER BY time DESC
 LIMIT 2;
 QUERY PLAN
- Limit (actual rows=2 loops=1)
-   ->  Nested Loop (actual rows=2 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1 loops=1)
+ Limit (actual rows=2.00 loops=1)
+   ->  Nested Loop (actual rows=2.00 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1.00 loops=1)
                Order: metrics_space."time" DESC
-               ->  Merge Append (actual rows=1 loops=1)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=1.00 loops=1)
+                     Sort Key: metrics_space."time" DESC
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                           Index Searches: 1
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                           Index Searches: 1
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                           Index Searches: 1
                ->  Merge Append (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Key: metrics_space."time" DESC
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                           Index Searches: 0
                ->  Merge Append (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Key: metrics_space."time" DESC
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                           Index Searches: 0
                      ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         ->  Materialize (actual rows=2 loops=1)
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(21 rows)
+                           Index Searches: 0
+         ->  Materialize (actual rows=2.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+(31 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -794,30 +928,40 @@ FROM (
     ORDER BY time DESC
     LIMIT 2) l;
 QUERY PLAN
- Nested Loop (actual rows=4 loops=1)
-   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Materialize (actual rows=2 loops=2)
-         ->  Subquery Scan on l (actual rows=2 loops=1)
-               ->  Limit (actual rows=2 loops=1)
-                     ->  Result (actual rows=2 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=2 loops=1)
+ Nested Loop (actual rows=4.00 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+   ->  Materialize (actual rows=2.00 loops=2)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Subquery Scan on l (actual rows=2.00 loops=1)
+               ->  Limit (actual rows=2.00 loops=1)
+                     ->  Result (actual rows=2.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=2.00 loops=1)
                                  Order: metrics_space."time" DESC
-                                 ->  Merge Append (actual rows=2 loops=1)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2 loops=1)
-                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+                                 ->  Merge Append (actual rows=2.00 loops=1)
+                                       Sort Key: metrics_space."time" DESC
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=2.00 loops=1)
+                                             Index Searches: 1
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             Index Searches: 1
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             Index Searches: 1
                                  ->  Merge Append (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       Sort Key: metrics_space."time" DESC
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                             Index Searches: 0
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                             Index Searches: 0
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                             Index Searches: 0
                                  ->  Merge Append (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       Sort Key: metrics_space."time" DESC
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                             Index Searches: 0
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                             Index Searches: 0
                                        ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-(23 rows)
+                                             Index Searches: 0
+(33 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -830,16 +974,19 @@ WHERE device_id = 1
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1.00 loops=1)
          Order: metrics_space."time" DESC
-         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                Filter: (device_id = 1)
+               Index Searches: 1
          ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                Filter: (device_id = 1)
+               Index Searches: 0
          ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
                Filter: (device_id = 1)
-(9 rows)
+               Index Searches: 0
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -849,25 +996,34 @@ FROM :TEST_TABLE
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1.00 loops=1)
          Order: metrics_space."time" DESC
-         ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1.00 loops=1)
+               Sort Key: metrics_space."time" DESC
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Index Searches: 1
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Index Searches: 1
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Index Searches: 1
          ->  Merge Append (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Key: metrics_space."time" DESC
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
          ->  Merge Append (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Key: metrics_space."time" DESC
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-(18 rows)
+                     Index Searches: 0
+(27 rows)
 
 SET enable_nestloop TO on;
 -- test LATERAL with correlated query
@@ -884,37 +1040,46 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_1."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_4."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Merge Append (actual rows=1 loops=3)
-                           Sort Key: o_7."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
+                                 Index Searches: 3
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-(30 rows)
+                                 Index Searches: 3
+(39 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -930,37 +1095,46 @@ FROM generate_series('2000-01-10'::timestamptz, '2000-01-11', '1d') AS g (time)
   ORDER BY time
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=2 loops=1)
-   ->  Function Scan on generate_series g (actual rows=2 loops=1)
-   ->  Limit (actual rows=1 loops=2)
-         ->  Result (actual rows=1 loops=2)
-               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=1 loops=2)
+ Nested Loop Left Join (actual rows=2.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=2.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=2)
+         ->  Result (actual rows=1.00 loops=2)
+               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=1.00 loops=2)
                      Order: o."time"
-                     ->  Merge Append (actual rows=0 loops=2)
-                           Sort Key: o_1."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
+                     ->  Merge Append (actual rows=0.00 loops=2)
+                           Sort Key: o."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
+                                 Index Searches: 2
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
+                                 Index Searches: 2
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Merge Append (actual rows=1 loops=2)
-                           Sort Key: o_4."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=1 loops=2)
+                                 Index Searches: 2
+                     ->  Merge Append (actual rows=1.00 loops=2)
+                           Sort Key: o."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=1.00 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=1 loops=2)
+                                 Index Searches: 2
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=1.00 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=1 loops=2)
+                                 Index Searches: 2
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=1.00 loops=2)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Index Searches: 2
                      ->  Merge Append (never executed)
-                           Sort Key: o_7."time"
+                           Sort Key: o."time"
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (never executed)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-(30 rows)
+                                 Index Searches: 0
+(39 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -976,37 +1150,46 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_1."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_4."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Merge Append (actual rows=1 loops=3)
-                           Sort Key: o_7."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1 loops=3)
+                                 Index Searches: 3
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=1.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=1.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=1.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-(30 rows)
+                                 Index Searches: 3
+(39 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -1023,37 +1206,46 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=0 loops=3)
-         ->  Result (actual rows=0 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=0 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=0.00 loops=3)
+         ->  Result (actual rows=0.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_1."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_4."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_4 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_5 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_6 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_7."time" DESC
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_7 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_8 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
+                                 Index Searches: 3
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o_9 (actual rows=0.00 loops=3)
                                  Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
-(30 rows)
+                                 Index Searches: 3
+(39 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -1069,29 +1261,36 @@ WHERE o1.time < '2000-02-01'
   AND o2.device_id = 2
 ORDER BY o1.time;
 QUERY PLAN
- Merge Join (actual rows=13674 loops=1)
+ Merge Join (actual rows=13674.00 loops=1)
    Merge Cond: (o1."time" = o2."time")
-   ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
                Index Cond: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Index Cond: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
                Index Cond: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
                Filter: (device_id = 1)
-   ->  Materialize (actual rows=13674 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=13674 loops=1)
+               Index Searches: 1
+   ->  Materialize (actual rows=13674.00 loops=1)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
+                     Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
+                     Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (actual rows=5038.00 loops=1)
                      Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(22 rows)
+                     Index Searches: 1
+(29 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -1107,47 +1306,63 @@ WHERE o1.time < '2000-01-08'
 ORDER BY o1.time
 LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Merge Join (actual rows=10 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Merge Join (actual rows=10.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=2 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=2.00 loops=1)
                Order: o1."time"
-               ->  Merge Append (actual rows=2 loops=1)
-                     Sort Key: o1_1."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2 loops=1)
+               ->  Merge Append (actual rows=2.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=2.00 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=1 loops=1)
+                           Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=1.00 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=1 loops=1)
+                           Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=1.00 loops=1)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                           Index Searches: 1
                ->  Merge Append (never executed)
-                     Sort Key: o1_4."time"
+                     Sort Key: o1."time"
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_4 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_5 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_6 (never executed)
                            Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Materialize (actual rows=10 loops=1)
-               ->  Result (actual rows=6 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=6 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=10.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Result (actual rows=6.00 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Merge Append (actual rows=6 loops=1)
-                                 Sort Key: o2_1."time"
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2 loops=1)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=4 loops=1)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=2 loops=1)
+                           ->  Merge Append (actual rows=6.00 loops=1)
+                                 Sort Key: o2."time"
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2.00 loops=1)
+                                       Index Searches: 1
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=4.00 loops=1)
+                                       Index Searches: 1
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=2.00 loops=1)
+                                       Index Searches: 1
                            ->  Merge Append (never executed)
-                                 Sort Key: o2_4."time"
+                                 Sort Key: o2."time"
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_4 (never executed)
+                                       Index Searches: 0
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_5 (never executed)
+                                       Index Searches: 0
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_6 (never executed)
+                                       Index Searches: 0
                            ->  Merge Append (never executed)
-                                 Sort Key: o2_7."time"
+                                 Sort Key: o2."time"
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_7 (never executed)
+                                       Index Searches: 0
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_8 (never executed)
+                                       Index Searches: 0
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_9 (never executed)
-(40 rows)
+                                       Index Searches: 0
+(56 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -1163,40 +1378,52 @@ FROM :TEST_TABLE o1
 WHERE o1.device_id = 1
 ORDER BY time;
 QUERY PLAN
- Merge Join (actual rows=1 loops=1)
+ Merge Join (actual rows=1.00 loops=1)
    Merge Cond: (o1."time" = ((InitPlan 1).col1))
-   ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
                Filter: (device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Filter: (device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
+               Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
                Filter: (device_id = 1)
-   ->  Sort (actual rows=1 loops=1)
+               Index Searches: 1
+   ->  Sort (actual rows=1.00 loops=1)
          Sort Key: ((InitPlan 1).col1)
          Sort Method: quicksort 
-         ->  Result (actual rows=1 loops=1)
+         ->  Result (actual rows=1.00 loops=1)
                InitPlan 1
-                 ->  Limit (actual rows=1 loops=1)
-                       ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1 loops=1)
+                 ->  Limit (actual rows=1.00 loops=1)
+                       ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1.00 loops=1)
                              Order: metrics_space."time" DESC
-                             ->  Merge Append (actual rows=1 loops=1)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
+                             ->  Merge Append (actual rows=1.00 loops=1)
+                                   Sort Key: metrics_space."time" DESC
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                         Index Searches: 1
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                         Index Searches: 1
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                         Index Searches: 1
                              ->  Merge Append (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   Sort Key: metrics_space."time" DESC
                                    ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Searches: 0
                                    ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Searches: 0
                                    ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Searches: 0
                              ->  Merge Append (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   Sort Key: metrics_space."time" DESC
                                    ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Searches: 0
                                    ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Searches: 0
                                    ->  Index Scan Backward using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-(33 rows)
+                                         Index Searches: 0
+(45 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -1212,27 +1439,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -1245,27 +1479,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -1278,11 +1519,11 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
          Sort Key: o1."time"
          Sort Method: quicksort 
-         ->  Result (actual rows=0 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                One-Time Filter: false
 (6 rows)
 
@@ -1297,27 +1538,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -1330,27 +1578,34 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -1363,27 +1618,34 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -1397,27 +1659,34 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -1430,27 +1699,34 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -1462,47 +1738,66 @@ FROM :TEST_TABLE o1
   ORDER BY o1.time
   LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
          Join Filter: (o1.device_id = o2.device_id)
          Rows Removed by Join Filter: 400
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Merge Append (actual rows=100 loops=1)
-                     Sort Key: o1_1."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=21 loops=1)
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=60 loops=1)
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=21 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=21.00 loops=1)
+                           Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (actual rows=60.00 loops=1)
+                           Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (actual rows=21.00 loops=1)
+                           Index Searches: 1
                ->  Merge Append (never executed)
-                     Sort Key: o1_4."time"
+                     Sort Key: o1."time"
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_4 (never executed)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_5 (never executed)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_6 (never executed)
+                           Index Searches: 0
                ->  Merge Append (never executed)
-                     Sort Key: o1_7."time"
+                     Sort Key: o1."time"
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_7 (never executed)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_8 (never executed)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_9 (never executed)
-         ->  Materialize (actual rows=500 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=101 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=500.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=101.00 loops=1)
                      Order: o2."time"
-                     ->  Merge Append (actual rows=101 loops=1)
-                           Sort Key: o2_1."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=21 loops=1)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=61 loops=1)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=21 loops=1)
+                     ->  Merge Append (actual rows=101.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_1 (actual rows=21.00 loops=1)
+                                 Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_2 (actual rows=61.00 loops=1)
+                                 Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_3 (actual rows=21.00 loops=1)
+                                 Index Searches: 1
                      ->  Merge Append (never executed)
-                           Sort Key: o2_4."time"
+                           Sort Key: o2."time"
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_4 (never executed)
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_5 (never executed)
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_6 (never executed)
+                                 Index Searches: 0
                      ->  Merge Append (never executed)
-                           Sort Key: o2_7."time"
+                           Sort Key: o2."time"
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_7 (never executed)
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_8 (never executed)
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o2_9 (never executed)
-(40 rows)
+                                 Index Searches: 0
+(59 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -1514,25 +1809,33 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Nested Loop (actual rows=100 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=1 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Nested Loop (actual rows=100.00 loops=1)
+         Disabled: true
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Append (actual rows=100 loops=1)
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           Index Cond: ((device_id = 1) AND (device_id = 1))
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 20kB
+               ->  Append (actual rows=100.00 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                           Index Cond: ((device_id = 1) AND (device_id = 1))
+                           Index Cond: (device_id = 1)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                           Index Cond: ((device_id = 1) AND (device_id = 1))
-(18 rows)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 0
+(26 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -1546,27 +1849,34 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 1)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                      Filter: (device_id = 1)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                      Filter: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 2)
+                           Index Searches: 1
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                            Index Cond: (device_id = 2)
+                           Index Searches: 0
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                            Index Cond: (device_id = 2)
-(20 rows)
+                           Index Searches: 0
+(27 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -1581,38 +1891,49 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o3."time" = o1."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                      Filter: (device_id = 3)
+                     Index Searches: 1
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
                      Filter: (device_id = 3)
+                     Index Searches: 0
                ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
                      Filter: (device_id = 3)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Merge Join (actual rows=100 loops=1)
+                     Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Merge Join (actual rows=100.00 loops=1)
                      Merge Cond: (o1."time" = o2."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                  Filter: (device_id = 1)
+                                 Index Searches: 1
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
                                  Filter: (device_id = 1)
+                                 Index Searches: 0
                            ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
                                  Filter: (device_id = 1)
-                     ->  Materialize (actual rows=100 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100 loops=1)
+                                 Index Searches: 0
+                     ->  Materialize (actual rows=100.00 loops=1)
+                           Storage: Memory  Maximum Storage: 17kB
+                           ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        Index Cond: (device_id = 2)
+                                       Index Searches: 1
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
                                        Index Cond: (device_id = 2)
+                                       Index Searches: 0
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
-(31 rows)
+                                       Index Searches: 0
+(42 rows)
 
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_compressed'
@@ -1641,26 +1962,31 @@ FROM :TEST_TABLE,
 ORDER BY time DESC
 LIMIT 2;
 QUERY PLAN
- Limit (actual rows=2 loops=1)
-   ->  Nested Loop (actual rows=2 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+ Limit (actual rows=2.00 loops=1)
+   ->  Nested Loop (actual rows=2.00 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1.00 loops=1)
                Order: metrics_compressed."time" DESC
-               ->  Sort (actual rows=1 loops=1)
+               ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=25190.00 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-         ->  Materialize (actual rows=2 loops=1)
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(19 rows)
+               ->  Merge Append (never executed)
+                     Sort Key: metrics_compressed."time" DESC
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+                           Index Searches: 0
+         ->  Materialize (actual rows=2.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+(24 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -1675,28 +2001,33 @@ FROM (
     ORDER BY time DESC
     LIMIT 2) l;
 QUERY PLAN
- Nested Loop (actual rows=4 loops=1)
-   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Materialize (actual rows=2 loops=2)
-         ->  Subquery Scan on l (actual rows=2 loops=1)
-               ->  Limit (actual rows=2 loops=1)
-                     ->  Result (actual rows=2 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=2 loops=1)
+ Nested Loop (actual rows=4.00 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+   ->  Materialize (actual rows=2.00 loops=2)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Subquery Scan on l (actual rows=2.00 loops=1)
+               ->  Limit (actual rows=2.00 loops=1)
+                     ->  Result (actual rows=2.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=2.00 loops=1)
                                  Order: metrics_compressed."time" DESC
-                                 ->  Sort (actual rows=2 loops=1)
+                                 ->  Sort (actual rows=2.00 loops=1)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
                                        Sort Method: top-N heapsort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=25190.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
                                  ->  Sort (never executed)
                                        Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(21 rows)
+                                 ->  Merge Append (never executed)
+                                       Sort Key: metrics_compressed."time" DESC
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+                                             Index Searches: 0
+(26 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -1709,19 +2040,29 @@ WHERE device_id = 1
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1.00 loops=1)
          Order: metrics_compressed."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                     Index Searches: 0
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                     Filter: (device_id = 1)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Index Searches: 0
+(22 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -1731,23 +2072,27 @@ FROM :TEST_TABLE
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1.00 loops=1)
          Order: metrics_compressed."time" DESC
-         ->  Sort (actual rows=1 loops=1)
+         ->  Sort (actual rows=1.00 loops=1)
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=25190.00 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-         ->  Sort (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(16 rows)
+         ->  Merge Append (never executed)
+               Sort Key: metrics_compressed."time" DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
+(20 rows)
 
 SET enable_nestloop TO on;
 -- test LATERAL with correlated query
@@ -1764,36 +2109,41 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
                      Chunks excluded during startup: 0
                      Chunks excluded during runtime: 2
                      ->  Sort (never executed)
                            Sort Key: o_1."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                      ->  Sort (never executed)
                            Sort Key: o_2."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                       Rows Removed by Filter: 12
-(29 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.33 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.33 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=0.67 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Index Searches: 3
+(34 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -1809,36 +2159,43 @@ FROM generate_series('2000-01-10'::timestamptz, '2000-01-11', '1d') AS g (time)
   ORDER BY time
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=2 loops=1)
-   ->  Function Scan on generate_series g (actual rows=2 loops=1)
-   ->  Limit (actual rows=1 loops=2)
-         ->  Result (actual rows=1 loops=2)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1 loops=2)
+ Nested Loop Left Join (actual rows=2.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=2.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=2)
+         ->  Result (actual rows=1.00 loops=2)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1.00 loops=2)
                      Order: o."time"
                      Chunks excluded during startup: 0
-                     Chunks excluded during runtime: 2
-                     ->  Sort (never executed)
-                           Sort Key: o_1."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                     ->  Sort (actual rows=1 loops=2)
+                     Chunks excluded during runtime: 1
+                     ->  Merge Append (actual rows=0.00 loops=2)
+                           Sort Key: o."time"
+                           ->  Sort (actual rows=0.00 loops=2)
+                                 Sort Key: o_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                                             Rows Removed by Filter: 18
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Index Searches: 2
+                     ->  Sort (actual rows=1.00 loops=2)
                            Sort Key: o_2."time"
                            Sort Method: top-N heapsort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=3600 loops=2)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=3600.00 loops=2)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 3900
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=2)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.50 loops=2)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 22
                      ->  Sort (never executed)
                            Sort Key: o_3."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-(29 rows)
+(36 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -1854,39 +2211,44 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
                      Chunks excluded during startup: 0
                      Chunks excluded during runtime: 2
                      ->  Sort (never executed)
                            Sort Key: o_1."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                      ->  Sort (never executed)
                            Sort Key: o_2."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                     ->  Sort (actual rows=1 loops=3)
-                           Sort Key: o_3."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                 Rows Removed by Filter: 4063
-                                 Vectorized Filter: ("time" < now())
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
-                                       Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
-                                       Rows Removed by Filter: 12
-(32 rows)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: top-N heapsort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=3147.33 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Rows Removed by Filter: 3650
+                                       Vectorized Filter: ("time" < now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=7.33 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
+                                             Rows Removed by Filter: 11
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_3 (actual rows=0.67 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Index Searches: 3
+(37 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -1903,14 +2265,29 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=0 loops=3)
-         ->  Result (actual rows=0 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=0.00 loops=3)
+         ->  Result (actual rows=0.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
-                     Chunks excluded during startup: 3
-(7 rows)
+                     Chunks excluded during startup: 2
+                     Chunks excluded during runtime: 0
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
+                                             Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
+                                             Rows Removed by Filter: 18
+                           ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
+                                 Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Index Searches: 3
+(22 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -1926,38 +2303,57 @@ WHERE o1.time < '2000-02-01'
   AND o2.device_id = 2
 ORDER BY o1.time;
 QUERY PLAN
- Merge Join (actual rows=13674 loops=1)
+ Merge Join (actual rows=13674.00 loops=1)
    Merge Cond: (o1."time" = o2."time")
-   ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                           Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
-               Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-   ->  Materialize (actual rows=13674 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=13674 loops=1)
+                     Index Searches: 1
+   ->  Materialize (actual rows=13674.00 loops=1)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+               ->  Merge Append (actual rows=3598.00 loops=1)
+                     Sort Key: o2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
+                           Index Cond: ((device_id = 2) AND ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
-                     Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(31 rows)
+                           Index Searches: 1
+(50 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -1973,42 +2369,52 @@ WHERE o1.time < '2000-01-08'
 ORDER BY o1.time
 LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Merge Join (actual rows=10 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Merge Join (actual rows=10.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=2 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=2.00 loops=1)
                Order: o1."time"
-               ->  Sort (actual rows=2 loops=1)
-                     Sort Key: o1_1."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Merge Append (actual rows=2.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Sort Key: o1_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Index Cond: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                           Index Searches: 1
                ->  Sort (never executed)
                      Sort Key: o1_2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Materialize (actual rows=10 loops=1)
-               ->  Result (actual rows=6 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=6 loops=1)
+         ->  Materialize (actual rows=10.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Result (actual rows=6.00 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Sort (actual rows=6 loops=1)
-                                 Sort Key: o2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                           ->  Merge Append (actual rows=6.00 loops=1)
+                                 Sort Key: o2."time"
+                                 ->  Sort (actual rows=5.00 loops=1)
+                                       Sort Key: o2_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=2.00 loops=1)
+                                       Index Searches: 1
                            ->  Sort (never executed)
                                  Sort Key: o2_2."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                            ->  Sort (never executed)
                                  Sort Key: o2_3."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(35 rows)
+(45 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -2024,41 +2430,54 @@ FROM :TEST_TABLE o1
 WHERE o1.device_id = 1
 ORDER BY time;
 QUERY PLAN
- Merge Join (actual rows=1 loops=1)
+ Merge Join (actual rows=1.00 loops=1)
    Merge Cond: (o1."time" = ((InitPlan 1).col1))
-   ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         ->  Merge Append (actual rows=3598.00 loops=1)
+               Sort Key: o1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: (device_id = 1)
-   ->  Sort (actual rows=1 loops=1)
+                     Index Searches: 1
+   ->  Sort (actual rows=1.00 loops=1)
          Sort Key: ((InitPlan 1).col1)
          Sort Method: quicksort 
-         ->  Result (actual rows=1 loops=1)
+         ->  Result (actual rows=1.00 loops=1)
                InitPlan 1
-                 ->  Limit (actual rows=1 loops=1)
-                       ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+                 ->  Limit (actual rows=1.00 loops=1)
+                       ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1.00 loops=1)
                              Order: metrics_compressed."time" DESC
-                             ->  Sort (actual rows=1 loops=1)
+                             ->  Sort (actual rows=1.00 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
-                                   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                                   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=25190.00 loops=1)
+                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                             ->  Sort (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-(34 rows)
+                             ->  Merge Append (never executed)
+                                   Sort Key: metrics_compressed."time" DESC
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                   ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (never executed)
+                                         Index Searches: 0
+(47 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -2074,33 +2493,52 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -2113,33 +2551,52 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -2152,11 +2609,11 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
          Sort Key: o1."time"
          Sort Method: quicksort 
-         ->  Result (actual rows=0 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                One-Time Filter: false
 (6 rows)
 
@@ -2171,33 +2628,52 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -2210,33 +2686,52 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -2249,33 +2744,52 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -2289,33 +2803,52 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -2328,33 +2861,52 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -2366,30 +2918,38 @@ FROM :TEST_TABLE o1
   ORDER BY o1.time
   LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
-         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o1_1."time", o1_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=25190 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2_1."time", o2_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(23 rows)
+ Limit (actual rows=100.00 loops=1)
+   ->  Sort (actual rows=100.00 loops=1)
+         Sort Key: o1."time"
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=68370.00 loops=1)
+               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
+               ->  Append (actual rows=68370.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=16392.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1598.00 loops=1)
+                           Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=25190.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=25190.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=30.00 loops=1)
+                                 Index Searches: 1
+               ->  Hash (actual rows=68370.00 loops=1)
+                     ->  Append (actual rows=68370.00 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=16392.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o2_1 (actual rows=1598.00 loops=1)
+                                 Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=25190.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=25190.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30.00 loops=1)
+                                       Index Searches: 1
+(32 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2401,31 +2961,49 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Nested Loop (actual rows=100 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=1 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Nested Loop (actual rows=100.00 loops=1)
+         Disabled: true
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=1.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Append (actual rows=100 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                 Index Cond: ((device_id = 1) AND (device_id = 1))
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 20kB
+               ->  Append (actual rows=100.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: ((device_id = 1) AND (device_id = 1))
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: ((device_id = 1) AND (device_id = 1))
-(24 rows)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 0
+(42 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -2439,33 +3017,52 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                           Filter: (device_id = 1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (actual rows=100.00 loops=1)
+                           Sort Key: o2."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 2)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                       Index Searches: 1
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(45 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -2480,47 +3077,76 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o3."time" = o1."time")
-         ->  Custom Scan (ChunkAppend) on metrics_compressed o3 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=100.00 loops=1)
+                     Sort Key: o3."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           Filter: (device_id = 3)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 3)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o3_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                            Index Cond: (device_id = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o3_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                            Index Cond: (device_id = 3)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Merge Join (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Merge Join (actual rows=100.00 loops=1)
                      Merge Cond: (o1."time" = o2."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                           ->  Merge Append (actual rows=100.00 loops=1)
+                                 Sort Key: o1."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                                       Filter: (device_id = 1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             Index Cond: (device_id = 1)
+                                             Index Searches: 1
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                        Index Cond: (device_id = 1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                        Index Cond: (device_id = 1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                                       Index Searches: 0
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                        Index Cond: (device_id = 1)
-                     ->  Materialize (actual rows=100 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100 loops=1)
+                                       Index Searches: 0
+                     ->  Materialize (actual rows=100.00 loops=1)
+                           Storage: Memory  Maximum Storage: 17kB
+                           ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                                 ->  Merge Append (actual rows=100.00 loops=1)
+                                       Sort Key: o2."time"
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                             Filter: (device_id = 2)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                                   Index Cond: (device_id = 2)
+                                                   Index Searches: 1
+                                       ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                              Index Cond: (device_id = 2)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                             Index Searches: 1
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 2)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                             Index Searches: 0
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 2)
-(40 rows)
+                                             Index Searches: 0
+(69 rows)
 
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'
@@ -2549,58 +3175,59 @@ FROM :TEST_TABLE,
 ORDER BY time DESC
 LIMIT 2;
 QUERY PLAN
- Limit (actual rows=2 loops=1)
-   ->  Nested Loop (actual rows=2 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+ Limit (actual rows=2.00 loops=1)
+   ->  Nested Loop (actual rows=2.00 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1.00 loops=1)
                Order: metrics_space_compressed."time" DESC
-               ->  Merge Append (actual rows=1 loops=1)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Sort (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=1.00 loops=1)
+                     Sort Key: metrics_space_compressed."time" DESC
+                     ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: _hyper_X_X_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                     ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: _hyper_X_X_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=15114.00 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: _hyper_X_X_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                ->  Merge Append (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Key: metrics_space_compressed."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_X_X_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_X_X_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_X_X_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Merge Append (never executed)
-                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Key: metrics_space_compressed."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_X_X_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_X_X_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_X_X_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-         ->  Materialize (actual rows=2 loops=1)
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(51 rows)
+         ->  Materialize (actual rows=2.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+(52 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -2615,60 +3242,61 @@ FROM (
     ORDER BY time DESC
     LIMIT 2) l;
 QUERY PLAN
- Nested Loop (actual rows=4 loops=1)
-   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Materialize (actual rows=2 loops=2)
-         ->  Subquery Scan on l (actual rows=2 loops=1)
-               ->  Limit (actual rows=2 loops=1)
-                     ->  Result (actual rows=2 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=2 loops=1)
+ Nested Loop (actual rows=4.00 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
+   ->  Materialize (actual rows=2.00 loops=2)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Subquery Scan on l (actual rows=2.00 loops=1)
+               ->  Limit (actual rows=2.00 loops=1)
+                     ->  Result (actual rows=2.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=2.00 loops=1)
                                  Order: metrics_space_compressed."time" DESC
-                                 ->  Merge Append (actual rows=2 loops=1)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
-                                       ->  Sort (actual rows=2 loops=1)
+                                 ->  Merge Append (actual rows=2.00 loops=1)
+                                       Sort Key: metrics_space_compressed."time" DESC
+                                       ->  Sort (actual rows=2.00 loops=1)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
                                              Sort Method: top-N heapsort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                       ->  Sort (actual rows=1 loops=1)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                                       ->  Sort (actual rows=1.00 loops=1)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
                                              Sort Method: top-N heapsort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                       ->  Sort (actual rows=1 loops=1)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=15114.00 loops=1)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                       ->  Sort (actual rows=1.00 loops=1)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
                                              Sort Method: top-N heapsort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                                  ->  Merge Append (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       Sort Key: metrics_space_compressed."time" DESC
                                        ->  Sort (never executed)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        ->  Sort (never executed)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        ->  Sort (never executed)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  ->  Merge Append (never executed)
-                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       Sort Key: metrics_space_compressed."time" DESC
                                        ->  Sort (never executed)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        ->  Sort (never executed)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        ->  Sort (never executed)
                                              Sort Key: _hyper_X_X_chunk."time" DESC
-                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(53 rows)
+(54 rows)
 
 SET enable_nestloop TO off;
 -- test plan with best index is chosen
@@ -2681,19 +3309,22 @@ WHERE device_id = 1
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1.00 loops=1)
          Order: metrics_space_compressed."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     Index Searches: 0
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Index Searches: 0
+(15 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -2703,53 +3334,53 @@ FROM :TEST_TABLE
 ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
- Limit (actual rows=1 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+ Limit (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1.00 loops=1)
          Order: metrics_space_compressed."time" DESC
-         ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_X_X_chunk."time" DESC
-               ->  Sort (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1.00 loops=1)
+               Sort Key: metrics_space_compressed."time" DESC
+               ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Sort (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+               ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-               ->  Sort (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=15114.00 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Key: metrics_space_compressed."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Key: metrics_space_compressed."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (48 rows)
 
@@ -2768,91 +3399,91 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_1."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_1."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_2."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_3."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_4."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_4."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_4 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_5."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_5 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_6."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_6 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                     ->  Merge Append (actual rows=1 loops=3)
-                           Sort Key: o_7."time" DESC
-                           ->  Sort (actual rows=1 loops=3)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
                                  Sort Key: o_7."time" DESC
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_7 (actual rows=720.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.67 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
-                           ->  Sort (actual rows=1 loops=3)
+                           ->  Sort (actual rows=1.00 loops=3)
                                  Sort Key: o_8."time" DESC
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_8 (actual rows=2160.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2438
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 7
-                           ->  Sort (actual rows=1 loops=3)
+                           ->  Sort (actual rows=1.00 loops=3)
                                  Sort Key: o_9."time" DESC
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_9 (actual rows=720.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.67 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
 (87 rows)
@@ -2871,84 +3502,84 @@ FROM generate_series('2000-01-10'::timestamptz, '2000-01-11', '1d') AS g (time)
   ORDER BY time
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=2 loops=1)
-   ->  Function Scan on generate_series g (actual rows=2 loops=1)
-   ->  Limit (actual rows=1 loops=2)
-         ->  Result (actual rows=1 loops=2)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1 loops=2)
+ Nested Loop Left Join (actual rows=2.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=2.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=2)
+         ->  Result (actual rows=1.00 loops=2)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1.00 loops=2)
                      Order: o."time"
-                     ->  Merge Append (actual rows=0 loops=2)
-                           Sort Key: o_1."time"
-                           ->  Sort (actual rows=0 loops=2)
+                     ->  Merge Append (actual rows=0.00 loops=2)
+                           Sort Key: o."time"
+                           ->  Sort (actual rows=0.00 loops=2)
                                  Sort Key: o_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
-                           ->  Sort (actual rows=0 loops=2)
+                           ->  Sort (actual rows=0.00 loops=2)
                                  Sort Key: o_2."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 12
-                           ->  Sort (actual rows=0 loops=2)
+                           ->  Sort (actual rows=0.00 loops=2)
                                  Sort Key: o_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
-                     ->  Merge Append (actual rows=1 loops=2)
-                           Sort Key: o_4."time"
-                           ->  Sort (actual rows=1 loops=2)
+                     ->  Merge Append (actual rows=1.00 loops=2)
+                           Sort Key: o."time"
+                           ->  Sort (actual rows=1.00 loops=2)
                                  Sort Key: o_4."time"
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=720 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_4 (actual rows=720.00 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 780
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.50 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
-                           ->  Sort (actual rows=1 loops=2)
+                           ->  Sort (actual rows=1.00 loops=2)
                                  Sort Key: o_5."time"
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=2160 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_5 (actual rows=2160.00 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2340
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.50 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 14
-                           ->  Sort (actual rows=1 loops=2)
+                           ->  Sort (actual rows=1.00 loops=2)
                                  Sort Key: o_6."time"
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=720 loops=2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_6 (actual rows=720.00 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 780
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.50 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
                      ->  Merge Append (never executed)
-                           Sort Key: o_7."time"
+                           Sort Key: o."time"
                            ->  Sort (never executed)
                                  Sort Key: o_7."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (never executed)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_7 (never executed)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                            ->  Sort (never executed)
                                  Sort Key: o_8."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (never executed)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_8 (never executed)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                            ->  Sort (never executed)
                                  Sort Key: o_9."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (never executed)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_9 (never executed)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
@@ -2968,100 +3599,100 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=1 loops=3)
-         ->  Result (actual rows=1 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=1.00 loops=3)
+         ->  Result (actual rows=1.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1.00 loops=3)
                      Order: o."time" DESC
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_1."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_1."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 6
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_2."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 18
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_3."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 6
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_4."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_4."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_4 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 6
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_5."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_5 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 18
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_6."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_6 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 6
-                     ->  Merge Append (actual rows=1 loops=3)
-                           Sort Key: o_7."time" DESC
-                           ->  Sort (actual rows=1 loops=3)
+                     ->  Merge Append (actual rows=1.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=1.00 loops=3)
                                  Sort Key: o_7."time" DESC
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_7 (actual rows=720.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.67 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 2
-                           ->  Sort (actual rows=1 loops=3)
+                           ->  Sort (actual rows=1.00 loops=3)
                                  Sort Key: o_8."time" DESC
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_8 (actual rows=2160.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2438
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 7
-                           ->  Sort (actual rows=1 loops=3)
+                           ->  Sort (actual rows=1.00 loops=3)
                                  Sort Key: o_9."time" DESC
                                  Sort Method: top-N heapsort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_9 (actual rows=720.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
                                        Vectorized Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1.67 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_min_1 < now()))
                                              Rows Removed by Filter: 2
 (96 rows)
@@ -3081,97 +3712,97 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-03', '1d') AS g (time)
   ORDER BY time DESC
   LIMIT 1) l ON TRUE;
 QUERY PLAN
- Nested Loop Left Join (actual rows=3 loops=1)
-   ->  Function Scan on generate_series g (actual rows=3 loops=1)
-   ->  Limit (actual rows=0 loops=3)
-         ->  Result (actual rows=0 loops=3)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=0 loops=3)
+ Nested Loop Left Join (actual rows=3.00 loops=1)
+   ->  Function Scan on generate_series g (actual rows=3.00 loops=1)
+   ->  Limit (actual rows=0.00 loops=3)
+         ->  Result (actual rows=0.00 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=0.00 loops=3)
                      Order: o."time" DESC
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_1."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_1."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_1 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 6
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_2."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_2 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 18
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_3."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_3 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 6
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_4."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_4."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_4 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 6
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_5."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_5 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 18
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_6."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_6 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 6
-                     ->  Merge Append (actual rows=0 loops=3)
-                           Sort Key: o_7."time" DESC
-                           ->  Sort (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0.00 loops=3)
+                           Sort Key: o."time" DESC
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_7."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_7 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 4
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_8."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_8 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 12
-                           ->  Sort (actual rows=0 loops=3)
+                           ->  Sort (actual rows=0.00 loops=3)
                                  Sort Key: o_9."time" DESC
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o_9 (actual rows=0.00 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Vectorized Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)) AND (_ts_meta_max_1 > now()))
                                              Rows Removed by Filter: 4
 (93 rows)
@@ -3190,38 +3821,45 @@ WHERE o1.time < '2000-02-01'
   AND o2.device_id = 2
 ORDER BY o1.time;
 QUERY PLAN
- Merge Join (actual rows=13674 loops=1)
+ Merge Join (actual rows=13674.00 loops=1)
    Merge Cond: (o1."time" = o2."time")
-   ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
                Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: ((device_id = 1) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-   ->  Materialize (actual rows=13674 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=13674 loops=1)
+                     Index Searches: 1
+   ->  Materialize (actual rows=13674.00 loops=1)
+         Storage: Memory  Maximum Storage: 17kB
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=13674.00 loops=1)
                Order: o2."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=5038 loops=1)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=5038.00 loops=1)
                      Vectorized Filter: ("time" < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Index Cond: ((device_id = 2) AND (_ts_meta_min_1 < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone))
-(31 rows)
+                           Index Searches: 1
+(38 rows)
 
 -- test JOIN
 -- last chunk of o2 should not be executed
@@ -3237,104 +3875,105 @@ WHERE o1.time < '2000-01-08'
 ORDER BY o1.time
 LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Merge Join (actual rows=10 loops=1)
+ Limit (actual rows=10.00 loops=1)
+   ->  Merge Join (actual rows=10.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=2 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=2.00 loops=1)
                Order: o1."time"
-               ->  Merge Append (actual rows=2 loops=1)
-                     Sort Key: o1_1."time"
-                     ->  Sort (actual rows=2 loops=1)
+               ->  Merge Append (actual rows=2.00 loops=1)
+                     Sort Key: o1."time"
+                     ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: o1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
                                  Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                                        Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: o1_2."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=10794 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=10794.00 loops=1)
                                  Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12.00 loops=1)
                                        Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: o1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=3598 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=3598.00 loops=1)
                                  Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                                        Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
-                     Sort Key: o1_4."time"
+                     Sort Key: o1."time"
                      ->  Sort (never executed)
                            Sort Key: o1_4."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_4 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_4 (never executed)
                                  Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: o1_5."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_5 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_5 (never executed)
                                  Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: o1_6."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_6 (never executed)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_6 (never executed)
                                  Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Materialize (actual rows=10 loops=1)
-               ->  Result (actual rows=6 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=6 loops=1)
+         ->  Materialize (actual rows=10.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Result (actual rows=6.00 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=6.00 loops=1)
                            Order: o2."time"
-                           ->  Merge Append (actual rows=6 loops=1)
-                                 Sort Key: o2_1."time"
-                                 ->  Sort (actual rows=2 loops=1)
+                           ->  Merge Append (actual rows=6.00 loops=1)
+                                 Sort Key: o2."time"
+                                 ->  Sort (actual rows=2.00 loops=1)
                                        Sort Key: o2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                                 ->  Sort (actual rows=4 loops=1)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 ->  Sort (actual rows=4.00 loops=1)
                                        Sort Key: o2_2."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                                 ->  Sort (actual rows=2 loops=1)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=10794.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12.00 loops=1)
+                                 ->  Sort (actual rows=2.00 loops=1)
                                        Sort Key: o2_3."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=3598.00 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
                            ->  Merge Append (never executed)
-                                 Sort Key: o2_4."time"
+                                 Sort Key: o2."time"
                                  ->  Sort (never executed)
                                        Sort Key: o2_4."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_4 (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: o2_5."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_5 (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: o2_6."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_6 (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                            ->  Merge Append (never executed)
-                                 Sort Key: o2_7."time"
+                                 Sort Key: o2."time"
                                  ->  Sort (never executed)
                                        Sort Key: o2_7."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_7 (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: o2_8."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_8 (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: o2_9."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (never executed)
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_9 (never executed)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(97 rows)
+(98 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -3350,73 +3989,76 @@ FROM :TEST_TABLE o1
 WHERE o1.device_id = 1
 ORDER BY time;
 QUERY PLAN
- Merge Join (actual rows=1 loops=1)
+ Merge Join (actual rows=1.00 loops=1)
    Merge Cond: (o1."time" = ((InitPlan 1).col1))
-   ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=13674 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=13674.00 loops=1)
          Order: o1."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=5038 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=5038.00 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=5038 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Searches: 1
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=5038.00 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                      Index Cond: (device_id = 1)
-   ->  Sort (actual rows=1 loops=1)
+                     Index Searches: 1
+   ->  Sort (actual rows=1.00 loops=1)
          Sort Key: ((InitPlan 1).col1)
          Sort Method: quicksort 
-         ->  Result (actual rows=1 loops=1)
+         ->  Result (actual rows=1.00 loops=1)
                InitPlan 1
-                 ->  Limit (actual rows=1 loops=1)
-                       ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+                 ->  Limit (actual rows=1.00 loops=1)
+                       ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1.00 loops=1)
                              Order: metrics_space_compressed."time" DESC
-                             ->  Merge Append (actual rows=1 loops=1)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
-                                   ->  Sort (actual rows=1 loops=1)
+                             ->  Merge Append (actual rows=1.00 loops=1)
+                                   Sort Key: metrics_space_compressed."time" DESC
+                                   ->  Sort (actual rows=1.00 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                   ->  Sort (actual rows=1 loops=1)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                                   ->  Sort (actual rows=1.00 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                   ->  Sort (actual rows=1 loops=1)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=15114.00 loops=1)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                   ->  Sort (actual rows=1.00 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5038.00 loops=1)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
                              ->  Merge Append (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   Sort Key: metrics_space_compressed."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Merge Append (never executed)
-                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   Sort Key: metrics_space_compressed."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
-                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-(66 rows)
+(69 rows)
 
 RESET enable_hashjoin;
 RESET enable_hashagg;
@@ -3432,33 +4074,40 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test JOIN on time column with USING
 -- should use 2 ChunkAppend
@@ -3471,33 +4120,40 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test NATURAL JOIN on time column
 -- should use 2 ChunkAppend
@@ -3510,11 +4166,11 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
+ Limit (actual rows=0.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
          Sort Key: o1."time"
          Sort Method: quicksort 
-         ->  Result (actual rows=0 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                One-Time Filter: false
 (6 rows)
 
@@ -3529,33 +4185,40 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test RIGHT JOIN on time column
 -- should use 2 ChunkAppend
@@ -3568,33 +4231,40 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test JOIN on time column with ON clause expression order switched
 -- should use 2 ChunkAppend
@@ -3607,33 +4277,40 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test JOIN on time column with equality condition in WHERE clause
 -- should use 2 ChunkAppend
@@ -3647,33 +4324,40 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test JOIN on time column with ORDER BY 2nd hypertable
 -- should use 2 ChunkAppend
@@ -3686,33 +4370,40 @@ WHERE o1.device_id = 1
 ORDER BY o2.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test JOIN on time column and device_id
 -- should use 2 ChunkAppend
@@ -3724,55 +4415,70 @@ FROM :TEST_TABLE o1
   ORDER BY o1.time
   LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
-         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o1_1."time", o1_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=10794 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_4 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_5 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_6 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_7 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_8 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Sort (actual rows=100 loops=1)
-                     Sort Key: o2_1."time", o2_1.device_id
-                     Sort Method: quicksort 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(48 rows)
+ Limit (actual rows=100.00 loops=1)
+   ->  Sort (actual rows=100.00 loops=1)
+         Sort Key: o1."time"
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=68370.00 loops=1)
+               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
+               ->  Append (actual rows=68370.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=3598.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (actual rows=10794.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=12.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (actual rows=3598.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_4 (actual rows=5038.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_5 (actual rows=15114.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_6 (actual rows=5038.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_7 (actual rows=5038.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_8 (actual rows=15114.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_9 (actual rows=5038.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                                 Index Searches: 1
+               ->  Hash (actual rows=68370.00 loops=1)
+                     ->  Append (actual rows=68370.00 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (actual rows=10794.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (actual rows=3598.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_4 (actual rows=5038.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_5 (actual rows=15114.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_6 (actual rows=5038.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_7 (actual rows=5038.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_8 (actual rows=15114.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18.00 loops=1)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_9 (actual rows=5038.00 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6.00 loops=1)
+                                       Index Searches: 1
+(64 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -3784,31 +4490,39 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Nested Loop (actual rows=100 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=1 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Nested Loop (actual rows=100.00 loops=1)
+         Disabled: true
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=1.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=1 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Append (actual rows=100 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                 Index Cond: ((device_id = 1) AND (device_id = 1))
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 20kB
+               ->  Append (actual rows=100.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: ((device_id = 1) AND (device_id = 1))
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: ((device_id = 1) AND (device_id = 1))
-(24 rows)
+                                 Index Cond: (device_id = 1)
+                                 Index Searches: 0
+(32 rows)
 
 -- test JOIN on time column with implicit join
 -- should use 2 ChunkAppend
@@ -3822,33 +4536,40 @@ WHERE o1.time = o2.time
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                Order: o1."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 1)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                      Order: o2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                 Index Searches: 1
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                 Index Searches: 0
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                  Index Cond: (device_id = 2)
-(26 rows)
+                                 Index Searches: 0
+(33 rows)
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
@@ -3863,47 +4584,58 @@ WHERE o1.device_id = 1
 ORDER BY o1.time
 LIMIT 100;
 QUERY PLAN
- Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
+ Limit (actual rows=100.00 loops=1)
+   ->  Merge Join (actual rows=100.00 loops=1)
          Merge Cond: (o3."time" = o1."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
                Order: o3."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o3_1 (actual rows=100 loops=1)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                            Index Cond: (device_id = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o3_2 (never executed)
+                           Index Searches: 1
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o3_3 (never executed)
+                           Index Searches: 0
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
-         ->  Materialize (actual rows=100 loops=1)
-               ->  Merge Join (actual rows=100 loops=1)
+                           Index Searches: 0
+         ->  Materialize (actual rows=100.00 loops=1)
+               Storage: Memory  Maximum Storage: 17kB
+               ->  Merge Join (actual rows=100.00 loops=1)
                      Merge Cond: (o1."time" = o2."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
                            Order: o1."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=100 loops=1)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
+                                       Index Searches: 1
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                        Index Cond: (device_id = 1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (never executed)
+                                       Index Searches: 0
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                        Index Cond: (device_id = 1)
-                     ->  Materialize (actual rows=100 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100 loops=1)
+                                       Index Searches: 0
+                     ->  Materialize (actual rows=100.00 loops=1)
+                           Storage: Memory  Maximum Storage: 17kB
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
                                  Order: o2."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                             Index Searches: 1
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                              Index Cond: (device_id = 2)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                             Index Searches: 0
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                                              Index Cond: (device_id = 2)
-(40 rows)
+                                             Index Searches: 0
+(51 rows)
 
 RESET enable_seqscan;
 -- Disable plain/sorted aggregation to get a deterministic test output
@@ -3922,28 +4654,28 @@ SET timescaledb.enable_chunkwise_aggregation = OFF;
 (1 row)
 
 QUERY PLAN
- Sort (actual rows=20 loops=1)
-   Sort Key: (time_bucket('@ 1 day'::interval, tbl1_1."time"))
+ Sort (actual rows=20.00 loops=1)
+   Sort Key: (time_bucket('@ 1 day'::interval, tbl1."time"))
    Sort Method: quicksort 
-   ->  HashAggregate (actual rows=20 loops=1)
-         Group Key: time_bucket('@ 1 day'::interval, tbl1_1."time")
-         ->  Merge Join (actual rows=9121 loops=1)
-               Merge Cond: ((tbl1_1.device = tbl2_1.device) AND (tbl1_1."time" = tbl2_1."time"))
-               ->  Sort (actual rows=9121 loops=1)
-                     Sort Key: tbl1_1.device, tbl1_1."time"
+   ->  HashAggregate (actual rows=20.00 loops=1)
+         Group Key: time_bucket('@ 1 day'::interval, tbl1."time")
+         ->  Merge Join (actual rows=9121.00 loops=1)
+               Merge Cond: ((tbl1.device = tbl2.device) AND (tbl1."time" = tbl2."time"))
+               ->  Sort (actual rows=9121.00 loops=1)
+                     Sort Key: tbl1.device, tbl1."time"
                      Sort Method: quicksort 
-                     ->  Append (actual rows=9121 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl1_1 (actual rows=1300 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl1_2 (actual rows=3360 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl1_3 (actual rows=3360 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl1_4 (actual rows=1101 loops=1)
-               ->  Sort (actual rows=9121 loops=1)
-                     Sort Key: tbl2_1.device, tbl2_1."time"
+                     ->  Append (actual rows=9121.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl1_1 (actual rows=1300.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl1_2 (actual rows=3360.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl1_3 (actual rows=3360.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl1_4 (actual rows=1101.00 loops=1)
+               ->  Sort (actual rows=9121.00 loops=1)
+                     Sort Key: tbl2.device, tbl2."time"
                      Sort Method: quicksort 
-                     ->  Append (actual rows=9121 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl2_1 (actual rows=1300 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl2_2 (actual rows=3360 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl2_3 (actual rows=3360 loops=1)
-                           ->  Seq Scan on _hyper_X_X_chunk tbl2_4 (actual rows=1101 loops=1)
+                     ->  Append (actual rows=9121.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl2_1 (actual rows=1300.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl2_2 (actual rows=3360.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl2_3 (actual rows=3360.00 loops=1)
+                           ->  Seq Scan on _hyper_X_X_chunk tbl2_4 (actual rows=1101.00 loops=1)
 (24 rows)
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -16,29 +16,36 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
  Limit (actual rows=5.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+   ->  Merge Append (actual rows=5.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: (compress_hyper_X_X_chunk.device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(20 rows)
 
 -- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
+ Limit (actual rows=5.00 loops=1)
    Output: "time", device_id, v0, v1, v2, v3
-   ->  Sort (actual rows=0.00 loops=1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
          Output: "time", device_id, v0, v1, v2, v3
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Output: "time", device_id, v0, v1, v2, v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(5 rows)
 
 -- this should use ColumnarScan node
 :PREFIX_NO_VERBOSE
@@ -51,7 +58,9 @@ QUERY PLAN
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(7 rows)
+         ->  Parallel Seq Scan on _hyper_X_X_chunk
+         ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(9 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
@@ -65,7 +74,9 @@ QUERY PLAN
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(9 rows)
+               ->  Parallel Seq Scan on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(11 rows)
 
 -- test expressions
 :PREFIX
@@ -83,33 +94,45 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Result (actual rows=7196.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Append (actual rows=7196.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk t (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+(11 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(2 rows)
+ Append (actual rows=17990.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+   ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(4 rows)
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+ Append (actual rows=0.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Filter: (device_id < 0)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
-(3 rows)
+(7 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
 QUERY PLAN
  Result (actual rows=17990.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(3 rows)
+   ->  Append (actual rows=17990.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(5 rows)
 
 -- test constraints not present in targetlist
 :PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -117,10 +140,14 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+(10 rows)
 
 -- test order not present in targetlist
 :PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -128,45 +155,67 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+(10 rows)
 
 -- test column with all NULL
 :PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Filter: (device_id = 1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Index Cond: (device_id = 1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
          Index Cond: (device_id = 1)
-(3 rows)
+(7 rows)
 
 -- test qual pushdown
 -- v3 is not segment by or order by column so should not be pushed down
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
 QUERY PLAN
- Sort (actual rows=0.00 loops=1)
+ Sort (actual rows=719.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
-         Rows Removed by Filter: 17990
-         Batches Removed by Filter: 20
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-(12 rows)
+   ->  Append (actual rows=719.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 16392
+               Batches Removed by Filter: 18
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=719.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 879
+(17 rows)
 
 -- device_id constraint should be pushed down
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 -- test IS NULL / IS NOT NULL
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
@@ -176,10 +225,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
-(8 rows)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id IS NOT NULL)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id IS NOT NULL)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -187,10 +240,14 @@ QUERY PLAN
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: quicksort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: (device_id IS NULL)
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
-(7 rows)
+(11 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
@@ -199,19 +256,32 @@ QUERY PLAN
    ->  Sort (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Append (actual rows=7196.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+(11 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 --test var op var
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
@@ -221,10 +291,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id = v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -233,41 +306,64 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+(11 rows)
 
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 3)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                           Filter: (device_id = 3)
+                           Rows Removed by Filter: 14
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id = 3)
-(4 rows)
+(13 rows)
 
 -- test function calls
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-                     Index Cond: (device_id = length("substring"(version(), 1, 3)))
-(6 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+                           Index Cond: (device_id = length("substring"(version(), 1, 3)))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: (device_id = length("substring"(version(), 1, 3)))
+(11 rows)
 
 -- test segment meta pushdown
 -- order by column and const
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-               Index Cond: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk.device_id
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+                           Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -276,11 +372,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -289,11 +388,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -302,11 +404,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -315,11 +420,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -328,11 +436,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+(12 rows)
 
 --pushdowns between order by and segment by columns
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
@@ -342,10 +453,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: (v0 < 1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: (v0 < 1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < 1)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -354,10 +468,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v0 < device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -366,10 +483,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -378,43 +498,61 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v1 = device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+(11 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
-   ->  Gather Merge (actual rows=0.00 loops=1)
+ Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=0.00 loops=2)
+         ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: quicksort 
-               Worker 1:  Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=2)
-                     Filter: (v0 = v1)
-                     Rows Removed by Filter: 8995
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(12 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+(17 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         Rows Removed by Filter: 31
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: ((compress_hyper_X_X_chunk.device_id = 1) AND (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(11 rows)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: ((compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_X_X_chunk.device_id = 1))
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: ((_hyper_X_X_chunk.device_id = 1) AND (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+(21 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -424,11 +562,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(12 rows)
 
 --functions optimized as well
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
@@ -438,86 +579,126 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < now())
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < now())
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < now())
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" < now())
+(12 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
-               ->  Seq Scan on compress_hyper_X_X_chunk
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+(8 rows)
 
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+QUERY PLAN
+ Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+(15 rows)
+
+:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit
    ->  Gather Merge
          Workers Planned: 2
          ->  Sort
-               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(7 rows)
-
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
-QUERY PLAN
- Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-(3 rows)
+               Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time" DESC
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+(9 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE;
 QUERY PLAN
- Finalize Aggregate (actual rows=1.00 loops=1)
-   ->  Gather (actual rows=1.00 loops=1)
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather
+         Output: (PARTIAL count(*))
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=0.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(7 rows)
-
--- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-QUERY PLAN
- Finalize GroupAggregate (actual rows=5.00 loops=1)
-   Group Key: _hyper_X_X_chunk.device_id
-   ->  Gather Merge (actual rows=20.00 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Sort (actual rows=10.00 loops=2)
-                           Sort Key: compress_hyper_X_X_chunk.device_id
-                           Worker 0:  Sort Method: quicksort 
-                           Worker 1:  Sort Method: quicksort 
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
 (12 rows)
 
--- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+-- test aggregate with GROUP BY
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- WindowAgg (actual rows=5.00 loops=1)
-   ->  Finalize GroupAggregate (actual rows=5.00 loops=1)
+ Finalize GroupAggregate
+   Output: count(*), _hyper_X_X_chunk.device_id
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+               Sort Key: _hyper_X_X_chunk.device_id
+               ->  Partial HashAggregate
+                     Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                     Group Key: _hyper_X_X_chunk.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                       Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+(19 rows)
+
+-- test window functions with GROUP BY
+:PREFIX_NO_ANALYZE SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+QUERY PLAN
+ WindowAgg
+   Output: sum((count(*))) OVER (?), _hyper_X_X_chunk.device_id
+   ->  Finalize GroupAggregate
+         Output: _hyper_X_X_chunk.device_id, count(*)
          Group Key: _hyper_X_X_chunk.device_id
-         ->  Gather Merge (actual rows=20.00 loops=1)
+         ->  Gather Merge
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
                Workers Planned: 2
-               Workers Launched: 2
-               ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                           ->  Sort (actual rows=10.00 loops=2)
-                                 Sort Key: compress_hyper_X_X_chunk.device_id
-                                 Worker 0:  Sort Method: quicksort 
-                                 Worker 1:  Sort Method: quicksort 
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(13 rows)
+               ->  Sort
+                     Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+                     Sort Key: _hyper_X_X_chunk.device_id
+                     ->  Partial HashAggregate
+                           Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                           Group Key: _hyper_X_X_chunk.device_id
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+                                       ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                             Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                                 ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+(21 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -529,12 +710,15 @@ QUERY PLAN
    Sort Key: q.v1
    Sort Method: quicksort 
    ->  Subquery Scan on q (actual rows=17990.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-               ->  Sort (actual rows=20.00 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(9 rows)
+         ->  Merge Append (actual rows=17990.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                     ->  Sort (actual rows=18.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(12 rows)
 
 -- test CTE join
 :PREFIX WITH q1 AS (
@@ -547,87 +731,142 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
 QUERY PLAN
  Merge Join (actual rows=3598.00 loops=1)
    Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Index Cond: (device_id = 1)
+   ->  Sort (actual rows=3598.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=3598.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+                     Index Cond: (device_id = 1)
    ->  Materialize (actual rows=3598.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                     Index Cond: (device_id = 2)
-(9 rows)
+         ->  Sort (actual rows=3598.00 loops=1)
+               Sort Key: _hyper_X_X_chunk_1."time"
+               Sort Method: quicksort 
+               ->  Append (actual rows=3598.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=0.00 loops=1)
+                           Index Cond: (device_id = 2)
+(23 rows)
 
 -- test indexes
 SET enable_seqscan TO FALSE;
 -- IndexScans should work
 :PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(17 rows)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(16 rows)
 
 -- whole row reference should work
 :PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: test_table."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Filter: (test_table.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=1598.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Index Cond: (test_table.device_id = 1)
+(16 rows)
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
    Output: count(*)
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --ensure that we can get a nested loop
 SET enable_seqscan TO TRUE;
 SET enable_hashjoin TO FALSE;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
@@ -642,24 +881,33 @@ QUERY PLAN
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   ->  Append (actual rows=3598.00 loops=2)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(21 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
@@ -674,13 +922,17 @@ QUERY PLAN
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   ->  Append (actual rows=3598.00 loops=2)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(21 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
@@ -695,12 +947,16 @@ QUERY PLAN
                Sort Key: "*VALUES*".column1
                ->  Values Scan on "*VALUES*"
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
-         Output: _hyper_X_X_chunk.device_id
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(14 rows)
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Output: _hyper_X_X_chunk.device_id
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(18 rows)
 
 RESET seq_page_cost;
 -- test view
@@ -708,10 +964,19 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 :PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
@@ -726,15 +991,23 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         ->  Sort
-               Sort Key: m1."time", m1.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: (m1."time" = "time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(10 rows)
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -755,19 +1028,29 @@ QUERY PLAN
                      Sort Key: m1."time", m1.device_id
                      ->  Parallel Hash Join
                            Hash Cond: (m3."time" = m1."time")
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                 ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                                       Recheck Cond: (device_id = 3)
-                                       ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
-                                             Index Cond: (device_id = 3)
+                           ->  Parallel Append
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
+                                       Index Cond: (device_id = 3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
+                                       Filter: (device_id = 3)
+                                       ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                                             Recheck Cond: (device_id = 3)
+                                             ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
+                                                   Index Cond: (device_id = 3)
                            ->  Parallel Hash
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: (m1."time" = "time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(20 rows)
+                                 ->  Parallel Append
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                             ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                       ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(30 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -785,14 +1068,28 @@ QUERY PLAN
  Limit
    ->  Merge Join
          Merge Cond: (m1."time" = m2."time")
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+         ->  Merge Append
+               Sort Key: m1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                     Filter: (device_id = 1)
+                     ->  Sort
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1
                      Index Cond: (device_id = 1)
          ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Merge Append
+                     Sort Key: m2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Sort
+                                 Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                       Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
-(10 rows)
+(24 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -853,12 +1150,16 @@ QUERY PLAN
                Sort Key: m1."time", m1.device_id
                ->  Parallel Hash Left Join
                      Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
                      ->  Parallel Hash
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(12 rows)
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 ->  Parallel Seq Scan on _hyper_X_X_chunk m2
+(16 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -879,13 +1180,19 @@ QUERY PLAN
          ->  Hash Right Join
                Hash Cond: (m2."time" = m1."time")
                Join Filter: (m1.device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Seq Scan on compress_hyper_X_X_chunk
-(12 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk
+                           ->  Seq Scan on _hyper_X_X_chunk m1
+(18 rows)
 
 -- test implicit self-join
 :PREFIX_NO_VERBOSE
@@ -904,12 +1211,16 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -930,15 +1241,18 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 RESET enable_mergejoin;
-RESET parallel_leader_participation;
 :PREFIX
 SELECT *
 FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
@@ -951,13 +1265,16 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-                     Rows Removed by Filter: 17
-(9 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: ("time" = g."time")
+                     Rows Removed by Filter: 81
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                           Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ("time" = g."time")
+(13 rows)
 
 -- test prepared statement
 SET plan_cache_mode TO force_generic_plan;
@@ -965,10 +1282,14 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
 :PREFIX EXECUTE prep;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(9 rows)
 
 EXECUTE prep;
  count 
@@ -1016,24 +1337,30 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 50
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=29)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+(12 rows)
 
 :PREFIX EXECUTE param_prep (2);
 QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 81
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+(12 rows)
 
 EXECUTE param_prep (1);
              time             |             time             

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -16,29 +16,36 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
  Limit (actual rows=5.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+   ->  Merge Append (actual rows=5.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: (compress_hyper_X_X_chunk.device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(20 rows)
 
 -- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
+ Limit (actual rows=5.00 loops=1)
    Output: "time", device_id, v0, v1, v2, v3
-   ->  Sort (actual rows=0.00 loops=1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
          Output: "time", device_id, v0, v1, v2, v3
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Output: "time", device_id, v0, v1, v2, v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(5 rows)
 
 -- this should use ColumnarScan node
 :PREFIX_NO_VERBOSE
@@ -51,7 +58,9 @@ QUERY PLAN
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(7 rows)
+         ->  Parallel Seq Scan on _hyper_X_X_chunk
+         ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(9 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
@@ -65,7 +74,9 @@ QUERY PLAN
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(9 rows)
+               ->  Parallel Seq Scan on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(11 rows)
 
 -- test expressions
 :PREFIX
@@ -83,33 +94,45 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Result (actual rows=7196.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Append (actual rows=7196.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk t (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+(11 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(2 rows)
+ Append (actual rows=17990.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+   ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(4 rows)
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+ Append (actual rows=0.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Filter: (device_id < 0)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
-(3 rows)
+(7 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
 QUERY PLAN
  Result (actual rows=17990.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(3 rows)
+   ->  Append (actual rows=17990.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(5 rows)
 
 -- test constraints not present in targetlist
 :PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -117,10 +140,14 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+(10 rows)
 
 -- test order not present in targetlist
 :PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -128,45 +155,67 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+(10 rows)
 
 -- test column with all NULL
 :PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Filter: (device_id = 1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Index Cond: (device_id = 1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
          Index Cond: (device_id = 1)
-(3 rows)
+(7 rows)
 
 -- test qual pushdown
 -- v3 is not segment by or order by column so should not be pushed down
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
 QUERY PLAN
- Sort (actual rows=0.00 loops=1)
+ Sort (actual rows=719.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
-         Rows Removed by Filter: 17990
-         Batches Removed by Filter: 20
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-(12 rows)
+   ->  Append (actual rows=719.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 16392
+               Batches Removed by Filter: 18
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=719.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 879
+(17 rows)
 
 -- device_id constraint should be pushed down
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 -- test IS NULL / IS NOT NULL
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
@@ -176,10 +225,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
-(8 rows)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id IS NOT NULL)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id IS NOT NULL)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -187,10 +240,14 @@ QUERY PLAN
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: quicksort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: (device_id IS NULL)
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
-(7 rows)
+(11 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
@@ -199,19 +256,32 @@ QUERY PLAN
    ->  Sort (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Append (actual rows=7196.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+(11 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 --test var op var
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
@@ -221,10 +291,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id = v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -233,41 +306,64 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+(11 rows)
 
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 3)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                           Filter: (device_id = 3)
+                           Rows Removed by Filter: 14
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id = 3)
-(4 rows)
+(13 rows)
 
 -- test function calls
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-                     Index Cond: (device_id = length("substring"(version(), 1, 3)))
-(6 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+                           Index Cond: (device_id = length("substring"(version(), 1, 3)))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: (device_id = length("substring"(version(), 1, 3)))
+(11 rows)
 
 -- test segment meta pushdown
 -- order by column and const
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-               Index Cond: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk.device_id
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+                           Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -276,11 +372,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -289,11 +388,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -302,11 +404,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -315,11 +420,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -328,11 +436,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+(12 rows)
 
 --pushdowns between order by and segment by columns
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
@@ -342,10 +453,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: (v0 < 1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: (v0 < 1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < 1)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -354,10 +468,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v0 < device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -366,10 +483,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -378,43 +498,61 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v1 = device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+(11 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
-   ->  Gather Merge (actual rows=0.00 loops=1)
+ Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=0.00 loops=2)
+         ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: quicksort 
-               Worker 1:  Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=2)
-                     Filter: (v0 = v1)
-                     Rows Removed by Filter: 8995
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(12 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+(17 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         Rows Removed by Filter: 31
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: ((compress_hyper_X_X_chunk.device_id = 1) AND (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(11 rows)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: ((compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_X_X_chunk.device_id = 1))
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: ((_hyper_X_X_chunk.device_id = 1) AND (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+(21 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -424,11 +562,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(12 rows)
 
 --functions optimized as well
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
@@ -438,86 +579,126 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < now())
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < now())
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < now())
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" < now())
+(12 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
-               ->  Seq Scan on compress_hyper_X_X_chunk
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+(8 rows)
 
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+QUERY PLAN
+ Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+(15 rows)
+
+:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit
    ->  Gather Merge
          Workers Planned: 2
          ->  Sort
-               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(7 rows)
-
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
-QUERY PLAN
- Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-(3 rows)
+               Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time" DESC
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+(9 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE;
 QUERY PLAN
- Finalize Aggregate (actual rows=1.00 loops=1)
-   ->  Gather (actual rows=1.00 loops=1)
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather
+         Output: (PARTIAL count(*))
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=0.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(7 rows)
-
--- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-QUERY PLAN
- Finalize GroupAggregate (actual rows=5.00 loops=1)
-   Group Key: _hyper_X_X_chunk.device_id
-   ->  Gather Merge (actual rows=20.00 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Sort (actual rows=10.00 loops=2)
-                           Sort Key: compress_hyper_X_X_chunk.device_id
-                           Worker 0:  Sort Method: quicksort 
-                           Worker 1:  Sort Method: quicksort 
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
 (12 rows)
 
--- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+-- test aggregate with GROUP BY
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- WindowAgg (actual rows=5.00 loops=1)
-   ->  Finalize GroupAggregate (actual rows=5.00 loops=1)
+ Finalize GroupAggregate
+   Output: count(*), _hyper_X_X_chunk.device_id
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+               Sort Key: _hyper_X_X_chunk.device_id
+               ->  Partial HashAggregate
+                     Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                     Group Key: _hyper_X_X_chunk.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                       Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+(19 rows)
+
+-- test window functions with GROUP BY
+:PREFIX_NO_ANALYZE SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+QUERY PLAN
+ WindowAgg
+   Output: sum((count(*))) OVER (?), _hyper_X_X_chunk.device_id
+   ->  Finalize GroupAggregate
+         Output: _hyper_X_X_chunk.device_id, count(*)
          Group Key: _hyper_X_X_chunk.device_id
-         ->  Gather Merge (actual rows=20.00 loops=1)
+         ->  Gather Merge
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
                Workers Planned: 2
-               Workers Launched: 2
-               ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                           ->  Sort (actual rows=10.00 loops=2)
-                                 Sort Key: compress_hyper_X_X_chunk.device_id
-                                 Worker 0:  Sort Method: quicksort 
-                                 Worker 1:  Sort Method: quicksort 
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(13 rows)
+               ->  Sort
+                     Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+                     Sort Key: _hyper_X_X_chunk.device_id
+                     ->  Partial HashAggregate
+                           Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                           Group Key: _hyper_X_X_chunk.device_id
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+                                       ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                             Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                                 ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+(21 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -529,12 +710,15 @@ QUERY PLAN
    Sort Key: q.v1
    Sort Method: quicksort 
    ->  Subquery Scan on q (actual rows=17990.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-               ->  Sort (actual rows=20.00 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(9 rows)
+         ->  Merge Append (actual rows=17990.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                     ->  Sort (actual rows=18.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(12 rows)
 
 -- test CTE join
 :PREFIX WITH q1 AS (
@@ -547,87 +731,142 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
 QUERY PLAN
  Merge Join (actual rows=3598.00 loops=1)
    Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Index Cond: (device_id = 1)
+   ->  Sort (actual rows=3598.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=3598.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+                     Index Cond: (device_id = 1)
    ->  Materialize (actual rows=3598.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                     Index Cond: (device_id = 2)
-(9 rows)
+         ->  Sort (actual rows=3598.00 loops=1)
+               Sort Key: _hyper_X_X_chunk_1."time"
+               Sort Method: quicksort 
+               ->  Append (actual rows=3598.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=0.00 loops=1)
+                           Index Cond: (device_id = 2)
+(23 rows)
 
 -- test indexes
 SET enable_seqscan TO FALSE;
 -- IndexScans should work
 :PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(17 rows)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(16 rows)
 
 -- whole row reference should work
 :PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: test_table."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Filter: (test_table.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=1598.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Index Cond: (test_table.device_id = 1)
+(16 rows)
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
    Output: count(*)
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --ensure that we can get a nested loop
 SET enable_seqscan TO TRUE;
 SET enable_hashjoin TO FALSE;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
@@ -642,24 +881,33 @@ QUERY PLAN
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   ->  Append (actual rows=3598.00 loops=2)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(21 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
@@ -674,13 +922,17 @@ QUERY PLAN
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   ->  Append (actual rows=3598.00 loops=2)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(21 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
@@ -695,12 +947,16 @@ QUERY PLAN
                Sort Key: "*VALUES*".column1
                ->  Values Scan on "*VALUES*"
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
-         Output: _hyper_X_X_chunk.device_id
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(14 rows)
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Output: _hyper_X_X_chunk.device_id
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(18 rows)
 
 RESET seq_page_cost;
 -- test view
@@ -708,10 +964,19 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 :PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
@@ -726,15 +991,23 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         ->  Sort
-               Sort Key: m1."time", m1.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: ("time" = m1."time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(10 rows)
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -755,19 +1028,29 @@ QUERY PLAN
                      Sort Key: m1."time", m1.device_id
                      ->  Parallel Hash Join
                            Hash Cond: (m3."time" = m1."time")
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                 ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                                       Recheck Cond: (device_id = 3)
-                                       ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
-                                             Index Cond: (device_id = 3)
+                           ->  Parallel Append
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
+                                       Index Cond: (device_id = 3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
+                                       Filter: (device_id = 3)
+                                       ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                                             Recheck Cond: (device_id = 3)
+                                             ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
+                                                   Index Cond: (device_id = 3)
                            ->  Parallel Hash
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: ("time" = m1."time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(20 rows)
+                                 ->  Parallel Append
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                             ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                       ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(30 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -785,14 +1068,28 @@ QUERY PLAN
  Limit
    ->  Merge Join
          Merge Cond: (m1."time" = m2."time")
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+         ->  Merge Append
+               Sort Key: m1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                     Filter: (device_id = 1)
+                     ->  Sort
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1
                      Index Cond: (device_id = 1)
          ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Merge Append
+                     Sort Key: m2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Sort
+                                 Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                       Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
-(10 rows)
+(24 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -853,12 +1150,16 @@ QUERY PLAN
                Sort Key: m1."time", m1.device_id
                ->  Parallel Hash Left Join
                      Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
                      ->  Parallel Hash
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(12 rows)
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 ->  Parallel Seq Scan on _hyper_X_X_chunk m2
+(16 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -879,13 +1180,19 @@ QUERY PLAN
          ->  Hash Right Join
                Hash Cond: (m2."time" = m1."time")
                Join Filter: (m1.device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Seq Scan on compress_hyper_X_X_chunk
-(12 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk
+                           ->  Seq Scan on _hyper_X_X_chunk m1
+(18 rows)
 
 -- test implicit self-join
 :PREFIX_NO_VERBOSE
@@ -904,12 +1211,16 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -930,15 +1241,18 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 RESET enable_mergejoin;
-RESET parallel_leader_participation;
 :PREFIX
 SELECT *
 FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
@@ -951,13 +1265,16 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-                     Rows Removed by Filter: 17
-(9 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: ("time" = g."time")
+                     Rows Removed by Filter: 81
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                           Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ("time" = g."time")
+(13 rows)
 
 -- test prepared statement
 SET plan_cache_mode TO force_generic_plan;
@@ -965,10 +1282,14 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
 :PREFIX EXECUTE prep;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(9 rows)
 
 EXECUTE prep;
  count 
@@ -1016,24 +1337,30 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 50
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=29)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+(12 rows)
 
 :PREFIX EXECUTE param_prep (2);
 QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 81
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+(12 rows)
 
 EXECUTE param_prep (1);
              time             |             time             

--- a/tsl/test/shared/expected/transparent_decompress_chunk-17.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-17.out
@@ -16,29 +16,36 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
  Limit (actual rows=5.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+   ->  Merge Append (actual rows=5.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: (compress_hyper_X_X_chunk.device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(20 rows)
 
 -- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
+ Limit (actual rows=5.00 loops=1)
    Output: "time", device_id, v0, v1, v2, v3
-   ->  Sort (actual rows=0.00 loops=1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
          Output: "time", device_id, v0, v1, v2, v3
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Output: "time", device_id, v0, v1, v2, v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(5 rows)
 
 -- this should use ColumnarScan node
 :PREFIX_NO_VERBOSE
@@ -51,7 +58,9 @@ QUERY PLAN
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(7 rows)
+         ->  Parallel Seq Scan on _hyper_X_X_chunk
+         ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(9 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
@@ -65,7 +74,9 @@ QUERY PLAN
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(9 rows)
+               ->  Parallel Seq Scan on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(11 rows)
 
 -- test expressions
 :PREFIX
@@ -83,33 +94,45 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Result (actual rows=7196.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Append (actual rows=7196.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk t (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+(11 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(2 rows)
+ Append (actual rows=17990.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+   ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(4 rows)
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+ Append (actual rows=0.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Filter: (device_id < 0)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
-(3 rows)
+(7 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
 QUERY PLAN
  Result (actual rows=17990.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(3 rows)
+   ->  Append (actual rows=17990.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(5 rows)
 
 -- test constraints not present in targetlist
 :PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -117,10 +140,14 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+(10 rows)
 
 -- test order not present in targetlist
 :PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -128,45 +155,67 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(6 rows)
+(10 rows)
 
 -- test column with all NULL
 :PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Filter: (device_id = 1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Index Cond: (device_id = 1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
          Index Cond: (device_id = 1)
-(3 rows)
+(7 rows)
 
 -- test qual pushdown
 -- v3 is not segment by or order by column so should not be pushed down
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
 QUERY PLAN
- Sort (actual rows=0.00 loops=1)
+ Sort (actual rows=719.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
-         Rows Removed by Filter: 17990
-         Batches Removed by Filter: 20
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-(12 rows)
+   ->  Append (actual rows=719.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 16392
+               Batches Removed by Filter: 18
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=719.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 879
+(17 rows)
 
 -- device_id constraint should be pushed down
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 -- test IS NULL / IS NOT NULL
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
@@ -176,10 +225,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
-(8 rows)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id IS NOT NULL)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id IS NOT NULL)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -187,31 +240,53 @@ QUERY PLAN
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: quicksort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: (device_id IS NULL)
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
-(7 rows)
+(11 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Sort (actual rows=10.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Sort (actual rows=5.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 12
+         ->  Sort (actual rows=6.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-(7 rows)
+(16 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 --test var op var
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
@@ -221,10 +296,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id = v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -233,41 +311,64 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+(11 rows)
 
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 3)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                           Filter: (device_id = 3)
+                           Rows Removed by Filter: 14
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id = 3)
-(4 rows)
+(13 rows)
 
 -- test function calls
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-                     Index Cond: (device_id = length("substring"(version(), 1, 3)))
-(6 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+                           Index Cond: (device_id = length("substring"(version(), 1, 3)))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: (device_id = length("substring"(version(), 1, 3)))
+(11 rows)
 
 -- test segment meta pushdown
 -- order by column and const
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-               Index Cond: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk.device_id
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+                           Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -276,11 +377,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -289,11 +393,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -302,11 +409,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -315,11 +425,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -328,11 +441,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+(12 rows)
 
 --pushdowns between order by and segment by columns
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
@@ -342,10 +458,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: (v0 < 1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: (v0 < 1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < 1)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -354,10 +473,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v0 < device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -366,10 +488,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -378,43 +503,61 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v1 = device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+(11 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
-   ->  Gather Merge (actual rows=0.00 loops=1)
+ Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=0.00 loops=2)
+         ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: quicksort 
-               Worker 1:  Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=2)
-                     Filter: (v0 = v1)
-                     Rows Removed by Filter: 8995
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(12 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+(17 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         Rows Removed by Filter: 31
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: ((compress_hyper_X_X_chunk.device_id = 1) AND (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(11 rows)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: ((compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_X_X_chunk.device_id = 1))
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: ((_hyper_X_X_chunk.device_id = 1) AND (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+(21 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -424,11 +567,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(12 rows)
 
 --functions optimized as well
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
@@ -438,86 +584,127 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < now())
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < now())
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < now())
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" < now())
+(12 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
-               ->  Seq Scan on compress_hyper_X_X_chunk
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+(8 rows)
 
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 QUERY PLAN
  Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Workers Planned: 2
          ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(7 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+(15 rows)
 
 :PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-(3 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time" DESC
+               ->  Seq Scan on _hyper_X_X_chunk
+(10 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE;
 QUERY PLAN
- Finalize Aggregate (actual rows=1.00 loops=1)
-   ->  Gather (actual rows=1.00 loops=1)
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather
+         Output: (PARTIAL count(*))
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=0.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(7 rows)
-
--- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-QUERY PLAN
- Finalize GroupAggregate (actual rows=5.00 loops=1)
-   Group Key: _hyper_X_X_chunk.device_id
-   ->  Gather Merge (actual rows=20.00 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Sort (actual rows=10.00 loops=2)
-                           Sort Key: compress_hyper_X_X_chunk.device_id
-                           Worker 0:  Sort Method: quicksort 
-                           Worker 1:  Sort Method: quicksort 
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
 (12 rows)
 
--- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+-- test aggregate with GROUP BY
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- WindowAgg (actual rows=5.00 loops=1)
-   ->  Finalize GroupAggregate (actual rows=5.00 loops=1)
+ Finalize GroupAggregate
+   Output: count(*), _hyper_X_X_chunk.device_id
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+               Sort Key: _hyper_X_X_chunk.device_id
+               ->  Partial HashAggregate
+                     Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                     Group Key: _hyper_X_X_chunk.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                       Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+(19 rows)
+
+-- test window functions with GROUP BY
+:PREFIX_NO_ANALYZE SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+QUERY PLAN
+ WindowAgg
+   Output: sum((count(*))) OVER (?), _hyper_X_X_chunk.device_id
+   ->  Finalize GroupAggregate
+         Output: _hyper_X_X_chunk.device_id, count(*)
          Group Key: _hyper_X_X_chunk.device_id
-         ->  Gather Merge (actual rows=20.00 loops=1)
+         ->  Gather Merge
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
                Workers Planned: 2
-               Workers Launched: 2
-               ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                           ->  Sort (actual rows=10.00 loops=2)
-                                 Sort Key: compress_hyper_X_X_chunk.device_id
-                                 Worker 0:  Sort Method: quicksort 
-                                 Worker 1:  Sort Method: quicksort 
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(13 rows)
+               ->  Sort
+                     Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+                     Sort Key: _hyper_X_X_chunk.device_id
+                     ->  Partial HashAggregate
+                           Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                           Group Key: _hyper_X_X_chunk.device_id
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+                                       ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                             Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                                 ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+(21 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -529,12 +716,15 @@ QUERY PLAN
    Sort Key: q.v1
    Sort Method: quicksort 
    ->  Subquery Scan on q (actual rows=17990.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-               ->  Sort (actual rows=20.00 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(9 rows)
+         ->  Merge Append (actual rows=17990.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                     ->  Sort (actual rows=18.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(12 rows)
 
 -- test CTE join
 :PREFIX WITH q1 AS (
@@ -547,87 +737,142 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
 QUERY PLAN
  Merge Join (actual rows=3598.00 loops=1)
    Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Index Cond: (device_id = 1)
+   ->  Sort (actual rows=3598.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=3598.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+                     Index Cond: (device_id = 1)
    ->  Materialize (actual rows=3598.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                     Index Cond: (device_id = 2)
-(9 rows)
+         ->  Sort (actual rows=3598.00 loops=1)
+               Sort Key: _hyper_X_X_chunk_1."time"
+               Sort Method: quicksort 
+               ->  Append (actual rows=3598.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=0.00 loops=1)
+                           Index Cond: (device_id = 2)
+(23 rows)
 
 -- test indexes
 SET enable_seqscan TO FALSE;
 -- IndexScans should work
 :PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(17 rows)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(16 rows)
 
 -- whole row reference should work
 :PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   Sort Key: test_table."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Filter: (test_table.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=1598.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Index Cond: (test_table.device_id = 1)
+(16 rows)
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
    Output: count(*)
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(7 rows)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --ensure that we can get a nested loop
 SET enable_seqscan TO TRUE;
 SET enable_hashjoin TO FALSE;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
@@ -642,24 +887,33 @@ QUERY PLAN
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   ->  Append (actual rows=3598.00 loops=2)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(21 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-(6 rows)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+(12 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
@@ -674,13 +928,17 @@ QUERY PLAN
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=2)
-         Output: _hyper_X_X_chunk.device_id
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=2)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(16 rows)
+   ->  Append (actual rows=3598.00 loops=2)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=799.00 loops=2)
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(21 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
@@ -695,12 +953,16 @@ QUERY PLAN
                Sort Key: "*VALUES*".column1
                ->  Values Scan on "*VALUES*"
                      Output: "*VALUES*".column1
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
-         Output: _hyper_X_X_chunk.device_id
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
-(14 rows)
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Output: _hyper_X_X_chunk.device_id
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk
+               Output: _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(18 rows)
 
 RESET seq_page_cost;
 -- test view
@@ -708,10 +970,19 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 :PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(13 rows)
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
@@ -726,15 +997,23 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         ->  Sort
-               Sort Key: m1."time", m1.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: ("time" = m1."time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(10 rows)
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -755,19 +1034,29 @@ QUERY PLAN
                      Sort Key: m1."time", m1.device_id
                      ->  Parallel Hash Join
                            Hash Cond: (m3."time" = m1."time")
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                 ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                                       Recheck Cond: (device_id = 3)
-                                       ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
-                                             Index Cond: (device_id = 3)
+                           ->  Parallel Append
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
+                                       Index Cond: (device_id = 3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
+                                       Filter: (device_id = 3)
+                                       ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                                             Recheck Cond: (device_id = 3)
+                                             ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
+                                                   Index Cond: (device_id = 3)
                            ->  Parallel Hash
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: ("time" = m1."time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(20 rows)
+                                 ->  Parallel Append
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                             ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                       ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(30 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -785,14 +1074,28 @@ QUERY PLAN
  Limit
    ->  Merge Join
          Merge Cond: (m1."time" = m2."time")
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+         ->  Merge Append
+               Sort Key: m1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                     Filter: (device_id = 1)
+                     ->  Sort
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1
                      Index Cond: (device_id = 1)
          ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Merge Append
+                     Sort Key: m2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Sort
+                                 Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                       Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
-(10 rows)
+(24 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -853,12 +1156,16 @@ QUERY PLAN
                Sort Key: m1."time", m1.device_id
                ->  Parallel Hash Left Join
                      Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
                      ->  Parallel Hash
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(12 rows)
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 ->  Parallel Seq Scan on _hyper_X_X_chunk m2
+(16 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -879,13 +1186,19 @@ QUERY PLAN
          ->  Hash Right Join
                Hash Cond: (m2."time" = m1."time")
                Join Filter: (m1.device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Seq Scan on compress_hyper_X_X_chunk
-(12 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk
+                           ->  Seq Scan on _hyper_X_X_chunk m1
+(18 rows)
 
 -- test implicit self-join
 :PREFIX_NO_VERBOSE
@@ -904,12 +1217,16 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -930,15 +1247,18 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 RESET enable_mergejoin;
-RESET parallel_leader_participation;
 :PREFIX
 SELECT *
 FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
@@ -951,13 +1271,16 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-                     Rows Removed by Filter: 17
-(9 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: ("time" = g."time")
+                     Rows Removed by Filter: 81
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                           Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ("time" = g."time")
+(13 rows)
 
 -- test prepared statement
 SET plan_cache_mode TO force_generic_plan;
@@ -965,10 +1288,14 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
 :PREFIX EXECUTE prep;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
-(4 rows)
+(9 rows)
 
 EXECUTE prep;
  count 
@@ -1016,24 +1343,30 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 50
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=29)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+(12 rows)
 
 :PREFIX EXECUTE param_prep (2);
 QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.00 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-(8 rows)
+         ->  Append (actual rows=0.00 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 81
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+(12 rows)
 
 EXECUTE param_prep (1);
              time             |             time             

--- a/tsl/test/shared/expected/transparent_decompress_chunk-18.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-18.out
@@ -16,30 +16,38 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
  Limit (actual rows=5.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Merge Append (actual rows=5.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: (compress_hyper_X_X_chunk.device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
                Index Searches: 1
-(10 rows)
+(21 rows)
 
 -- must not use ColumnarScan node
 :PREFIX_VERBOSE
 SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
+ Limit (actual rows=5.00 loops=1)
    Output: "time", device_id, v0, v1, v2, v3
-   ->  Sort (actual rows=0.00 loops=1)
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=5.00 loops=1)
          Output: "time", device_id, v0, v1, v2, v3
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Output: "time", device_id, v0, v1, v2, v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
-(9 rows)
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
+         Index Searches: 1
+(6 rows)
 
 -- this should use ColumnarScan node
 :PREFIX_NO_VERBOSE
@@ -52,7 +60,9 @@ QUERY PLAN
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(7 rows)
+         ->  Parallel Seq Scan on _hyper_X_X_chunk
+         ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(9 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT * FROM :TEST_TABLE UNION ALL SELECT * FROM :TEST_TABLE ORDER BY time;
@@ -66,7 +76,9 @@ QUERY PLAN
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(9 rows)
+               ->  Parallel Seq Scan on _hyper_X_X_chunk
+               ->  Parallel Seq Scan on _hyper_X_X_chunk _hyper_X_X_chunk_1
+(11 rows)
 
 -- test expressions
 :PREFIX
@@ -84,35 +96,49 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Result (actual rows=7196.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Append (actual rows=7196.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+                           Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk t (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      Index Searches: 1
-(8 rows)
+(13 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(2 rows)
+ Append (actual rows=17990.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+   ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(4 rows)
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+ Append (actual rows=0.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+         Filter: (device_id < 0)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
+               Index Searches: 1
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
          Index Searches: 1
-(4 rows)
+(9 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
 QUERY PLAN
  Result (actual rows=17990.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(3 rows)
+   ->  Append (actual rows=17990.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+(5 rows)
 
 -- test constraints not present in targetlist
 :PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -120,11 +146,16 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+                     Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
                Index Searches: 1
-(7 rows)
+(12 rows)
 
 -- test order not present in targetlist
 :PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
@@ -132,48 +163,72 @@ QUERY PLAN
  Sort (actual rows=3598.00 loops=1)
    Sort Key: _hyper_X_X_chunk.v1
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+                     Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
                Index Searches: 1
-(7 rows)
+(12 rows)
 
 -- test column with all NULL
 :PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Filter: (device_id = 1)
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Index Cond: (device_id = 1)
+               Index Searches: 1
+   ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
          Index Cond: (device_id = 1)
          Index Searches: 1
-(4 rows)
+(9 rows)
 
 -- test qual pushdown
 -- v3 is not segment by or order by column so should not be pushed down
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
 QUERY PLAN
- Sort (actual rows=0.00 loops=1)
+ Sort (actual rows=719.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
-         Rows Removed by Filter: 17990
-         Batches Removed by Filter: 20
-         Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-(12 rows)
+   ->  Append (actual rows=719.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 16392
+               Batches Removed by Filter: 18
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=719.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 879
+(17 rows)
 
 -- device_id constraint should be pushed down
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
                Index Searches: 1
-(5 rows)
+(14 rows)
 
 -- test IS NULL / IS NOT NULL
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
@@ -183,10 +238,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
-(8 rows)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id IS NOT NULL)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id IS NOT NULL)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -194,34 +253,57 @@ QUERY PLAN
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: quicksort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
+                     Filter: (device_id IS NULL)
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
+                           Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
                      Index Searches: 1
-(8 rows)
+(13 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Sort (actual rows=10.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=7196.00 loops=1)
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
+         ->  Sort (actual rows=5.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 12
+         ->  Sort (actual rows=6.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      Index Searches: 1
-(8 rows)
+(17 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=10.00 loops=1)
                Index Cond: (device_id = 1)
                Index Searches: 1
-(5 rows)
+(14 rows)
 
 --test var op var
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
@@ -231,10 +313,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id = v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id = v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -243,42 +328,65 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v1)
+(11 rows)
 
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 3)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+                           Filter: (device_id = 3)
+                           Rows Removed by Filter: 14
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id = 3)
                Index Searches: 1
-(5 rows)
+(14 rows)
 
 -- test function calls
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-                     Index Cond: (device_id = length("substring"(version(), 1, 3)))
-(6 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+                           Index Cond: (device_id = length("substring"(version(), 1, 3)))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: (device_id = length("substring"(version(), 1, 3)))
+(11 rows)
 
 -- test segment meta pushdown
 -- order by column and const
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-               Index Cond: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               Vectorized Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk.device_id
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+                           Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -287,11 +395,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -300,11 +411,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -313,11 +427,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -326,11 +443,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(12 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -339,11 +459,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+(12 rows)
 
 --pushdowns between order by and segment by columns
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
@@ -353,10 +476,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: (v0 < 1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: (v0 < 1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < 1)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -365,10 +491,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v0 < device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v0 < device_id)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -377,10 +506,13 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id < v0)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (device_id < v0)
+(11 rows)
 
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -389,44 +521,62 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (v1 = device_id)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (v1 = device_id)
+(11 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=0.00 loops=1)
-   ->  Gather Merge (actual rows=0.00 loops=1)
+ Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=0.00 loops=2)
+         ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: quicksort 
-               Worker 1:  Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=2)
-                     Filter: (v0 = v1)
-                     Rows Removed by Filter: 8995
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(12 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+                           Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+(17 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
-         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         Rows Removed by Filter: 31
-         Reverse: true
-         Bulk Decompression: true
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: ((compress_hyper_X_X_chunk.device_id = 1) AND (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Sort (actual rows=1.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           Filter: ((compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_X_X_chunk.device_id = 1))
+                           Rows Removed by Filter: 16
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: ((_hyper_X_X_chunk.device_id = 1) AND (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
                Index Searches: 1
-(12 rows)
+(22 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -436,11 +586,14 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(12 rows)
 
 --functions optimized as well
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
@@ -450,88 +603,128 @@ QUERY PLAN
          Workers Planned: 2
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-                           Filter: (_ts_meta_min_1 < now())
-(9 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+                           Vectorized Filter: ("time" < now())
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (_ts_meta_min_1 < now())
+                     ->  Parallel Seq Scan on _hyper_X_X_chunk
+                           Filter: ("time" < now())
+(12 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Sort
-               Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
-               ->  Seq Scan on compress_hyper_X_X_chunk
-(5 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk
+(8 rows)
 
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 QUERY PLAN
  Limit
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
    ->  Gather Merge
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Workers Planned: 2
          ->  Sort
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(7 rows)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                           Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+(15 rows)
 
 :PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
-(3 rows)
+   ->  Merge Append
+         Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time" DESC
+               ->  Seq Scan on _hyper_X_X_chunk
+(10 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE;
 QUERY PLAN
- Finalize Aggregate (actual rows=1.00 loops=1)
-   ->  Gather (actual rows=1.00 loops=1)
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather
+         Output: (PARTIAL count(*))
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=0.50 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(7 rows)
-
--- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-QUERY PLAN
- Finalize GroupAggregate (actual rows=5.00 loops=1)
-   Group Key: _hyper_X_X_chunk.device_id
-   ->  Gather Merge (actual rows=20.00 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                     ->  Sort (actual rows=10.00 loops=2)
-                           Sort Key: compress_hyper_X_X_chunk.device_id
-                           Worker 0:  Sort Method: quicksort 
-                           Worker 1:  Sort Method: quicksort 
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Parallel Append
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                 Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
 (12 rows)
 
--- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+-- test aggregate with GROUP BY
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- WindowAgg (actual rows=5.00 loops=1)
+ Finalize GroupAggregate
+   Output: count(*), _hyper_X_X_chunk.device_id
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Gather Merge
+         Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+               Sort Key: _hyper_X_X_chunk.device_id
+               ->  Partial HashAggregate
+                     Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                     Group Key: _hyper_X_X_chunk.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                       Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                 Output: _hyper_X_X_chunk.device_id
+(19 rows)
+
+-- test window functions with GROUP BY
+:PREFIX_NO_ANALYZE SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+QUERY PLAN
+ WindowAgg
+   Output: sum((count(*))) OVER w1, _hyper_X_X_chunk.device_id
    Window: w1 AS ()
-   Storage: Memory  Maximum Storage: 17kB
-   ->  Finalize GroupAggregate (actual rows=5.00 loops=1)
+   ->  Finalize GroupAggregate
+         Output: _hyper_X_X_chunk.device_id, count(*)
          Group Key: _hyper_X_X_chunk.device_id
-         ->  Gather Merge (actual rows=20.00 loops=1)
+         ->  Gather Merge
+               Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
                Workers Planned: 2
-               Workers Launched: 2
-               ->  Custom Scan (VectorAgg) (actual rows=10.00 loops=2)
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-                           ->  Sort (actual rows=10.00 loops=2)
-                                 Sort Key: compress_hyper_X_X_chunk.device_id
-                                 Worker 0:  Sort Method: quicksort 
-                                 Worker 1:  Sort Method: quicksort 
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10.00 loops=2)
-(15 rows)
+               ->  Sort
+                     Output: _hyper_X_X_chunk.device_id, (PARTIAL count(*))
+                     Sort Key: _hyper_X_X_chunk.device_id
+                     ->  Partial HashAggregate
+                           Output: _hyper_X_X_chunk.device_id, PARTIAL count(*)
+                           Group Key: _hyper_X_X_chunk.device_id
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+                                       ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
+                                             Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                                 ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk
+                                       Output: _hyper_X_X_chunk.device_id
+(22 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -543,12 +736,16 @@ QUERY PLAN
    Sort Key: q.v1
    Sort Method: quicksort 
    ->  Subquery Scan on q (actual rows=17990.00 loops=1)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=17990.00 loops=1)
-               ->  Sort (actual rows=20.00 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20.00 loops=1)
-(9 rows)
+         ->  Merge Append (actual rows=17990.00 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
+                     ->  Sort (actual rows=18.00 loops=1)
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+                     Index Searches: 1
+(13 rows)
 
 -- test CTE join
 :PREFIX WITH q1 AS (
@@ -561,143 +758,229 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
 QUERY PLAN
  Merge Join (actual rows=3598.00 loops=1)
    Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Index Cond: (device_id = 1)
-               Index Searches: 1
+   ->  Sort (actual rows=3598.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=3598.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+                     Filter: (device_id = 1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Index Cond: (device_id = 1)
+                           Index Searches: 1
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
+                     Index Cond: (device_id = 1)
+                     Index Searches: 1
    ->  Materialize (actual rows=3598.00 loops=1)
          Storage: Memory  Maximum Storage: 17kB
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
-                     Index Cond: (device_id = 2)
-                     Index Searches: 1
-(12 rows)
+         ->  Sort (actual rows=3598.00 loops=1)
+               Sort Key: _hyper_X_X_chunk_1."time"
+               Sort Method: quicksort 
+               ->  Append (actual rows=3598.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598.00 loops=1)
+                           Filter: (device_id = 2)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4.00 loops=1)
+                                 Index Cond: (device_id = 2)
+                                 Index Searches: 1
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=0.00 loops=1)
+                           Index Cond: (device_id = 2)
+                           Index Searches: 1
+(28 rows)
 
 -- test indexes
 SET enable_seqscan TO FALSE;
 -- IndexScans should work
 :PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         Index Searches: 1
-(8 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+                     Index Searches: 1
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+               Index Searches: 1
+(19 rows)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         Index Searches: 1
-(8 rows)
+   Sort Key: _hyper_X_X_chunk."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+                     Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
+               Index Searches: 1
+(18 rows)
 
 -- whole row reference should work
 :PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598.00 loops=1)
+ Sort (actual rows=3598.00 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Reverse: true
-   Bulk Decompression: true
-   ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         Index Searches: 1
-(8 rows)
+   Sort Key: test_table."time"
+   Sort Method: quicksort 
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Filter: (test_table.device_id = 1)
+               Reverse: true
+               Bulk Decompression: true
+               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+                     Index Searches: 1
+         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=1598.00 loops=1)
+               Output: test_table.*, test_table.device_id, test_table."time"
+               Index Cond: (test_table.device_id = 1)
+               Index Searches: 1
+(18 rows)
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+               Index Searches: 1
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
          Index Searches: 1
-(7 rows)
+(14 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
    Output: count(*)
-   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         Bulk Decompression: false
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Bulk Decompression: false
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+                     Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+                     Index Searches: 1
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
                Index Searches: 1
-(8 rows)
+(14 rows)
 
 --ensure that we can get a nested loop
 SET enable_seqscan TO TRUE;
 SET enable_hashjoin TO FALSE;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+               Index Searches: 1
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
          Index Searches: 1
-(7 rows)
+(14 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=7196.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+ Append (actual rows=7196.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+               Index Searches: 1
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
          Index Searches: 1
-(7 rows)
+(14 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+ Append (actual rows=3598.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = 1)
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+               Index Searches: 1
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = 1)
          Index Searches: 1
-(7 rows)
+(14 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=7196.00 loops=1)
-   Output: _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=8.00 loops=1)
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+ Append (actual rows=7196.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+               Index Searches: 1
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
          Index Searches: 1
-(7 rows)
+(14 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
 :PREFIX_NO_ANALYZE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
 QUERY PLAN
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
-   Output: _hyper_X_X_chunk.device_id
-   ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
-         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
-         Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
-(5 rows)
+ Append
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+         Output: _hyper_X_X_chunk.device_id
+         Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk
+         Output: _hyper_X_X_chunk.device_id
+         Index Cond: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+(10 rows)
 
 RESET seq_page_cost;
 -- test view
@@ -705,11 +988,20 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 :PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+   ->  Merge Append (actual rows=10.00 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Sort (actual rows=1.00 loops=1)
+                     Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                           Filter: (device_id = 1)
+                           Rows Removed by Filter: 16
+         ->  Index Scan Backward using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
                Index Cond: (device_id = 1)
                Index Searches: 1
-(5 rows)
+(14 rows)
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
@@ -724,15 +1016,23 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         ->  Sort
-               Sort Key: m1."time", m1.device_id
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: (m1."time" = "time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(10 rows)
+         ->  Gather Merge
+               Workers Planned: 2
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -753,19 +1053,29 @@ QUERY PLAN
                      Sort Key: m1."time", m1.device_id
                      ->  Parallel Hash Join
                            Hash Cond: (m3."time" = m1."time")
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                 ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                                       Recheck Cond: (device_id = 3)
-                                       ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
-                                             Index Cond: (device_id = 3)
+                           ->  Parallel Append
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
+                                       Index Cond: (device_id = 3)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
+                                       Filter: (device_id = 3)
+                                       ->  Parallel Bitmap Heap Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                                             Recheck Cond: (device_id = 3)
+                                             ->  Bitmap Index Scan on compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx
+                                                   Index Cond: (device_id = 3)
                            ->  Parallel Hash
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-               Filter: (m1."time" = "time")
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-                     Index Cond: (device_id = m1.device_id)
-(20 rows)
+                                 ->  Parallel Append
+                                       ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                             ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                                       ->  Parallel Seq Scan on _hyper_X_X_chunk m1
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                     Filter: (m1."time" = "time")
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           Index Cond: (device_id = m1.device_id)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: ("time" = m1."time")
+                     Filter: (m1.device_id = device_id)
+(30 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -783,14 +1093,28 @@ QUERY PLAN
  Limit
    ->  Merge Join
          Merge Cond: (m1."time" = m2."time")
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-               ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk
+         ->  Merge Append
+               Sort Key: m1."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                     Filter: (device_id = 1)
+                     ->  Sort
+                           Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                                 Filter: (device_id = 1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1
                      Index Cond: (device_id = 1)
          ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Merge Append
+                     Sort Key: m2."time"
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Sort
+                                 Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                       Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
-(10 rows)
+(24 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -851,12 +1175,16 @@ QUERY PLAN
                Sort Key: m1."time", m1.device_id
                ->  Parallel Hash Left Join
                      Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                     ->  Parallel Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+                           ->  Parallel Seq Scan on _hyper_X_X_chunk m1
                      ->  Parallel Hash
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(12 rows)
+                           ->  Parallel Append
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                       ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 ->  Parallel Seq Scan on _hyper_X_X_chunk m2
+(16 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE
@@ -877,13 +1205,19 @@ QUERY PLAN
          ->  Hash Right Join
                Hash Cond: (m2."time" = m1."time")
                Join Filter: (m1.device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                           Filter: (device_id = 2)
+                           ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                                 Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
                            Index Cond: (device_id = 2)
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           ->  Seq Scan on compress_hyper_X_X_chunk
-(12 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                                 ->  Seq Scan on compress_hyper_X_X_chunk
+                           ->  Seq Scan on _hyper_X_X_chunk m1
+(18 rows)
 
 -- test implicit self-join
 :PREFIX_NO_VERBOSE
@@ -902,12 +1236,16 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -928,15 +1266,18 @@ QUERY PLAN
          Sort Key: m1."time", m1.device_id, m2.device_id
          ->  Hash Join
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                     ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+                     ->  Seq Scan on _hyper_X_X_chunk m1
                ->  Hash
-                     ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(10 rows)
+                     ->  Append
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                           ->  Seq Scan on _hyper_X_X_chunk m2
+(14 rows)
 
 RESET enable_mergejoin;
-RESET parallel_leader_participation;
 :PREFIX
 SELECT *
 FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
@@ -949,13 +1290,17 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.16 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
-                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-                     Rows Removed by Filter: 17
-(9 rows)
+         ->  Append (actual rows=0.16 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
+                     Filter: ("time" = g."time")
+                     Rows Removed by Filter: 81
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
+                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                           Rows Removed by Filter: 16
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ("time" = g."time")
+                     Index Searches: 27
+(14 rows)
 
 -- test prepared statement
 SET plan_cache_mode TO force_generic_plan;
@@ -963,11 +1308,16 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
 :PREFIX EXECUTE prep;
 QUERY PLAN
  Aggregate (actual rows=1.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=4.00 loops=1)
+   ->  Append (actual rows=3598.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
+               Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
+                     Index Cond: (device_id = 1)
+                     Index Searches: 1
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Index Cond: (device_id = 1)
                Index Searches: 1
-(5 rows)
+(11 rows)
 
 EXECUTE prep;
  count 
@@ -1015,26 +1365,34 @@ QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.16 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-                     Index Searches: 32
-(9 rows)
+         ->  Append (actual rows=0.16 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.09 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 50
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.09 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                           Index Searches: 32
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.07 loops=29)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+                     Index Searches: 29
+(14 rows)
 
 :PREFIX EXECUTE param_prep (2);
 QUERY PLAN
  Nested Loop (actual rows=5.00 loops=1)
    ->  Function Scan on generate_series g (actual rows=32.00 loops=1)
    ->  Limit (actual rows=0.16 loops=32)
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
-               Filter: ("time" = g."time")
-               Rows Removed by Filter: 81
-               ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
-                     Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
-                     Index Searches: 32
-(9 rows)
+         ->  Append (actual rows=0.16 loops=32)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
+                     Filter: (("time" = g."time") AND (device_id = $1))
+                     Rows Removed by Filter: 81
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                           Index Searches: 32
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
+                     Index Cond: ((device_id = $1) AND ("time" = g."time"))
+                     Index Searches: 27
+(14 rows)
 
 EXECUTE param_prep (1);
              time             |             time             

--- a/tsl/test/shared/sql/include/constraint_exclusion_prepared_query.sql
+++ b/tsl/test/shared/sql/include/constraint_exclusion_prepared_query.sql
@@ -104,7 +104,7 @@ RESET timescaledb.enable_chunk_append;
 
 -- test prepared statement with params and generic plan
 SET plan_cache_mode TO force_generic_plan;
-PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1;
+PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time = $1 ORDER BY device_id, time;
 
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 :PREFIX EXECUTE prep('2000-01-10 23:42');

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -58,6 +58,7 @@ ANALYZE metrics_compressed;
 -- compress chunks
 ALTER TABLE metrics_compressed SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
 SELECT compress_chunk(show_chunks('metrics_compressed'));
+UPDATE metrics_compressed SET v3 = 42 WHERE device_id=1 AND time > '2000-01-01' AND time < '2000-01-02';
 
 -- Reindexing compressed hypertable to update statistics
 -- this is for planner tests which depend on them

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -107,7 +107,7 @@ ORDER BY time, device_id;
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -121,18 +121,18 @@ ORDER BY time, device_id;
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 
-:PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX_NO_ANALYZE SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 
 :PREFIX_NO_VERBOSE SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE;
 
 -- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX_NO_ANALYZE SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 
 -- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX_NO_ANALYZE SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -298,7 +298,6 @@ ORDER BY m1.time,
     m2.device_id
 LIMIT 10;
 RESET enable_mergejoin;
-RESET parallel_leader_participation;
 
 :PREFIX
 SELECT *


### PR DESCRIPTION
None of the tables in the shared test database had partially compressed
chunks, to increase test coverage for partial chunks make the compressed
hypertable have partial chunks as well.
