### PR TITLE
Retain compression settings when disabling columnstore

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -814,8 +814,6 @@ disable_compression(Hypertable *ht, WithClauseResult *with_clause_options)
 		ts_hypertable_unset_compressed(ht);
 	}
 
-	ts_compression_settings_delete(ht->main_table_relid);
-
 	return true;
 }
 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -2556,3 +2556,35 @@ SELECT * FROM timescaledb_information.hypertable_compression_settings WHERE hype
 ------------+-----------+---------+--------------------------+-------
  mix_pg_ts  |           | "time"  |                          | 
 
+-- test that compression settings are retained when disabling and re-enabling columnstore
+CREATE TABLE retain_settings(time timestamptz NOT NULL, device text, value float);
+ create_hypertable 
+-------------------
+ (1,public)
+
+SELECT create_hypertable('retain_settings', 'time');
+ create_hypertable 
+-------------------
+ (1,public)
+
+ALTER TABLE retain_settings SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time DESC');
+-- settings stored before disable
+SELECT segmentby, orderby FROM _timescaledb_catalog.compression_settings WHERE relid = 'retain_settings'::regclass;
+ segmentby | orderby  
+-----------+----------
+ {device}  | {time}
+
+-- disable and check settings are retained
+ALTER TABLE retain_settings SET (timescaledb.columnstore = false);
+SELECT segmentby, orderby FROM _timescaledb_catalog.compression_settings WHERE relid = 'retain_settings'::regclass;
+ segmentby | orderby  
+-----------+----------
+ {device}  | {time}
+
+-- re-enable and verify settings restored
+ALTER TABLE retain_settings SET (timescaledb.columnstore = true);
+SELECT segmentby, orderby FROM _timescaledb_catalog.compression_settings WHERE relid = 'retain_settings'::regclass;
+ segmentby | orderby  
+-----------+----------
+ {device}  | {time}
+


### PR DESCRIPTION
### Retain Compression Settings When Disabling Columnstore

This PR fixes issue #8841 by ensuring that compression settings are preserved when disabling columnstore on a hypertable. Previously, disabling columnstore would delete custom compression settings, preventing users from restoring their configurations when re-enabling columnstore. With this change, settings are retained, allowing seamless restoration.

- Removes deletion of compression settings in `disable_compression`
- Adds a test to verify settings persistence

Fixes #8841