### PR TITLE
Don't create parameterized MergeAppend paths

### DIFF
--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -1483,6 +1483,14 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 			continue;
 		}
 
+		if (!bms_is_empty(chunk_rel->lateral_relids) || !bms_is_empty(req_outer))
+		{
+			/*
+			 * Parametrized MergeAppend paths are not supported.
+			 */
+			continue;
+		}
+
 		if (IsA(decompression_path, SortPath))
 		{
 			/*


### PR DESCRIPTION
With commit 53fbc362, we started creating parameterized MergeAppend paths which started triggering newly added asserts in PG18. Since these paths are not supported by Postgres for a while, skip creating them in the first place.

https://github.com/postgres/postgres/commit/f47b33a1

Disable-check: force-changelog-file