### PR TITLE
Remove scheduled runs for APT package installcheck

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -1,9 +1,6 @@
-# Test running make installcheck on our ubuntu and debian packages for the latest version.
+# Test running make installcheck on our APT packages.
 name: "Packaging tests: Installcheck for APT"
 "on":
-  schedule:
-    # run daily 0:00 on main branch
-    - cron: '0 0 * * *'
   pull_request:
     paths: .github/workflows/apt-installcheck.yaml
   push:


### PR DESCRIPTION
It's broken at the moment, we can enable it with the new release that fixes the tests.