### PR TITLE
Add GUC for WAL based invalidation

### DIFF
--- a/.unreleased/pr_8774
+++ b/.unreleased/pr_8774
@@ -1,0 +1,1 @@
+Fixes: #8774 Add GUC for WAL based invalidation

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -11,4 +11,5 @@ END
 $$;
 
 DROP VIEW IF EXISTS timescaledb_information.job_stats;
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -11,4 +11,5 @@ END
 $$;
 
 DROP VIEW IF EXISTS timescaledb_information.job_stats;
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
 

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -128,11 +128,7 @@ SELECT ht.schema_name AS hypertable_schema,
   mat_ht.schema_name AS materialization_hypertable_schema,
   mat_ht.table_name AS materialization_hypertable_name,
   directview.viewdefinition AS view_definition,
-  cagg.finalized,
-  CASE WHEN _timescaledb_functions.has_invalidation_trigger(format('%I.%I', ht.schema_name, ht.table_name)::regclass)
-       THEN 'trigger'
-       ELSE 'wal'
-  END AS invalidate_using
+  cagg.finalized
 FROM _timescaledb_catalog.continuous_agg cagg,
   _timescaledb_catalog.hypertable ht,
   LATERAL (

--- a/src/guc.c
+++ b/src/guc.c
@@ -93,6 +93,7 @@ TSDLLEXPORT bool ts_guc_enable_cagg_sort_pushdown = true;
 #endif
 TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify = true;
 TSDLLEXPORT int ts_guc_cagg_max_individual_materializations = 10;
+TSDLLEXPORT bool ts_guc_enable_cagg_wal_based_invalidation = false;
 TSDLLEXPORT int ts_guc_cagg_wal_batch_size = 10000;
 TSDLLEXPORT int ts_guc_cagg_low_work_mem = GUC_CAGG_LOW_WORK_MEM_VALUE;
 TSDLLEXPORT int ts_guc_cagg_high_work_mem = GUC_CAGG_HIGH_WORK_MEM_VALUE;
@@ -961,6 +962,19 @@ _guc_init(void)
 							 "Enable warnings for poor compression ratio",
 							 &ts_guc_enable_compression_ratio_warnings,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_cagg_wal_based_invalidation"),
+							 "Enable experimental invalidations for continuous aggregates using "
+							 "WAL",
+							 "Use WAL to track changes to hypertables for continuous aggregates. "
+							 "This is not meant for production use.",
+							 &ts_guc_enable_cagg_wal_based_invalidation,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -28,6 +28,7 @@ extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;
 extern TSDLLEXPORT bool ts_guc_enable_cagg_window_functions;
 extern TSDLLEXPORT int ts_guc_cagg_max_individual_materializations;
+extern TSDLLEXPORT bool ts_guc_enable_cagg_wal_based_invalidation;
 extern TSDLLEXPORT int ts_guc_cagg_wal_batch_size;
 extern TSDLLEXPORT int ts_guc_cagg_low_work_mem;
 extern TSDLLEXPORT int ts_guc_cagg_high_work_mem;

--- a/src/with_clause/create_materialized_view_with_clause.c
+++ b/src/with_clause/create_materialized_view_with_clause.c
@@ -59,11 +59,6 @@ static const WithClauseDefinition continuous_aggregate_with_clause_def[] = {
         .arg_names = {"compress_chunk_interval", "compress_chunk_time_interval", NULL},
          .type_id = INTERVALOID,
     },
-	[CreateMaterializedViewFlagInvalidateUsing] = {
-        .arg_names = {"invalidate_using", NULL},
-		.type_id = TEXTOID,
-		.default_val = (Datum) 0,
-	},
 };
 
 WithClauseResult *

--- a/src/with_clause/create_materialized_view_with_clause.h
+++ b/src/with_clause/create_materialized_view_with_clause.h
@@ -20,7 +20,6 @@ typedef enum CreateMaterializedViewFlags
 	CreateMaterializedViewFlagSegmentBy,
 	CreateMaterializedViewFlagOrderBy,
 	CreateMaterializedViewFlagCompressChunkTimeInterval,
-	CreateMaterializedViewFlagInvalidateUsing,
 } CreateMaterializedViewFlags;
 
 extern TSDLLEXPORT WithClauseResult *

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -30,6 +30,7 @@
 #include "debug_point.h"
 #include "dimension.h"
 #include "export.h"
+#include "guc.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
 #include "invalidation.h"
@@ -223,15 +224,33 @@ update_cache_entry(ContinuousAggsCacheInvalEntry *cache_entry, int64 timeval)
 Datum
 continuous_agg_trigfn(PG_FUNCTION_ARGS)
 {
+	if (!CALLED_AS_TRIGGER(fcinfo))
+		ereport(ERROR,
+				errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
+				errmsg("function \"%s\" was not called by trigger manager",
+					   get_func_name(fcinfo->flinfo->fn_oid)));
 	/*
 	 * Use TriggerData to determine which row to return/work with, in the case
 	 * of updates, we'll need to call the functions twice, once with the old
 	 * rows (which act like deletes) and once with the new rows.
 	 */
-	TriggerData *trigdata = (TriggerData *) fcinfo->context;
+	TriggerData *trigdata = castNode(TriggerData, fcinfo->context);
+
+	if (ts_guc_enable_cagg_wal_based_invalidation)
+	{
+		if (!TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
+			return PointerGetDatum(trigdata->tg_trigtuple);
+		else
+			return PointerGetDatum(trigdata->tg_newtuple);
+	}
+
+	if (!TRIGGER_FIRED_AFTER(trigdata->tg_event) || !TRIGGER_FIRED_FOR_ROW(trigdata->tg_event))
+		ereport(ERROR,
+				errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
+				errmsg("continuous agg trigger function must be called in per row after trigger"));
+
 	char *hypertable_id_str;
 	int32 hypertable_id;
-
 	if (trigdata == NULL || trigdata->tg_trigger == NULL || trigdata->tg_trigger->tgnargs < 0)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -240,20 +259,12 @@ continuous_agg_trigfn(PG_FUNCTION_ARGS)
 	hypertable_id_str = trigdata->tg_trigger->tgargs[0];
 	hypertable_id = atol(hypertable_id_str);
 
-	if (!CALLED_AS_TRIGGER(fcinfo))
-		ereport(ERROR,
-				errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
-				errmsg("function \"%s\" was not called by trigger manager",
-					   get_func_name(fcinfo->flinfo->fn_oid)));
-	if (!TRIGGER_FIRED_AFTER(trigdata->tg_event) || !TRIGGER_FIRED_FOR_ROW(trigdata->tg_event))
-		ereport(ERROR,
-				errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
-				errmsg("continuous agg trigger function must be called in per row after trigger"));
 	execute_cagg_trigger(hypertable_id,
 						 trigdata->tg_relation,
 						 trigdata->tg_trigtuple,
 						 trigdata->tg_newtuple,
 						 TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event));
+
 	if (!TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
 		return PointerGetDatum(trigdata->tg_trigtuple);
 	else

--- a/tsl/src/continuous_aggs/invalidation_multi.c
+++ b/tsl/src/continuous_aggs/invalidation_multi.c
@@ -155,9 +155,6 @@ multi_invalidation_hypertable_entry_init(MultiInvalidationState *state,
 	const Dimension *const dim = hyperspace_get_open_dimension(ht->space, 0);
 	ListCell *lc;
 
-	Ensure(!OidIsValid(get_trigger_oid(ht->main_table_relid, CAGGINVAL_TRIGGER_NAME, true)),
-		   "hypertable has invalidation trigger, which was not expected");
-
 	entry->hypertable_id = hypertable_id;
 	entry->dimtype = ts_dimension_get_partition_type(dim);
 	entry->caggs = NIL;

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -194,20 +194,6 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		ts_cache_release(&hcache);
 	}
 
-	/*
-	 * We do not support changing the invalidation method on a continuous
-	 * aggregate. We will add support for this using a dedicated function
-	 * since it needs to be changed for the hypertable.
-	 */
-	if (!with_clause_options[CreateMaterializedViewFlagInvalidateUsing].is_default)
-	{
-		ereport(ERROR,
-				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("cannot change invalidation method for continuous aggregate"),
-				errdetail("All continuous aggregates for a hypertable need to use the same "
-						  "invalidation collection method."));
-	}
-
 	List *compression_options = ts_continuous_agg_get_compression_defelems(with_clause_options);
 
 	if (list_length(compression_options) > 0)

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -25,7 +25,7 @@ select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 ERROR:  unrecognized parameter "timescaledb.myfill"
-HINT:  Valid timescaledb parameters are: continuous, create_group_indexes, materialized_only, columnstore, finalized, chunk_interval, segmentby, orderby, compress_chunk_interval, invalidate_using
+HINT:  Valid timescaledb parameters are: continuous, create_group_indexes, materialized_only, columnstore, finalized, chunk_interval, segmentby, orderby, compress_chunk_interval
 --valid PG option
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, check_option = LOCAL )
 as

--- a/tsl/test/expected/cagg_invalidation_multi.out
+++ b/tsl/test/expected/cagg_invalidation_multi.out
@@ -10,6 +10,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 
 SET datestyle TO 'ISO, YMD';
 SET timezone TO 'UTC';
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
 CREATE VIEW hypertable_invalidation_thresholds AS
 SELECT format('%I.%I', ht.schema_name, ht.table_name)::regclass AS hypertable,
@@ -90,8 +91,7 @@ SELECT * FROM invalidation_slots;
 -- set client_min_messages to debug2;
 CREATE MATERIALIZED VIEW cond_10
 WITH (timescaledb.continuous,
-      timescaledb.materialized_only = true,
-      timescaledb.invalidate_using = 'wal')
+      timescaledb.materialized_only = true)
 AS
     SELECT time_bucket(BIGINT '10', time) AS bucket,
            device, avg(temp) AS avg_temp
@@ -100,8 +100,7 @@ AS
 NOTICE:  refreshing continuous aggregate "cond_10"
 CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
-      timescaledb.materialized_only = true,
-      timescaledb.invalidate_using = 'wal')
+      timescaledb.materialized_only = true)
 AS
 SELECT time_bucket(BIGINT '20', time) AS bucket,
        device, avg(temp) AS avg_temp
@@ -110,8 +109,7 @@ GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "cond_20"
 CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
-      timescaledb.materialized_only=true,
-      timescaledb.invalidate_using = 'wal')
+      timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(10, time) AS bucket,
        device,
@@ -119,16 +117,6 @@ SELECT time_bucket(10, time) AS bucket,
 FROM measurements
 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "measure_10"
--- There should be three continuous aggregates, two on one hypertable
--- and one on the other. All using the WAL.
-SELECT hypertable_name, view_name, materialization_hypertable_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates;
- hypertable_name | view_name  | materialization_hypertable_name | invalidate_using 
------------------+------------+---------------------------------+------------------
- conditions      | cond_10    | _materialized_hypertable_3      | wal
- conditions      | cond_20    | _materialized_hypertable_4      | wal
- measurements    | measure_10 | _materialized_hypertable_5      | wal
-
 -- We need to refresh to move the invalidation threshold, or
 -- invalidations will not be generated. Check initial value of
 -- thresholds and materialization invalidations.

--- a/tsl/test/expected/cagg_refresh_using_merge.out
+++ b/tsl/test/expected/cagg_refresh_using_merge.out
@@ -4,7 +4,6 @@
 -- Enable MERGE statements for continuous aggregate refresh
 SET timescaledb.enable_merge_on_cagg_refresh TO ON;
 SET timezone TO PST8PDT;
-\set invalidate_using trigger
 \ir include/cagg_refresh_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -18,16 +17,15 @@ SELECT create_hypertable('conditions', 'time');
 -- Test refresh on a cagg built on an empty table
 CREATE MATERIALIZED VIEW daily_temp
 WITH (timescaledb.continuous,
-      timescaledb.invalidate_using = :'invalidate_using',
       timescaledb.materialized_only=true)
 AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
-psql:include/cagg_refresh_common.sql:18: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:17: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL, force => true);
-psql:include/cagg_refresh_common.sql:19: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:18: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 SELECT setseed(.12);
  setseed 
 ---------
@@ -75,16 +73,16 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 17:00 PDT', '2020-05
 -- These refreshes will fail since they don't align with the bucket's
 -- time zone
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-04');
-psql:include/cagg_refresh_common.sql:48: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:47: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 PDT', '2020-05-04 00:00 PDT');
-psql:include/cagg_refresh_common.sql:49: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:48: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 -- Refresh window less than one bucket
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-03 23:59 UTC');
-psql:include/cagg_refresh_common.sql:52: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:51: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 -- Refresh window bigger than one bucket, but failing since it is not
@@ -93,7 +91,7 @@ HINT:  Align the refresh window with the bucket time zone or use at least two bu
 -- Refresh window:    [----------)
 -- Buckets:          [------|------]
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 01:00 UTC', '2020-05-04 08:00 UTC');
-psql:include/cagg_refresh_common.sql:58: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:57: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 \set VERBOSITY terse
@@ -174,46 +172,46 @@ ORDER BY 1 DESC,2;
 
 -- Test unusual, but valid input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
-psql:include/cagg_refresh_common.sql:81: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:80: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
-psql:include/cagg_refresh_common.sql:82: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:81: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Unbounded window forward in time
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
-psql:include/cagg_refresh_common.sql:85: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:84: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
 -- Unbounded window back in time
 CALL refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
-psql:include/cagg_refresh_common.sql:89: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:88: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Test bad input
 \set ON_ERROR_STOP 0
 -- Bad continuous aggregate name
 CALL refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:94: ERROR:  invalid continuous aggregate
+psql:include/cagg_refresh_common.sql:93: ERROR:  invalid continuous aggregate
 CALL refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:95: ERROR:  relation "xyz" does not exist at character 35
+psql:include/cagg_refresh_common.sql:94: ERROR:  relation "xyz" does not exist at character 35
 -- Valid object, but not a continuous aggregate
 CALL refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:97: ERROR:  relation "conditions" is not a continuous aggregate
+psql:include/cagg_refresh_common.sql:96: ERROR:  relation "conditions" is not a continuous aggregate
 -- Object ID with no object
 CALL refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:99: ERROR:  continuous aggregate does not exist
+psql:include/cagg_refresh_common.sql:98: ERROR:  continuous aggregate does not exist
 -- Lacking arguments
 CALL refresh_continuous_aggregate('daily_temp');
-psql:include/cagg_refresh_common.sql:101: ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
+psql:include/cagg_refresh_common.sql:100: ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03');
-psql:include/cagg_refresh_common.sql:102: ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
+psql:include/cagg_refresh_common.sql:101: ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
 -- Bad time ranges
 CALL refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
