### PR TITLE
Refactor chunk compression logic

### DIFF
--- a/.unreleased/pr_8819
+++ b/.unreleased/pr_8819
@@ -1,0 +1,1 @@
+Implements: #8819 Refactor chunk compression logic

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4591,6 +4591,12 @@ ts_chunk_is_compressed(const Chunk *chunk)
 }
 
 bool
+ts_chunk_needs_compression(const Chunk *chunk)
+{
+	return !ts_chunk_is_compressed(chunk);
+}
+
+bool
 ts_chunk_needs_recompression(const Chunk *chunk)
 {
 	Assert(ts_chunk_is_compressed(chunk));

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -226,6 +226,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(const Chunk *chun
 extern TSDLLEXPORT bool ts_chunk_is_unordered(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_partial(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_compressed(const Chunk *chunk);
+extern TSDLLEXPORT bool ts_chunk_needs_compression(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_needs_recompression(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(const Chunk *chunk,
 																	 ChunkOperation cmd,

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -660,6 +660,61 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	write_logical_replication_msg_decompression_end();
 }
 
+static bool
+recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
+{
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
+	bool recompressed = false;
+
+	if (!chunk_settings || !chunk_settings->fd.orderby)
+	{
+		elog(NOTICE,
+			 "in-memory recompression is disabled due to no order by, "
+			 "performing decompress/compress on chunk \"%s.%s\"",
+			 NameStr(chunk->fd.schema_name),
+			 NameStr(chunk->fd.table_name));
+		return false;
+	}
+	else if (!get_compressed_chunk_index_for_recompression(chunk))
+	{
+		elog(NOTICE,
+			 "in-memory recompression is disabled due to no compressed chunk index, "
+			 "performing decompress/compress on chunk \"%s.%s\"",
+			 NameStr(chunk->fd.schema_name),
+			 NameStr(chunk->fd.table_name));
+		return false;
+	}
+
+	/*
+	 * Choose recompression strategy based on chunk state and settings:
+	 * 1. Segmentwise recompression: For partial chunks
+	 * 2. In-memory recompression: For fully compressed chunks with matching settings
+	 * 3. Fallback to decompress/compress: When neither strategy is applicable
+	 */
+
+	if (ts_chunk_is_partial(chunk))
+	{
+		if (!ts_guc_enable_segmentwise_recompression)
+		{
+			ereport(NOTICE,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("segmentwise in-memory recompression functionality disabled, "
+							"set timescaledb.enable_segmentwise_recompression to on")));
+			return false;
+		}
+
+		*uncompressed_chunk_id = recompress_chunk_segmentwise_impl(chunk);
+		recompressed = true;
+	}
+	/* TODO: optimize cases where settings differ but recompression is still possible */
+	else if (recompress && ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings))
+	{
+		recompressed = recompress_chunk_in_memory_impl(chunk);
+	}
+
+	return recompressed;
+}
 /*
  * Create a new compressed chunk using existing table with compressed data.
  *
@@ -761,75 +816,35 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 
 	write_logical_replication_msg_compression_start();
 
-	if (ts_chunk_is_compressed(chunk))
+	if (ts_chunk_needs_compression(chunk))
 	{
-		CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
-		bool valid_orderby_settings = chunk_settings && chunk_settings->fd.orderby;
-		if (recompress)
+		uncompressed_chunk_id = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+	}
+	else if (recompress || ts_chunk_needs_recompression(chunk))
+	{
+		/* Try in-memory recompression first and then fall back to decompress/recompress */
+		bool recompressed = recompress_chunk_impl(chunk, &uncompressed_chunk_id, recompress);
+		if (!recompressed)
 		{
-			CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
-
-			/* try recompression first */
-			if (!valid_orderby_settings ||
-				!ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings) ||
-				!recompress_chunk_impl(chunk))
-			{
-				/* TODO: move away from manual decompression/compression */
-				elog(NOTICE,
-					 "falling back to compress/decompress, performing full "
-					 "recompression on "
-					 "chunk \"%s.%s\"",
-					 NameStr(chunk->fd.schema_name),
-					 NameStr(chunk->fd.table_name));
-				decompress_chunk_impl(chunk, false);
-				compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
-			}
-			write_logical_replication_msg_compression_end();
-			return uncompressed_chunk_id;
-		}
-		if (!ts_chunk_needs_recompression(chunk))
-		{
-			write_logical_replication_msg_compression_end();
-			ereport((if_not_compressed ? NOTICE : ERROR),
-					(errcode(ERRCODE_DUPLICATE_OBJECT),
-					 errmsg("chunk \"%s\" is already converted to columnstore",
-							get_rel_name(chunk->table_id))));
-			return uncompressed_chunk_id;
-		}
-
-		if (ts_guc_enable_segmentwise_recompression && valid_orderby_settings &&
-			ts_chunk_is_partial(chunk) && get_compressed_chunk_index_for_recompression(chunk))
-		{
-			uncompressed_chunk_id = recompress_chunk_segmentwise_impl(chunk);
-		}
-		else
-		{
-			if (!ts_guc_enable_segmentwise_recompression || !valid_orderby_settings)
-				elog(NOTICE,
-					 "segmentwise recompression is disabled%s, performing full "
-					 "recompression on "
-					 "chunk \"%s.%s\"",
-					 (ts_guc_enable_segmentwise_recompression && !valid_orderby_settings ?
-						  " due to no order by" :
-						  ""),
-					 NameStr(chunk->fd.schema_name),
-					 NameStr(chunk->fd.table_name));
-			/* try recompression first */
-			if (!recompress_chunk_impl(chunk))
-			{
-				/* TODO: move away from manual decompression/compression */
-				decompress_chunk_impl(chunk, false);
-				compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
-			}
+			/* TODO: move away from manual decompression/compression */
+			elog(DEBUG1,
+				 "falling back to compress/decompress, performing full "
+				 "recompression on chunk \"%s.%s\"",
+				 NameStr(chunk->fd.schema_name),
+				 NameStr(chunk->fd.table_name));
+			decompress_chunk_impl(chunk, false);
+			compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
 		}
 	}
 	else
 	{
-		uncompressed_chunk_id = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+		ereport((if_not_compressed ? NOTICE : ERROR),
+				(errcode(ERRCODE_DUPLICATE_OBJECT),
+				 errmsg("chunk \"%s\" is already converted to columnstore",
+						get_rel_name(chunk->table_id))));
 	}
 
 	write_logical_replication_msg_compression_end();
-
 	return uncompressed_chunk_id;
 }
 

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -764,7 +764,7 @@ perform_recompression(RecompressContext *recompress_ctx, Relation compressed_chu
  * recompression (e.g., partial, unordered, frozen).
  */
 bool
-recompress_chunk_impl(Chunk *uncompressed_chunk)
+recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 {
 	if (uncompressed_chunk == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("chunk cannot be NULL")));
@@ -790,6 +790,8 @@ recompress_chunk_impl(Chunk *uncompressed_chunk)
 	Ensure(settings != NULL,
 		   "compression settings not found for chunk \"%s\"",
 		   get_rel_name(uncompressed_chunk->table_id));
+
+	Ensure(settings->fd.orderby, "empty order by, cannot recompress in-memory");
 
 	LOCKMODE lockmode = ExclusiveLock;
 	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, lockmode);

--- a/tsl/src/compression/recompress.h
+++ b/tsl/src/compression/recompress.h
@@ -29,7 +29,7 @@ typedef struct RecompressContext
 extern Datum tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS);
 
 Oid recompress_chunk_segmentwise_impl(Chunk *chunk);
