### PR TITLE
Don't do direct batch delete optimizations on hypertables with continuous aggregates

### DIFF
--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -1731,6 +1731,9 @@ can_delete_without_decompression(ModifyHypertableState *ht_state, CompressionSet
 	if (ht_state->mt->returningLists)
 		return false;
 
+	if (ts_hypertable_has_continuous_aggregates(ht_state->ht->fd.id))
+		return false;
+
 	/*
 	 * If there are any DELETE row triggers on the hypertable we skip the optimization
 	 * to delete compressed batches directly.

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -3174,3 +3174,56 @@ BEGIN; DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 DELETE 615
 ROLLBACK
+-- test invalidation with direct batch delete optimizations
+CREATE TABLE cagg_inval(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
+CREATE TABLE
+INSERT INTO cagg_inval SELECT '2020-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+INSERT INTO cagg_inval SELECT '2021-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+SELECT count(compress_chunk(ch)) FROM show_chunks('cagg_inval') ch;
+ count 
+-------
+     2
+
+SET timescaledb.enable_compressed_direct_batch_delete TO on;
+SET
+-- delete without cagg should use optimization
+BEGIN;
+BEGIN
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches deleted: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=0.00 loops=1)
+
+ROLLBACK;
+ROLLBACK
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', time) FROM cagg_inval GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg1"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+-- should not use direct batch delete
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=2.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=1.00 loops=1)
+
+-- should have invalidation entry
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+            45 |      1577865600000000 |        1609488000000000
+

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -3174,3 +3174,56 @@ BEGIN; DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 DELETE 615
 ROLLBACK
+-- test invalidation with direct batch delete optimizations
+CREATE TABLE cagg_inval(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
+CREATE TABLE
+INSERT INTO cagg_inval SELECT '2020-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+INSERT INTO cagg_inval SELECT '2021-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+SELECT count(compress_chunk(ch)) FROM show_chunks('cagg_inval') ch;
+ count 
+-------
+     2
+
+SET timescaledb.enable_compressed_direct_batch_delete TO on;
+SET
+-- delete without cagg should use optimization
+BEGIN;
+BEGIN
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches deleted: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=0.00 loops=1)
+
+ROLLBACK;
+ROLLBACK
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', time) FROM cagg_inval GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg1"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+-- should not use direct batch delete
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=2.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=1.00 loops=1)
+
+-- should have invalidation entry
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+            45 |      1577865600000000 |        1609488000000000
+

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -3174,3 +3174,56 @@ BEGIN; DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 DELETE 615
 ROLLBACK
+-- test invalidation with direct batch delete optimizations
+CREATE TABLE cagg_inval(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
+CREATE TABLE
+INSERT INTO cagg_inval SELECT '2020-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+INSERT INTO cagg_inval SELECT '2021-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+SELECT count(compress_chunk(ch)) FROM show_chunks('cagg_inval') ch;
+ count 
+-------
+     2
+
+SET timescaledb.enable_compressed_direct_batch_delete TO on;
+SET
+-- delete without cagg should use optimization
+BEGIN;
+BEGIN
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches deleted: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=0.00 loops=1)
+
+ROLLBACK;
+ROLLBACK
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', time) FROM cagg_inval GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg1"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+-- should not use direct batch delete
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=2.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=1.00 loops=1)
+
+-- should have invalidation entry
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+            45 |      1577865600000000 |        1609488000000000
+

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -3174,3 +3174,56 @@ BEGIN; DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 DELETE 615
 ROLLBACK
+-- test invalidation with direct batch delete optimizations
+CREATE TABLE cagg_inval(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
+CREATE TABLE
+INSERT INTO cagg_inval SELECT '2020-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+INSERT INTO cagg_inval SELECT '2021-01-01'::timestamptz, 'd1', 1.0;
+INSERT 0 1
+SELECT count(compress_chunk(ch)) FROM show_chunks('cagg_inval') ch;
+ count 
+-------
+     2
+
+SET timescaledb.enable_compressed_direct_batch_delete TO on;
+SET
+-- delete without cagg should use optimization
+BEGIN;
+BEGIN
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches deleted: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=0.00 loops=1)
+
+ROLLBACK;
+ROLLBACK
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', time) FROM cagg_inval GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg1"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+-- should not use direct batch delete
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 2
+   ->  Delete on cagg_inval (actual rows=0.00 loops=1)
+         Delete on _hyper_45_86_chunk cagg_inval_1
+         Delete on _hyper_45_87_chunk cagg_inval_2
+         ->  Append (actual rows=2.00 loops=1)
+               ->  Seq Scan on _hyper_45_86_chunk cagg_inval_1 (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_45_87_chunk cagg_inval_2 (actual rows=1.00 loops=1)
+
+-- should have invalidation entry
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+            45 |      1577865600000000 |        1609488000000000
+

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1676,3 +1676,25 @@ BEGIN; DELETE FROM delete_counter; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN; DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 
+-- test invalidation with direct batch delete optimizations
+CREATE TABLE cagg_inval(time timestamptz, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time');
+
+INSERT INTO cagg_inval SELECT '2020-01-01'::timestamptz, 'd1', 1.0;
+INSERT INTO cagg_inval SELECT '2021-01-01'::timestamptz, 'd1', 1.0;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('cagg_inval') ch;
+SET timescaledb.enable_compressed_direct_batch_delete TO on;
+
+-- delete without cagg should use optimization
+BEGIN;
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+ROLLBACK;
+
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', time) FROM cagg_inval GROUP BY 1;
+
+-- should not use direct batch delete
+EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
+
+-- should have invalidation entry
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+


### PR DESCRIPTION
On hypertables with continuous aggregates direct batch deletes don't
produce invalidation entries so we have to disable this optimization
until we produce invalidations in direct batch delete.

Fixes #8800

Disable-check: approval-count
Disable-check: force-changelog-file
