### PR TITLE
Set next_start for WITH clause compression policy

### DIFF
--- a/.unreleased/pr_8799
+++ b/.unreleased/pr_8799
@@ -1,0 +1,1 @@
+Fixes: #8799 Set next_start for WITH clause compression policy

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -339,6 +339,11 @@ policy_compression_add_internal(Oid user_rel_oid, Datum compress_after_datum,
 										initial_start,
 										timezone);
 
+	if (!TIMESTAMP_NOT_FINITE(initial_start))
+	{
+		ts_bgw_job_stat_upsert_next_start(job_id, initial_start);
+	}
+
 	ts_cache_release(&hcache);
 	PG_RETURN_INT32(job_id);
 }
@@ -404,11 +409,6 @@ policy_compression_add(PG_FUNCTION_ARGS)
 											 initial_start,
 											 valid_timezone);
 
-	if (!TIMESTAMP_NOT_FINITE(initial_start))
-	{
-		int32 job_id = DatumGetInt32(retval);
-		ts_bgw_job_stat_upsert_next_start(job_id, initial_start);
-	}
 	return retval;
 }
 

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -371,19 +371,21 @@ SELECT hypertable_name, compression_enabled FROM timescaledb_information.hyperta
 -----------------+---------------------
  t25_policy      | t
 
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy' AND proc_name = 'policy_compression';
- hypertable_name | schedule_interval |                       config                        
------------------+-------------------+-----------------------------------------------------
- t25_policy      | @ 1 day           | {"hypertable_id": 70, "compress_after": "@ 7 days"}
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy' AND proc_name = 'policy_compression';
+ hypertable_name | schedule_interval |           next_start           |                       config                        
+-----------------+-------------------+--------------------------------+-----------------------------------------------------
+ t25_policy      | @ 1 day           | in 01 days 00 hours 00 minutes | {"hypertable_id": 70, "compress_after": "@ 7 days"}
 
 ROLLBACK;
 -- test compression policy creation with custom chunk interval
 BEGIN;
 CREATE TABLE t25_policy_custom(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval='3 days',tsdb.columnstore=true);
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_custom' AND proc_name = 'policy_compression';
-  hypertable_name  | schedule_interval |                       config                        
--------------------+-------------------+-----------------------------------------------------
- t25_policy_custom | @ 1 day           | {"hypertable_id": 72, "compress_after": "@ 3 days"}
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_custom' AND proc_name = 'policy_compression';
+  hypertable_name  | schedule_interval |           next_start           |                       config                        
+-------------------+-------------------+--------------------------------+-----------------------------------------------------
+ t25_policy_custom | @ 1 day           | in 01 days 00 hours 00 minutes | {"hypertable_id": 72, "compress_after": "@ 3 days"}
 
 ROLLBACK;
 -- test compression policy creation with integer partition column (int2)
@@ -394,10 +396,11 @@ SELECT hypertable_name, compression_enabled FROM timescaledb_information.hyperta
 -----------------+---------------------
  t25_policy_int2 | t
 
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int2' AND proc_name = 'policy_compression';
- hypertable_name | schedule_interval |                    config                    
------------------+-------------------+----------------------------------------------
- t25_policy_int2 | @ 1 day           | {"hypertable_id": 74, "compress_after": 100}
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int2' AND proc_name = 'policy_compression';
+ hypertable_name | schedule_interval |           next_start           |                    config                    
+-----------------+-------------------+--------------------------------+----------------------------------------------
+ t25_policy_int2 | @ 1 day           | in 01 days 00 hours 00 minutes | {"hypertable_id": 74, "compress_after": 100}
 
 ROLLBACK;
 -- test compression policy creation with integer partition column (int4)
@@ -408,10 +411,11 @@ SELECT hypertable_name, compression_enabled FROM timescaledb_information.hyperta
 -----------------+---------------------
  t25_policy_int4 | t
 
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int4' AND proc_name = 'policy_compression';
- hypertable_name | schedule_interval |                    config                     
------------------+-------------------+-----------------------------------------------
- t25_policy_int4 | @ 1 day           | {"hypertable_id": 76, "compress_after": 1000}
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int4' AND proc_name = 'policy_compression';
+ hypertable_name | schedule_interval |           next_start           |                    config                     
+-----------------+-------------------+--------------------------------+-----------------------------------------------
+ t25_policy_int4 | @ 1 day           | in 01 days 00 hours 00 minutes | {"hypertable_id": 76, "compress_after": 1000}
 
 ROLLBACK;
 -- test compression policy creation with integer partition column (int8)
