### PR TITLE
Make is_valid_query volatile

### DIFF
--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -67,7 +67,7 @@ continuous_agg_validate_query(PG_FUNCTION_ARGS)
 {
 	text *query_text = PG_GETARG_TEXT_P(0);
 	char *sql;
-	bool is_valid_query = false;
+	volatile bool is_valid_query = false;
 	Datum datum_sql;
 	TupleDesc tupdesc;
 	ErrorData *edata;


### PR DESCRIPTION
Test cagg_utils failed in package test for ARM, in the part that test if a query is a valid cagg query. The error codes are messages were correct, just the "is valid" flag was true instead of false despite the error. My theory is that not declaring is_valid_query as volatile somehow enabled the compiler to reorder instructions incorrectly on arm. I am not 100% sure making this variable volatile will fix the issue (need repackaging to test), but it is the right way regardless

Disable-check: force-changelog-file