### PR TITLE
Display chunks view range as timestamps for UUIDv7

### DIFF
--- a/.unreleased/pr_8786
+++ b/.unreleased/pr_8786
@@ -1,0 +1,1 @@
+Implements: #8786 Display chunks view range as timestamps for UUIDv7

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,3 @@
-
 DROP FUNCTION IF EXISTS _timescaledb_functions.policy_job_stat_history_retention;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,3 +1,2 @@
-
 DROP FUNCTION IF EXISTS _timescaledb_functions.policy_job_stat_history_retention;
-
+DROP VIEW IF EXISTS timescaledb_information.chunks;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -178,22 +178,22 @@ FROM (
     dim.column_name AS primary_dimension,
     dim.column_type AS primary_dimension_type,
     row_number() OVER (PARTITION BY chcons.chunk_id ORDER BY dim.id) AS chunk_dimension_num,
-    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date']::regtype[]) THEN
+    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date', 'uuid']::regtype[]) THEN
       _timescaledb_functions.to_timestamp(dimsl.range_start)
     ELSE
       NULL
     END AS range_start,
-    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date']::regtype[]) THEN
+    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date', 'uuid']::regtype[]) THEN
       _timescaledb_functions.to_timestamp(dimsl.range_end)
     ELSE
       NULL
     END AS range_end,
-    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date']::regtype[]) THEN
+    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date', 'uuid']::regtype[]) THEN
       NULL
     ELSE
       dimsl.range_start
     END AS integer_range_start,
-    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date']::regtype[]) THEN
+    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date', 'uuid']::regtype[]) THEN
       NULL
     ELSE
       dimsl.range_end

--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -239,8 +239,8 @@ ORDER BY id DESC;
 CREATE VIEW chunk_ranges AS
 SELECT
   chunk_name,
-  _timescaledb_functions.to_timestamp(range_start_integer) AS range_start,
-  _timescaledb_functions.to_timestamp(range_end_integer) AS range_end
+  range_start,
+  range_end
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'uuid_events';
 SELECT * FROM chunk_ranges;

--- a/test/sql/uuid.sql
+++ b/test/sql/uuid.sql
@@ -141,8 +141,8 @@ ORDER BY id DESC;
 CREATE VIEW chunk_ranges AS
 SELECT
   chunk_name,
-  _timescaledb_functions.to_timestamp(range_start_integer) AS range_start,
-  _timescaledb_functions.to_timestamp(range_end_integer) AS range_end
+  range_start,
+  range_end
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'uuid_events';
 


### PR DESCRIPTION
When using the chunks view, it makes sense to show the time range as timestamp for UUIDv7-partitioned tables. Previously, the range was a unix timestamp integer.