### PR TITLE
Report the commit information while building the extension

### DIFF
--- a/src/gitcommit.cmake
+++ b/src/gitcommit.cmake
@@ -34,7 +34,10 @@ if(GIT_FOUND)
      OR _log_RESULT)
     message(STATUS "Unable to get git commit information")
   else()
-    message(STATUS "Building commit ${EXT_GIT_COMMIT_TAG} (${EXT_GIT_COMMIT_HASH}), ${EXT_GIT_COMMIT_TIME}")
+    message(
+      STATUS
+        "Building commit ${EXT_GIT_COMMIT_TAG} (${EXT_GIT_COMMIT_HASH}), ${EXT_GIT_COMMIT_TIME}"
+    )
   endif()
 endif()
 


### PR DESCRIPTION
For some reason our APT packages report `_timescaledb_functions.get_git_commit().commit_tag`  as "2.22.1-dirty", this will help to debug it.

Disable-check: force-changelog-file