### PR TITLE
Declarative Partitioning for Hypertables

### DIFF
--- a/.unreleased/pr_8890
+++ b/.unreleased/pr_8890
@@ -1,0 +1,1 @@
+Implements: #8890 Declarative Partitioning for Hypertables

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
     license_guc.c
     osm_callbacks.c
     partitioning.c
+    partition_chunk.c
     process_utility.c
     scanner.c
     scan_iterator.c

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -279,9 +279,7 @@ extern TSDLLEXPORT void ts_chunk_detach_by_relid(Oid relid);
 		Assert((chunk)->fd.hypertable_id > 0);                                                     \
 		Assert(OidIsValid((chunk)->table_id));                                                     \
 		Assert(OidIsValid((chunk)->hypertable_relid));                                             \
-		Assert((chunk)->constraints);                                                              \
 		Assert((chunk)->cube);                                                                     \
-		Assert((chunk)->cube->num_slices == (chunk)->constraints->num_dimension_constraints);      \
 		Assert((chunk)->relkind == RELKIND_RELATION || (chunk)->relkind == RELKIND_FOREIGN_TABLE); \
 	} while (0)
 

--- a/src/guc.c
+++ b/src/guc.c
@@ -145,6 +145,8 @@ bool ts_guc_enable_tss_callbacks = true;
 TSDLLEXPORT bool ts_guc_enable_delete_after_compression = false;
 TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh = false;
 
+bool ts_guc_enable_partitioned_hypertables = false;
+
 /* default value of ts_guc_max_open_chunks_per_insert and
  * ts_guc_max_cached_chunks_per_hypertable will be set as their respective boot-value when the
  * GUC mechanism starts up */