@@ -422,10 +426,11 @@ SELECT hypertable_name, compression_enabled FROM timescaledb_information.hyperta
 -----------------+---------------------
  t25_policy_int8 | t
 
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int8' AND proc_name = 'policy_compression';
- hypertable_name | schedule_interval |                     config                     
------------------+-------------------+------------------------------------------------
- t25_policy_int8 | @ 1 day           | {"hypertable_id": 78, "compress_after": 10000}
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int8' AND proc_name = 'policy_compression';
+ hypertable_name | schedule_interval |           next_start           |                     config                     
+-----------------+-------------------+--------------------------------+------------------------------------------------
+ t25_policy_int8 | @ 1 day           | in 01 days 00 hours 00 minutes | {"hypertable_id": 78, "compress_after": 10000}
 
 ROLLBACK;
 BEGIN;
@@ -546,9 +551,10 @@ SELECT hypertable_name, compression_enabled FROM timescaledb_information.hyperta
 -----------------+---------------------
  events          | t
 
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 'events' AND proc_name = 'policy_compression';
- hypertable_name | schedule_interval |                        config                         
------------------+-------------------+-------------------------------------------------------
- events          | @ 1 day           | {"hypertable_id": 100, "compress_after": "@ 2 hours"}
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 'events' AND proc_name = 'policy_compression';
+ hypertable_name | schedule_interval |           next_start           |                        config                         
+-----------------+-------------------+--------------------------------+-------------------------------------------------------
+ events          | @ 1 day           | in 01 days 00 hours 00 minutes | {"hypertable_id": 100, "compress_after": "@ 2 hours"}
 
 ROLLBACK;

--- a/tsl/test/sql/create_table_with.sql
+++ b/tsl/test/sql/create_table_with.sql
@@ -224,34 +224,39 @@ ROLLBACK;
 BEGIN;
 CREATE TABLE t25_policy(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.columnstore=true);
 SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 't25_policy';
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy' AND proc_name = 'policy_compression';
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy' AND proc_name = 'policy_compression';
 ROLLBACK;
 
 -- test compression policy creation with custom chunk interval
 BEGIN;
 CREATE TABLE t25_policy_custom(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval='3 days',tsdb.columnstore=true);
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_custom' AND proc_name = 'policy_compression';
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_custom' AND proc_name = 'policy_compression';
 ROLLBACK;
 
 -- test compression policy creation with integer partition column (int2)
 BEGIN;
 CREATE TABLE t25_policy_int2(time int2 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=100,tsdb.columnstore=true);
 SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 't25_policy_int2';
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int2' AND proc_name = 'policy_compression';
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int2' AND proc_name = 'policy_compression';
 ROLLBACK;
 
 -- test compression policy creation with integer partition column (int4)
 BEGIN;
 CREATE TABLE t25_policy_int4(time int4 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=1000,tsdb.columnstore=true);
 SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 't25_policy_int4';
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int4' AND proc_name = 'policy_compression';
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int4' AND proc_name = 'policy_compression';
 ROLLBACK;
 
 -- test compression policy creation with integer partition column (int8)
 BEGIN;
 CREATE TABLE t25_policy_int8(time int8 NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=10000,tsdb.columnstore=true);
 SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 't25_policy_int8';
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int8' AND proc_name = 'policy_compression';
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes"') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 't25_policy_int8' AND proc_name = 'policy_compression';
 ROLLBACK;
 BEGIN;
 -- don't allow empty orderby
@@ -355,5 +360,6 @@ WITH (
      tsdb.compress=true
 );
 SELECT hypertable_name, compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 'events';
-SELECT hypertable_name, schedule_interval, config FROM timescaledb_information.jobs WHERE hypertable_name = 'events' AND proc_name = 'policy_compression';
+SELECT hypertable_name, schedule_interval, TO_CHAR(next_start - NOW(),'"in" DD "days" HH24 "hours" MI "minutes') as next_start, config
+FROM timescaledb_information.jobs WHERE hypertable_name = 'events' AND proc_name = 'policy_compression';
 ROLLBACK;


### PR DESCRIPTION
When adding the policy with initial_start, we also need to upsert the next_start column for the job in bgw_job_stat catalog table.

Fixes #8788