-bool recompress_chunk_impl(Chunk *uncompressed_chunk);
+bool recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk);
 
 /* Result of matching an uncompressed tuple against a compressed batch */
 enum Batch_match_result

--- a/tsl/test/expected/compress_auto_sparse_index.out
+++ b/tsl/test/expected/compress_auto_sparse_index.out
@@ -28,7 +28,6 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 -- Should be disabled with the GUC
 set timescaledb.auto_sparse_indexes to off;
 select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
  count 
 -------
      1
@@ -42,7 +41,6 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 
 reset timescaledb.auto_sparse_indexes;
 select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
  count 
 -------
      1
@@ -76,7 +74,6 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 drop index ii;
 create index ii on sparse((value + 1));
 select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
  count 
 -------
      1
@@ -92,7 +89,6 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 drop index ii;
 create index ii on sparse using hash(value);
 select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
  count 
 -------
      1
@@ -108,7 +104,6 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 -- When the chunk is recompressed without index, no sparse index is created.
 drop index ii;
 select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
  count 
 -------
      1

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -223,7 +223,6 @@ select * from settings;
  _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal.compress_hyper_4_2_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
 
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_3_1_chunk"
  count 
 -------
      1
@@ -410,7 +409,6 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'minmax("x")');
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_5_4_chunk"
  count 
 -------
      1
@@ -448,7 +446,6 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x');
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_5_4_chunk"
  count 
 -------
      1
@@ -486,7 +483,6 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = '');
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_5_4_chunk"
  count 
 -------
      1