@@ -1206,6 +1208,20 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+#ifdef TS_DEBUG
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_partitioned_hypertables"),
+							 "Enable hypertables using declarative partitioning",
+							 "Enable experimental support for creating hypertables using "
+							 "PostgreSQL's native declarative partitioning",
+							 &ts_guc_enable_partitioned_hypertables,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+#endif
 
 #ifdef USE_TELEMETRY
 	DefineCustomEnumVariable(MAKE_EXTOPTION("telemetry_level"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -151,6 +151,8 @@ extern TSDLLEXPORT DebugRequireOption ts_guc_debug_require_batch_sorted_merge;
 
 extern TSDLLEXPORT bool ts_guc_debug_allow_cagg_with_deprecated_funcs;
 
+extern bool ts_guc_enable_partitioned_hypertables;
+
 void _guc_init(void);
 
 typedef enum

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -25,6 +25,7 @@
 #include "annotations.h"
 #include "dimension.h"
 #include "errors.h"
+#include "guc.h"
 #include "hypertable_cache.h"
 #include "indexing.h"
 #include "partitioning.h"
@@ -357,7 +358,8 @@ ts_indexing_root_table_create_index(IndexStmt *stmt, const char *queryString,
 			char relkind = get_rel_relkind(lfirst_oid(lc));
 
 			if (relkind != RELKIND_RELATION && relkind != RELKIND_MATVIEW &&
-				relkind != RELKIND_FOREIGN_TABLE)
+				relkind != RELKIND_FOREIGN_TABLE &&
+				!(relkind == RELKIND_PARTITIONED_TABLE && ts_guc_enable_partitioned_hypertables))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 						 errmsg("cannot create index on hypertable \"%s\"",

--- a/src/init.c
+++ b/src/init.c
@@ -19,6 +19,7 @@
 #include "guc.h"
 #include "license_guc.h"
 #include "nodes/constraint_aware_append/constraint_aware_append.h"
+#include "partition_chunk.h"
 #include "ts_catalog/catalog.h"
 #include "version.h"
 
@@ -43,6 +44,9 @@ extern void _event_trigger_fini(void);
 
 extern void _conn_plain_init();
 extern void _conn_plain_fini();
+
+extern void _executor_init(void);
+extern void _executor_fini(void);
 
 #ifdef TS_USE_OPENSSL
 extern void _conn_ssl_init();
@@ -83,6 +87,7 @@ cleanup_on_pg_proc_exit(int code, Datum arg)
 	_cache_invalidate_fini();
 	_hypertable_cache_fini();
 	_cache_fini();
+	_executor_fini();
 }
 
 void
@@ -114,6 +119,7 @@ _PG_init(void)
 	_process_utility_init();
 	_guc_init();
 	_conn_plain_init();
+	_executor_init();
 #ifdef TS_USE_OPENSSL
 	_conn_ssl_init();
 #endif

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -602,7 +602,6 @@ ExecInsert(ModifyTableContext *context,
 	OnConflictAction onconflict = node->onConflictAction;
 	bool skip_generated_column_computations = false;
 
-	Assert(!mtstate->mt_partition_tuple_routing);
 
 	/*
 	 * If the input result relation is a partitioned table, find the leaf

--- a/src/partition_chunk.c
+++ b/src/partition_chunk.c
@@ -1,0 +1,437 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+#include <access/attmap.h>
+#include <access/toast_compression.h>
+#include <catalog/heap.h>
+#include <catalog/pg_constraint.h>
+#include <commands/tablecmds.h>
+#include <executor/executor.h>
+#include <nodes/makefuncs.h>
+#include <nodes/parsenodes.h>
+#include <rewrite/rewriteManip.h>
+#include <utils/partcache.h>
+
+#include "chunk.h"
+#include "extension.h"
+#include "guc.h"
+#include "hypercube.h"
+#include "hypertable.h"
+#include "partition_chunk.h"
+
+void _executor_init(void);
+void _executor_fini(void);
+static ExecutorEnd_hook_type prev_executor_end_hook = NULL;
+
+/*
+ * Cache and the memory context to store recently created chunks to be attached
+ * as partitions.
+ */
+static HTAB *PartChunkCache = NULL;
+static MemoryContext PartChunkCacheCxt = NULL;
+
+/*
+ * Transaction callback to clean up the partition chunk cache on abort.
+ * Memory context is deleted by the portal context cleanup. Just nullify the
+ * pointers here.
+ */
+static void
+partcache_xact_callback(XactEvent event, void *arg)
+{
+	switch (event)
+	{
+		case XACT_EVENT_ABORT:
+		case XACT_EVENT_PARALLEL_ABORT:
+			PartChunkCache = NULL;
+			PartChunkCacheCxt = NULL;
+			break;
+
+		default:
+			/* do nothing? */
+			break;
+	}
+}
+
+/*
+ * Insert a chunk into the partition cache.
+ */
+void
+ts_partition_cache_insert_chunk(const Hypertable *ht, Oid chunk_relid)
+{
+	PartChunkCacheEntry *entry;
+	bool found;
+
+	if (PartChunkCache == NULL)
+	{
+		if (PartChunkCacheCxt == NULL)
+			PartChunkCacheCxt = AllocSetContextCreate(PortalContext,
+													  "partition chunk cache",
+													  ALLOCSET_DEFAULT_SIZES);
+
+		HASHCTL ctl;
+		ctl.hcxt =
+			AllocSetContextCreate(PortalContext, "partition chunk cache", ALLOCSET_DEFAULT_SIZES);
+		ctl.keysize = sizeof(Oid);
+		ctl.entrysize = sizeof(PartChunkCacheEntry);
+
+		PartChunkCache = hash_create("partition chunk cache",
+									 256, /* start small, grows automatically */
+									 &ctl,
+									 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+		RegisterXactCallback(partcache_xact_callback, NULL);
+	}
+
+	entry = hash_search(PartChunkCache, &ht->main_table_relid, HASH_ENTER, &found);
+	if (!found)
+		entry->chunk_oids = NIL;
+
+	MemoryContext oldctx = MemoryContextSwitchTo(PartChunkCacheCxt);
+	entry->chunk_oids = lappend_oid(entry->chunk_oids, chunk_relid);
+	MemoryContextSwitchTo(oldctx);
+}
+
+/*
+ * Get a partition cache entry by hypertable relid.
+ */
+PartChunkCacheEntry *
+ts_partition_cache_get_by_hypertable(Oid ht_relid)
+{
+	PartChunkCacheEntry *entry;
+
+	if (PartChunkCache == NULL)
+		return NULL;
+
+	entry = (PartChunkCacheEntry *) hash_search(PartChunkCache, &ht_relid, HASH_FIND, NULL);
+
+	return entry;
+}
+
+/*
+ * Destroy the partition chunk cache.
+ */
+void
+ts_partition_cache_destroy(void)
+{
+	if (PartChunkCache != NULL)
+	{
+		hash_destroy(PartChunkCache);
+		PartChunkCache = NULL;
+		PartChunkCacheCxt = NULL;
+	}
+}
+
+/*
+ * Fill the attribute and constraint lists by copying from the parent hypertable attributes.
+ * Partition chunk's attributes are derived from the hypertable's attributes including storage,
+ * compression, generation expressions, and default values.
+ *
+ * The constraints list is filled with the CHECK and NOT NULL constraints on attributes.
+ *
+ * This code is adapted from MergeAttributes() in tablecmds.c.
+ */
+void
+ts_partition_chunk_prepare_attributes(Oid ht_relid, List **attlist, List **constraints)
+{
+	Relation rel = table_open(ht_relid, AccessShareLock);
+	TupleDesc tupleDesc = RelationGetDescr(rel);
+	TupleConstr *constr = tupleDesc->constr;
+	AttrMap *newattmap = make_attrmap(tupleDesc->natts);
+	List *inherited_defaults = NIL;
+	List *cols_with_defaults = NIL;
+	int child_attno = 0;
+
+	for (int parent_attno = 1; parent_attno <= tupleDesc->natts; parent_attno++)
+	{
+		Form_pg_attribute attribute = TupleDescAttr(tupleDesc, parent_attno - 1);
+		char *attributeName = NameStr(attribute->attname);
+		ColumnDef *newdef;
+
+		/*
+		 * Ignore dropped columns in the parent.
+		 */
+		if (attribute->attisdropped)
+			continue; /* leave newattmap->attnums entry as zero */
+
+		/*
+		 * Create new column definition
+		 */
+		newdef = makeColumnDef(attributeName,
+							   attribute->atttypid,
+							   attribute->atttypmod,
+							   attribute->attcollation);
+		newdef->type = T_ColumnDef;
+		newdef->is_not_null = attribute->attnotnull;
+		newdef->storage = attribute->attstorage;
+		newdef->generated = attribute->attgenerated;
+		if (CompressionMethodIsValid(attribute->attcompression))
+			newdef->compression = pstrdup(GetCompressionMethodName(attribute->attcompression));
+
+		newdef->inhcount = 0;
+		newdef->is_local = false;
+		newattmap->attnums[parent_attno - 1] = ++child_attno;
+
+		/*
+		 * Locate default/generation expression if any
+		 */
+		if (attribute->atthasdef)
+		{
+			Node *this_default = NULL;
+
+			/* Find default in constraint structure */
+			if (constr != NULL)
+			{
+				AttrDefault *attrdef = constr->defval;
+
+				for (int i = 0; i < constr->num_defval; i++)
+				{
+					if (attrdef[i].adnum == parent_attno)
+					{
+						this_default = stringToNode(attrdef[i].adbin);
+						break;
+					}
+				}
+			}
+			if (this_default == NULL)
+				elog(ERROR,
+					 "default expression not found for attribute %d of relation \"%s\"",
+					 parent_attno,
+					 RelationGetRelationName(rel));
+
+			/*
+			 * If it's a GENERATED default, it might contain Vars that
+			 * need to be mapped to the inherited column(s)' new numbers.
+			 * We can't do that till newattmap is ready, so just remember
+			 * all the inherited default expressions for the moment.
+			 */
+			inherited_defaults = lappend(inherited_defaults, this_default);
+			cols_with_defaults = lappend(cols_with_defaults, newdef);
+		}
+		*attlist = lappend(*attlist, newdef);
+	}
+
+	/*
+	 * Now process any inherited default expressions, adjusting attnos
+	 * using the completed newattmap map.
+	 */
+	ListCell *lc1, *lc2;
+	forboth (lc1, inherited_defaults, lc2, cols_with_defaults)
+	{
+		Node *this_default = (Node *) lfirst(lc1);
+		ColumnDef *def = (ColumnDef *) lfirst(lc2);
+		bool found_whole_row;
+
+		/* Adjust Vars to match new table's column numbering */
+		this_default =
+			map_variable_attnos(this_default, 1, 0, newattmap, InvalidOid, &found_whole_row);
+
+		/*
+		 * For the moment we have to reject whole-row variables.  We could
+		 * convert them, if we knew the new table's rowtype OID, but that
+		 * hasn't been assigned yet.  (A variable could only appear in a
+		 * generation expression, so the error message is correct.)
+		 */
+		if (found_whole_row)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot convert whole-row table reference"),
+					 errdetail("Generation expression for column \"%s\" contains a whole-row "
+							   "reference to table \"%s\".",
+							   def->colname,
+							   RelationGetRelationName(rel))));
+
+		Assert(def->raw_default == NULL);
+		def->cooked_default = this_default;
+	}
+
+	/*
+	 * Now copy the CHECK constraints of this parent, adjusting attnos
+	 * using the completed newattmap map.
+	 */
+	if (constr && constr->num_check > 0)
+	{
+		for (int i = 0; i < constr->num_check; i++)
+		{
+			Node *expr;
+			bool found_whole_row;
+
+			/* ignore if the constraint is non-inheritable */
+			if (constr->check[i].ccnoinherit)
+				continue;
+
+			/* Adjust Vars to match new table's column numbering */
+			expr = map_variable_attnos(stringToNode(constr->check[i].ccbin),
+									   1,
+									   0,
+									   newattmap,
+									   InvalidOid,
+									   &found_whole_row);
+
+			/*
+			 * For the moment we have to reject whole-row variables. We
+			 * could convert them, if we knew the new table's rowtype OID,
+			 * but that hasn't been assigned yet.
+			 */
+			if (found_whole_row)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("cannot convert whole-row table reference")));
+
+			Constraint *c = makeNode(Constraint);
+			c->type = T_Constraint;
+			c->contype = CONSTR_CHECK;
+			c->conname = pstrdup(constr->check[i].ccname);
+			c->skip_validation = !constr->check[i].ccvalid;
+			c->initially_valid = true;
+			c->location = -1;
+			c->is_no_inherit = constr->check[i].ccnoinherit;
+			c->raw_expr = NULL;
+			c->cooked_expr = nodeToString(expr);
+			*constraints = lappend(*constraints, c);
+#if PG18_GE
+			c->is_enforced = constr->check[i].ccenforced;
+#endif
+		}
+	}
+
+#if PG18_GE
+	/* A row is added into pg_constraints for each NOT NULL constraint since PG18 */
+	List *notnulls = RelationGetNotNullConstraints(ht_relid, false, false);
+	foreach_ptr(Constraint, nn, notnulls)
+	{
+		Assert(nn->contype == CONSTR_NOTNULL);
+		*constraints = lappend(*constraints, nn);
+	}
+#endif
+
+	free_attrmap(newattmap);
+	table_close(rel, NoLock);
+}
+
+/*
+ * Attach a standalone chunk to a partitioned hypertable as a partition.
+ */
+static void
+partition_chunk_attach(const Hypertable *ht, const Chunk *chunk)
+{
+	/* Currently only single-dimensional partitioned hypertables are supported */
+	Assert(chunk->cube->num_slices == 1);
+
+	const Dimension *dim =
+		ts_hyperspace_get_dimension_by_id(ht->space, chunk->cube->slices[0]->fd.dimension_id);
+	Oid dimtype = ts_dimension_get_partition_type(dim);
+
+	A_Const prd_lower =  {
+		.type = T_A_Const,
+		.val.sval = {
+			.type = T_String,
+			.sval = ts_internal_to_time_string(chunk->cube->slices[0]->fd.range_start, dimtype),
+		},
+		.location = -1
+	};
+	A_Const prd_upper =  {
+		.type = T_A_Const,
+		.val.sval = {
+			.type = T_String,
+			.sval = ts_internal_to_time_string(chunk->cube->slices[0]->fd.range_end, dimtype),
+		},
+		.location = -1
+	};
+	PartitionBoundSpec pbspec = {
+		.type = T_PartitionBoundSpec,
+		.is_default = false,
+		.location = -1,
+		.strategy = PARTITION_STRATEGY_RANGE,
+		.lowerdatums = list_make1(&prd_lower),
+		.upperdatums = list_make1(&prd_upper),
+	};
+	PartitionCmd partcmd = {
+		.type = T_PartitionCmd,
+		.name = makeRangeVar((char *) NameStr(chunk->fd.schema_name),
+							 (char *) NameStr(chunk->fd.table_name),
+							 0),
+		.bound = &pbspec,
+		.concurrent = false,
+	};
+	AlterTableCmd altercmd = {
+		.type = T_AlterTableCmd,
+		.subtype = AT_AttachPartition,
+		.def = (Node *) &partcmd,
+		.missing_ok = false,
+	};
+	AlterTableStmt alterstmt = {
+		.type = T_AlterTableStmt,
+		.cmds = list_make1(&altercmd),
+		.missing_ok = false,
+		.objtype = OBJECT_TABLE,
+		.relation = makeRangeVar((char *) NameStr(ht->fd.schema_name),
+								 (char *) NameStr(ht->fd.table_name),
+								 0),
+	};
+
+	LOCKMODE lockmode = AlterTableGetLockLevel(alterstmt.cmds);
+	AlterTableUtilityContext atcontext = {
+		.relid = AlterTableLookupRelation(&alterstmt, lockmode),
+	};
+
+	AlterTable(&alterstmt, lockmode, &atcontext);
+}
+
+/*
+ * ExecutoreEnd hook to attach cached partition chunks to their hypertables.
+ */
+
+static void
+ts_executor_end_hook(QueryDesc *queryDesc)
+{
+	ListCell *lc;
+
+	if (prev_executor_end_hook)
+		prev_executor_end_hook(queryDesc);
+	else
+		standard_ExecutorEnd(queryDesc);
+
+	/*
+	 * Chunks cannot be created as a partition or attached as partition until
+	 * this point since Postgres does not allow such operations when there is
+	 * an open reference to the parent table. ModifyTable node opens the parent
+	 * table and it only gets closed in ExecEndPlan.
+	 */
+	if (queryDesc->operation == CMD_INSERT && PartChunkCache != NULL && ts_extension_is_loaded())
+	{
+		Cache *hcache = ts_hypertable_cache_pin();
+		HASH_SEQ_STATUS status;
+		PartChunkCacheEntry *entry;
+
+		hash_seq_init(&status, PartChunkCache);
+		while ((entry = hash_seq_search(&status)) != NULL)
+		{
+			foreach (lc, entry->chunk_oids)
+			{
+				Hypertable *ht =
+					ts_hypertable_cache_get_entry(hcache, entry->ht_relid, CACHE_FLAG_MISSING_OK);
+
+				if (ht)
+					partition_chunk_attach(ht, ts_chunk_get_by_relid(lfirst_oid(lc), true));
+			}
+		}
+
+		ts_cache_release(&hcache);
+		ts_partition_cache_destroy();
+	}
+}
+
+void
+_executor_init(void)
+{
+	prev_executor_end_hook = ExecutorEnd_hook;
+	ExecutorEnd_hook = ts_executor_end_hook;
+}
+
+void
+_executor_fini(void)
+{
+	ExecutorEnd_hook = prev_executor_end_hook;
+}

