### PR TITLE
Fix dead code in  PG 18 sort_transform_ec

### DIFF
--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -377,7 +377,7 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig, Relids child_relids
 				newec->ec_members = lappend(newec->ec_members, em);
 
 			int i = -1;
-			for (; i >= 0; i = bms_next_member(em->em_relids, i))
+			while ((i = bms_next_member(em->em_relids, i)) >= 0)
 			{
 				RelOptInfo *child_rel = root->simple_rel_array[i];
 

--- a/tsl/test/expected/plan_skip_scan_dagg-18.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-18.out
@@ -3471,16 +3471,28 @@ stable expression in targetlist on skip_scan_htc
          Sort Key: ((skip_scan_htc.dev + 1))
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_26_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_27_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_28_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_29_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
 
 -- But expressions over distinct aggregates are supported
 :PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;

--- a/tsl/test/shared/expected/gapfill-18.out
+++ b/tsl/test/shared/expected/gapfill-18.out
@@ -220,14 +220,13 @@ LIMIT 1;
 FROM gapfill_plan_test
 ORDER BY 1;
 --- QUERY PLAN ---
- Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   ->  Result
-         ->  Append
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
+ Result
+   ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+         Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
 
 SET max_parallel_workers_per_gather TO 0;
 -- test sort optimizations with locf
@@ -289,16 +288,13 @@ ORDER BY 1,2;
 FROM gapfill_plan_test
 ORDER BY 2,1;
 --- QUERY PLAN ---
- Incremental Sort
-   Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   Presorted Key: gapfill_plan_test.value
-   ->  Result
-         ->  Merge Append
-               Sort Key: gapfill_plan_test.value
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+ Result
+   ->  Merge Append
+         Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
 
 DROP TABLE gapfill_plan_test;
 \set METRICS metrics_int
@@ -3017,15 +3013,14 @@ FROM metrics
 GROUP BY 1;
 --- QUERY PLAN ---
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Result
+               ->  Merge Append
+                     Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
 
 -- issue #3834
 -- test projection handling in gapfill


### PR DESCRIPTION
The loop condition prevents execution. Change to use the standard bms_next_member() iteration pattern using while loop instead of for.

Was an coverity issue
Issues were discovered after fixing this code:  #8963
Disable-check: force-changelog-file