### PR TITLE
Enable uuid compression

### DIFF
--- a/.unreleased/pr_8798
+++ b/.unreleased/pr_8798
@@ -1,0 +1,1 @@
+Implements: #8798 Enable UUID compression by default.

--- a/src/guc.c
+++ b/src/guc.c
@@ -116,7 +116,7 @@ bool ts_guc_enable_chunk_skipping = false;
 TSDLLEXPORT bool ts_guc_enable_segmentwise_recompression = true;
 TSDLLEXPORT bool ts_guc_enable_exclusive_locking_recompression = false;
 TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
-TSDLLEXPORT bool ts_guc_enable_uuid_compression = false;
+TSDLLEXPORT bool ts_guc_enable_uuid_compression = true;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
@@ -896,7 +896,7 @@ _guc_init(void)
 							 "Enable uuid compression functionality",
 							 "Enable uuid compression",
 							 &ts_guc_enable_uuid_compression,
-							 false,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/test/sql/updates/post.sparse_index.sql
+++ b/test/sql/updates/post.sparse_index.sql
@@ -24,5 +24,8 @@ WHERE id = (
 )
 \gset
 
-\d+ :chunk
+-- Note: we can't use \d+ here because it prevents changing the TOAST storage flag
+--   if we do, like in the UUID compression changes from external to extended, then
+--   the upgrade tests fail
+\d :chunk
 

--- a/tsl/test/expected/compress_bloom_sparse-15.out
+++ b/tsl/test/expected/compress_bloom_sparse-15.out
@@ -54,7 +54,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_v2_bloom1_value | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
  value                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u     | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                        | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                        | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts                       | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 

--- a/tsl/test/expected/compress_bloom_sparse-16.out
+++ b/tsl/test/expected/compress_bloom_sparse-16.out
@@ -54,7 +54,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_v2_bloom1_value | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
  value                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u     | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                        | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                        | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts                       | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 

--- a/tsl/test/expected/compress_bloom_sparse-17.out
+++ b/tsl/test/expected/compress_bloom_sparse-17.out
@@ -54,7 +54,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_v2_bloom1_value | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
  value                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u     | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                        | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                        | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts                       | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 

--- a/tsl/test/expected/compress_bloom_sparse-18.out
+++ b/tsl/test/expected/compress_bloom_sparse-18.out
@@ -54,7 +54,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_v2_bloom1_value | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
  value                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u     | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                        | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                        | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts       | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts                       | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -243,7 +243,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  x                    | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  value                | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                    | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts   | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts   | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts                   | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
@@ -321,7 +321,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  x                    | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  value                | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                    | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts   | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts   | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts                   | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
@@ -395,7 +395,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  x                      | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  value_new              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  _ts_meta_v2_bloom1_u   | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
- u                      | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                      | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_min_ts_new | timestamp without time zone           |           |          |         | plain    | 1000         | 
  _ts_meta_v2_max_ts_new | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts_new                 | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
@@ -427,7 +427,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_max_1 | integer                               |           |          |         | plain    | 1000         | 
  x              | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  value_new      | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
- u              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u              | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  ts_new         | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
     "compress_hyper_6_7_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
@@ -465,7 +465,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  x                            | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  _ts_meta_v2_bloom1_value_new | _timescaledb_internal.bloom1          |           |          |         | external | 1000         | 
  value_new                    | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
- u                            | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u                            | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  ts_new                       | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
     "compress_hyper_6_8_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
@@ -502,7 +502,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_max_1 | integer                               |           |          |         | plain    | 1000         | 
  x              | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  value_new      | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
- u              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u              | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  ts_new         | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
     "compress_hyper_6_9_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
@@ -539,7 +539,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_min_1 | integer                               |           |          |         | plain    | 1000         | 
  _ts_meta_max_1 | integer                               |           |          |         | plain    | 1000         | 
  x              | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
- u              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
+ u              | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
  ts_new         | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
     "compress_hyper_6_10_chunk_value_new__ts_meta_min_1__ts_meta_idx" btree (value_new, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)


### PR DESCRIPTION
This change sets the default for the GUC value:

`timescaledb.enable_uuid_compression=true`

The UUID compression feature was introduced in 2.22.x with the feature flag disabled. With this change I enable the feature for upcoming releases by default, 2.23 and upwards.