-psql:include/cagg_refresh_common.sql:104: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
+psql:include/cagg_refresh_common.sql:103: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
-psql:include/cagg_refresh_common.sql:105: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
+psql:include/cagg_refresh_common.sql:104: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
-psql:include/cagg_refresh_common.sql:106: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:105: ERROR:  refresh window too small
 -- Bad time input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
-psql:include/cagg_refresh_common.sql:108: ERROR:  invalid time argument type "text"
+psql:include/cagg_refresh_common.sql:107: ERROR:  invalid time argument type "text"
 CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
-psql:include/cagg_refresh_common.sql:109: ERROR:  invalid time argument type "integer"
+psql:include/cagg_refresh_common.sql:108: ERROR:  invalid time argument type "integer"
 \set ON_ERROR_STOP 1
 -- Test forceful refreshment. Here we simulate the situation that we've seen
 -- with tiered data when `timescaledb.enable_tiered_reads` were disabled on the
@@ -229,7 +227,7 @@ WHERE user_view_name = 'daily_temp' \gset
 DELETE FROM :mat_ht;
 -- Run regular refresh, it should not touch previously materialized range
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-02', '2020-05-05 17:00');
-psql:include/cagg_refresh_common.sql:127: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:126: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
  day | device | avg_temp 
@@ -297,7 +295,7 @@ AS
 SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
 GROUP BY 1,2 WITH NO DATA;
-psql:include/cagg_refresh_common.sql:176: ERROR:  custom time function required on hypertable "conditions_smallint"
+psql:include/cagg_refresh_common.sql:175: ERROR:  custom time function required on hypertable "conditions_smallint"
 \set ON_ERROR_STOP 1
 SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
  set_integer_now_func 
@@ -444,7 +442,7 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-psql:include/cagg_refresh_common.sql:281: NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
+psql:include/cagg_refresh_common.sql:280: NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
 SELECT * FROM weekly_temp_without_data;
  day | device | avg_temp 
 -----+--------+----------
@@ -464,7 +462,7 @@ SELECT * FROM weekly_temp_with_data ORDER BY 1,2;
 \set ON_ERROR_STOP 0
 -- REFRESH MATERIALIZED VIEW is blocked on continuous aggregates
 REFRESH MATERIALIZED VIEW weekly_temp_without_data;
-psql:include/cagg_refresh_common.sql:288: ERROR:  operation not supported on continuous aggregate
+psql:include/cagg_refresh_common.sql:287: ERROR:  operation not supported on continuous aggregate
 -- These should fail since we do not allow refreshing inside a
 -- transaction, not even as part of CREATE MATERIALIZED VIEW.
 DO LANGUAGE PLPGSQL $$ BEGIN
@@ -476,7 +474,7 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
 END $$;
-psql:include/cagg_refresh_common.sql:300: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
+psql:include/cagg_refresh_common.sql:299: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
 BEGIN;
 CREATE MATERIALIZED VIEW weekly_conditions
 WITH (timescaledb.continuous,
@@ -485,7 +483,7 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-psql:include/cagg_refresh_common.sql:309: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
+psql:include/cagg_refresh_common.sql:308: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
 COMMIT;
 \set ON_ERROR_STOP 1
 -- This should not fail since we do not refresh the continuous
@@ -518,7 +516,7 @@ DO $$
 BEGIN
   CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
 END; $$;
-psql:include/cagg_refresh_common.sql:346: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:345: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Procedure without subtransaction
 CREATE OR REPLACE PROCEDURE refresh_cagg_proc_normal()
 LANGUAGE PLPGSQL AS
@@ -527,7 +525,7 @@ BEGIN
   CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
 END; $$;
 CALL refresh_cagg_proc_normal();
-psql:include/cagg_refresh_common.sql:356: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:355: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 \set ON_ERROR_STOP 0
 -- Procedure with subtransaction
 CREATE OR REPLACE PROCEDURE refresh_cagg_proc_subtransaction()
@@ -542,7 +540,7 @@ EXCEPTION WHEN OTHERS THEN
   RAISE EXCEPTION '%', errmsg;
 END; $$;
 CALL refresh_cagg_proc_subtransaction();
-psql:include/cagg_refresh_common.sql:373: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
+psql:include/cagg_refresh_common.sql:372: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
 -- Function
 CREATE OR REPLACE FUNCTION refresh_cagg_fun()
 RETURNS INT LANGUAGE PLPGSQL AS
@@ -552,7 +550,7 @@ BEGIN
   RETURN 1;
 END; $$;
 SELECT * from  refresh_cagg_fun();
-psql:include/cagg_refresh_common.sql:384: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:383: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 -- Dynamic SQL
 DO $$
 BEGIN
@@ -560,7 +558,7 @@ BEGIN
       CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
   $inner$;
 END; $$;
-psql:include/cagg_refresh_common.sql:392: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:391: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 -- Trigger
 CREATE TABLE refresh_cagg_trigger_table(a int);
 CREATE FUNCTION refresh_cagg_trigger_fun()
@@ -571,14 +569,14 @@ END; $$;
 CREATE TRIGGER refresh_cagg_trigger AFTER INSERT ON refresh_cagg_trigger_table
 EXECUTE FUNCTION refresh_cagg_trigger_fun();
 INSERT INTO refresh_cagg_trigger_table VALUES(1);
-psql:include/cagg_refresh_common.sql:406: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:405: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 \set ON_ERROR_STOP 1
 -- check that cagg refresh is not blocked by decompression limit
 CREATE TABLE conditions_decompress_limit (time timestamptz NOT NULL, device text, temp float) WITH (tsdb.hypertable, tsdb.partition_column='time');
 INSERT INTO conditions_decompress_limit SELECT '2020-01-01','d' || i::text, 1.0 FROM generate_series(1,100) g(i);
 CREATE MATERIALIZED VIEW daily_temp_decompress_limit WITH (tsdb.continuous) AS SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp FROM conditions_decompress_limit GROUP BY 1,2 WITH NO DATA;
 ALTER MATERIALIZED VIEW daily_temp_decompress_limit SET (tsdb.columnstore,tsdb.segmentby = 'device');
-psql:include/cagg_refresh_common.sql:414: NOTICE:  defaulting compress_orderby to day
+psql:include/cagg_refresh_common.sql:413: NOTICE:  defaulting compress_orderby to day
 CALL refresh_continuous_aggregate('daily_temp_decompress_limit', NULL, NULL);
 SELECT compress_chunk(show_chunks('daily_temp_decompress_limit'));
               compress_chunk              

--- a/tsl/test/expected/cagg_refresh_using_trigger.out
+++ b/tsl/test/expected/cagg_refresh_using_trigger.out
@@ -2,7 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 SET timezone TO PST8PDT;
-\set invalidate_using trigger
 \ir include/cagg_refresh_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -16,16 +15,15 @@ SELECT create_hypertable('conditions', 'time');
 -- Test refresh on a cagg built on an empty table
 CREATE MATERIALIZED VIEW daily_temp
 WITH (timescaledb.continuous,
-      timescaledb.invalidate_using = :'invalidate_using',
       timescaledb.materialized_only=true)
 AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
-psql:include/cagg_refresh_common.sql:18: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:17: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL, force => true);
-psql:include/cagg_refresh_common.sql:19: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:18: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 SELECT setseed(.12);
  setseed 
 ---------
@@ -73,16 +71,16 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 17:00 PDT', '2020-05
 -- These refreshes will fail since they don't align with the bucket's
 -- time zone
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-04');
-psql:include/cagg_refresh_common.sql:48: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:47: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 PDT', '2020-05-04 00:00 PDT');
-psql:include/cagg_refresh_common.sql:49: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:48: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 -- Refresh window less than one bucket
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-03 23:59 UTC');
-psql:include/cagg_refresh_common.sql:52: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:51: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 -- Refresh window bigger than one bucket, but failing since it is not
@@ -91,7 +89,7 @@ HINT:  Align the refresh window with the bucket time zone or use at least two bu
 -- Refresh window:    [----------)
 -- Buckets:          [------|------]
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 01:00 UTC', '2020-05-04 08:00 UTC');
-psql:include/cagg_refresh_common.sql:58: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:57: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 \set VERBOSITY terse
@@ -172,46 +170,46 @@ ORDER BY 1 DESC,2;
 
 -- Test unusual, but valid input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
-psql:include/cagg_refresh_common.sql:81: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:80: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
-psql:include/cagg_refresh_common.sql:82: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:81: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Unbounded window forward in time
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
-psql:include/cagg_refresh_common.sql:85: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:84: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
 -- Unbounded window back in time
 CALL refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
-psql:include/cagg_refresh_common.sql:89: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:88: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Test bad input
 \set ON_ERROR_STOP 0
 -- Bad continuous aggregate name
 CALL refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:94: ERROR:  invalid continuous aggregate
+psql:include/cagg_refresh_common.sql:93: ERROR:  invalid continuous aggregate
 CALL refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:95: ERROR:  relation "xyz" does not exist at character 35
+psql:include/cagg_refresh_common.sql:94: ERROR:  relation "xyz" does not exist at character 35
 -- Valid object, but not a continuous aggregate
 CALL refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:97: ERROR:  relation "conditions" is not a continuous aggregate
+psql:include/cagg_refresh_common.sql:96: ERROR:  relation "conditions" is not a continuous aggregate
 -- Object ID with no object
 CALL refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:99: ERROR:  continuous aggregate does not exist
+psql:include/cagg_refresh_common.sql:98: ERROR:  continuous aggregate does not exist
 -- Lacking arguments
 CALL refresh_continuous_aggregate('daily_temp');
-psql:include/cagg_refresh_common.sql:101: ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
+psql:include/cagg_refresh_common.sql:100: ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03');
-psql:include/cagg_refresh_common.sql:102: ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
+psql:include/cagg_refresh_common.sql:101: ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
 -- Bad time ranges
 CALL refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
-psql:include/cagg_refresh_common.sql:104: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
+psql:include/cagg_refresh_common.sql:103: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
-psql:include/cagg_refresh_common.sql:105: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
+psql:include/cagg_refresh_common.sql:104: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
-psql:include/cagg_refresh_common.sql:106: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:105: ERROR:  refresh window too small
 -- Bad time input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
-psql:include/cagg_refresh_common.sql:108: ERROR:  invalid time argument type "text"
+psql:include/cagg_refresh_common.sql:107: ERROR:  invalid time argument type "text"
 CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
-psql:include/cagg_refresh_common.sql:109: ERROR:  invalid time argument type "integer"
+psql:include/cagg_refresh_common.sql:108: ERROR:  invalid time argument type "integer"
 \set ON_ERROR_STOP 1
 -- Test forceful refreshment. Here we simulate the situation that we've seen
 -- with tiered data when `timescaledb.enable_tiered_reads` were disabled on the
@@ -227,7 +225,7 @@ WHERE user_view_name = 'daily_temp' \gset
 DELETE FROM :mat_ht;
 -- Run regular refresh, it should not touch previously materialized range
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-02', '2020-05-05 17:00');
-psql:include/cagg_refresh_common.sql:127: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:126: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
  day | device | avg_temp 
@@ -295,7 +293,7 @@ AS
 SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
 GROUP BY 1,2 WITH NO DATA;
-psql:include/cagg_refresh_common.sql:176: ERROR:  custom time function required on hypertable "conditions_smallint"
+psql:include/cagg_refresh_common.sql:175: ERROR:  custom time function required on hypertable "conditions_smallint"
 \set ON_ERROR_STOP 1
 SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
  set_integer_now_func 
@@ -442,7 +440,7 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-psql:include/cagg_refresh_common.sql:281: NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
+psql:include/cagg_refresh_common.sql:280: NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
 SELECT * FROM weekly_temp_without_data;
  day | device | avg_temp 
 -----+--------+----------
@@ -462,7 +460,7 @@ SELECT * FROM weekly_temp_with_data ORDER BY 1,2;
 \set ON_ERROR_STOP 0
 -- REFRESH MATERIALIZED VIEW is blocked on continuous aggregates
 REFRESH MATERIALIZED VIEW weekly_temp_without_data;
-psql:include/cagg_refresh_common.sql:288: ERROR:  operation not supported on continuous aggregate
+psql:include/cagg_refresh_common.sql:287: ERROR:  operation not supported on continuous aggregate
 -- These should fail since we do not allow refreshing inside a
 -- transaction, not even as part of CREATE MATERIALIZED VIEW.
 DO LANGUAGE PLPGSQL $$ BEGIN
@@ -474,7 +472,7 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
 END $$;
-psql:include/cagg_refresh_common.sql:300: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
+psql:include/cagg_refresh_common.sql:299: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
 BEGIN;
 CREATE MATERIALIZED VIEW weekly_conditions
 WITH (timescaledb.continuous,
@@ -483,7 +481,7 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-psql:include/cagg_refresh_common.sql:309: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
+psql:include/cagg_refresh_common.sql:308: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
 COMMIT;
 \set ON_ERROR_STOP 1
 -- This should not fail since we do not refresh the continuous
@@ -516,7 +514,7 @@ DO $$
 BEGIN
   CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
 END; $$;
-psql:include/cagg_refresh_common.sql:346: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:345: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Procedure without subtransaction
 CREATE OR REPLACE PROCEDURE refresh_cagg_proc_normal()
 LANGUAGE PLPGSQL AS
@@ -525,7 +523,7 @@ BEGIN
   CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
 END; $$;
 CALL refresh_cagg_proc_normal();
-psql:include/cagg_refresh_common.sql:356: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:355: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 \set ON_ERROR_STOP 0
 -- Procedure with subtransaction
 CREATE OR REPLACE PROCEDURE refresh_cagg_proc_subtransaction()
@@ -540,7 +538,7 @@ EXCEPTION WHEN OTHERS THEN
   RAISE EXCEPTION '%', errmsg;
 END; $$;
 CALL refresh_cagg_proc_subtransaction();
-psql:include/cagg_refresh_common.sql:373: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
+psql:include/cagg_refresh_common.sql:372: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
 -- Function
 CREATE OR REPLACE FUNCTION refresh_cagg_fun()
 RETURNS INT LANGUAGE PLPGSQL AS
@@ -550,7 +548,7 @@ BEGIN
   RETURN 1;
 END; $$;
 SELECT * from  refresh_cagg_fun();
-psql:include/cagg_refresh_common.sql:384: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:383: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 -- Dynamic SQL
 DO $$
 BEGIN
@@ -558,7 +556,7 @@ BEGIN
       CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
   $inner$;
 END; $$;
-psql:include/cagg_refresh_common.sql:392: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:391: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 -- Trigger
 CREATE TABLE refresh_cagg_trigger_table(a int);
 CREATE FUNCTION refresh_cagg_trigger_fun()
@@ -569,14 +567,14 @@ END; $$;
 CREATE TRIGGER refresh_cagg_trigger AFTER INSERT ON refresh_cagg_trigger_table
 EXECUTE FUNCTION refresh_cagg_trigger_fun();
 INSERT INTO refresh_cagg_trigger_table VALUES(1);
-psql:include/cagg_refresh_common.sql:406: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:405: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 \set ON_ERROR_STOP 1
 -- check that cagg refresh is not blocked by decompression limit
 CREATE TABLE conditions_decompress_limit (time timestamptz NOT NULL, device text, temp float) WITH (tsdb.hypertable, tsdb.partition_column='time');
 INSERT INTO conditions_decompress_limit SELECT '2020-01-01','d' || i::text, 1.0 FROM generate_series(1,100) g(i);
 CREATE MATERIALIZED VIEW daily_temp_decompress_limit WITH (tsdb.continuous) AS SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp FROM conditions_decompress_limit GROUP BY 1,2 WITH NO DATA;
 ALTER MATERIALIZED VIEW daily_temp_decompress_limit SET (tsdb.columnstore,tsdb.segmentby = 'device');
-psql:include/cagg_refresh_common.sql:414: NOTICE:  defaulting compress_orderby to day
+psql:include/cagg_refresh_common.sql:413: NOTICE:  defaulting compress_orderby to day
 CALL refresh_continuous_aggregate('daily_temp_decompress_limit', NULL, NULL);
 SELECT compress_chunk(show_chunks('daily_temp_decompress_limit'));
               compress_chunk              

--- a/tsl/test/expected/cagg_refresh_using_wal.out
+++ b/tsl/test/expected/cagg_refresh_using_wal.out
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 SET timezone TO PST8PDT;
-\set invalidate_using wal
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 \ir include/cagg_refresh_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -16,16 +16,15 @@ SELECT create_hypertable('conditions', 'time');
 -- Test refresh on a cagg built on an empty table
 CREATE MATERIALIZED VIEW daily_temp
 WITH (timescaledb.continuous,
-      timescaledb.invalidate_using = :'invalidate_using',
       timescaledb.materialized_only=true)
 AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
-psql:include/cagg_refresh_common.sql:18: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:17: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL, force => true);
-psql:include/cagg_refresh_common.sql:19: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:18: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 SELECT setseed(.12);
  setseed 
 ---------
