### PR TITLE
Don't error on failure to update job stat

### DIFF
--- a/.unreleased/pr_8873
+++ b/.unreleased/pr_8873
@@ -1,0 +1,1 @@
+Fixes: #8873 Don't error on failure to update job stats


### PR DESCRIPTION
Failing to update job stats should not result in the job producing
an error instead this should be debug logged. This can happen when
jobs concurrently with job stat retention policy.

Fixes: #8854
