### PR TITLE
Reduce flakiness of compression_bgw

### DIFF
--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -730,15 +730,10 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE chunk_schema = :'chunk
 
 -- index size should not have decreased
 VACUUM ANALYZE :RECOMPRESS_CHUNK_NAME;
-SELECT
-pg_size_pretty(pg_table_size(:'RECOMPRESS_CHUNK_NAME')) AS table_only,
-pg_size_pretty(pg_indexes_size(:'RECOMPRESS_CHUNK_NAME')) AS indexes,
-pg_size_pretty(pg_total_relation_size(:'RECOMPRESS_CHUNK_NAME')) AS total;
- table_only | indexes | total 
-------------+---------+-------
- 16 kB      | 40 kB   | 56 kB
-
-SELECT pg_indexes_size(:'RECOMPRESS_CHUNK_NAME') = :SIZE_BEFORE_REINDEX as size_unchanged;
+-- index size can vary, vacuuming can even increase the size of the index
+-- just check that the index size hasn't decreased, this can only happen
+-- when running VACUUM FULL or REINDEX TABLE
+SELECT pg_indexes_size(:'RECOMPRESS_CHUNK_NAME') >= :SIZE_BEFORE_REINDEX as size_unchanged;
  size_unchanged 
 ----------------
  t


### PR DESCRIPTION
Index sizes can vary and can even increase in size with vacuuming. Changing the test to only check that index size reduces when reindexing the indexes.

Disable-check: force-changelog-file
Disable-check: approval-count