@@ -73,16 +72,16 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 17:00 PDT', '2020-05
 -- These refreshes will fail since they don't align with the bucket's
 -- time zone
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-04');
-psql:include/cagg_refresh_common.sql:48: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:47: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 PDT', '2020-05-04 00:00 PDT');
-psql:include/cagg_refresh_common.sql:49: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:48: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 -- Refresh window less than one bucket
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-03 23:59 UTC');
-psql:include/cagg_refresh_common.sql:52: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:51: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 -- Refresh window bigger than one bucket, but failing since it is not
@@ -91,7 +90,7 @@ HINT:  Align the refresh window with the bucket time zone or use at least two bu
 -- Refresh window:    [----------)
 -- Buckets:          [------|------]
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 01:00 UTC', '2020-05-04 08:00 UTC');
-psql:include/cagg_refresh_common.sql:58: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:57: ERROR:  refresh window too small
 DETAIL:  The refresh window must cover at least one bucket of data.
 HINT:  Align the refresh window with the bucket time zone or use at least two buckets.
 \set VERBOSITY terse
@@ -172,46 +171,46 @@ ORDER BY 1 DESC,2;
 
 -- Test unusual, but valid input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
-psql:include/cagg_refresh_common.sql:81: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:80: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
-psql:include/cagg_refresh_common.sql:82: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:81: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Unbounded window forward in time
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
-psql:include/cagg_refresh_common.sql:85: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:84: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
 -- Unbounded window back in time
 CALL refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
-psql:include/cagg_refresh_common.sql:89: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:88: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Test bad input
 \set ON_ERROR_STOP 0
 -- Bad continuous aggregate name
 CALL refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:94: ERROR:  invalid continuous aggregate
+psql:include/cagg_refresh_common.sql:93: ERROR:  invalid continuous aggregate
 CALL refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:95: ERROR:  relation "xyz" does not exist at character 35
+psql:include/cagg_refresh_common.sql:94: ERROR:  relation "xyz" does not exist at character 35
 -- Valid object, but not a continuous aggregate
 CALL refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:97: ERROR:  relation "conditions" is not a continuous aggregate
+psql:include/cagg_refresh_common.sql:96: ERROR:  relation "conditions" is not a continuous aggregate
 -- Object ID with no object
 CALL refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
-psql:include/cagg_refresh_common.sql:99: ERROR:  continuous aggregate does not exist
+psql:include/cagg_refresh_common.sql:98: ERROR:  continuous aggregate does not exist
 -- Lacking arguments
 CALL refresh_continuous_aggregate('daily_temp');
-psql:include/cagg_refresh_common.sql:101: ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
+psql:include/cagg_refresh_common.sql:100: ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03');
-psql:include/cagg_refresh_common.sql:102: ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
+psql:include/cagg_refresh_common.sql:101: ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
 -- Bad time ranges
 CALL refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
-psql:include/cagg_refresh_common.sql:104: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
+psql:include/cagg_refresh_common.sql:103: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
-psql:include/cagg_refresh_common.sql:105: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
+psql:include/cagg_refresh_common.sql:104: ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
-psql:include/cagg_refresh_common.sql:106: ERROR:  refresh window too small
+psql:include/cagg_refresh_common.sql:105: ERROR:  refresh window too small
 -- Bad time input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
-psql:include/cagg_refresh_common.sql:108: ERROR:  invalid time argument type "text"
+psql:include/cagg_refresh_common.sql:107: ERROR:  invalid time argument type "text"
 CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
-psql:include/cagg_refresh_common.sql:109: ERROR:  invalid time argument type "integer"
+psql:include/cagg_refresh_common.sql:108: ERROR:  invalid time argument type "integer"
 \set ON_ERROR_STOP 1
 -- Test forceful refreshment. Here we simulate the situation that we've seen
 -- with tiered data when `timescaledb.enable_tiered_reads` were disabled on the
@@ -227,7 +226,7 @@ WHERE user_view_name = 'daily_temp' \gset
 DELETE FROM :mat_ht;
 -- Run regular refresh, it should not touch previously materialized range
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-02', '2020-05-05 17:00');
-psql:include/cagg_refresh_common.sql:127: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:126: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
  day | device | avg_temp 
@@ -295,7 +294,7 @@ AS
 SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
 GROUP BY 1,2 WITH NO DATA;
-psql:include/cagg_refresh_common.sql:176: ERROR:  custom time function required on hypertable "conditions_smallint"
+psql:include/cagg_refresh_common.sql:175: ERROR:  custom time function required on hypertable "conditions_smallint"
 \set ON_ERROR_STOP 1
 SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
  set_integer_now_func 
@@ -442,7 +441,7 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-psql:include/cagg_refresh_common.sql:281: NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
+psql:include/cagg_refresh_common.sql:280: NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
 SELECT * FROM weekly_temp_without_data;
  day | device | avg_temp 
 -----+--------+----------
@@ -462,7 +461,7 @@ SELECT * FROM weekly_temp_with_data ORDER BY 1,2;
 \set ON_ERROR_STOP 0
 -- REFRESH MATERIALIZED VIEW is blocked on continuous aggregates
 REFRESH MATERIALIZED VIEW weekly_temp_without_data;
-psql:include/cagg_refresh_common.sql:288: ERROR:  operation not supported on continuous aggregate
+psql:include/cagg_refresh_common.sql:287: ERROR:  operation not supported on continuous aggregate
 -- These should fail since we do not allow refreshing inside a
 -- transaction, not even as part of CREATE MATERIALIZED VIEW.
 DO LANGUAGE PLPGSQL $$ BEGIN
@@ -474,7 +473,7 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
 END $$;
-psql:include/cagg_refresh_common.sql:300: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
+psql:include/cagg_refresh_common.sql:299: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
 BEGIN;
 CREATE MATERIALIZED VIEW weekly_conditions
 WITH (timescaledb.continuous,
@@ -483,7 +482,7 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-psql:include/cagg_refresh_common.sql:309: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
+psql:include/cagg_refresh_common.sql:308: ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
 COMMIT;
 \set ON_ERROR_STOP 1
 -- This should not fail since we do not refresh the continuous
@@ -516,7 +515,7 @@ DO $$
 BEGIN
   CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
 END; $$;
-psql:include/cagg_refresh_common.sql:346: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:345: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Procedure without subtransaction
 CREATE OR REPLACE PROCEDURE refresh_cagg_proc_normal()
 LANGUAGE PLPGSQL AS
@@ -525,7 +524,7 @@ BEGIN
   CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
 END; $$;
 CALL refresh_cagg_proc_normal();
-psql:include/cagg_refresh_common.sql:356: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
+psql:include/cagg_refresh_common.sql:355: NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 \set ON_ERROR_STOP 0
 -- Procedure with subtransaction
 CREATE OR REPLACE PROCEDURE refresh_cagg_proc_subtransaction()
@@ -540,7 +539,7 @@ EXCEPTION WHEN OTHERS THEN
   RAISE EXCEPTION '%', errmsg;
 END; $$;
 CALL refresh_cagg_proc_subtransaction();
-psql:include/cagg_refresh_common.sql:373: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
+psql:include/cagg_refresh_common.sql:372: ERROR:  refresh_continuous_aggregate() cannot run inside a transaction block
 -- Function
 CREATE OR REPLACE FUNCTION refresh_cagg_fun()
 RETURNS INT LANGUAGE PLPGSQL AS
@@ -550,7 +549,7 @@ BEGIN
   RETURN 1;
 END; $$;
 SELECT * from  refresh_cagg_fun();
-psql:include/cagg_refresh_common.sql:384: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:383: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 -- Dynamic SQL
 DO $$
 BEGIN
@@ -558,7 +557,7 @@ BEGIN
       CALL refresh_continuous_aggregate('daily_temp', '2020-05-03 00:00 UTC', '2020-05-04 00:00 UTC');
   $inner$;
 END; $$;
-psql:include/cagg_refresh_common.sql:392: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:391: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 -- Trigger
 CREATE TABLE refresh_cagg_trigger_table(a int);
 CREATE FUNCTION refresh_cagg_trigger_fun()
@@ -569,14 +568,14 @@ END; $$;
 CREATE TRIGGER refresh_cagg_trigger AFTER INSERT ON refresh_cagg_trigger_table
 EXECUTE FUNCTION refresh_cagg_trigger_fun();
 INSERT INTO refresh_cagg_trigger_table VALUES(1);
-psql:include/cagg_refresh_common.sql:406: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
+psql:include/cagg_refresh_common.sql:405: ERROR:  refresh_continuous_aggregate() cannot be executed from a function
 \set ON_ERROR_STOP 1
 -- check that cagg refresh is not blocked by decompression limit
 CREATE TABLE conditions_decompress_limit (time timestamptz NOT NULL, device text, temp float) WITH (tsdb.hypertable, tsdb.partition_column='time');
 INSERT INTO conditions_decompress_limit SELECT '2020-01-01','d' || i::text, 1.0 FROM generate_series(1,100) g(i);
 CREATE MATERIALIZED VIEW daily_temp_decompress_limit WITH (tsdb.continuous) AS SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp FROM conditions_decompress_limit GROUP BY 1,2 WITH NO DATA;
 ALTER MATERIALIZED VIEW daily_temp_decompress_limit SET (tsdb.columnstore,tsdb.segmentby = 'device');
-psql:include/cagg_refresh_common.sql:414: NOTICE:  defaulting compress_orderby to day
+psql:include/cagg_refresh_common.sql:413: NOTICE:  defaulting compress_orderby to day
 CALL refresh_continuous_aggregate('daily_temp_decompress_limit', NULL, NULL);
 SELECT compress_chunk(show_chunks('daily_temp_decompress_limit'));
               compress_chunk              
@@ -586,6 +585,7 @@ SELECT compress_chunk(show_chunks('daily_temp_decompress_limit'));
 INSERT INTO conditions_decompress_limit SELECT '2020-01-01','d' || i::text, 2.0 FROM generate_series(1,100) g(i);
 SET timescaledb.max_tuples_decompressed_per_dml_transaction TO 1;
 CALL refresh_continuous_aggregate('daily_temp_decompress_limit', NULL, NULL);
+psql:include/cagg_refresh_common.sql:418: NOTICE:  continuous aggregate "daily_temp_decompress_limit" is already up-to-date
 SHOW timescaledb.max_tuples_decompressed_per_dml_transaction;
  timescaledb.max_tuples_decompressed_per_dml_transaction 
 ---------------------------------------------------------

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -88,7 +88,6 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, de
                                   |    FROM device_readings                                                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, device_readings.observation_time)), device_readings.device_id;
 finalized                         | t
-invalidate_using                  | trigger
 
 \x
 -- Refresh interval
@@ -386,7 +385,7 @@ SELECT relname FROM pg_class WHERE oid = :mat_table;
 DROP TABLE whatever;
 -- Check that continuous_agg_invalidation_trigger() handles no arguments properly
 SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
-ERROR:  must supply hypertable id
+ERROR:  function "continuous_agg_invalidation_trigger" was not called by trigger manager
 -- Check that continuous_agg_invalidation_trigger() not crashes when an invalid ht id is used
 CREATE TABLE sensor_data (
 time timestamptz NOT NULL,
@@ -623,7 +622,7 @@ select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
 
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW bad_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM bad
      GROUP BY 1,2;
@@ -640,10 +639,11 @@ SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
 --
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 -- Test the option "invalidate_using". This should create the continuous
 -- aggregate and there should be a replication slot.
 CREATE MATERIALIZED VIEW magic1_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -657,7 +657,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- able to check that the slot remains after one continuous aggregate
 -- has been dropped.
 CREATE MATERIALIZED VIEW magic1_summary2_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -672,52 +672,11 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- the slot stays when we remove all continuous aggregates for a
 -- hypertable.
 CREATE MATERIALIZED VIEW magic2_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic2
      GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
-\set ON_ERROR_STOP 0
--- This should error out since we are using trigger-based collection
--- for "metrics".
-CREATE MATERIALIZED VIEW metrics_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM metrics
-     GROUP BY 1,2;
-ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
--- This should error out since we are using WAL-based collection for
--- "magic".
-CREATE MATERIALIZED VIEW magic1_summary1_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-ERROR:  cannot use trigger-based invalidation collection with hypertable that is using wal-based invalidation collection
--- This should error out because there is no such collection method.
-CREATE MATERIALIZED VIEW magic_summary1_magic
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-ERROR:  unrecognized value "magic" for invalidate_using
--- This should error out since we cannot add the trigger to the
--- hypertable when there are multiple caggs connected. Changing
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic1_summary2_wal
-      SET (timescaledb.invalidate_using = 'trigger');
-ERROR:  cannot change invalidation method for continuous aggregate
-\set ON_ERROR_STOP 1
--- Check that it was actually written to the catalog
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
- hypertable_name |      view_name      | invalidate_using 
------------------+---------------------+------------------
- magic1          | magic1_summary1_wal | wal
- magic1          | magic1_summary2_wal | wal
- magic2          | magic2_summary1_wal | wal
-
 SELECT count(*) FROM pg_replication_slots
  WHERE plugin = :'plugin_name'
    AND database = current_database();
@@ -734,7 +693,7 @@ SELECT count(*) FROM pg_replication_slots
    AND database = current_database();
  count 
 -------
-     1
+     0
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
@@ -745,7 +704,7 @@ SELECT count(*) FROM pg_replication_slots
    AND database = current_database();
  count 
 -------
-     1
+     0
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
@@ -758,39 +717,3 @@ SELECT count(*) FROM pg_replication_slots
 -------
      0
 
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
- hypertable_name | view_name | invalidate_using 
------------------+-----------+------------------
-
--- Check that trigger-based invalidation works as well, and give
--- proper errors when trying to modify them.
-CREATE MATERIALIZED VIEW magic3_day_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-NOTICE:  refreshing continuous aggregate "magic3_day_summary_trigger"
-CREATE MATERIALIZED VIEW magic3_week_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-NOTICE:  refreshing continuous aggregate "magic3_week_summary_trigger"
-\set ON_ERROR_STOP 0
--- This should error out since we already are using trigger-based
--- collection.
-CREATE MATERIALIZED VIEW magic3_week_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
--- This should error out since we cannot remove the trigger from the
--- hypertable when there are multiple caggs connected. Switching
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic3_day_summary_trigger
-      SET (timescaledb.invalidate_using = 'wal');
-ERROR:  cannot change invalidation method for continuous aggregate
-\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -88,7 +88,6 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, ob
                                   |    FROM device_readings                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, observation_time)), device_id;
 finalized                         | t
