### PR TITLE
Support show/drop chunks with UUIDv7 partitioning

### DIFF
--- a/.unreleased/pr_8746
+++ b/.unreleased/pr_8746
@@ -1,0 +1,2 @@
+Fixes: #8746 Support show/drop chunks with UUIDv7 partitioning
+Thanks: @brandonpurcell-dev For highlighting issues with show_chunks() and UUIDv7 partitioning

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2193,6 +2193,13 @@ ts_chunk_show_chunks(PG_FUNCTION_ARGS)
 		else
 			time_type = InvalidOid;
 
+		/*
+		 * Treat UUID (v7) as a timestamptz type. The expected input is an interval or absolute
+		 * timestamptz.
+		 */
+		if (IS_UUID_TYPE(time_type))
+			time_type = TIMESTAMPTZOID;
+
 		/* note that arg_types will be the same for all specified "ANY" elements for a given call */
 		arg_type = InvalidOid;
 		if (!PG_ARGISNULL(1))
@@ -4364,6 +4371,13 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 				 errmsg("hypertable has no open partitioning dimension")));
 
 	time_type = ts_dimension_get_partition_type(time_dim);
+
+	/*
+	 * Treat UUID (v7) as a timestamptz type. The expected input is an interval or absolute
+	 * timestamptz.
+	 */
+	if (IS_UUID_TYPE(time_type))
+		time_type = TIMESTAMPTZOID;
 
 	/* note that arg_types will be the same for all specified "ANY" elements for a given call */
 	if (!PG_ARGISNULL(1))

--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -257,11 +257,111 @@ ORDER BY id DESC;
  Wed Jan 01 01:00:00 2025 PST |      1 |    1
 (4 rows)
 
+CREATE VIEW chunk_ranges AS
+SELECT
+  chunk_name,
+  _timescaledb_functions.to_timestamp(range_start_integer) AS range_start,
+  _timescaledb_functions.to_timestamp(range_end_integer) AS range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'uuid_events';
+SELECT * FROM chunk_ranges;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_6_chunk | Tue Dec 31 16:00:00 2024 PST | Wed Jan 01 16:00:00 2025 PST
+ _hyper_1_7_chunk | Wed Jan 01 16:00:00 2025 PST | Thu Jan 02 16:00:00 2025 PST
+ _hyper_1_8_chunk | Thu Jan 02 16:00:00 2025 PST | Fri Jan 03 16:00:00 2025 PST
+(3 rows)
+
+SELECT show_chunks('uuid_events', older_than => INTERVAL '1 day');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+ _timescaledb_internal._hyper_1_8_chunk
+(3 rows)
+
+SELECT show_chunks('uuid_events', older_than => '2025-01-02');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_6_chunk
+(1 row)
+
+SELECT show_chunks('uuid_events', newer_than => '2025-01-02');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_8_chunk
+(1 row)
+
+SELECT drop_chunks('uuid_events', older_than => '2025-01-02');
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_6_chunk
+(1 row)
+
+SELECT show_chunks('uuid_events');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_7_chunk
+ _timescaledb_internal._hyper_1_8_chunk
+(2 rows)
+
 -- Insert non-v7 UUIDs
 \set ON_ERROR_STOP 0
 INSERT INTO uuid_events SELECT 'a8961135-cd89-4c4b-aa05-79df642407dd', 5, 5.0;
 ERROR:  a8961135-cd89-4c4b-aa05-79df642407dd is not a version 7 UUID
 \set ON_ERROR_STOP 1
+-- Insert as v7 UUID and later change to non-v7 to show effect on show_chunks()
+-- and drop_chunks()
+INSERT INTO uuid_events SELECT 'a8961135-cd89-7000-aa05-79df642407dd', 5, 5.0;
+SELECT * FROM chunk_ranges;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_7_chunk | Wed Jan 01 16:00:00 2025 PST | Thu Jan 02 16:00:00 2025 PST
+ _hyper_1_8_chunk | Thu Jan 02 16:00:00 2025 PST | Fri Jan 03 16:00:00 2025 PST
+ _hyper_1_9_chunk | Sun Nov 26 16:00:00 7843 PST | Mon Nov 27 16:00:00 7843 PST
+(3 rows)
+
+UPDATE uuid_events
+SET id = 'a8961135-cd89-4c4b-aa05-79df642407dd'
+WHERE id = 'a8961135-cd89-7000-aa05-79df642407dd';
+SELECT show_chunks('uuid_events', newer_than => '2025-01-02');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_8_chunk
+ _timescaledb_internal._hyper_1_9_chunk
+(2 rows)
+
+SELECT drop_chunks('uuid_events', newer_than => '2025-01-02');
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_8_chunk
+ _timescaledb_internal._hyper_1_9_chunk
+(2 rows)
+
+SELECT * FROM chunk_ranges;
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_1_7_chunk | Wed Jan 01 16:00:00 2025 PST | Thu Jan 02 16:00:00 2025 PST
+(1 row)
+
+INSERT INTO uuid_events SELECT to_uuidv7(now()), 6, 6.0;
+SELECT show_chunks('uuid_events', newer_than => INTERVAL '2 months');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_10_chunk
+(1 row)
+
+SELECT drop_chunks('uuid_events', newer_than => INTERVAL '2 months');
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_10_chunk
+(1 row)
+
+SELECT show_chunks('uuid_events', newer_than => INTERVAL '2 months');
+ show_chunks 
+-------------
+(0 rows)
+
 DROP TABLE uuid_events;
 BEGIN;
 -- Test UUID partition when using CREATE TABLE ... WITH


### PR DESCRIPTION
The functions show_chunk() and drop_chunks() didn't accept timestamps or intervals as older_than arguments when calling these functions on a UUIDv7-partitioned hypertable.

To fix this, add explicit checks for UUIDv7-partitioned tables and accept timestamptz time ranges.