### PR TITLE
Stabilize the collation test

### DIFF
--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -4,10 +4,24 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- We have different collation names such as en_US, en-US-x-icu and so on,
 -- that are available on different platforms.
+with encodings as (
+  select -1
+  union all
+  select encoding from pg_database where datname = current_database()
+)
+, pattern(pattern, priority) as (
+    values ('en_us%',  2), ('en_us_utf%8%', 1)
+)
+, collations as (
+    select priority, collname
+    from pg_collation join pattern
+    on collname ilike pattern
+    where collencoding in (select * from encodings)
+    order by priority, collencoding, collname
+)
 select * from (
     select 3 priority, 'C' "COLLATION"
-    union all (select 2, collname from pg_collation where collname ilike 'en_us%' order by collencoding, collname limit 1)
-    union all (select 1, collname from pg_collation where collname ilike 'en_us_utf%8%' order by collencoding, collname limit 1)
+    union all select * from collations
 ) c
 order by priority limit 1 \gset
 create table compressed_collation_ht(time timestamp, name text collate :"COLLATION",

--- a/tsl/test/sql/compressed_collation.sql
+++ b/tsl/test/sql/compressed_collation.sql
@@ -6,10 +6,24 @@
 
 -- We have different collation names such as en_US, en-US-x-icu and so on,
 -- that are available on different platforms.
+with encodings as (
+  select -1
+  union all
+  select encoding from pg_database where datname = current_database()
+)
+, pattern(pattern, priority) as (
+    values ('en_us%',  2), ('en_us_utf%8%', 1)
+)
+, collations as (
+    select priority, collname
+    from pg_collation join pattern
+    on collname ilike pattern
+    where collencoding in (select * from encodings)
+    order by priority, collencoding, collname
+)
 select * from (
     select 3 priority, 'C' "COLLATION"
-    union all (select 2, collname from pg_collation where collname ilike 'en_us%' order by collencoding, collname limit 1)
-    union all (select 1, collname from pg_collation where collname ilike 'en_us_utf%8%' order by collencoding, collname limit 1)
+    union all select * from collations
 ) c
 order by priority limit 1 \gset
 


### PR DESCRIPTION
The chosen collation must match the database encoding.