### PR TITLE
Fix a misnomer in a warning

### DIFF
--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -507,7 +507,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 			compression_ratio < POOR_COMPRESSION_THRESHOLD)
 			ereport(WARNING,
 					errcode(ERRCODE_WARNING),
-					errmsg("poor compression rate detected for chunk \"%s\"'",
+					errmsg("poor compression ratio detected for chunk \"%s\"'",
 						   get_rel_name(chunk_relid)),
 					errdetail("Chunk \"%s\" has a poor compression ratio: %.2f. Size before "
 							  "compression: " INT64_FORMAT

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2690,10 +2690,10 @@ SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_
             281
 
 ROLLBACK;
--- Test poor compression rate warning works as expected
+-- Test poor compression ratio warning works as expected
 -- Turn GUC on
 SET timescaledb.enable_compression_ratio_warnings TO ON;
--- Compressing a table with very few rows virtually guarantees a poor compression rate
+-- Compressing a table with very few rows virtually guarantees a poor compression ratio
 CREATE TABLE badly_compressed_ht (time timestamptz, device_id integer, a integer);
 SELECT create_hypertable('badly_compressed_ht', 'time');
          create_hypertable         
@@ -2707,7 +2707,7 @@ INSERT INTO badly_compressed_ht VALUES
 ('2025-04-25 02:00'::timestamp, 3, 3);
 \set VERBOSITY default
 SELECT compress_chunk(show_chunks('badly_compressed_ht'));
-WARNING:  poor compression rate detected for chunk "_hyper_57_116_chunk"'
+WARNING:  poor compression ratio detected for chunk "_hyper_57_116_chunk"'
 DETAIL:  Chunk "_hyper_57_116_chunk" has a poor compression ratio: 0.60. Size before compression: 24576 bytes. Size after compression: 40960 bytes
 HINT:  Changing compression settings for "badly_compressed_ht" can improve compression rate
               compress_chunk               

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1225,12 +1225,12 @@ where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'C
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
 ROLLBACK;
 
--- Test poor compression rate warning works as expected
+-- Test poor compression ratio warning works as expected
 
 -- Turn GUC on
 SET timescaledb.enable_compression_ratio_warnings TO ON;
 
--- Compressing a table with very few rows virtually guarantees a poor compression rate
+-- Compressing a table with very few rows virtually guarantees a poor compression ratio
 CREATE TABLE badly_compressed_ht (time timestamptz, device_id integer, a integer);
 SELECT create_hypertable('badly_compressed_ht', 'time');
 ALTER TABLE badly_compressed_ht set (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');


### PR DESCRIPTION
We mean compression "ratio" not "rate" here. Use the former consistently.

Disable-check: force-changelog-file