-invalidate_using                  | trigger
 
 \x
 -- Refresh interval
@@ -386,7 +385,7 @@ SELECT relname FROM pg_class WHERE oid = :mat_table;
 DROP TABLE whatever;
 -- Check that continuous_agg_invalidation_trigger() handles no arguments properly
 SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
-ERROR:  must supply hypertable id
+ERROR:  function "continuous_agg_invalidation_trigger" was not called by trigger manager
 -- Check that continuous_agg_invalidation_trigger() not crashes when an invalid ht id is used
 CREATE TABLE sensor_data (
 time timestamptz NOT NULL,
@@ -623,7 +622,7 @@ select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
 
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW bad_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM bad
      GROUP BY 1,2;
@@ -640,10 +639,11 @@ SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
 --
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 -- Test the option "invalidate_using". This should create the continuous
 -- aggregate and there should be a replication slot.
 CREATE MATERIALIZED VIEW magic1_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -657,7 +657,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- able to check that the slot remains after one continuous aggregate
 -- has been dropped.
 CREATE MATERIALIZED VIEW magic1_summary2_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -672,52 +672,11 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- the slot stays when we remove all continuous aggregates for a
 -- hypertable.
 CREATE MATERIALIZED VIEW magic2_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic2
      GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
-\set ON_ERROR_STOP 0
--- This should error out since we are using trigger-based collection
--- for "metrics".
-CREATE MATERIALIZED VIEW metrics_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM metrics
-     GROUP BY 1,2;
-ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
--- This should error out since we are using WAL-based collection for
--- "magic".
-CREATE MATERIALIZED VIEW magic1_summary1_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-ERROR:  cannot use trigger-based invalidation collection with hypertable that is using wal-based invalidation collection
--- This should error out because there is no such collection method.
-CREATE MATERIALIZED VIEW magic_summary1_magic
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-ERROR:  unrecognized value "magic" for invalidate_using
--- This should error out since we cannot add the trigger to the
--- hypertable when there are multiple caggs connected. Changing
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic1_summary2_wal
-      SET (timescaledb.invalidate_using = 'trigger');
-ERROR:  cannot change invalidation method for continuous aggregate
-\set ON_ERROR_STOP 1
--- Check that it was actually written to the catalog
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
- hypertable_name |      view_name      | invalidate_using 
------------------+---------------------+------------------
- magic1          | magic1_summary1_wal | wal
- magic1          | magic1_summary2_wal | wal
- magic2          | magic2_summary1_wal | wal
-
 SELECT count(*) FROM pg_replication_slots
  WHERE plugin = :'plugin_name'
    AND database = current_database();
@@ -734,7 +693,7 @@ SELECT count(*) FROM pg_replication_slots
    AND database = current_database();
  count 
 -------
-     1
+     0
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
@@ -745,7 +704,7 @@ SELECT count(*) FROM pg_replication_slots
    AND database = current_database();
  count 
 -------
-     1
+     0
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
@@ -758,39 +717,3 @@ SELECT count(*) FROM pg_replication_slots
 -------
      0
 
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
- hypertable_name | view_name | invalidate_using 
------------------+-----------+------------------
-
--- Check that trigger-based invalidation works as well, and give
--- proper errors when trying to modify them.
-CREATE MATERIALIZED VIEW magic3_day_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-NOTICE:  refreshing continuous aggregate "magic3_day_summary_trigger"
-CREATE MATERIALIZED VIEW magic3_week_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-NOTICE:  refreshing continuous aggregate "magic3_week_summary_trigger"
-\set ON_ERROR_STOP 0
--- This should error out since we already are using trigger-based
--- collection.
-CREATE MATERIALIZED VIEW magic3_week_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
--- This should error out since we cannot remove the trigger from the
--- hypertable when there are multiple caggs connected. Switching
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic3_day_summary_trigger
-      SET (timescaledb.invalidate_using = 'wal');
-ERROR:  cannot change invalidation method for continuous aggregate
-\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -88,7 +88,6 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, ob
                                   |    FROM device_readings                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, observation_time)), device_id;
 finalized                         | t
-invalidate_using                  | trigger
 
 \x
 -- Refresh interval
@@ -386,7 +385,7 @@ SELECT relname FROM pg_class WHERE oid = :mat_table;
 DROP TABLE whatever;
 -- Check that continuous_agg_invalidation_trigger() handles no arguments properly
 SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
