### PR TITLE
Fix sparse index bug that allowed multiple options

### DIFF
--- a/.unreleased/pr_8782
+++ b/.unreleased/pr_8782
@@ -1,0 +1,1 @@
+Fixes: #8782 Stops sparse index from allowing multiple options

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -420,6 +420,15 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 											sparse_index_with_clause_def,
 											TS_ARRAY_LEN(sparse_index_with_clause_def));
 	config.base.source = _SparseIndexSourceEnumConfig;
+
+	if (list_length(sparse_index_details->args) != 1)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("sparse index \"%s\" can only have one column",
+						ts_sparse_index_type_names[config.base.type])));
+	}
+
 	/* validate and extract column */
 	Node *arg = list_nth(sparse_index_details->args, 0);
 

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -100,6 +100,19 @@ alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), minmax("u")');
 ERROR:  duplicate column name "u"
+-- multiple columns
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u,ts")');
+ERROR:  column "u,ts" does not exist
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts)');
+ERROR:  sparse index "bloom" can only have one column
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,abc)');
+ERROR:  sparse index "bloom" can only have one column
 -- duplicate column
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -81,6 +81,19 @@ alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), minmax("u")');
 
+-- multiple columns
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u,ts")');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,abc)');
+
 -- duplicate column
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',


### PR DESCRIPTION
Add check to ensure sparse index configurations only provides one option. Previously, multiple options were being allowed but only the first one was getting considered.