### PR TITLE
Fix forward port of 2.22.1 update script

### DIFF
--- a/sql/updates/2.22.0--2.22.1.sql
+++ b/sql/updates/2.22.0--2.22.1.sql
@@ -1,0 +1,35 @@
+-- Fix wrong migration by removing all sparse index configurations
+-- which only contain auto sparse indexing definitions on hypertable
+DO $$
+DECLARE
+    rec RECORD;
+    num_config INT;
+BEGIN
+	IF NOT EXISTS (
+		SELECT column_name
+		FROM information_schema.columns
+		WHERE table_schema = '_timescaledb_catalog'
+		AND table_name = 'compression_settings'
+		AND column_name = 'index') THEN
+		RETURN;
+	END IF;
+
+    FOR rec IN
+        SELECT relid, compress_relid, index
+        FROM _timescaledb_catalog.compression_settings
+		WHERE compress_relid IS NULL
+    LOOP
+		num_config:=0;
+
+		SELECT count(*)
+		INTO num_config
+		FROM jsonb_array_elements(rec.index) AS idx
+		WHERE idx::jsonb @> '{"storage":"config"}'::jsonb;
+
+		IF num_config = 0 THEN
+            UPDATE _timescaledb_catalog.compression_settings
+            SET index = NULL
+            WHERE relid = rec.relid;
+		END IF;
+    END LOOP;
+END $$;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -12,39 +12,3 @@ $$;
 
 DROP VIEW IF EXISTS timescaledb_information.job_stats;
 
-
--- Fix wrong migration by removing all sparse index configurations
--- which only contain auto sparse indexing definitions on hypertable
-DO $$
-DECLARE
-    rec RECORD;
-    num_config INT;
-BEGIN
-	IF NOT EXISTS (
-		SELECT column_name
-		FROM information_schema.columns
-		WHERE table_schema = '_timescaledb_catalog'
-		AND table_name = 'compression_settings'
-		AND column_name = 'index') THEN
-		RETURN;
-	END IF;
-
-    FOR rec IN
-        SELECT relid, compress_relid, index
-        FROM _timescaledb_catalog.compression_settings
-		WHERE compress_relid IS NULL
-    LOOP
-		num_config:=0;
-
-		SELECT count(*)
-		INTO num_config
-		FROM jsonb_array_elements(rec.index) AS idx
-		WHERE idx::jsonb @> '{"storage":"config"}'::jsonb;
-
-		IF num_config = 0 THEN
-            UPDATE _timescaledb_catalog.compression_settings
-            SET index = NULL
-            WHERE relid = rec.relid;
-		END IF;
-    END LOOP;
-END $$;


### PR DESCRIPTION
Forwardport of 2.22.1 did not correctly adjust update script for
2.22.1 and added an empty file instead.

Disable-check: approval-count
Disable-check: force-changelog-file
