### PR TITLE
Skip updating job_stat if none exist

### DIFF
--- a/.unreleased/pr_8750
+++ b/.unreleased/pr_8750
@@ -1,0 +1,1 @@
+Fixes: #8750 Skip updating job_stat if none exist

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -248,7 +248,14 @@ worker_state_cleanup(ScheduledBgwJob *sjob)
 
 		job_stat = ts_bgw_job_stat_find(sjob->job.fd.id);
 
-		Assert(job_stat != NULL);
+		/* If there is no job stat, there is nothing to do below, so exit
+		 * early. Since there is no job stat entry, we don't need to mark the
+		 * end either. */
+		if (!job_stat)
+		{
+			sjob->may_need_mark_end = false;
+			return;
+		}
 
 		if (!ts_bgw_job_stat_end_was_marked(job_stat))
 		{


### PR DESCRIPTION
When cleaning up the worker state of a job either when switching to state `JOB_STATE_SCHEDULED` or when terminating a job early, it might be the case that there is no `job_stat` entry for the job since it was not yet created.

If that is the case, do not try to check if the `job_stat` entry was marked as ended.

Fixes #8037