### PR TITLE
Remove kerberos dependency from ci

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -74,7 +74,7 @@ jobs:
         docker pull ${BUILDER_IMAGE}
         docker buildx imagetools inspect ${BUILDER_IMAGE}
         docker run -i --rm -v $(pwd):/mnt -e EXTRA_PKGS="${EXTRA_PKGS}" ${BUILDER_IMAGE} bash <<"EOF"
-          apk add cmake gcc make build-base krb5-dev git ${EXTRA_PKGS}
+          apk add cmake gcc make build-base git ${EXTRA_PKGS}
           # We run the same extension on different docker images, old versions
           # have OpenSSL 1.1 and the new versions have OpenSSL 3, so we try to
           # pin the 1.1. Note that depending on PG version, both images might
@@ -98,7 +98,7 @@ jobs:
         docker pull ${TEST_IMAGE}
         docker buildx imagetools inspect ${TEST_IMAGE}
         docker run -i --rm -v $(pwd):/mnt -e EXTRA_PKGS="${EXTRA_PKGS}" ${TEST_IMAGE} bash <<"EOF"
-          apk add cmake gcc make build-base krb5-dev sudo coreutils ${EXTRA_PKGS}
+          apk add cmake gcc make build-base sudo coreutils ${EXTRA_PKGS}
           apk add openssl1.1-compat-dev || apk add openssl-dev
           cd /mnt
           cp build_abi/install_ext/* `pg_config --sharedir`/extension/

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         sudo apt-get update
         sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -94,7 +94,7 @@ jobs:
       run: |
         PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
         echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
-        apt-get install -y gcc make cmake libssl-dev libkrb5-dev libipc-run-perl \
+        apt-get install -y gcc make cmake libssl-dev libipc-run-perl \
           libtest-most-perl sudo gdb git wget gawk lbzip2 flex bison lcov base-files \
           locales clang-14 llvm-14 llvm-14-dev llvm-14-tools postgresql-client pkgconf \
           icu-devtools

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev python3-psutil
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common python3-psutil
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         sudo apt-get update
         sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Linux Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install pip postgresql-common libkrb5-dev
+          sudo apt-get install pip postgresql-common
 
       - name: Install testgres
         run: |

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common \
-            libkrb5-dev build-essential autoconf autoconf-archive \
+            build-essential autoconf autoconf-archive \
             libboost-regex-dev libsqlite3-dev jq
 
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -53,7 +53,7 @@ create_postgres_build_image() {
     docker run -d --name ${BUILD_CONTAINER_NAME} --env POSTGRES_HOST_AUTH_METHOD=trust -v ${BASE_DIR}:/src postgres:${PG_IMAGE_TAG}
 
     # Install build dependencies
-    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps postgresql-dev gdb coreutils dpkg-dev gcc git libc-dev make cmake util-linux-dev diffutils libssl3 openssl-dev krb5-dev && mkdir -p /build/debug"
+    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps postgresql-dev gdb coreutils dpkg-dev gcc git libc-dev make cmake util-linux-dev diffutils libssl3 && mkdir -p /build/debug"
     docker commit -a $USER -m "TimescaleDB build base image version $PG_IMAGE_TAG" ${BUILD_CONTAINER_NAME} ${image}
     remove_build_container ${BUILD_CONTAINER_NAME}
 


### PR DESCRIPTION
Kerberos library was needed for multinode but now its no longer
needed for building timescaledb

Disable-check: approval-count
Disable-check: force-changelog-file
