### PR TITLE
Remove PG18 from windows build test

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -64,8 +64,8 @@ jobs:
             pg_version: ${{ needs.config.outputs.pg16_latest }}
           - pg: 17
             pg_version: ${{ needs.config.outputs.pg17_latest }}
-          - pg: 18
-            pg_version: ${{ needs.config.outputs.pg18_latest }}
+#          - pg: 18
+#            pg_version: ${{ needs.config.outputs.pg18_latest }}
     env:
       # PostgreSQL configuration
       PGPORT: 55432


### PR DESCRIPTION
PG18 packages are not yet available for Windows so we have to skip
it for now.