--- a/src/partition_chunk.h
+++ b/src/partition_chunk.h
@@ -1,0 +1,28 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include "export.h"
+#include "guc.h"
+
+#define is_partitioning_allowed(relid)                                                             \
+	(ts_guc_enable_partitioned_hypertables && (get_rel_relkind(relid) == RELKIND_PARTITIONED_TABLE))
+
+/*
+ * Cache entry for chunks to be attached as partitions
+ */
+typedef struct PartChunkCacheEntry
+{
+	Oid ht_relid;
+	List *chunk_oids;
+} PartChunkCacheEntry;
+extern void ts_partition_cache_insert_chunk(const Hypertable *ht, Oid chunk_relid);
+extern PartChunkCacheEntry *ts_partition_cache_get_by_hypertable(Oid ht_relid);
+extern void ts_partition_cache_destroy(void);
+
+extern void ts_partition_chunk_prepare_attributes(Oid ht_relid, List **attlist, List **constraints);

--- a/test/expected/partitioned_hypertable.out
+++ b/test/expected/partitioned_hypertable.out
@@ -1,0 +1,252 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test declarative partitioning for hypertables
+-- Enable declarative partitioning for all subsequent tests
+SET timescaledb.enable_partitioned_hypertables = true;
+-- Basic hypertable creation with TIMESTAMPTZ
+CREATE TABLE metrics(
+    time TIMESTAMP WITH TIME ZONE,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+-- Create with TIMESTAMP
+CREATE TABLE metrics_ts(
+    time TIMESTAMP NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+-- Create with DATE
+CREATE TABLE metrics_date(
+    time DATE NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+-- Create with int
+CREATE TABLE metrics_int(
+    time INT NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+-- Create with custom chunk_time_interval
+CREATE TABLE metrics_custom_interval(
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time', timescaledb.chunk_interval='30 days');
+-- Verify hypertables are actually created and partitioned
+SELECT hypertable_name FROM timescaledb_information.hypertables
+WHERE hypertable_name IN ('metrics', 'metrics_ts', 'metrics_date', 'metrics_int', 'metrics_custom_interval')
+ORDER BY hypertable_name;
+     hypertable_name     
+-------------------------
+ metrics
+ metrics_custom_interval
+ metrics_date
+ metrics_int
+ metrics_ts
+
+SELECT DISTINCT(relkind) = 'p' FROM pg_class
+WHERE relname IN ('metrics', 'metrics_ts', 'metrics_date', 'metrics_int', 'metrics_custom_interval');
+ ?column? 
+----------
+ t
+
+\set ON_ERROR_STOP 0
+-- Try to create with invalid partition column type
+CREATE TABLE invalid(time TEXT, value FLOAT) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+ERROR:  invalid type for dimension "time"
+CREATE TABLE invalid(time TEXT, value FLOAT) WITH (timescaledb.hypertable);
+ERROR:  partition column could not be determined
+\set ON_ERROR_STOP 1
+DROP TABLE IF EXISTS metrics_ts;
+DROP TABLE IF EXISTS metrics_date;
+DROP TABLE IF EXISTS metrics_int;
+DROP TABLE IF EXISTS metrics_custom_interval;
+DROP TABLE IF EXISTS invalid;
+NOTICE:  table "invalid" does not exist, skipping
+-- Test PARTITION BY syntax
+CREATE TABLE metrics_partition_by(
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+) PARTITION BY RANGE (time) WITH (timescaledb.hypertable);
+\set ON_ERROR_STOP 0
+CREATE TABLE part_col_specified(time TIMESTAMPTZ, device TEXT) PARTITION BY RANGE (time) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+ERROR:  cannot specify both PARTITION BY and timescaledb.partition_column
+CREATE TABLE multiple_part_key(time TIMESTAMPTZ, time2 TIMESTAMP, device TEXT) PARTITION BY RANGE (time, time2) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+ERROR:  only single column partitioning is supported for partitioned hypertables
+CREATE TABLE bad_strategy(time TIMESTAMPTZ, device TEXT) PARTITION BY LIST (time) WITH (timescaledb.hypertable);
+ERROR:  only RANGE partitioning is supported for partitioned hypertables
+\set ON_ERROR_STOP 1
+DROP TABLE IF EXISTS metrics_partition_by;
+-- Insert Operations and Chunk Creation
+INSERT INTO metrics VALUES
+  ('2025-01-15 00:00:00+00', 'device1', 11.0),
+  ('2025-02-15 00:00:00+00', 'device2', 12.0),
+  ('2025-03-15 00:00:00+00', 'device3', 13.0);
+SELECT count(*) FROM show_chunks('metrics');
+ count 
+-------
+     3
+
+SELECT count(*) FROM metrics;
+ count 
+-------
+     3
+
+SELECT * FROM metrics ORDER BY time;
+             time             | device  | value 
+------------------------------+---------+-------
+ Tue Jan 14 16:00:00 2025 PST | device1 |    11
+ Fri Feb 14 16:00:00 2025 PST | device2 |    12
+ Fri Mar 14 17:00:00 2025 PDT | device3 |    13
+
+-- Verify chunk was created and attached as partition
+SELECT count(*) FROM show_chunks('metrics');
+ count 
+-------
+     3
+
+SELECT child.relname AS chunk, parent.relname AS hypertable
+FROM pg_inherits
+JOIN pg_class child ON inhrelid = child.oid
+JOIN pg_class parent ON inhparent = parent.oid
+WHERE parent.relname = 'metrics'
+LIMIT 1;
+      chunk       | hypertable 
+------------------+------------
+ _hyper_1_1_chunk | metrics
+
+-- Insert with CHECK constraint
+ALTER TABLE metrics ADD CONSTRAINT valcheck CHECK (value >= 0);
+-- Try inserting into existing and new chunk to violate CHECK constraint
+\set ON_ERROR_STOP 0
+INSERT INTO metrics VALUES ('2025-03-15 00:00:00+00', 'device1', -10.0);
+ERROR:  new row for relation "_hyper_1_3_chunk" violates check constraint "valcheck"
+INSERT INTO metrics VALUES ('2025-04-15 00:00:00+00', 'device1', -10.0);
+ERROR:  new row for relation "_hyper_1_4_chunk" violates check constraint "valcheck"
+\set ON_ERROR_STOP 1
+-- SELECT with WHERE on time (partition pruning)
+EXPLAIN (COSTS OFF)
+SELECT * FROM metrics WHERE time >= '2025-01-01' AND time < '2025-02-01';
+--- QUERY PLAN ---
+ Seq Scan on _hyper_1_1_chunk metrics
+   Filter: (("time" >= 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone) AND ("time" < 'Sat Feb 01 00:00:00 2025 PST'::timestamp with time zone))
+
+-- FOREIGN KEY from hypertable to regular table
+CREATE TABLE ref_table(id INT PRIMARY KEY, name TEXT);
+INSERT INTO ref_table VALUES (1, 'ref1'), (2, 'ref2');
+CREATE TABLE fk_table(
+  time TIMESTAMPTZ NOT NULL,
+  ref_id INT REFERENCES ref_table(id),
+  value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO fk_table VALUES ('2025-11-01', 1, 10.0);
+\set ON_ERROR_STOP 0
+INSERT INTO fk_table VALUES ('2025-11-01', 999, 20.0);
+ERROR:  insert or update on table "_hyper_8_5_chunk" violates foreign key constraint "fk_table_ref_id_fkey"
+\set ON_ERROR_STOP 1
+DROP TABLE ref_table CASCADE;
+NOTICE:  drop cascades to constraint fk_table_ref_id_fkey on table fk_table
+DROP TABLE fk_table CASCADE;
+-- FOREIGN KEY from hypertable to hypertable
+CREATE TABLE ref_ht(
+    time TIMESTAMPTZ NOT NULL ,
+    id INT,
+    CONSTRAINT ref_ht_pkey PRIMARY KEY (time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO ref_ht VALUES
+  ('2025-06-15 00:00:00+00', 1),
+  ('2025-07-15 00:00:00+00', 2);
+CREATE TABLE fk_ht(
+    time TIMESTAMPTZ NOT NULL,
+    ref_time TIMESTAMPTZ,
+    ref_id INT,
+    value FLOAT,
+    FOREIGN KEY (ref_time, ref_id) REFERENCES ref_ht(time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO fk_ht VALUES
+    ('2025-08-15 00:00:00+00', '2025-06-15 00:00:00+00', 1, 31.0);
+\set ON_ERROR_STOP 0
+INSERT INTO fk_ht VALUES
+    ('2025-08-15 00:00:00+00', '2025-01-01 00:00:00+00', 999, 32.0);
+ERROR:  insert or update on table "_hyper_10_8_chunk" violates foreign key constraint "fk_ht_ref_time_ref_id_fkey"
+\set ON_ERROR_STOP 1
+DROP TABLE ref_ht CASCADE;
+NOTICE:  drop cascades to constraint fk_ht_ref_time_ref_id_fkey on table fk_ht
+DROP TABLE fk_ht CASCADE;
+-- Test if foreign keys to hypertables not using declarative partitioning are still disallowed
+SET timescaledb.enable_partitioned_hypertables = false;
+CREATE TABLE ref_ht(
+    time TIMESTAMPTZ NOT NULL ,
+    id INT,
+    CONSTRAINT ref_ht_pkey PRIMARY KEY (time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO ref_ht VALUES
+  ('2025-06-15 00:00:00+00', 1),
+  ('2025-07-15 00:00:00+00', 2);
+SET timescaledb.enable_partitioned_hypertables = true;
+\set ON_ERROR_STOP 0
+CREATE TABLE fk_ht(
+    time TIMESTAMPTZ NOT NULL,
+    ref_time TIMESTAMPTZ,
+    ref_id INT,
+    value FLOAT,
+    FOREIGN KEY (ref_time, ref_id) REFERENCES ref_ht(time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+ERROR:  hypertables cannot be used as foreign key references of hypertables
+\set ON_ERROR_STOP 1
+DROP TABLE ref_ht CASCADE;
+DROP TABLE IF EXISTS fk_ht CASCADE;
+NOTICE:  table "fk_ht" does not exist, skipping
+-- Test partition wise joins
+CREATE TABLE metrics_pwj(
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO metrics_pwj VALUES
+  ('2025-01-15 00:00:00+00', 'device1', 11.0),
+  ('2025-02-15 00:00:00+00', 'device2', 12.0),
+  ('2025-03-15 00:00:00+00', 'device3', 13.0);
+SET enable_partitionwise_join = true;
+EXPLAIN (COSTS OFF)
+SELECT m1.device, m2.device
+FROM metrics AS m1
+JOIN metrics_pwj AS m2 ON m1.time = m2.time;
+--- QUERY PLAN ---
+ Append
+   ->  Nested Loop
+         Join Filter: (m1_1."time" = m2_1."time")
+         ->  Seq Scan on _hyper_1_1_chunk m1_1
+         ->  Seq Scan on _hyper_13_11_chunk m2_1
+   ->  Nested Loop
+         Join Filter: (m1_2."time" = m2_2."time")
+         ->  Seq Scan on _hyper_1_2_chunk m1_2
+         ->  Seq Scan on _hyper_13_12_chunk m2_2
+   ->  Nested Loop
+         Join Filter: (m1_3."time" = m2_3."time")
+         ->  Seq Scan on _hyper_1_3_chunk m1_3
+         ->  Seq Scan on _hyper_13_13_chunk m2_3
+
+SET enable_partitionwise_join = false;
+-- Transaction - ROLLBACK
+BEGIN;
+INSERT INTO metrics VALUES ('2024-12-20', 'rollback_test', 42.0);
+SELECT count(*)=1 FROM metrics WHERE device = 'rollback_test';
+ ?column? 
+----------
+ t
+
+ROLLBACK;
+SELECT count(*)=0 FROM metrics WHERE device = 'rollback_test';
+ ?column? 
+----------
+ t
+
+-- Reset GUC
+SET timescaledb.enable_partitioned_hypertables = false;
+-- Cleanup
+DROP TABLE IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS metrics_pwj CASCADE;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -112,6 +112,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     metadata.sql
     multi_transaction_index.sql
     net.sql
+    partitioned_hypertable.sql
     pg_dump.sql
     symbol_conflict.sql
     test_tss_callbacks.sql

--- a/test/sql/partitioned_hypertable.sql
+++ b/test/sql/partitioned_hypertable.sql
@@ -1,0 +1,215 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Test declarative partitioning for hypertables
+
+
+-- Enable declarative partitioning for all subsequent tests
+SET timescaledb.enable_partitioned_hypertables = true;
+
+-- Basic hypertable creation with TIMESTAMPTZ
+CREATE TABLE metrics(
+    time TIMESTAMP WITH TIME ZONE,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+
+-- Create with TIMESTAMP
+CREATE TABLE metrics_ts(
+    time TIMESTAMP NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+
+-- Create with DATE
+CREATE TABLE metrics_date(
+    time DATE NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+
+-- Create with int
+CREATE TABLE metrics_int(
+    time INT NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+
+-- Create with custom chunk_time_interval
+CREATE TABLE metrics_custom_interval(
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time', timescaledb.chunk_interval='30 days');
+
+-- Verify hypertables are actually created and partitioned
+SELECT hypertable_name FROM timescaledb_information.hypertables
+WHERE hypertable_name IN ('metrics', 'metrics_ts', 'metrics_date', 'metrics_int', 'metrics_custom_interval')
+ORDER BY hypertable_name;
+
+SELECT DISTINCT(relkind) = 'p' FROM pg_class
+WHERE relname IN ('metrics', 'metrics_ts', 'metrics_date', 'metrics_int', 'metrics_custom_interval');
+
+\set ON_ERROR_STOP 0
+-- Try to create with invalid partition column type
+CREATE TABLE invalid(time TEXT, value FLOAT) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+CREATE TABLE invalid(time TEXT, value FLOAT) WITH (timescaledb.hypertable);
+\set ON_ERROR_STOP 1
+
+DROP TABLE IF EXISTS metrics_ts;
+DROP TABLE IF EXISTS metrics_date;
+DROP TABLE IF EXISTS metrics_int;
+DROP TABLE IF EXISTS metrics_custom_interval;
+DROP TABLE IF EXISTS invalid;
+
+-- Test PARTITION BY syntax
+CREATE TABLE metrics_partition_by(
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+) PARTITION BY RANGE (time) WITH (timescaledb.hypertable);
+
+\set ON_ERROR_STOP 0
+CREATE TABLE part_col_specified(time TIMESTAMPTZ, device TEXT) PARTITION BY RANGE (time) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+CREATE TABLE multiple_part_key(time TIMESTAMPTZ, time2 TIMESTAMP, device TEXT) PARTITION BY RANGE (time, time2) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+CREATE TABLE bad_strategy(time TIMESTAMPTZ, device TEXT) PARTITION BY LIST (time) WITH (timescaledb.hypertable);
+\set ON_ERROR_STOP 1
+DROP TABLE IF EXISTS metrics_partition_by;
+
+-- Insert Operations and Chunk Creation
+INSERT INTO metrics VALUES
+  ('2025-01-15 00:00:00+00', 'device1', 11.0),
+  ('2025-02-15 00:00:00+00', 'device2', 12.0),
+  ('2025-03-15 00:00:00+00', 'device3', 13.0);
+SELECT count(*) FROM show_chunks('metrics');
+SELECT count(*) FROM metrics;
+
+SELECT * FROM metrics ORDER BY time;
+
+-- Verify chunk was created and attached as partition
+SELECT count(*) FROM show_chunks('metrics');
+
+SELECT child.relname AS chunk, parent.relname AS hypertable
+FROM pg_inherits
+JOIN pg_class child ON inhrelid = child.oid
+JOIN pg_class parent ON inhparent = parent.oid
+WHERE parent.relname = 'metrics'
+LIMIT 1;
+
+-- Insert with CHECK constraint
+ALTER TABLE metrics ADD CONSTRAINT valcheck CHECK (value >= 0);
+
+-- Try inserting into existing and new chunk to violate CHECK constraint
+\set ON_ERROR_STOP 0
+INSERT INTO metrics VALUES ('2025-03-15 00:00:00+00', 'device1', -10.0);
+INSERT INTO metrics VALUES ('2025-04-15 00:00:00+00', 'device1', -10.0);
+\set ON_ERROR_STOP 1
+
+
+-- SELECT with WHERE on time (partition pruning)
+EXPLAIN (COSTS OFF)
+SELECT * FROM metrics WHERE time >= '2025-01-01' AND time < '2025-02-01';
+
+
+-- FOREIGN KEY from hypertable to regular table
+CREATE TABLE ref_table(id INT PRIMARY KEY, name TEXT);
+INSERT INTO ref_table VALUES (1, 'ref1'), (2, 'ref2');
+
+CREATE TABLE fk_table(
+  time TIMESTAMPTZ NOT NULL,
+  ref_id INT REFERENCES ref_table(id),
+  value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO fk_table VALUES ('2025-11-01', 1, 10.0);
+
+\set ON_ERROR_STOP 0
+INSERT INTO fk_table VALUES ('2025-11-01', 999, 20.0);
+\set ON_ERROR_STOP 1
+
+DROP TABLE ref_table CASCADE;
+DROP TABLE fk_table CASCADE;
+
+-- FOREIGN KEY from hypertable to hypertable
+CREATE TABLE ref_ht(
+    time TIMESTAMPTZ NOT NULL ,
+    id INT,
+    CONSTRAINT ref_ht_pkey PRIMARY KEY (time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO ref_ht VALUES
+  ('2025-06-15 00:00:00+00', 1),
+  ('2025-07-15 00:00:00+00', 2);
+
+CREATE TABLE fk_ht(
+    time TIMESTAMPTZ NOT NULL,
+    ref_time TIMESTAMPTZ,
+    ref_id INT,
+    value FLOAT,
+    FOREIGN KEY (ref_time, ref_id) REFERENCES ref_ht(time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO fk_ht VALUES
+    ('2025-08-15 00:00:00+00', '2025-06-15 00:00:00+00', 1, 31.0);
+\set ON_ERROR_STOP 0
+INSERT INTO fk_ht VALUES
+    ('2025-08-15 00:00:00+00', '2025-01-01 00:00:00+00', 999, 32.0);
+\set ON_ERROR_STOP 1
+
+DROP TABLE ref_ht CASCADE;
+DROP TABLE fk_ht CASCADE;
+
+-- Test if foreign keys to hypertables not using declarative partitioning are still disallowed
+SET timescaledb.enable_partitioned_hypertables = false;
+CREATE TABLE ref_ht(
+    time TIMESTAMPTZ NOT NULL ,
+    id INT,
+    CONSTRAINT ref_ht_pkey PRIMARY KEY (time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO ref_ht VALUES
+  ('2025-06-15 00:00:00+00', 1),
+  ('2025-07-15 00:00:00+00', 2);
+SET timescaledb.enable_partitioned_hypertables = true;
+
+\set ON_ERROR_STOP 0
+CREATE TABLE fk_ht(
+    time TIMESTAMPTZ NOT NULL,
+    ref_time TIMESTAMPTZ,
+    ref_id INT,
+    value FLOAT,
+    FOREIGN KEY (ref_time, ref_id) REFERENCES ref_ht(time, id)
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+\set ON_ERROR_STOP 1
+
+DROP TABLE ref_ht CASCADE;
+DROP TABLE IF EXISTS fk_ht CASCADE;
+
+-- Test partition wise joins
+CREATE TABLE metrics_pwj(
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+) WITH (timescaledb.hypertable, timescaledb.partition_column='time');
+INSERT INTO metrics_pwj VALUES
+  ('2025-01-15 00:00:00+00', 'device1', 11.0),
+  ('2025-02-15 00:00:00+00', 'device2', 12.0),
+  ('2025-03-15 00:00:00+00', 'device3', 13.0);
+
+SET enable_partitionwise_join = true;
+EXPLAIN (COSTS OFF)
+SELECT m1.device, m2.device
+FROM metrics AS m1
+JOIN metrics_pwj AS m2 ON m1.time = m2.time;
+SET enable_partitionwise_join = false;
+
+-- Transaction - ROLLBACK
+BEGIN;
+INSERT INTO metrics VALUES ('2024-12-20', 'rollback_test', 42.0);
+SELECT count(*)=1 FROM metrics WHERE device = 'rollback_test';
+ROLLBACK;
+SELECT count(*)=0 FROM metrics WHERE device = 'rollback_test';
+
+-- Reset GUC
+SET timescaledb.enable_partitioned_hypertables = false;
+
+-- Cleanup
+DROP TABLE IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS metrics_pwj CASCADE;


### PR DESCRIPTION
Adopt PostgreSQL's declarative partitioning for hypertables. This makes hypertables partitioned tables and their chunks partitions.

This commit is the first step of declarative partitioning efforts. It includes minimal set of features initially and everything is behind a new GUC `enable_partitioned_hypertables`. If the GUC is enabled, hypertables will be created as partitioned tables. Chunks will be created during inserts as needed, but they'll be attached as partitions instead.

To create partitioned hypertable, use `CREATE TABLE ... WITH (tsdb.hypertable)`. Only single dimensional hypertables are supported.

There may be some features that works with hypertables using declarative partitioning, and some doesn't. It's planned to support such features in later commits.

This commit still requires more testing. Included tests are to show how hypertables use declarative partitioning, and features like partition-wise joins, hypertable to hypertable foreign keys work.