### PR TITLE
backport: Allow compression when bloom sparse index is configured but disabled …

### DIFF
--- a/.unreleased/bloom-warning
+++ b/.unreleased/bloom-warning
@@ -1,0 +1,1 @@
+Fixes: #8807 Only warn but not fail the compression if bloom filter indexes are configured but disabled with a GUC.

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -449,7 +449,9 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 				ereport(ERROR,
 						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 						 errmsg("Creating bloom sparse index is disabled"),
-						 errhint("Set \"enable_sparse_index_bloom\" to true.")));
+						 errhint("Either set \"enable_sparse_index_bloom\" to true or remove the "
+								 "bloom filter indexes from \"sparse_index\" configuration of the "
+								 "hypertable.")));
 			}
 			/*
 			 * The column type must be hashable. For some types we use our own hash functions

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -399,10 +399,12 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 			{
 				if (!ts_guc_enable_sparse_index_bloom)
 				{
-					ereport(ERROR,
+					ereport(WARNING,
 							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 							 errmsg("Creating bloom sparse index is disabled"),
-							 errhint("Set \"enable_sparse_index_bloom\" to true.")));
+							 errhint("Either set \"enable_sparse_index_bloom\" to true or remove "
+									 "the bloom filter indexes from \"sparse_index\" configuration "
+									 "of the hypertable.")));
 				}
 				/*
 				 * Add bloom filter sparse index for this column.

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -386,6 +386,16 @@ select count(*) from test_sparse_index where ts between '2021-01-07' and '2021-0
                Rows Removed by Filter: 9
 (10 rows)
 
+-- Test recompression when the bloom filter index is disabled by a GUC
+set timescaledb.enable_sparse_index_bloom to off;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
+WARNING:  Creating bloom sparse index is disabled
+ count 
+-------
+     1
+(1 row)
+
+reset timescaledb.enable_sparse_index_bloom;
 -- Test rename column
 -- change a non-sparse index column
 alter table test_sparse_index rename value to value_new;
@@ -395,7 +405,7 @@ select * from settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                   index                                                                                    
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  test_sparse_index                      |                                                |           | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "minmax", "column": "ts_new", "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
- _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_5_chunk |           | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "minmax", "column": "ts_new", "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+ _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_6_chunk |           | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "minmax", "column": "ts_new", "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
 (2 rows)
 
 select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
@@ -404,7 +414,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
             where table_name = 'test_sparse_index') limit 1)
 \gset
 \d+ :chunk
-                                         Table "_timescaledb_internal.compress_hyper_6_5_chunk"
+                                         Table "_timescaledb_internal.compress_hyper_6_6_chunk"
          Column         |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
 ------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
  _ts_meta_count         | integer                               |           |          |         | plain    | 1000         | 
@@ -418,7 +428,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  _ts_meta_v2_max_ts_new | timestamp without time zone           |           |          |         | plain    | 1000         | 
  ts_new                 | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
-    "compress_hyper_6_5_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
+    "compress_hyper_6_6_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
 Options: toast_tuple_target=128
 
 -- Test same minmax and orderby column
@@ -438,7 +448,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
             where table_name = 'test_sparse_index') limit 1)
 \gset
 \d+ :chunk
-                                     Table "_timescaledb_internal.compress_hyper_6_6_chunk"
+                                     Table "_timescaledb_internal.compress_hyper_6_7_chunk"
      Column     |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
 ----------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
  _ts_meta_count | integer                               |           |          |         | plain    | 1000         | 
@@ -449,14 +459,14 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  u              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  ts_new         | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
-    "compress_hyper_6_6_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
+    "compress_hyper_6_7_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
 Options: toast_tuple_target=128
 
 select * from settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                          index                          
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+---------------------------------------------------------
  test_sparse_index                      |                                                | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "config"}]
- _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_6_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "config"}]
+ _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_7_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "config"}]
 (2 rows)
 
 -- Test auto sparse index
@@ -477,7 +487,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
             where table_name = 'test_sparse_index') limit 1)
 \gset
 \d+ :chunk
-                                            Table "_timescaledb_internal.compress_hyper_6_7_chunk"
+                                            Table "_timescaledb_internal.compress_hyper_6_8_chunk"
             Column            |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
 ------------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
  _ts_meta_count               | integer                               |           |          |         | plain    | 1000         | 
@@ -489,14 +499,14 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  u                            | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  ts_new                       | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
-    "compress_hyper_6_7_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
+    "compress_hyper_6_8_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
 Options: toast_tuple_target=128
 
 select * from settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                          index                                                          
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------
  test_sparse_index                      |                                                | {}        | {x}     | {f}          | {f}                | 
- _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_7_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "value_new", "source": "default"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+ _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_8_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "value_new", "source": "default"}, {"type": "minmax", "column": "x", "source": "orderby"}]
 (2 rows)
 
 -- Test empty sparse index
@@ -517,7 +527,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
             where table_name = 'test_sparse_index') limit 1)
 \gset
 \d+ :chunk
-                                     Table "_timescaledb_internal.compress_hyper_6_8_chunk"
+                                     Table "_timescaledb_internal.compress_hyper_6_9_chunk"
      Column     |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
 ----------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
  _ts_meta_count | integer                               |           |          |         | plain    | 1000         | 
@@ -528,14 +538,14 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  u              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  ts_new         | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
-    "compress_hyper_6_8_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
+    "compress_hyper_6_9_chunk__ts_meta_min_1__ts_meta_max_1_idx" btree (_ts_meta_min_1, _ts_meta_max_1)
 Options: toast_tuple_target=128
 
 select * from settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                     index                                      
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------
  test_sparse_index                      |                                                | {}        | {x}     | {f}          | {f}                | [{"source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
- _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_8_chunk | {}        | {x}     | {f}          | {f}                | [{"source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+ _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_9_chunk | {}        | {x}     | {f}          | {f}                | [{"source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
 (2 rows)
 
 -- Test default orderby without sparse index
@@ -556,7 +566,7 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
             where table_name = 'test_sparse_index') limit 1)
 \gset
 \d+ :chunk
-                                     Table "_timescaledb_internal.compress_hyper_6_9_chunk"
+                                     Table "_timescaledb_internal.compress_hyper_6_10_chunk"
      Column     |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
 ----------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
  _ts_meta_count | integer                               |           |          |         | plain    | 1000         | 
@@ -567,14 +577,14 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
  u              | _timescaledb_internal.compressed_data |           |          |         | extended | 0            | 
  ts_new         | _timescaledb_internal.compressed_data |           |          |         | external | 0            | 
 Indexes:
-    "compress_hyper_6_9_chunk_value_new__ts_meta_min_1__ts_meta__idx" btree (value_new, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)
+    "compress_hyper_6_10_chunk_value_new__ts_meta_min_1__ts_meta_idx" btree (value_new, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)
 Options: toast_tuple_target=128
 
 select * from settings;
-                 relid                  |                 compress_relid                 |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                          index                           
-----------------------------------------+------------------------------------------------+-------------+---------+--------------+--------------------+----------------------------------------------------------
- test_sparse_index                      |                                                |             |         |              |                    | 
- _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_9_chunk | {value_new} | {x}     | {t}          | {t}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
+                 relid                  |                 compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                          index                           
+----------------------------------------+-------------------------------------------------+-------------+---------+--------------+--------------------+----------------------------------------------------------
+ test_sparse_index                      |                                                 |             |         |              |                    | 
+ _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_10_chunk | {value_new} | {x}     | {t}          | {t}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
 (2 rows)
 
 reset timescaledb.enable_sparse_index_bloom;

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -499,8 +499,8 @@ BEGIN;
 CREATE TABLE t40(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time', tsdb.index='bloom(value)');
 ERROR:  cannot set sparse index option without orderby option
 ROLLBACK;
-reset timescaledb.enable_sparse_index_bloom;
 \set ON_ERROR_STOP 1
+reset timescaledb.enable_sparse_index_bloom;
 -- test UUID partitioning + compression
 BEGIN;
 CREATE TABLE IF NOT EXISTS events (

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -235,6 +235,15 @@ select count(*) from test_sparse_index where u = '90ec9e8e-4501-4232-9d03-6d7cf6
 explain (analyze, verbose, costs off, timing off, summary off)
 select count(*) from test_sparse_index where ts between '2021-01-07' and '2021-01-14';
 
+
+-- Test recompression when the bloom filter index is disabled by a GUC
+set timescaledb.enable_sparse_index_bloom to off;
+
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
+
+reset timescaledb.enable_sparse_index_bloom;
+
+
 -- Test rename column
 -- change a non-sparse index column
 alter table test_sparse_index rename value to value_new;

--- a/tsl/test/sql/create_table_with.sql
+++ b/tsl/test/sql/create_table_with.sql
@@ -299,8 +299,9 @@ ROLLBACK;
 BEGIN;
 CREATE TABLE t40(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time', tsdb.index='bloom(value)');
 ROLLBACK;
-reset timescaledb.enable_sparse_index_bloom;
 \set ON_ERROR_STOP 1
+
+reset timescaledb.enable_sparse_index_bloom;
 
 -- test UUID partitioning + compression
 BEGIN;


### PR DESCRIPTION
…(#8807)

At the moment the compression would fail with an error which is disruptive if we want to temporarily disable the bloom filter indexes on a database. Lower the message severity to WARNING. Still treat it as an error when configuring new indexes.

(cherry picked from commit 3854a227752aac483280b3372f0bccafb6554fd3)