@@ -524,7 +520,6 @@ alter table test_sparse_index reset (timescaledb.compress_segmentby,
     timescaledb.compress_orderby,
     timescaledb.compress_index);
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_5_4_chunk"
  count 
 -------
      1

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2463,7 +2463,6 @@ NOTICE:  chunk "_hyper_47_102_chunk" is already converted to columnstore
 
 -- unless we specify recompress := true
 SELECT compress_chunk(:'CHUNK', recompress := true);
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_47_102_chunk"
               compress_chunk               
 -------------------------------------------
  _timescaledb_internal._hyper_47_102_chunk

--- a/tsl/test/expected/compression_nulls_and_defaults.out
+++ b/tsl/test/expected/compression_nulls_and_defaults.out
@@ -47,7 +47,7 @@ select * from t;
 
 insert into t (ts,c1) values (7,7);
 select compress_chunk(show_chunks('t'));
-NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_1_1_chunk"
+NOTICE:  in-memory recompression is disabled due to no order by, performing decompress/compress on chunk "_timescaledb_internal._hyper_1_1_chunk"
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -137,7 +137,7 @@ select * from t;
   6 |  6 |  
 
 select compress_chunk(show_chunks('t'));
-NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_5_6_chunk"
+NOTICE:  in-memory recompression is disabled due to no order by, performing decompress/compress on chunk "_timescaledb_internal._hyper_5_6_chunk"
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_5_6_chunk
@@ -307,7 +307,7 @@ select * from t;
 alter table t alter column a set default 7.2;
 insert into t (ts,c1) values (7,7);
 select compress_chunk(show_chunks('t'));
-NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_13_15_chunk"
+NOTICE:  in-memory recompression is disabled due to no order by, performing decompress/compress on chunk "_timescaledb_internal._hyper_13_15_chunk"
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_13_15_chunk

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -300,6 +300,7 @@ INSERT INTO hyper VALUES (20, 1, 1);
 SELECT compress_chunk(show_chunks('hyper'));
 NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
 NOTICE:  chunk "_hyper_1_2_chunk" is already converted to columnstore
+NOTICE:  in-memory recompression is disabled due to no compressed chunk index, performing decompress/compress on chunk "_timescaledb_internal._hyper_1_3_chunk"
 NOTICE:  chunk "_hyper_1_4_chunk" is already converted to columnstore
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -247,7 +247,6 @@ ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb
 SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
 -- recompressing chunks should apply current hypertable settings
 SELECT compress_chunk(:'CHUNK', recompress:=true);
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_3_8_chunk"
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_3_8_chunk
@@ -274,7 +273,6 @@ SELECT * FROM settings;
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='');
 SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
 SELECT compress_chunk(:'CHUNK', recompress:=true);
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_3_8_chunk"
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_3_8_chunk
@@ -327,8 +325,6 @@ SELECT * FROM ht_settings;
 -- test decompression uses the correct settings
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='');
 SELECT compress_chunk(show_chunks('metrics'), recompress:=true);
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_3_6_chunk"
-NOTICE:  falling back to compress/decompress, performing full recompression on chunk "_timescaledb_internal._hyper_3_8_chunk"
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_3_6_chunk

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -594,7 +594,7 @@ ERROR:  segmentwise recompression cannot be applied for compression with no orde
 \set ON_ERROR_STOP 1
 -- Compress wrapper: do full recompress instead of by segment
 SELECT compress_chunk(:'chunk_to_compress');
-NOTICE:  segmentwise recompression is disabled due to no order by, performing full recompression on chunk "_timescaledb_internal._hyper_20_21_chunk"
+NOTICE:  in-memory recompression is disabled due to no order by, performing decompress/compress on chunk "_timescaledb_internal._hyper_20_21_chunk"
 INFO:  using tuplesort to scan rows from "_hyper_20_21_chunk" for converting to columnstore
               compress_chunk              
 ------------------------------------------
@@ -625,7 +625,7 @@ ERROR:  segmentwise recompression functionality disabled, enable it by first set
 \set ON_ERROR_STOP 1
 -- When GUC is OFF, entire chunk should be fully uncompressed and compressed instead
 SELECT compress_chunk(:'chunk_to_compress');
-NOTICE:  segmentwise recompression is disabled, performing full recompression on chunk "_timescaledb_internal._hyper_22_24_chunk"
+NOTICE:  segmentwise in-memory recompression functionality disabled, set timescaledb.enable_segmentwise_recompression to on
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_22_24_chunk


### PR DESCRIPTION
Simplify tsl_compress_chunk_wrapper by extracting recompression logic into a dedicated function and introducing helper functions for chunk state checks. Rename recompress_chunk_impl to recompress_chunk_in_memory_impl for clarity.