### PR TITLE
Remove UNLOGGED check during truncation

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -189,7 +189,6 @@ truncate_relation(Oid table_oid)
 #else
 		RelationSetNewRelfilenumber(rel, rel->rd_rel->relpersistence);
 #endif
-		Assert(rel->rd_rel->relpersistence != RELPERSISTENCE_UNLOGGED);
 		table_close(rel, NoLock);
 	}
 

--- a/tsl/test/expected/insert_memory_usage.out
+++ b/tsl/test/expected/insert_memory_usage.out
@@ -6,6 +6,7 @@
 -- we'll have to log it from a trigger that runs after the query is completed.
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);
+alter table uk_price_paid set unlogged;
 -- Aim to about 100 partitions, the data is from 1995 to 2022.
 select create_hypertable('uk_price_paid', 'date', chunk_time_interval => interval '90 day');
      create_hypertable      

--- a/tsl/test/sql/insert_memory_usage.sql
+++ b/tsl/test/sql/insert_memory_usage.sql
@@ -9,6 +9,7 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 
 create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);
+alter table uk_price_paid set unlogged;
 -- Aim to about 100 partitions, the data is from 1995 to 2022.
 select create_hypertable('uk_price_paid', 'date', chunk_time_interval => interval '90 day');
 


### PR DESCRIPTION
We enabled creating unlogged hypertables so removing an outdated assertion.

Disable-check: force-changelog-file