-ERROR:  must supply hypertable id
+ERROR:  function "continuous_agg_invalidation_trigger" was not called by trigger manager
 -- Check that continuous_agg_invalidation_trigger() not crashes when an invalid ht id is used
 CREATE TABLE sensor_data (
 time timestamptz NOT NULL,
@@ -623,7 +622,7 @@ select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
 
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW bad_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM bad
      GROUP BY 1,2;
@@ -640,10 +639,11 @@ SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
 --
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 -- Test the option "invalidate_using". This should create the continuous
 -- aggregate and there should be a replication slot.
 CREATE MATERIALIZED VIEW magic1_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -657,7 +657,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- able to check that the slot remains after one continuous aggregate
 -- has been dropped.
 CREATE MATERIALIZED VIEW magic1_summary2_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -672,52 +672,11 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- the slot stays when we remove all continuous aggregates for a
 -- hypertable.
 CREATE MATERIALIZED VIEW magic2_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic2
      GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
-\set ON_ERROR_STOP 0
--- This should error out since we are using trigger-based collection
--- for "metrics".
-CREATE MATERIALIZED VIEW metrics_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM metrics
-     GROUP BY 1,2;
-ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
--- This should error out since we are using WAL-based collection for
--- "magic".
-CREATE MATERIALIZED VIEW magic1_summary1_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-ERROR:  cannot use trigger-based invalidation collection with hypertable that is using wal-based invalidation collection
--- This should error out because there is no such collection method.
-CREATE MATERIALIZED VIEW magic_summary1_magic
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-ERROR:  unrecognized value "magic" for invalidate_using
--- This should error out since we cannot add the trigger to the
--- hypertable when there are multiple caggs connected. Changing
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic1_summary2_wal
-      SET (timescaledb.invalidate_using = 'trigger');
-ERROR:  cannot change invalidation method for continuous aggregate
-\set ON_ERROR_STOP 1
--- Check that it was actually written to the catalog
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
- hypertable_name |      view_name      | invalidate_using 
------------------+---------------------+------------------
- magic1          | magic1_summary1_wal | wal
- magic1          | magic1_summary2_wal | wal
- magic2          | magic2_summary1_wal | wal
-
 SELECT count(*) FROM pg_replication_slots
  WHERE plugin = :'plugin_name'
    AND database = current_database();
@@ -734,7 +693,7 @@ SELECT count(*) FROM pg_replication_slots
    AND database = current_database();
  count 
 -------
-     1
+     0
 
 DROP MATERIALIZED VIEW magic1_summary1_wal;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
@@ -745,7 +704,7 @@ SELECT count(*) FROM pg_replication_slots
    AND database = current_database();
  count 
 -------
-     1
+     0
 
 DROP MATERIALIZED VIEW magic1_summary2_wal;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
@@ -758,39 +717,3 @@ SELECT count(*) FROM pg_replication_slots
 -------
      0
 
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
- hypertable_name | view_name | invalidate_using 
------------------+-----------+------------------
-
--- Check that trigger-based invalidation works as well, and give
--- proper errors when trying to modify them.
-CREATE MATERIALIZED VIEW magic3_day_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-NOTICE:  refreshing continuous aggregate "magic3_day_summary_trigger"
-CREATE MATERIALIZED VIEW magic3_week_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-NOTICE:  refreshing continuous aggregate "magic3_week_summary_trigger"
-\set ON_ERROR_STOP 0
--- This should error out since we already are using trigger-based
--- collection.
-CREATE MATERIALIZED VIEW magic3_week_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-ERROR:  cannot use wal-based invalidation collection with hypertable that is using trigger-based invalidation collection
--- This should error out since we cannot remove the trigger from the
--- hypertable when there are multiple caggs connected. Switching
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic3_day_summary_trigger
-      SET (timescaledb.invalidate_using = 'wal');
-ERROR:  cannot change invalidation method for continuous aggregate
-\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-18.out
+++ b/tsl/test/expected/cagg_usage-18.out
@@ -6,6 +6,10 @@
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 SET timezone TO PST8PDT;
+SELECT _timescaledb_functions.invalidation_plugin_name() AS plugin_name \gset
+CREATE VIEW invalidation_slots AS
+SELECT * FROM pg_replication_slots
+ WHERE plugin = :'plugin_name';
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (
@@ -18,7 +22,6 @@ SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
    table_name    
 -----------------
  device_readings
-(1 row)
 
 --Next, create your continuous aggregate view
 CREATE MATERIALIZED VIEW device_summary
@@ -36,7 +39,6 @@ SELECT add_continuous_aggregate_policy('device_summary', NULL, '2 h'::interval, 
  add_continuous_aggregate_policy 
 ---------------------------------
                             1000
-(1 row)
 
 --Next, insert some data into the raw hypertable
 INSERT INTO device_readings
@@ -47,7 +49,6 @@ SELECT ts, 'device_2', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01
 SELECT * FROM device_summary;
  bucket | device_id | metric_avg | metric_spread 
 --------+-----------+------------+---------------
-(0 rows)
 
 -- Simulate a policy that refreshes with lag, i.e., it doesn't refresh
 -- the entire data set. In this case up to the given date.
@@ -66,7 +67,6 @@ SELECT * FROM device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, de
  Sun Dec 30 18:00:00 2018 PST | device_2  | 1546193700 |          1800
  Sun Dec 30 17:00:00 2018 PST | device_1  | 1546190100 |          1800
  Sun Dec 30 17:00:00 2018 PST | device_2  | 1546190100 |          1800
-(10 rows)
 
 --You can view informaton about your continuous aggregates. The meaning of these fields will be explained further down.
 \x
@@ -98,20 +98,17 @@ SELECT schedule_interval FROM _timescaledb_config.bgw_job WHERE id = 1000;
  schedule_interval 
 -------------------
  @ 2 hours
-(1 row)
 
 -- You can change this setting with ALTER VIEW (equivalently, specify in WITH clause of CREATE VIEW)
 SELECT alter_job(1000, schedule_interval := '1h');
                                                                                                                         alter_job                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (1000,"@ 1 hour","@ 0",-1,"@ 2 hours",t,"{""end_offset"": ""@ 2 hours"", ""start_offset"": null, ""mat_hypertable_id"": 2}",-infinity,_timescaledb_functions.policy_refresh_continuous_aggregate_check,f,,,"Refresh Continuous Aggregate Policy [1000]")
-(1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job WHERE id = 1000;
  schedule_interval 
 -------------------
  @ 1 hour
-(1 row)
 
 --
 -- Refresh with lag
@@ -123,26 +120,22 @@ SELECT max(observation_time) FROM device_readings;
              max              
 ------------------------------
  Mon Dec 31 00:00:00 2018 PST
-(1 row)
 
 SELECT max(bucket) FROM device_summary;
              max              
 ------------------------------
  Sun Dec 30 21:00:00 2018 PST
-(1 row)
 
 CALL refresh_continuous_aggregate('device_summary', NULL, '2018-12-31 01:00');
 SELECT max(observation_time) FROM device_readings;
              max              
 ------------------------------
  Mon Dec 31 00:00:00 2018 PST
-(1 row)
 
 SELECT max(bucket) FROM device_summary;
              max              
 ------------------------------
  Mon Dec 31 00:00:00 2018 PST
-(1 row)
 
 --
 -- Invalidations
@@ -153,7 +146,6 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
             bucket            | device_id | metric_avg | metric_spread 
 ------------------------------+-----------+------------+---------------
  Sun Dec 30 13:00:00 2018 PST | device_1  | 1546175700 |          1800
-(1 row)
 
 INSERT INTO device_readings VALUES ('Sun Dec 30 13:01:00 2018 PST', 'device_1', 1.0);
 --Change not reflected before materializer runs.
@@ -161,7 +153,6 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
             bucket            | device_id | metric_avg | metric_spread 
 ------------------------------+-----------+------------+---------------
  Sun Dec 30 13:00:00 2018 PST | device_1  | 1546175700 |          1800
-(1 row)
 
 CALL refresh_continuous_aggregate('device_summary', NULL, NULL);
 --But is reflected after.
@@ -169,7 +160,6 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
             bucket            | device_id |    metric_avg    | metric_spread 
 ------------------------------+-----------+------------------+---------------
  Sun Dec 30 13:00:00 2018 PST | device_1  | 1030783800.33333 |    1546176599
-(1 row)
 
 --
 -- Dealing with timezones
@@ -212,7 +202,6 @@ SELECT min(min_time)::timestamp FROM device_summary;
            min            
 --------------------------
  Sat Dec 01 00:00:00 2018
-(1 row)
 
 -- Option 3: use stable expressions in the cagg definition
 -- in this case it is up to the user to ensure cagg refreshes
@@ -243,17 +232,14 @@ $BODY$
 $BODY$;
 CREATE TABLE device_readings_int(time int, value float);
 SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
-NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
  (6,public,device_readings_int,t)
-(1 row)
 
 SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
  set_integer_now_func 
 ----------------------
  
-(1 row)
 
 CREATE MATERIALIZED VIEW device_readings_mat_only
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -268,7 +254,6 @@ INSERT INTO device_readings_int SELECT i, i*10 FROM generate_series(10,40,10) AS
 SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
  time_bucket | avg 
 -------------+-----
-(0 rows)
 
 -- jit aggregate should have 4 rows
 SELECT * FROM device_readings_jit ORDER BY time_bucket;
@@ -278,7 +263,6 @@ SELECT * FROM device_readings_jit ORDER BY time_bucket;
           20 | 200
           30 | 300
           40 | 400
-(4 rows)
 
 -- simulate a refresh policy with lag, i.e., one that doesn't refresh
 -- up to the latest data. Max value is 40.
@@ -290,7 +274,6 @@ SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
 -------------+-----
           10 | 100
           20 | 200
-(2 rows)
 
 -- jit aggregate should have 4 rows
 SELECT * FROM device_readings_jit ORDER BY time_bucket;
@@ -300,7 +283,6 @@ SELECT * FROM device_readings_jit ORDER BY time_bucket;
           20 | 200
           30 | 300
           40 | 400
-(4 rows)
 
 -- add 2 more rows
 INSERT INTO device_readings_int SELECT i, i*10 FROM generate_series(50,60,10) AS g(i);
@@ -310,7 +292,6 @@ SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
 -------------+-----
           10 | 100
           20 | 200
-(2 rows)
 
 -- jit aggregate should have 6 rows
 SELECT * FROM device_readings_jit ORDER BY time_bucket;
@@ -322,7 +303,6 @@ SELECT * FROM device_readings_jit ORDER BY time_bucket;
           40 | 400
           50 | 500
           60 | 600
-(6 rows)
 
 -- hardcoding now to 100 will lead to 80 watermark
 CREATE OR REPLACE FUNCTION device_readings_int_now()
@@ -343,7 +323,6 @@ SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
           40 | 400
           50 | 500
           60 | 600
-(6 rows)
 
 -- jit aggregate should have 6 rows
 SELECT * FROM device_readings_jit ORDER BY time_bucket;
@@ -355,7 +334,6 @@ SELECT * FROM device_readings_jit ORDER BY time_bucket;
           40 | 400
           50 | 500
           60 | 600
-(6 rows)
 
 -- START OF BASIC USAGE TESTS --
 -- Check that continuous aggregate and materialized table is dropped
@@ -365,7 +343,6 @@ SELECT * FROM create_hypertable('whatever', 'time');
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              9 | public      | whatever   | t
-(1 row)
 
 CREATE MATERIALIZED VIEW whatever_summary WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 hour', time) AS bucket, avg(metric)
@@ -382,7 +359,6 @@ SELECT relname FROM pg_class WHERE oid = :mat_table;
            relname           
 -----------------------------
  _materialized_hypertable_10
-(1 row)
 
 ----------------------------------------------------------------
 -- Should generate an error since the cagg is dependent on the table.
@@ -403,14 +379,13 @@ DROP MATERIALIZED VIEW whatever_summary;
 SELECT relname FROM pg_class WHERE oid = :mat_table;
  relname 
 ---------
-(0 rows)
 
 ----------------------------------------------------------------
 -- Cleanup
 DROP TABLE whatever;
 -- Check that continuous_agg_invalidation_trigger() handles no arguments properly
 SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
-ERROR:  must supply hypertable id
+ERROR:  function "continuous_agg_invalidation_trigger" was not called by trigger manager
 -- Check that continuous_agg_invalidation_trigger() not crashes when an invalid ht id is used
 CREATE TABLE sensor_data (
 time timestamptz NOT NULL,
@@ -433,11 +408,9 @@ DROP TABLE sensor_data;
 -- END OF BASIC USAGE TESTS --
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');
-NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  metrics
-(1 row)
 
 INSERT INTO metrics SELECT generate_series('1999-12-20'::timestamptz,'2000-02-01'::timestamptz,'12 day'::interval), 'dev1', 0.25;
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
@@ -450,7 +423,6 @@ SELECT * FROM cagg1;
  Sat Jan 01 00:00:00 2000 PST
  Thu Jan 13 00:00:00 2000 PST
  Tue Jan 25 00:00:00 2000 PST
-(4 rows)
 
 CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
 SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
@@ -460,7 +432,6 @@ SELECT * FROM cagg2;
 ------------------------------
  Wed Dec 01 00:00:00 1999 PST
  Sat Jan 01 00:00:00 2000 PST
-(2 rows)
 
 -- custom origin with variable size
 CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
@@ -471,7 +442,6 @@ SELECT * FROM cagg3;
 ------------------------------
  Wed Dec 01 00:00:00 1999 PST
  Sat Jan 01 00:00:00 2000 PST
-(2 rows)
 
 -- offset with variable size
 CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
@@ -482,7 +452,6 @@ SELECT * FROM cagg4;
 ------------------------------
  Thu Dec 16 00:00:00 1999 PST
  Sun Jan 16 00:00:00 2000 PST
-(2 rows)
 
 --
 -- drop chunks tests
@@ -500,7 +469,6 @@ ORDER BY 1;
  _hyper_12_19_chunk |            0 | f       |        
  _hyper_12_20_chunk |            0 | f       |        
  _hyper_12_21_chunk |            0 | f       |        
-(4 rows)
 
 -- all caggs in the new format (finalized=true)
 SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
@@ -510,14 +478,12 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
  cagg2          | t
  cagg3          | t
  cagg4          | t
-(4 rows)
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_12_18_chunk
-(1 row)
 
 -- should return 3 chunks
 SELECT
@@ -531,7 +497,6 @@ ORDER BY 1;
  _hyper_12_19_chunk |            0 | f       |        
  _hyper_12_20_chunk |            0 | f       |        
  _hyper_12_21_chunk |            0 | f       |        
-(3 rows)
 
 -- let's update the catalog to fake an old format cagg (finalized=false)
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -545,7 +510,6 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
  cagg2          | t
  cagg3          | t
  cagg4          | t
-(4 rows)
 
 -- cagg1 now is in the old format (finalized=false)
 -- dropping chunk should NOT remove the catalog data
@@ -553,7 +517,6 @@ SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestampt
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_12_19_chunk
-(1 row)
 
 -- should return 3 chunks and one of them should be marked as dropped
 SELECT
@@ -567,7 +530,6 @@ ORDER BY 1;
  _hyper_12_19_chunk |            0 | t       |        
  _hyper_12_20_chunk |            0 | f       |        
  _hyper_12_21_chunk |            0 | f       |        
-(3 rows)
 
 -- remove the fake old format cagg
 DROP MATERIALIZED VIEW cagg1;
@@ -579,14 +541,12 @@ SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE 
  cagg2          | t
  cagg3          | t
  cagg4          | t
-(3 rows)
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_12_20_chunk
-(1 row)
 
 -- should return 2 chunks and one of them should be marked as dropped
 -- because we dropped chunk before when an old format cagg exists
@@ -600,5 +560,160 @@ ORDER BY 1;
 --------------------+--------------+---------+---------
  _hyper_12_19_chunk |            0 | t       |        
  _hyper_12_21_chunk |            0 | f       |        
-(2 rows)
+
+\set ON_ERROR_STOP 1
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+
+CREATE TABLE magic1(time timestamptz not null, device int, value float);
+CREATE TABLE magic2(time timestamptz not null, device int, value float);
+CREATE TABLE magic3(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('magic1','time');
+ table_name 
+------------
+ magic1
+
+SELECT table_name FROM create_hypertable('magic2','time');
+ table_name 
+------------
+ magic2
+
+SELECT table_name FROM create_hypertable('magic3','time');
+ table_name 
+------------
+ magic3
+
+INSERT INTO magic1
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic2
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+INSERT INTO magic3
+SELECT generate_series('1999-12-20'::timestamptz, '2000-02-01'::timestamptz, '12 day'::interval),
+       (100 * random())::int,
+       100 * random();
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+
+-- Creating a materialized view with a failure between adding the slot
+-- and finishing adding the slot should not leave a slot around.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE bad(time timestamptz not null, device int, value float);
+SELECT table_name FROM create_hypertable('bad','time');
+ table_name 
+------------
+ bad
+
+-- We create such an error by setting the hypertable id sequence
+-- number to an already existing one, which will generate an error
+-- when adding the new hypertable data to the catalog.
+select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
+select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
+ setval 
+--------
+     19
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW bad_summary_wal
+  WITH (timescaledb.continuous)
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM bad
+     GROUP BY 1,2;
+ERROR:  duplicate key value violates unique constraint "hypertable_pkey"
+\set ON_ERROR_STOP 1
+-- There should be no replication slot around.
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     0
+
+-- Advance the sequence again to consume the value we set before.
+SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
+--
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
+-- Test the option "invalidate_using". This should create the continuous
+-- aggregate and there should be a replication slot.
+CREATE MATERIALIZED VIEW magic1_summary1_wal
+  WITH (timescaledb.continuous)
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary1_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+
+-- Create another continuous aggregate on the same hypertable to be
+-- able to check that the slot remains after one continuous aggregate
+-- has been dropped.
+CREATE MATERIALIZED VIEW magic1_summary2_wal
+  WITH (timescaledb.continuous)
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic1
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic1_summary2_wal"
+SELECT count(*) FROM invalidation_slots WHERE database = current_database();
+ count 
+-------
+     1
+
+-- Create another continuous aggregate on a different hypertable that
+-- uses WAL-based invalidation collection. This is used to check that
+-- the slot stays when we remove all continuous aggregates for a
+-- hypertable.
+CREATE MATERIALIZED VIEW magic2_summary1_wal
+  WITH (timescaledb.continuous)
+    AS SELECT time_bucket('1 day', time), device, avg(value)
+         FROM magic2
+     GROUP BY 1,2;
+NOTICE:  refreshing continuous aggregate "magic2_summary1_wal"
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = :'plugin_name'
+   AND database = current_database();
+ count 
+-------
+     1
+
+DROP MATERIALIZED VIEW magic2_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_40_chunk
+-- Slot should be there. We have another hypertable using WAL-based
+-- invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = :'plugin_name'
+   AND database = current_database();
+ count 
+-------
+     0
+
+DROP MATERIALIZED VIEW magic1_summary1_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_38_chunk
+-- Slot should be there. We have yet another continuous aggregate for
+-- the hypertable using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = :'plugin_name'
+   AND database = current_database();
+ count 
+-------
+     0
+
+DROP MATERIALIZED VIEW magic1_summary2_wal;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_39_chunk
+-- Now slot should be gone and we should not have any continuous
+-- aggregates using WAL-based invalidation collection.
+SELECT count(*) FROM pg_replication_slots
+ WHERE plugin = :'plugin_name'
+   AND database = current_database();
+ count 
+-------
+     0
 

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -2091,7 +2091,6 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, con
                                   |    FROM conditions                                                  +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, conditions.timec));
 finalized                         | t
-invalidate_using                  | trigger
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -2091,7 +2091,6 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, tim
                                   |    FROM conditions                                       +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, timec));
 finalized                         | t
-invalidate_using                  | trigger
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -2091,7 +2091,6 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, tim
                                   |    FROM conditions                                       +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, timec));
 finalized                         | t
-invalidate_using                  | trigger
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs-18.out
+++ b/tsl/test/expected/continuous_aggs-18.out
@@ -16,17 +16,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_config.bgw_job;
  id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
 ----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
-(0 rows)
 
 --TEST1 ---
 --basic test with count
 create table foo (a integer, b integer, c integer);
 select table_name from create_hypertable('foo', 'a', chunk_time_interval=> 10);
-NOTICE:  adding not-null constraint to column "a"
  table_name 
 ------------
  foo
-(1 row)
 
 insert into foo values( 3 , 16 , 20);
 insert into foo values( 1 , 10 , 20);
@@ -42,7 +39,6 @@ SELECT set_integer_now_func('foo', 'integer_now_foo');
  set_integer_now_func 
 ----------------------
  
-(1 row)
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -56,7 +52,6 @@ SELECT * FROM _timescaledb_config.bgw_job;
   id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |       owner       | scheduled | fixed_schedule | initial_start | hypertable_id |                             config                              |      check_schema      |                check_name                 | timezone 
 ------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+-------------------+-----------+----------------+---------------+---------------+-----------------------------------------------------------------+------------------------+-------------------------------------------+----------
  1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_functions | policy_refresh_continuous_aggregate | default_perm_user | t         | f              |               |             2 | {"end_offset": 2, "start_offset": null, "mat_hypertable_id": 2} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
-(1 row)
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -78,7 +73,6 @@ select * from mat_m1 order by a ;
  1 |      5
  2 |      3
  3 |      1
-(3 rows)
 
 --check triggers on user hypertable --
 SET ROLE :ROLE_SUPERUSER;
@@ -89,7 +83,6 @@ order by tgname;
 ------------------------------+--------+-----------+---------
  ts_cagg_invalidation_trigger |     29 | O         | foo
  ts_insert_blocker            |      7 | O         | foo
-(2 rows)
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- TEST2 ---
@@ -99,13 +92,11 @@ SHOW enable_partitionwise_aggregate;
  enable_partitionwise_aggregate 
 --------------------------------
  off
-(1 row)
 
 SET enable_partitionwise_aggregate = on;
 SELECT * FROM _timescaledb_config.bgw_job;
  id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
 ----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
