### PR TITLE
Fix cached utility statements

### DIFF
--- a/.unreleased/pr_8739
+++ b/.unreleased/pr_8739
@@ -1,0 +1,2 @@
+Fixes: #8739 Fix cached utility statements
+Thanks: @t-aistleitner for reporting an issue with utility statements in plpgsql functions

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -5415,9 +5415,13 @@ timescaledb_ddl_command_start(PlannedStmt *pstmt, const char *query_string, bool
 	}
 
 	/*
-	 * Process Utility/DDL operation locally then pass it on for
-	 * execution in TSL.
+	 * Since we might alter the parsetree and strip timescaledb options
+	 * before passing it to Postgres, we need to make a copy of the original
+	 * statement in case it is cached.
 	 */
+	args.pstmt = copyObject(pstmt);
+	args.parsetree = args.pstmt->utilityStmt;
+
 	result = process_ddl_command_start(&args);
 
 	if (result == DDL_CONTINUE)

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -604,3 +604,35 @@ SELECT i4489('a'), i4489('a');
      0 |     0
 (1 row)
 
+-- test DDL inside function
+CREATE OR REPLACE FUNCTION ddl_function() RETURNS VOID LANGUAGE PLPGSQL AS $$
+BEGIN
+  DROP TABLE IF EXISTS func_table;
+  CREATE TABLE func_table(time timestamptz) WITH (tsdb.hypertable, tsdb.partition_column='time');
+END
+$$;
+SELECT ddl_function();
+NOTICE:  table "func_table" does not exist, skipping
+ ddl_function 
+--------------
+ 
+(1 row)
+
+SELECT hypertable_name from timescaledb_information.hypertables WHERE hypertable_name='func_table';
+ hypertable_name 
+-----------------
+ func_table
+(1 row)
+
+SELECT ddl_function();
+ ddl_function 
+--------------
+ 
+(1 row)
+
+SELECT hypertable_name from timescaledb_information.hypertables WHERE hypertable_name='func_table';
+ hypertable_name 
+-----------------
+ func_table
+(1 row)
+

--- a/test/sql/ddl.sql
+++ b/test/sql/ddl.sql
@@ -134,3 +134,18 @@ SELECT i4489('1'), i4489('1');
 -- should return 0 (zero) in all cases handled by the exception
 SELECT i4489(), i4489();
 SELECT i4489('a'), i4489('a');
+
+-- test DDL inside function
+CREATE OR REPLACE FUNCTION ddl_function() RETURNS VOID LANGUAGE PLPGSQL AS $$
+BEGIN
+  DROP TABLE IF EXISTS func_table;
+  CREATE TABLE func_table(time timestamptz) WITH (tsdb.hypertable, tsdb.partition_column='time');
+END
+$$;
+
+SELECT ddl_function();
+SELECT hypertable_name from timescaledb_information.hypertables WHERE hypertable_name='func_table';
+
+SELECT ddl_function();
+SELECT hypertable_name from timescaledb_information.hypertables WHERE hypertable_name='func_table';
+


### PR DESCRIPTION
When using utility statements in functions that are cached we would
alter the cached versions leading to malfunctions on repeated calls.

Fixes: #8600
