### PR TITLE
Mark the variable changed inside PG_TRY/CATCH block as volatile

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1149,7 +1149,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 	Oid db_oid = DatumGetObjectId(MyBgworkerEntry->bgw_main_arg);
 	BgwParams params;
 	BgwJob *job;
-	JobResult res = JOB_FAILURE_IN_EXECUTION;
+	JobResult volatile res = JOB_FAILURE_IN_EXECUTION;
 	bool got_lock;
 	instr_time start;
 	instr_time duration;


### PR DESCRIPTION
Otherwise its modification might not survive the setjmp/longjmp.

Disable-check: force-changelog-file