### PR TITLE
Fix decoding of UUID v7 timestamp microseconds

### DIFF
--- a/.unreleased/pr_8876
+++ b/.unreleased/pr_8876
@@ -1,0 +1,1 @@
+Fixes: #8875 Fix decoding of UUID v7 timestamp microseconds

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -173,7 +173,7 @@ ts_uuid_v7_extract_unixtime(const pg_uuid_t *uuid, uint64 *unixtime_ms, uint16 *
 	if (extra_us)
 	{
 		/* Optionally, get the sub ms part as microseconds, reversing the scaling */
-		*extra_us = (((uuid->data[6] & 0xF) << 8) | uuid->data[7]) * 1000 / (1 << 12);
+		*extra_us = ((((uuid->data[6] & 0xF) << 8) | uuid->data[7]) + 1) * 1000 / (1 << 12);
 	}
 
 	return is_uuidv7;

--- a/tsl/test/expected/compression_uuid.out
+++ b/tsl/test/expected/compression_uuid.out
@@ -326,7 +326,6 @@ WHERE
 --   generate a UUID v7 based on the timestamp and
 --   extract the timestamp from the UUID and
 --   compare the timestamp to the original one
---   1 microsecond difference is allowed due to scaling of decimals to binaries
 --
 CREATE TABLE subms AS SELECT to_uuidv7(x) u, x ts
 FROM
@@ -340,7 +339,7 @@ FROM
       subms
   ) x
 WHERE
-  (x.ts - x.ts2) > '00:00:00.000001' OR (x.ts - x.ts2) < '-00:00:00.000001';
+  x.ts <> x.ts2;
  u | ts | ts2 
 ---+----+-----
 

--- a/tsl/test/expected/vector_agg_uuid.out
+++ b/tsl/test/expected/vector_agg_uuid.out
@@ -130,15 +130,14 @@ where uuid_ts < '2025-06-25 16:16:46.347779+01' and ver = 7
 order by 1,2;
  ver |                  u                   | ts |               uuid_ts               
 -----+--------------------------------------+----+-------------------------------------
-   7 | 01941f29-7c00-706a-bea9-105dad841304 | 17 | Tue Dec 31 16:00:00.000025 2024 PST
-   7 | 01941f2a-665f-7722-b4b5-cf4e70e666d0 | 18 | Tue Dec 31 16:00:59.999445 2024 PST
+   7 | 01941f29-7c00-706a-bea9-105dad841304 | 17 | Tue Dec 31 16:00:00.000026 2024 PST
+   7 | 01941f2a-665f-7722-b4b5-cf4e70e666d0 | 18 | Tue Dec 31 16:00:59.999446 2024 PST
    7 | 0197a7a9-b48b-7c71-92cb-eb724822bb0f |  4 | Wed Jun 25 08:16:46.347777 2025 PDT
    7 | 0197a7a9-b48b-7c71-92cb-eb724822bb0f |  3 | Wed Jun 25 08:16:46.347777 2025 PDT
    7 | 0197a7a9-b48b-7c71-92cb-eb724822bb0f |  2 | Wed Jun 25 08:16:46.347777 2025 PDT
    7 | 0197a7a9-b48b-7c71-92cb-eb724822bb0f |  1 | Wed Jun 25 08:16:46.347777 2025 PDT
    7 | 0197a7a9-b48b-7c75-a810-8acf630e634f |  5 | Wed Jun 25 08:16:46.347778 2025 PDT
    7 | 0197a7a9-b48b-7c75-a810-8acf630e634f |  6 | Wed Jun 25 08:16:46.347778 2025 PDT
-   7 | 0197a7a9-b48b-7c76-b616-69e64a802b5c |  7 | Wed Jun 25 08:16:46.347778 2025 PDT
 
 SELECT ver, u, count(*), sum(ts) from uuid_table
 where uuid_ts < '2025-06-25 16:16:46.347779+01' and ver = 7
@@ -149,6 +148,5 @@ group by 1,2 order by 1,2;
    7 | 01941f2a-665f-7722-b4b5-cf4e70e666d0 |     1 |  18
    7 | 0197a7a9-b48b-7c71-92cb-eb724822bb0f |     4 |  10
    7 | 0197a7a9-b48b-7c75-a810-8acf630e634f |     2 |  11
-   7 | 0197a7a9-b48b-7c76-b616-69e64a802b5c |     1 |   7
 
 RESET timescaledb.debug_require_vector_agg;

--- a/tsl/test/sql/compression_uuid.sql
+++ b/tsl/test/sql/compression_uuid.sql
@@ -244,7 +244,6 @@ WHERE
 --   generate a UUID v7 based on the timestamp and
 --   extract the timestamp from the UUID and
 --   compare the timestamp to the original one
---   1 microsecond difference is allowed due to scaling of decimals to binaries
 --
 CREATE TABLE subms AS SELECT to_uuidv7(x) u, x ts
 FROM
@@ -259,7 +258,7 @@ FROM
       subms
   ) x
 WHERE
-  (x.ts - x.ts2) > '00:00:00.000001' OR (x.ts - x.ts2) < '-00:00:00.000001';
+  x.ts <> x.ts2;
 
 
 -- Make sure UUIDv7 compression is enabled


### PR DESCRIPTION
Fix decoding of UUID v7 timestamp microseconds

Fixes #8875, decoding was 1 microsecond off for most microsecond values.