### PR TITLE
Add custom sanitizer patch for PG18

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -123,7 +123,12 @@ jobs:
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
         # Add instrumentation to the Postgres memory contexts. For more details, see
         # https://github.com/timescale/eng-database/wiki/Using-Address-Sanitizer#adding-more-instrumentation
-        patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation.patch
+        PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
+        if [ ${PG_MAJOR} -lt 18 ]; then
+          patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation.patch
+        else
+          patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation-PG18GE.patch
+        fi
         cd ~/$PG_SRC_DIR
         ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml

--- a/test/postgres-asan-instrumentation-PG18GE.patch
+++ b/test/postgres-asan-instrumentation-PG18GE.patch
@@ -1,0 +1,53 @@
+diff --git a/src/backend/utils/misc/stack_depth.c b/src/backend/utils/misc/stack_depth.c
+index 8f7cf531fbc..2f7b1cebbe6 100644
+--- a/src/backend/utils/misc/stack_depth.c
++++ b/src/backend/utils/misc/stack_depth.c
+@@ -108,6 +108,12 @@ check_stack_depth(void)
+ bool
+ stack_is_too_deep(void)
+ {
++       /*
++        * Pointer arithmetics to determine stack depth doesn't work under
++        * AddressSanitizer.
++        */
++       return false;
++
+        char            stack_top_loc;
+        ssize_t         stack_depth;
+
+diff --git a/src/include/utils/memdebug.h b/src/include/utils/memdebug.h
+index e88b4c6e8e..4ccbbf0146 100644
+--- a/src/include/utils/memdebug.h
++++ b/src/include/utils/memdebug.h
+@@ -19,6 +19,31 @@
+ 
+ #ifdef USE_VALGRIND
+ #include <valgrind/memcheck.h>
++
++#elif __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
++
++#include <sanitizer/asan_interface.h>
++
++#define VALGRIND_MAKE_MEM_DEFINED(addr, size) \
++ ASAN_UNPOISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MAKE_MEM_NOACCESS(addr, size) \
++ ASAN_POISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MAKE_MEM_UNDEFINED(addr, size) \
++ ASAN_UNPOISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MEMPOOL_ALLOC(context, addr, size) \
++ ASAN_UNPOISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MEMPOOL_FREE(context, addr) \
++ ASAN_POISON_MEMORY_REGION(addr, 1 /* Length unknown, poison first byte. */)
++
++#define VALGRIND_CHECK_MEM_IS_DEFINED(addr, size) do {} while (0)
++#define VALGRIND_CREATE_MEMPOOL(context, redzones, zeroed) do {} while (0)
++#define VALGRIND_DESTROY_MEMPOOL(context) do {} while (0)
++#define VALGRIND_MEMPOOL_CHANGE(context, optr, nptr, size) do {} while (0)
++
+ #else
+ #define VALGRIND_CHECK_MEM_IS_DEFINED(addr, size)			do {} while (0)
+ #define VALGRIND_CREATE_MEMPOOL(context, redzones, zeroed)	do {} while (0)


### PR DESCRIPTION
Due to a move of a patched function, we need to version out
our patch file to apply the patch in the correct place.

https://github.com/postgres/postgres/commit/c91963da1

Sanitizer run with this change: https://github.com/timescale/timescaledb/actions/runs/18588855008/job/52998977997

Disable-check: force-changelog-file
Disable-check: approval-count