-(0 rows)
 
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
@@ -117,7 +108,6 @@ select table_name from create_hypertable( 'conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 insert into conditions values ( '2010-01-01 09:00:00-08', 'SFO', 55, 45);
 insert into conditions values ( '2010-01-02 09:00:00-08', 'por', 100, 100);
@@ -155,7 +145,6 @@ FROM timescaledb_information.hypertables ORDER BY 1,2;
 -------------------+-----------------
  public            | conditions
  public            | foo
-(2 rows)
 
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
@@ -174,7 +163,6 @@ order by timec;
  Fri Jan 01 16:00:00 2010 PST | NYC  |  230 |  190
  Wed Oct 31 17:00:00 2018 PDT | NYC  |   45 |   35
  Thu Nov 01 17:00:00 2018 PDT | NYC  |   35 |   15
-(4 rows)
 
 select time_bucket('1day', timec), min(location), sum(temperature), sum(humidity)
 from conditions
@@ -186,7 +174,6 @@ order by 1;
  Fri Jan 01 16:00:00 2010 PST | NYC | 230 | 190
  Wed Oct 31 17:00:00 2018 PDT | NYC |  45 |  35
  Thu Nov 01 17:00:00 2018 PDT | NYC |  35 |  15
-(4 rows)
 
 SET enable_partitionwise_aggregate = off;
 -- TEST3 --
@@ -204,7 +191,6 @@ select table_name from create_hypertable( 'conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 insert into conditions values ( '2010-01-01 09:00:00-08', 'SFO', 55, 45);
 insert into conditions values ( '2010-01-02 09:00:00-08', 'por', 100, 100);
@@ -247,7 +233,6 @@ order by timec;
  Sun Dec 27 16:00:00 2009 PST | NYC  |   620 | 23.8746727726266
  Sun Jan 03 16:00:00 2010 PST | SFO  |   175 |                 
  Sun Oct 28 17:00:00 2018 PDT | NYC  |   190 |               10
-(3 rows)
 
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+ sum(humidity), stddev(humidity)
@@ -259,7 +244,6 @@ order by time_bucket('1week', timec);
  Sun Dec 27 16:00:00 2009 PST | NYC |      620 | 23.8746727726266
  Sun Jan 03 16:00:00 2010 PST | SFO |      175 |                 
  Sun Oct 28 17:00:00 2018 PDT | NYC |      190 |               10
-(3 rows)
 
 -- TEST4 --
 --materialized view with group by clause + expression in SELECT
@@ -303,7 +287,6 @@ order by timec;
 ------------------------------+------+-------+------------------
  Sun Dec 27 16:00:00 2009 PST | NYC  |   210 | 7.07106781186548
  Sun Oct 28 17:00:00 2018 PDT | NYC  |   190 |               10
-(2 rows)
 
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+ sum(humidity), stddev(humidity)
@@ -315,7 +298,6 @@ order by time_bucket('1week', timec);
 ------------------------------+-----+----------+------------------
  Sun Dec 27 16:00:00 2009 PST | NYC |      210 | 7.07106781186548
  Sun Oct 28 17:00:00 2018 PDT | NYC |      190 |               10
-(2 rows)
 
 -- TEST5 --
 ---------test with having clause ----------------------
@@ -354,7 +336,6 @@ order by sumth;
 ------------------------------+------+-------+------------------
  Sun Oct 28 17:00:00 2018 PDT | NYC  |   190 |               10
  Sun Dec 27 16:00:00 2009 PST | NYC  |   620 | 23.8746727726266
-(2 rows)
 
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -366,7 +347,6 @@ order by sum(temperature)+sum(humidity);
 ------------------------------+-----+----------+------------------
  Sun Oct 28 17:00:00 2018 PDT | NYC |      190 |               10
  Sun Dec 27 16:00:00 2009 PST | NYC |      620 | 23.8746727726266
-(2 rows)
 
 -- TEST6 --
 --group by with more than 1 group column
@@ -386,7 +366,6 @@ select table_name from create_hypertable( 'conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 55, 75, 40, 70;
@@ -421,7 +400,6 @@ order by attnum, attname;
       2 | loc
       3 | sumth
       4 | stddev
-(4 rows)
 
 DROP MATERIALIZED VIEW mat_naming;
 --naming with default names
@@ -451,7 +429,6 @@ order by attnum, attname;
       2 | location
       3 | sumth
       4 | stddev
-(4 rows)
 
 DROP MATERIALIZED VIEW mat_naming;
 --naming with view col names
@@ -481,7 +458,6 @@ order by attnum, attname;
       2 | loc
       3 | sum_t_h
       4 | stdd
-(4 rows)
 
 DROP MATERIALIZED VIEW mat_naming;
 CREATE MATERIALIZED VIEW mat_m1(timec, minl, sumth, stddevh)
@@ -511,7 +487,6 @@ order by attnum, attname;
       2 | minl
       3 | sumth
       4 | stddevh
-(4 rows)
 
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
@@ -530,7 +505,6 @@ order by timec, minl;
  Sun Dec 16 16:00:00 2018 PST | NYC  |  1470 | 15.5662356498831
  Sun Dec 23 16:00:00 2018 PST | NYC  |  1470 | 15.5662356498831
  Sun Dec 30 16:00:00 2018 PST | NYC  |   210 | 21.2132034355964
-(3 rows)
 
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -543,7 +517,6 @@ order by time_bucket('1week', timec), min(location);
  Sun Dec 16 16:00:00 2018 PST | NYC |     1470 | 15.5662356498831
  Sun Dec 23 16:00:00 2018 PST | NYC |     1470 | 15.5662356498831
  Sun Dec 30 16:00:00 2018 PST | NYC |      210 | 21.2132034355964
-(3 rows)
 
 --check view defintion in information views
 select view_name, view_definition from timescaledb_information.continuous_aggregates
@@ -557,7 +530,6 @@ where view_name::text like 'mat_m1';
            |    FROM conditions                                                                       +
            |   GROUP BY (time_bucket('@ 7 days'::interval, timec))                                    +
            |  HAVING ((min(location) >= 'NYC'::text) AND (avg(temperature) > (20)::double precision));
-(1 row)
 
 --TEST6 -- select from internal view
 SET ROLE :ROLE_SUPERUSER;
@@ -581,7 +553,6 @@ select table_name from create_hypertable( 'conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 55, 75, 40, 70, NULL;
@@ -603,7 +574,6 @@ psql:include/cont_agg_equal.sql:8: NOTICE:  materialized view "mat_test" does no
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
-(1 row)
 
 SELECT
   $$
@@ -618,7 +588,6 @@ psql:include/cont_agg_equal.sql:8: NOTICE:  drop cascades to table _timescaledb_
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
-(1 row)
 
 --TEST7 -- drop tests for view and hypertable
 --DROP tests
@@ -647,32 +616,27 @@ WHERE user_view_name = 'mat_test';
  count 
 -------
      1
-(1 row)
 
 --mat table, user_view, direct view and partial view all there
 select count(*) from pg_class where relname = :'PART_VIEW_NAME';
  count 
 -------
      1
-(1 row)
 
 select count(*) from pg_class where relname = :'MAT_TABLE_NAME';
  count 
 -------
      1
-(1 row)
 
 select count(*) from pg_class where relname = :'DIR_VIEW_NAME';
  count 
 -------
      1
-(1 row)
 
 select count(*) from pg_class where relname = 'mat_test';
  count 
 -------
      1
-(1 row)
 
 DROP MATERIALIZED VIEW mat_test;
 NOTICE:  drop cascades to 2 other objects
@@ -683,32 +647,27 @@ WHERE user_view_name = 'mat_test';
  count 
 -------
      0
-(1 row)
 
 --mat table, user_view, direct view and partial view all gone
 select count(*) from pg_class where relname = :'PART_VIEW_NAME';
  count 
 -------
      0
-(1 row)
 
 select count(*) from pg_class where relname = :'MAT_TABLE_NAME';
  count 
 -------
      0
-(1 row)
 
 select count(*) from pg_class where relname = :'DIR_VIEW_NAME';
  count 
 -------
      0
-(1 row)
 
 select count(*) from pg_class where relname = 'mat_test';
  count 
 -------
      0
-(1 row)
 
 --test dropping raw table
 DROP TABLE conditions;
@@ -725,7 +684,6 @@ select table_name from create_hypertable( 'conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 --no data in hyper table on purpose so that CASCADE is not required because of chunks
 CREATE MATERIALIZED VIEW mat_drop_test(timec, minl, sumt , sumh)
@@ -763,13 +721,11 @@ select count(*) from _timescaledb_catalog.continuous_aggs_invalidation_threshold
  count 
 -------
      1
-(1 row)
 
 select count(*) from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
  count 
 -------
      1
-(1 row)
 
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -781,49 +737,41 @@ WHERE user_view_name = 'mat_drop_test';
  count 
 -------
      0
-(1 row)
 
 select count(*) from _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  count 
 -------
      0
-(1 row)
 
 select count(*) from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
  count 
 -------
      0
-(1 row)
 
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
  count 
 -------
      0
-(1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job;
  id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
 ----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
-(0 rows)
 
 --mat table, user_view, and partial view all gone
 select count(*) from pg_class where relname = :'PART_VIEW_NAME';
  count 
 -------
      0
-(1 row)
 
 select count(*) from pg_class where relname = :'MAT_TABLE_NAME';
  count 
 -------
      0
-(1 row)
 
 select count(*) from pg_class where relname = 'mat_drop_test';
  count 
 -------
      0
-(1 row)
 
 --TEST With options
 CREATE TABLE conditions (
@@ -839,7 +787,6 @@ select table_name from create_hypertable( 'conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous,
@@ -852,31 +799,26 @@ SELECT add_continuous_aggregate_policy('mat_with_test', NULL, '5 h'::interval, '
  add_continuous_aggregate_policy 
 ---------------------------------
                             1001
-(1 row)
 
 SELECT alter_job(id, schedule_interval => '1h') FROM _timescaledb_config.bgw_job;
                                                                                                                          alter_job                                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (1001,"@ 1 hour","@ 0",-1,"@ 12 hours",t,"{""end_offset"": ""@ 5 hours"", ""start_offset"": null, ""mat_hypertable_id"": 20}",-infinity,_timescaledb_functions.policy_refresh_continuous_aggregate_check,f,,,"Refresh Continuous Aggregate Policy [1001]")
-(1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
  schedule_interval 
 -------------------
  @ 1 hour
-(1 row)
 
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
                                                                                                                           alter_job                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (1001,"@ 2 hours","@ 0",-1,"@ 12 hours",t,"{""end_offset"": ""@ 5 hours"", ""start_offset"": null, ""mat_hypertable_id"": 20}",-infinity,_timescaledb_functions.policy_refresh_continuous_aggregate_check,f,,,"Refresh Continuous Aggregate Policy [1001]")
-(1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
  schedule_interval 
 -------------------
  @ 2 hours
-(1 row)
 
 select indexname, indexdef from pg_indexes where tablename =
 (SELECT h.table_name
@@ -887,7 +829,6 @@ order by indexname;
                indexname               |                                                             indexdef                                                             
 ---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------
  _materialized_hypertable_20_timec_idx | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
-(1 row)
 
 DROP MATERIALIZED VIEW mat_with_test;
 --no additional indexes
@@ -907,7 +848,6 @@ WHERE user_view_name = 'mat_with_test');
                indexname               |                                                             indexdef                                                             
 ---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------
  _materialized_hypertable_21_timec_idx | CREATE INDEX _materialized_hypertable_21_timec_idx ON _timescaledb_internal._materialized_hypertable_21 USING btree (timec DESC)
-(1 row)
 
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -925,14 +865,12 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  table_name 
 ------------
  conditions
-(1 row)
 
 CREATE OR REPLACE FUNCTION integer_now_conditions() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
 SELECT set_integer_now_func('conditions', 'integer_now_conditions');
  set_integer_now_func 
 ----------------------
  
-(1 row)
 
 CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous,
@@ -945,19 +883,16 @@ SELECT add_continuous_aggregate_policy('mat_with_test', NULL, 500::integer, '12 
  add_continuous_aggregate_policy 
 ---------------------------------
                             1002
-(1 row)
 
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
                                                                                                                      alter_job                                                                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (1002,"@ 2 hours","@ 0",-1,"@ 12 hours",t,"{""end_offset"": 500, ""start_offset"": null, ""mat_hypertable_id"": 23}",-infinity,_timescaledb_functions.policy_refresh_continuous_aggregate_check,f,,,"Refresh Continuous Aggregate Policy [1002]")
-(1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
  schedule_interval 
 -------------------
  @ 2 hours
-(1 row)
 
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -973,18 +908,15 @@ SELECT create_hypertable(
     chunk_time_interval => 10,
     partitioning_column => 'dev',
     number_partitions => 3);
-NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (24,public,space_table,t)
-(1 row)
 
 CREATE OR REPLACE FUNCTION integer_now_space_table() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), BIGINT '0') FROM space_table $$;
 SELECT set_integer_now_func('space_table', 'integer_now_space_table');
  set_integer_now_func 
 ----------------------
  
-(1 row)
 
 CREATE MATERIALIZED VIEW space_view
 WITH (timescaledb.continuous,
@@ -1009,7 +941,6 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
  time_bucket | count 
 -------------+-------
-(0 rows)
 
 CALL refresh_continuous_aggregate('space_view', NULL, NULL);
 SELECT * FROM space_view ORDER BY 1;
@@ -1017,7 +948,6 @@ SELECT * FROM space_view ORDER BY 1;
 -------------+-------
            0 |     4
            8 |     4
-(2 rows)
 
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
@@ -1025,7 +955,6 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 -------------+-------
            0 |     4
            8 |     4
-(2 rows)
 
 INSERT INTO space_table VALUES (3, 2, 1);
 CALL refresh_continuous_aggregate('space_view', NULL, NULL);
@@ -1034,7 +963,6 @@ SELECT * FROM space_view ORDER BY 1;
 -------------+-------
            0 |     5
            8 |     4
-(2 rows)
 
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
@@ -1042,7 +970,6 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 -------------+-------
            0 |     5
            8 |     4
-(2 rows)
 
 INSERT INTO space_table VALUES (2, 3, 1);
 CALL refresh_continuous_aggregate('space_view', NULL, NULL);
@@ -1051,7 +978,6 @@ SELECT * FROM space_view ORDER BY 1;
 -------------+-------
            0 |     6
            8 |     4
-(2 rows)
 
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
@@ -1059,7 +985,6 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 -------------+-------
            0 |     6
            8 |     4
-(2 rows)
 
 DROP TABLE space_table CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -1104,14 +1029,12 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  table_name 
 ------------
  conditions
-(1 row)
 
 CREATE OR REPLACE FUNCTION integer_now_conditions() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
 SELECT set_integer_now_func('conditions', 'integer_now_conditions');
  set_integer_now_func 
 ----------------------
  
-(1 row)
 
 insert into conditions
 select generate_series(0, 200, 10), 'POR', 55, 75, 40, 70, NULL;
@@ -1131,7 +1054,6 @@ SELECT * FROM mat_ffunc_test ORDER BY time_bucket;
            0 | 
          100 | 
          200 | 
-(3 rows)
 
 DROP MATERIALIZED view mat_ffunc_test;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_65_chunk
@@ -1151,7 +1073,6 @@ SELECT * FROM mat_ffunc_test ORDER BY time_bucket;
            0 |                              
          100 |                              
          200 |                              
-(3 rows)
 
 --refresh mat view test when time_bucket is not projected --
 DROP MATERIALIZED VIEW mat_ffunc_test;
@@ -1172,7 +1093,6 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
  POR      |  75
  POR      |  75
  POR      |  75
-(4 rows)
 
 -- test for bug when group by is not in project list
 CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false) as
@@ -1187,7 +1107,6 @@ select * from conditions_grpby_view order by 1, 2;
            0 | 750
          100 | 750
          200 |  75
-(4 rows)
 
 CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec), sum(humidity)
@@ -1202,14 +1121,12 @@ select * from conditions_grpby_view2 order by 1, 2;
            0 | 750
          100 | 750
          200 |  75
-(4 rows)
 
 -- Test internal functions for continuous aggregates
 SELECT test.continuous_aggs_find_view('mat_refresh_test');
  continuous_aggs_find_view 
 ---------------------------
  
-(1 row)
 
 -- Test pseudotype/enum handling
 CREATE TYPE status_enum AS ENUM (
@@ -1230,7 +1147,6 @@ FROM
  table_name 
 ------------
  cagg_types
-(1 row)
 
 INSERT INTO cagg_types
 SELECT
@@ -1255,7 +1171,6 @@ SELECT * FROM mat_types;
          time_bucket          | status |     names     |  floats   
 ------------------------------+--------+---------------+-----------
  Fri Dec 31 16:00:00 1999 PST | yellow | {foo,bar,baz} | {1,2.5,3}
-(1 row)
 
 -------------------------------------------------------------------------------------
 -- Test issue #2616 where cagg view contains an experssion with several aggregates in
@@ -1270,7 +1185,6 @@ WARNING:  column type "timestamp without time zone" used for "timestamp" does no
         create_hypertable        
 ---------------------------------
  (34,public,water_consumption,t)
-(1 row)
 
 INSERT INTO public.water_consumption (sensor_id, timestamp, water_index) VALUES
   (1, '2010-11-03 09:42:30', 1030),
@@ -1304,7 +1218,6 @@ SELECT * FROM water_consumption_aggregation_minute ORDER BY water_consumption;
          1 | Wed Nov 03 09:46:00 2010 |                 7
          1 | Wed Nov 03 09:45:00 2010 |                 8
          1 | Wed Nov 03 09:44:00 2010 |                10
-(4 rows)
 
 SELECT sensor_id,
        time_bucket(INTERVAL '1 minute', timestamp) + '1 minute' AS timestamp,
@@ -1318,7 +1231,6 @@ ORDER BY water_consumption;
          1 | Wed Nov 03 09:46:00 2010 |                 7
          1 | Wed Nov 03 09:45:00 2010 |                 8
          1 | Wed Nov 03 09:44:00 2010 |                10
-(4 rows)
 
 -- Simplified test, where the view doesn't contain all group by clauses
 CREATE MATERIALIZED VIEW water_consumption_no_select_bucket
@@ -1338,7 +1250,6 @@ SELECT * FROM water_consumption_no_select_bucket ORDER BY water_consumption;
          1 |                 7
          1 |                 8
          1 |                10
-(4 rows)
 
 SELECT sensor_id,
        (max(water_index) - min(water_index))                    AS water_consumption
@@ -1351,7 +1262,6 @@ ORDER BY water_consumption;
          1 |                 7
          1 |                 8
          1 |                10
-(4 rows)
 
 -- The test with SELECT matching GROUP BY and placing aggregate expression not the last
 CREATE MATERIALIZED VIEW water_consumption_aggregation_no_addition
@@ -1372,7 +1282,6 @@ SELECT * FROM water_consumption_aggregation_no_addition ORDER BY water_consumpti
          1 |                 7 | Wed Nov 03 09:45:00 2010
          1 |                 8 | Wed Nov 03 09:44:00 2010
          1 |                10 | Wed Nov 03 09:43:00 2010
-(4 rows)
 
 SELECT sensor_id,
        (max(water_index) - min(water_index))                    AS water_consumption,
@@ -1386,7 +1295,6 @@ ORDER BY water_consumption;
          1 |                 7 | Wed Nov 03 09:45:00 2010
          1 |                 8 | Wed Nov 03 09:44:00 2010
          1 |                10 | Wed Nov 03 09:43:00 2010
-(4 rows)
 
 DROP TABLE water_consumption CASCADE;
 NOTICE:  drop cascades to 6 other objects
@@ -1397,11 +1305,9 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_37_75_chunk
 --- github issue 2655 ---
 create table raw_data(time timestamptz, search_query text, cnt integer, cnt2 integer);
 select create_hypertable('raw_data','time', chunk_time_interval=>'15 days'::interval);
-NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (38,public,raw_data,t)
-(1 row)
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
@@ -1445,7 +1351,6 @@ SELECT * FROM search_query_count_1m ORDER BY 1, 2;
 --------------+-------+------------------------------
  Q1           |     3 | Fri Dec 31 16:00:00 1999 PST
  Q2           |     2 | Sat Jan 01 16:00:00 2000 PST
-(2 rows)
 
 --only 1 of these should appear in the result
 insert into raw_data select '2000-01-02 00:00+0','Q3', 0, 0;
@@ -1457,7 +1362,6 @@ SELECT * FROM search_query_count_1m ORDER BY 1, 2;
  Q1           |     3 | Fri Dec 31 16:00:00 1999 PST
  Q2           |     2 | Sat Jan 01 16:00:00 2000 PST
  Q4           |     1 | Sun Jan 02 16:00:00 2000 PST
-(3 rows)
 
 --refresh search_query_count_2---
 CALL refresh_continuous_aggregate('search_query_count_2', NULL, NULL);
@@ -1467,7 +1371,6 @@ SELECT * FROM search_query_count_2 ORDER BY 1, 2;
  Q1           |     3 |   6 | Fri Dec 31 16:00:00 1999 PST
  Q2           |     2 |  30 | Sat Jan 01 16:00:00 2000 PST
  Q4           |     1 |  20 | Sun Jan 02 16:00:00 2000 PST
-(3 rows)
 
 --refresh search_query_count_3---
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, NULL);
@@ -1480,7 +1383,6 @@ SELECT * FROM search_query_count_3 ORDER BY 1, 2, 3;
  Q2           |     1 |  10 | Sat Jan 01 16:00:00 2000 PST
  Q2           |     1 |  20 | Sat Jan 01 16:00:00 2000 PST
  Q4           |     1 |  20 | Sun Jan 02 16:00:00 2000 PST
-(6 rows)
 
 --- TEST enable compression on continuous aggregates
 CREATE VIEW cagg_compression_status as
@@ -1505,7 +1407,6 @@ FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
 ----------------------+-----------------------------
  search_query_count_3 | _materialized_hypertable_41
-(1 row)
 
 \x
 SELECT * FROM timescaledb_information.compression_settings
@@ -1533,7 +1434,6 @@ FROM show_chunks('search_query_count_3') ch;
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_41_79_chunk
-(1 row)
 
 SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
  search_query | count | sum |            bucket            
@@ -1544,7 +1444,6 @@ SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
  Q2           |     1 |  10 | Sat Jan 01 16:00:00 2000 PST
  Q2           |     1 |  20 | Sat Jan 01 16:00:00 2000 PST
  Q4           |     1 |  20 | Sun Jan 02 16:00:00 2000 PST
-(6 rows)
 
 -- insert into a new region of the hypertable and then refresh the cagg
 -- (note we still do not support refreshes into existing regions.
@@ -1567,7 +1466,6 @@ SELECT _timescaledb_functions.to_timestamp(w) FROM _timescaledb_functions.cagg_w
          to_timestamp         
 ------------------------------
  Wed May 09 17:01:00 2001 PDT
-(1 row)
 
 SELECT chunk_name, range_start, range_end, is_compressed
 FROM timescaledb_information.chunks
@@ -1577,7 +1475,6 @@ ORDER BY 1;
 --------------------+------------------------------+------------------------------+---------------
  _hyper_41_79_chunk | Fri Dec 24 16:00:00 1999 PST | Mon May 22 17:00:00 2000 PDT | t
  _hyper_41_83_chunk | Sun Mar 18 16:00:00 2001 PST | Wed Aug 15 17:00:00 2001 PDT | f
-(2 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
@@ -1586,7 +1483,6 @@ WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
                  41 |  -9223372036854775808 |     -210866803200000001
                  41 |       959817600000000 |         988675199999999
                  41 |       991353600000000 |     9223372036854775807
-(3 rows)
 
 SELECT * from search_query_count_3
 WHERE bucket > '2001-01-01'
@@ -1594,7 +1490,6 @@ ORDER BY 1, 2, 3;
  search_query | count | sum |            bucket            
 --------------+-------+-----+------------------------------
  Q3           |     1 | 100 | Wed May 09 17:00:00 2001 PDT
-(1 row)
 
 --now disable compression , will error out --
 \set ON_ERROR_STOP 0
@@ -1607,7 +1502,6 @@ WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             
 ------------------------------------------
  _timescaledb_internal._hyper_41_79_chunk
-(1 row)
 
 --disable compression on cagg after decompressing all chunks--
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
@@ -1616,7 +1510,6 @@ FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
 ----------------------+-----------------------------
  search_query_count_3 | _materialized_hypertable_41
-(1 row)
 
 SELECT view_name, materialized_only, compression_enabled
 FROM timescaledb_information.continuous_aggregates
@@ -1624,7 +1517,6 @@ where view_name = 'search_query_count_3';
       view_name       | materialized_only | compression_enabled 
 ----------------------+-------------------+---------------------
  search_query_count_3 | f                 | f
-(1 row)
 
 -- TEST caggs on table with more columns than in the cagg view defn --
 CREATE TABLE test_morecols ( time TIMESTAMPTZ NOT NULL,
@@ -1634,7 +1526,6 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
       create_hypertable      
 -----------------------------
  (43,public,test_morecols,t)
-(1 row)
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
@@ -1648,14 +1539,12 @@ SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_44_89_chunk
-(1 row)
 
 SELECT * FROM test_morecols_cagg ORDER BY time_bucket;
          time_bucket          |         avg         | count 
 ------------------------------+---------------------+-------
  Fri Nov 23 16:00:00 2018 PST | 55.0000000000000000 |    23
  Sun Dec 23 16:00:00 2018 PST | 55.0000000000000000 |     8
-(2 rows)
 
 SELECT view_name, materialized_only, compression_enabled
 FROM timescaledb_information.continuous_aggregates
@@ -1663,7 +1552,6 @@ where view_name = 'test_morecols_cagg';
      view_name      | materialized_only | compression_enabled 
 --------------------+-------------------+---------------------
  test_morecols_cagg | f                 | t
-(1 row)
 
 --should keep compressed option, modify only materialized --
 ALTER MATERIALIZED VIEW test_morecols_cagg SET (timescaledb.materialized_only='true');
@@ -1673,7 +1561,6 @@ where view_name = 'test_morecols_cagg';
      view_name      | materialized_only | compression_enabled 
 --------------------+-------------------+---------------------
  test_morecols_cagg | t                 | t
-(1 row)
 
 CREATE TABLE issue3248(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON issue3248(time DESC);
@@ -1682,7 +1569,6 @@ SELECT create_hypertable('issue3248','time',create_default_indexes:=false);
     create_hypertable    
 -------------------------
  (46,public,issue3248,t)
-(1 row)
 
 ALTER TABLE issue3248 DROP COLUMN filler_1;
 INSERT INTO issue3248(time,device_id,v0,v1,v2,v3)
@@ -1708,7 +1594,6 @@ SELECT
   FROM issue3248 AS m,
        LATERAL(SELECT m FROM issue3248_cagg WHERE avg IS NULL LIMIT 1) AS lat;
 --
-(0 rows)
 
 -- test that option create_group_indexes is taken into account
 CREATE TABLE test_group_idx (
@@ -1717,11 +1602,9 @@ symbol int,
 value numeric
 );
 select create_hypertable('test_group_idx', 'time');
-NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (48,public,test_group_idx,t)
-(1 row)
 
 insert into test_group_idx
 select t, round(random()*10), random()*5
@@ -1761,7 +1644,6 @@ where view_name like 'cagg_index_%' ORDER BY view_name;
  cagg_index_default | _materialized_hypertable_51
  cagg_index_false   | _materialized_hypertable_50
  cagg_index_true    | _materialized_hypertable_49
-(3 rows)
 
 -- now make sure a group index has been created when explicitly asked for
 \x on
@@ -1772,7 +1654,7 @@ join pg_class c
     and tablename = relname
 where tablename in (select materialization_hypertable_name from timescaledb_information.continuous_aggregates
 where view_name like 'cagg_index_%')
-order by tablename;
+order by tablename, indexname;
 -[ RECORD 1 ]-------------------------------------------------------------------------------------------------------------------------------------------------
 schemaname | _timescaledb_internal
 tablename  | _materialized_hypertable_49
@@ -1823,7 +1705,6 @@ SELECT create_hypertable('conditions', 'timec');
     create_hypertable     
 --------------------------
  (52,public,conditions,t)
-(1 row)
 
 INSERT INTO conditions
 VALUES
@@ -1854,7 +1735,6 @@ SELECT * FROM mat_m1 ORDER BY 1, 2, 3;
  Sun Dec 27 16:00:00 2009 PST |     2 | 120
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
  Sun Oct 28 17:00:00 2018 PDT |     3 |  80
-(5 rows)
 
 -- aggregate with FILTER
 DROP MATERIALIZED VIEW mat_m1;
@@ -1875,7 +1755,6 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
  Sun Dec 27 16:00:00 2009 PST |    
  Sun Jan 03 16:00:00 2010 PST |  75
  Sun Oct 28 17:00:00 2018 PDT |    
-(5 rows)
 
 -- aggregate with filter in having clause
 DROP MATERIALIZED VIEW mat_m1;
@@ -1896,7 +1775,6 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
  Sun Dec 27 16:00:00 2009 PST |  65
  Sun Dec 27 16:00:00 2009 PST | 100
  Sun Jan 03 16:00:00 2010 PST |  75
-(4 rows)
 
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
@@ -1915,7 +1793,6 @@ SELECT * FROM mat_m1 ORDER BY 1;
  Sun Dec 27 16:00:00 2009 PST |   45
  Sun Jan 03 16:00:00 2010 PST |  100
  Sun Oct 28 17:00:00 2018 PDT |   15
-(3 rows)
 
 -- hypothetical-set aggr
 DROP MATERIALIZED VIEW mat_m1;
@@ -1936,7 +1813,6 @@ SELECT * FROM mat_m1 ORDER BY 1;
  Sun Dec 27 16:00:00 2009 PST |    5 |          3 |          0.8
  Sun Jan 03 16:00:00 2010 PST |    1 |          1 |            0
  Sun Oct 28 17:00:00 2018 PDT |    4 |          4 |            1
-(3 rows)
 
 -- userdefined aggregate without combine function
 DROP MATERIALIZED VIEW mat_m1;
@@ -1964,7 +1840,6 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
  100 |    55
  100 |    75
  100 |   100
-(5 rows)
 
 -- ORDER BY in the view definition
 DROP MATERIALIZED VIEW mat_m1;
@@ -1998,7 +1873,6 @@ SELECT pg_get_viewdef('mat_m1',true);
    GROUP BY (time_bucket('@ 7 days'::interval, conditions.timec))                                                                                                                 +
    ORDER BY (sum(conditions.temperature)) DESC)                                                                                                                                   +
    ORDER BY 3 DESC;
-(1 row)
 
 -- Ordered result
 SELECT * FROM mat_m1;
@@ -2007,7 +1881,6 @@ SELECT * FROM mat_m1;
  Sun Dec 27 16:00:00 2009 PST |     5 | 330
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
-(3 rows)
 
 -- Insert new data and query again to make sure we produce ordered data
 INSERT INTO conditions VALUES ('2018-11-10 09:00:00-08', 'SFO', 10, 10);
@@ -2018,7 +1891,6 @@ SELECT * FROM mat_m1;
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
  Sun Nov 04 16:00:00 2018 PST |     1 |  10
-(4 rows)
 
 -- This new row will change the order again
 INSERT INTO conditions VALUES ('2018-11-11 09:00:00-08', 'SFO', 400, 400);
@@ -2029,26 +1901,24 @@ SELECT * FROM mat_m1;
  Sun Dec 27 16:00:00 2009 PST |     5 | 330
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
-(4 rows)
 
 -- Merge Append
-EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM mat_m1;
+--- QUERY PLAN ---
  Merge Append
-   Sort Key: _hyper_59_123_chunk.sum DESC
+   Sort Key: _materialized_hypertable_59.sum DESC
    ->  Merge Append
-         Sort Key: _hyper_59_123_chunk.sum DESC
+         Sort Key: _materialized_hypertable_59.sum DESC
          ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
                Index Cond: (time_bucket < 'Sun Nov 04 16:00:00 2018 PST'::timestamp with time zone)
          ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
                Index Cond: (time_bucket < 'Sun Nov 04 16:00:00 2018 PST'::timestamp with time zone)
    ->  Sort
-         Sort Key: (sum(_hyper_52_111_chunk.temperature)) DESC
+         Sort Key: (sum(conditions.temperature)) DESC
          ->  Finalize GroupAggregate
-               Group Key: (time_bucket('@ 7 days'::interval, _hyper_52_111_chunk.timec))
+               Group Key: (time_bucket('@ 7 days'::interval, conditions.timec))
                ->  Merge Append
-                     Sort Key: (time_bucket('@ 7 days'::interval, _hyper_52_111_chunk.timec))
+                     Sort Key: (time_bucket('@ 7 days'::interval, conditions.timec))
                      ->  Partial GroupAggregate
                            Group Key: time_bucket('@ 7 days'::interval, _hyper_52_111_chunk.timec)
                            ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
@@ -2057,7 +1927,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                            Group Key: time_bucket('@ 7 days'::interval, _hyper_52_125_chunk.timec)
                            ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
                                  Index Cond: (timec >= 'Sun Nov 04 16:00:00 2018 PST'::timestamp with time zone)
-(22 rows)
 
 -- Ordering by another column
 SELECT * FROM mat_m1 ORDER BY count;
@@ -2067,27 +1936,25 @@ SELECT * FROM mat_m1 ORDER BY count;
  Sun Nov 04 16:00:00 2018 PST |     2 | 410
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Dec 27 16:00:00 2009 PST |     5 | 330
-(4 rows)
 
-EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
+--- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_59_123_chunk.count
+   Sort Key: _materialized_hypertable_59.count
    ->  Merge Append
-         Sort Key: _hyper_59_123_chunk.sum DESC
+         Sort Key: _materialized_hypertable_59.sum DESC
          ->  Merge Append
-               Sort Key: _hyper_59_123_chunk.sum DESC
+               Sort Key: _materialized_hypertable_59.sum DESC
                ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
                      Index Cond: (time_bucket < 'Sun Nov 04 16:00:00 2018 PST'::timestamp with time zone)
                ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
                      Index Cond: (time_bucket < 'Sun Nov 04 16:00:00 2018 PST'::timestamp with time zone)
          ->  Sort
-               Sort Key: (sum(_hyper_52_111_chunk.temperature)) DESC
+               Sort Key: (sum(conditions.temperature)) DESC
                ->  Finalize GroupAggregate
-                     Group Key: (time_bucket('@ 7 days'::interval, _hyper_52_111_chunk.timec))
+                     Group Key: (time_bucket('@ 7 days'::interval, conditions.timec))
                      ->  Merge Append
-                           Sort Key: (time_bucket('@ 7 days'::interval, _hyper_52_111_chunk.timec))
+                           Sort Key: (time_bucket('@ 7 days'::interval, conditions.timec))
                            ->  Partial GroupAggregate
                                  Group Key: time_bucket('@ 7 days'::interval, _hyper_52_111_chunk.timec)
                                  ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
@@ -2096,7 +1963,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                                  Group Key: time_bucket('@ 7 days'::interval, _hyper_52_125_chunk.timec)
                                  ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
                                        Index Cond: (timec >= 'Sun Nov 04 16:00:00 2018 PST'::timestamp with time zone)
-(24 rows)
 
 -- Change the type of cagg
 ALTER MATERIALIZED VIEW mat_m1 SET (timescaledb.materialized_only=true);
@@ -2109,7 +1975,6 @@ SELECT pg_get_viewdef('mat_m1',true);
      sum                                                  +
     FROM _timescaledb_internal._materialized_hypertable_59+
    ORDER BY sum DESC;
-(1 row)
 
 -- Now the query will show only the materialized data, without last two
 -- records inserted into the original hypertable (last two insers above)
@@ -2119,17 +1984,14 @@ SELECT * FROM mat_m1;
  Sun Dec 27 16:00:00 2009 PST |     5 | 330
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
-(3 rows)
 
 -- Merge Append
-EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM mat_m1;
+--- QUERY PLAN ---
  Merge Append
-   Sort Key: _hyper_59_123_chunk.sum DESC
+   Sort Key: _materialized_hypertable_59.sum DESC
    ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
    ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
-(4 rows)
 
 -- Ordering by another column
 SELECT * FROM mat_m1 ORDER BY count;
@@ -2138,18 +2000,15 @@ SELECT * FROM mat_m1 ORDER BY count;
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Dec 27 16:00:00 2009 PST |     5 | 330
-(3 rows)
 
-EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
+--- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_59_123_chunk.count
+   Sort Key: _materialized_hypertable_59.count
    ->  Merge Append
-         Sort Key: _hyper_59_123_chunk.sum DESC
+         Sort Key: _materialized_hypertable_59.sum DESC
          ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
          ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
-(6 rows)
 
 SELECT h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME"
@@ -2167,7 +2026,6 @@ SELECT * FROM mat_m1;
  Sun Nov 04 16:00:00 2018 PST |     2 | 410
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
-(3 rows)
 
 -- Querying direct the materialization hypertable doesn't
 -- produce ordered records
@@ -2177,7 +2035,6 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME";
  Sun Jan 03 16:00:00 2010 PST |     1 |  75
  Sun Oct 28 17:00:00 2018 PDT |     3 | 115
  Sun Nov 04 16:00:00 2018 PST |     2 | 410
-(3 rows)
 
 --
 -- Testing the coexistence of both types of supported CAggs
@@ -2199,7 +2056,6 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 INSERT INTO conditions VALUES
   ('2010-01-01 09:00:00-08', 'SFO', 55, 45),
@@ -2243,7 +2099,6 @@ SELECT count(*) FROM conditions_summary_new;
  count 
 -------
      4
-(1 row)
 
 -- Parallel planning test for realtime Continuous Aggregate
 DROP TABLE conditions CASCADE;
@@ -2257,7 +2112,6 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
  table_name 
 ------------
  conditions
-(1 row)
 
 INSERT INTO conditions
 SELECT t, 10 FROM generate_series('2023-01-01 00:00-03'::timestamptz, '2023-12-31 23:59-03'::timestamptz, '1 hour'::interval) AS t;
@@ -2274,21 +2128,19 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
  set_config 
 ------------
  on
-(1 row)
 
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;
 -- Parallel planning
-EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket >= '2023-07-01';
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (BUFFERS OFF, COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket >= '2023-07-01';
+--- QUERY PLAN ---
  Merge Append
-   Sort Key: _hyper_63_183_chunk.sum DESC
+   Sort Key: _materialized_hypertable_63.sum DESC
    ->  Gather Merge
          Workers Planned: 2
          ->  Sort
-               Sort Key: _hyper_63_183_chunk.sum DESC
+               Sort Key: _materialized_hypertable_63.sum DESC
                ->  Parallel Append
                      ->  Parallel Index Scan using _hyper_63_183_chunk__materialized_hypertable_63_time_bucket_idx on _hyper_63_183_chunk
                            Index Cond: ((time_bucket < 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
@@ -2306,5 +2158,4 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
                            ->  Parallel Index Scan Backward using _hyper_62_182_chunk_conditions_timec_idx on _hyper_62_182_chunk
                                  Index Cond: ((timec >= 'Mon Jan 01 16:00:00 2024 PST'::timestamp with time zone) AND (timec >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, timec) >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone)
-(23 rows)
 

--- a/tsl/test/isolation/specs/cagg_concurrent_process_wal.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_process_wal.spec
@@ -12,6 +12,7 @@
 setup
 {
   SET timezone TO PST8PDT;
+  SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 
   CREATE TABLE temperature (
     time timestamptz NOT NULL,
@@ -39,7 +40,7 @@ setup
 # All the below need to be in separate transactions.
 setup {
   CREATE MATERIALIZED VIEW cagg_1
-    WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal') AS
+    WITH (timescaledb.continuous) AS
     SELECT time_bucket('4 hour', time), avg(value)
       FROM temperature
       GROUP BY 1 ORDER BY 1
@@ -48,7 +49,7 @@ setup {
 
 setup {
   CREATE MATERIALIZED VIEW cagg_2
-    WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal') AS
+    WITH (timescaledb.continuous) AS
     SELECT time_bucket('4 hour', time), avg(value)
       FROM temperature
       GROUP BY 1 ORDER BY 1

--- a/tsl/test/sql/cagg_refresh_using_merge.sql
+++ b/tsl/test/sql/cagg_refresh_using_merge.sql
@@ -6,7 +6,6 @@
 SET timescaledb.enable_merge_on_cagg_refresh TO ON;
 SET timezone TO PST8PDT;
 
-\set invalidate_using trigger
 \ir include/cagg_refresh_common.sql
 
 -- Additional tests for MERGE refresh

--- a/tsl/test/sql/cagg_refresh_using_trigger.sql
+++ b/tsl/test/sql/cagg_refresh_using_trigger.sql
@@ -4,5 +4,4 @@
 
 SET timezone TO PST8PDT;
 
-\set invalidate_using trigger
 \ir include/cagg_refresh_common.sql

--- a/tsl/test/sql/cagg_refresh_using_wal.sql
+++ b/tsl/test/sql/cagg_refresh_using_wal.sql
@@ -3,6 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 SET timezone TO PST8PDT;
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
 
-\set invalidate_using wal
 \ir include/cagg_refresh_common.sql

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -425,7 +425,7 @@ select currval('_timescaledb_catalog.hypertable_id_seq') - 1 as prev_htid \gset
 select setval('_timescaledb_catalog.hypertable_id_seq', :prev_htid, false);
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW bad_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM bad
      GROUP BY 1,2;
@@ -439,10 +439,12 @@ SELECT FROM nextval('_timescaledb_catalog.hypertable_id_seq');
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timescaledb.enable_cagg_wal_based_invalidation TO true;
+
 -- Test the option "invalidate_using". This should create the continuous
 -- aggregate and there should be a replication slot.
 CREATE MATERIALIZED VIEW magic1_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -453,7 +455,7 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- able to check that the slot remains after one continuous aggregate
 -- has been dropped.
 CREATE MATERIALIZED VIEW magic1_summary2_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic1
      GROUP BY 1,2;
@@ -465,46 +467,10 @@ SELECT count(*) FROM invalidation_slots WHERE database = current_database();
 -- the slot stays when we remove all continuous aggregates for a
 -- hypertable.
 CREATE MATERIALIZED VIEW magic2_summary1_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
+  WITH (timescaledb.continuous)
     AS SELECT time_bucket('1 day', time), device, avg(value)
          FROM magic2
      GROUP BY 1,2;
-
-\set ON_ERROR_STOP 0
--- This should error out since we are using trigger-based collection
--- for "metrics".
-CREATE MATERIALIZED VIEW metrics_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM metrics
-     GROUP BY 1,2;
-
--- This should error out since we are using WAL-based collection for
--- "magic".
-CREATE MATERIALIZED VIEW magic1_summary1_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-
--- This should error out because there is no such collection method.
-CREATE MATERIALIZED VIEW magic_summary1_magic
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'magic')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic1
-     GROUP BY 1,2;
-
--- This should error out since we cannot add the trigger to the
--- hypertable when there are multiple caggs connected. Changing
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic1_summary2_wal
-      SET (timescaledb.invalidate_using = 'trigger');
-\set ON_ERROR_STOP 1
-
--- Check that it was actually written to the catalog
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
 
 SELECT count(*) FROM pg_replication_slots
  WHERE plugin = :'plugin_name'
@@ -534,38 +500,3 @@ SELECT count(*) FROM pg_replication_slots
  WHERE plugin = :'plugin_name'
    AND database = current_database();
 
-SELECT hypertable_name, view_name, invalidate_using
-  FROM timescaledb_information.continuous_aggregates
- WHERE view_name like 'magic_\_summary%';
-
--- Check that trigger-based invalidation works as well, and give
--- proper errors when trying to modify them.
-CREATE MATERIALIZED VIEW magic3_day_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 day', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-
-CREATE MATERIALIZED VIEW magic3_week_summary_trigger
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'trigger')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-
-\set ON_ERROR_STOP 0
-
--- This should error out since we already are using trigger-based
--- collection.
-CREATE MATERIALIZED VIEW magic3_week_summary_wal
-  WITH (timescaledb.continuous, timescaledb.invalidate_using = 'wal')
-    AS SELECT time_bucket('1 week', time), device, avg(value)
-         FROM magic3
-     GROUP BY 1,2;
-
--- This should error out since we cannot remove the trigger from the
--- hypertable when there are multiple caggs connected. Switching
--- invalidation collection method is more complicated than this.
-ALTER MATERIALIZED VIEW magic3_day_summary_trigger
-      SET (timescaledb.invalidate_using = 'wal');
-
-\set ON_ERROR_STOP 1

--- a/tsl/test/sql/include/cagg_refresh_common.sql
+++ b/tsl/test/sql/include/cagg_refresh_common.sql
@@ -8,7 +8,6 @@ SELECT create_hypertable('conditions', 'time');
 -- Test refresh on a cagg built on an empty table
 CREATE MATERIALIZED VIEW daily_temp
 WITH (timescaledb.continuous,
-      timescaledb.invalidate_using = :'invalidate_using',
       timescaledb.materialized_only=true)
 AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp


### PR DESCRIPTION
Put WAL based invalidation behind a GUC and decouple it from
trigger based invalidation. WAL based invalidation is experimental
and and should require explicit opt-in before being available.
This also removes the cagg seting for invalidation method, since
invalidation is per hypertable the configuration at the cagg level
was misplaced.

This patch also removes the field from the cagg view since we don't
this feature to be user visible while it is still experimental.
