### PR TITLE
Add support for continuous aggregate invalidation to direct compress

### DIFF
--- a/.unreleased/pr_8909
+++ b/.unreleased/pr_8909
@@ -1,0 +1,1 @@
+Implements: #8909 Support direct compress on hypertables with continuous aggregates

--- a/src/copy.c
+++ b/src/copy.c
@@ -279,6 +279,13 @@ TSCopyMultiInsertBufferInit(TSCopyMultiInsertInfo *miinfo, ChunkInsertState *cis
 												 sort,
 												 ts_guc_direct_compress_copy_tuple_sort_limit);
 
+			if (miinfo->has_continuous_aggregate)
+			{
+				ts_cm_functions->compressor_set_invalidation(buffer->compressor,
+															 miinfo->ht,
+															 RelationGetRelid(cis->rel));
+			}
+
 			/*
 			 * The sorting done in the compressor is only a local sort for the
 			 * currently ingested batch and will produce overlapping batches for
@@ -796,14 +803,7 @@ choose_copy_method(Hypertable *ht, CopyChunkState *ccstate, ResultRelInfo *resul
 
 	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht) && ts_guc_enable_direct_compress_copy)
 	{
-		if (ts_hypertable_has_continuous_aggregates(ccstate->ctr->hypertable->fd.id))
-		{
-			ereport(WARNING,
-					(errmsg(
-						"disabling direct compress because the destination table has continuous "
-						"aggregates")));
-		}
-		else if (ts_indexing_relation_has_primary_or_unique_index(ccstate->rel))
+		if (ts_indexing_relation_has_primary_or_unique_index(ccstate->rel))
 		{
 			ereport(WARNING,
 					(errmsg("disabling direct compress because the destination table has unique "

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -139,6 +139,7 @@ typedef struct CrossModuleFunctions
 	void (*columnstore_setup)(Hypertable *ht, WithClauseResult *with_clause_options);
 	RowCompressor *(*compressor_init)(Relation in_rel, BulkWriter **bulk_writer, bool sort,
 									  int tuple_sort_limit);
+	void (*compressor_set_invalidation)(RowCompressor *compressor, Hypertable *ht, Oid chunk_relid);
 	void (*compressor_add_slot)(RowCompressor *compressor, BulkWriter *bulk_writer,
 								TupleTableSlot *slot);
 	void (*compressor_flush)(RowCompressor *compressor, BulkWriter *bulk_writer);

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -64,14 +64,6 @@ should_use_direct_compress(ModifyHypertableState *state)
 	if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		return false;
 
-	if (ts_hypertable_has_continuous_aggregates(ht->fd.id))
-	{
-		ereport(WARNING,
-				(errmsg("disabling direct compress because the destination table has continuous "
-						"aggregates")));
-		return false;
-	}
-
 	if (resultRelInfo->ri_TrigDesc)
 	{
 		ereport(WARNING,

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2426,6 +2426,12 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 					bool sort = ts_guc_enable_direct_compress_insert_sort_batches && !ts_guc_enable_direct_compress_insert_client_sorted;
 					ht_state->compressor = ts_cm_functions->compressor_init(ctr->cis->rel, &ht_state->bulk_writer, sort, ts_guc_direct_compress_insert_tuple_sort_limit);
 					ht_state->compressor_relid = RelationGetRelid(ctr->cis->rel);
+
+					if (ht_state->has_continuous_aggregate)
+					{
+						ts_cm_functions->compressor_set_invalidation(ht_state->compressor, ctr->hypertable, RelationGetRelid(ctr->cis->rel));
+					}
+
 					/* if client does not commit to global ordering, set chunk to unordered */
 					if (!ts_guc_enable_direct_compress_insert_client_sorted)
 					{

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -225,6 +225,13 @@ typedef struct PerColumn
 	int16 segmentby_column_index;
 } PerColumn;
 
+typedef struct InvalidationSettings
+{
+	int32 hypertable_id;
+	Oid chunk_relid;
+	AttrNumber invalidation_column_offset;
+} InvalidationSettings;
+
 typedef struct RowCompressor
 {
 	/* memory context reset per-row is stored */
@@ -250,6 +257,9 @@ typedef struct RowCompressor
 	 */
 	int16 *uncompressed_col_to_compressed_col;
 	int16 count_metadata_column_offset;
+
+	/* for continuous aggregate invalidation */
+	InvalidationSettings *invalidation;
 
 	/* the number of uncompressed rows compressed into the current compressed row */
 	uint32 rows_compressed_into_current_value;
@@ -372,9 +382,10 @@ extern void row_compressor_init(RowCompressor *row_compressor, const Compression
 								const TupleDesc noncompressed_tupdesc,
 								const TupleDesc compressed_tupdesc);
 
-RowCompressor *row_compressor_alloc(void);
 extern RowCompressor *tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort,
 										  int tuple_sort_limit);
+extern void tsl_compressor_set_invalidation(RowCompressor *compressor, Hypertable *ht,
+											Oid chunk_relid);
 extern void tsl_compressor_add_slot(RowCompressor *compressor, BulkWriter *bulk_writer,
 									TupleTableSlot *slot);
 extern void tsl_compressor_flush(RowCompressor *compressor, BulkWriter *bulk_writer);

--- a/tsl/src/continuous_aggs/insert.h
+++ b/tsl/src/continuous_aggs/insert.h
@@ -9,6 +9,8 @@
 
 extern void _continuous_aggs_cache_inval_init(void);
 extern void _continuous_aggs_cache_inval_fini(void);
+extern void continuous_agg_invalidate_range(int32 hypertable_id, Oid chunk_relid, int64 start,
+											int64 end);
 extern void continuous_agg_dml_invalidate(int32 hypertable_id, Relation chunk_rel,
 										  HeapTuple chunk_tuple, HeapTuple chunk_newtuple,
 										  bool update);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -182,6 +182,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.decompress_target_segments = decompress_target_segments,
 	.columnstore_setup = tsl_columnstore_setup,
 	.compressor_init = tsl_compressor_init,
+	.compressor_set_invalidation = tsl_compressor_set_invalidation,
 	.compressor_add_slot = tsl_compressor_add_slot,
 	.compressor_flush = tsl_compressor_flush,
 	.compressor_free = tsl_compressor_free,

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1321,3 +1321,113 @@ SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 CALL _timescaledb_functions.process_hypertable_invalidations('measurements');
 ERROR:  must be owner of hypertable "measurements"
 \set ON_ERROR_STOP 1
+-- test direct compress insert invalidation
+CREATE TABLE direct_compress_insert(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_compress_insert SELECT '2025-01-01';
+CREATE MATERIALIZED VIEW cagg_insert WITH (tsdb.continuous) AS SELECT time_bucket('1day', time) FROM direct_compress_insert GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_insert"
+SET timescaledb.enable_direct_compress_insert = true;
+EXPLAIN (analyze,buffers off,costs off,timing off,summary off) INSERT INTO direct_compress_insert SELECT '2024-01-01'::timestamptz + format('%sm',i)::interval FROM generate_series(1,1000) g(i);
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Direct Compress: true
+   ->  Insert on direct_compress_insert (actual rows=0.00 loops=1)
+         ->  Function Scan on generate_series g (actual rows=1000.00 loops=1)
+
+EXPLAIN (analyze,buffers off,costs off,timing off,summary off) INSERT INTO direct_compress_insert SELECT '2024-01-01'::timestamptz - format('%sm',i)::interval FROM generate_series(1,1000) g(i);
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Direct Compress: true
+   ->  Insert on direct_compress_insert (actual rows=0.00 loops=1)
+         ->  Function Scan on generate_series g (actual rows=1000.00 loops=1)
+
+-- should have 2 entries
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) start, _timescaledb_functions.to_timestamp(greatest_modified_value) end from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log WHERE hypertable_id = 18 ORDER BY 1,2;
+         start          |          end           
+------------------------+------------------------
+ 2023-12-31 07:20:00+00 | 2023-12-31 23:59:00+00
+ 2024-01-01 00:01:00+00 | 2024-01-01 16:40:00+00
+
+EXPLAIN (analyze,buffers off,costs off,timing off,summary off) INSERT INTO direct_compress_insert SELECT '2023-12-31'::timestamptz + format('%sm',i)::interval FROM generate_series(1,2000) g(i);
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Direct Compress: true
+   ->  Insert on direct_compress_insert (actual rows=0.00 loops=1)
+         ->  Function Scan on generate_series g (actual rows=2000.00 loops=1)
+
+-- should have 3 entries
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) start, _timescaledb_functions.to_timestamp(greatest_modified_value) end from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log WHERE hypertable_id = 18 ORDER BY 1,2;
+         start          |          end           
+------------------------+------------------------
+ 2023-12-31 00:01:00+00 | 2023-12-31 16:40:00+00
+ 2023-12-31 07:20:00+00 | 2023-12-31 23:59:00+00
+ 2023-12-31 16:41:00+00 | 2024-01-01 09:20:00+00
+ 2024-01-01 00:01:00+00 | 2024-01-01 16:40:00+00
+
+-- should have 1 uncompressed and 1 compressed chunk
+EXPLAIN (costs off,timing off,summary off) SELECT FROM direct_compress_insert;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_18_59_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_18_61_chunk
+         ->  Seq Scan on compress_hyper_19_62_chunk
+
+-- test direct compress copy invalidation
+CREATE TABLE direct_compress_copy(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO direct_compress_copy SELECT '2025-01-01';
+WARNING:  disabling direct compress because of too small batch size
+CREATE MATERIALIZED VIEW cagg_copy WITH (tsdb.continuous) AS SELECT time_bucket('1day', time) FROM direct_compress_copy GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_copy"
+SET timescaledb.enable_direct_compress_copy = true;
+COPY direct_compress_copy FROM STDIN;
+-- should have 1 entries now
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) start, _timescaledb_functions.to_timestamp(greatest_modified_value) end from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log WHERE hypertable_id = 21 ORDER BY 1,2;
+         start          |          end           
+------------------------+------------------------
+ 2023-01-01 00:00:00+00 | 2023-01-03 00:00:00+00
+
+COPY direct_compress_copy FROM STDIN;
+-- should have 2 entries now
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) start, _timescaledb_functions.to_timestamp(greatest_modified_value) end from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log WHERE hypertable_id = 21 ORDER BY 1,2;
+         start          |          end           
+------------------------+------------------------
+ 2022-12-31 00:00:00+00 | 2023-01-03 00:00:00+00
+ 2023-01-01 00:00:00+00 | 2023-01-03 00:00:00+00
+
+-- range spanning multiple chunks
+COPY direct_compress_copy FROM STDIN;
+-- should have 3 entries now
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) start, _timescaledb_functions.to_timestamp(greatest_modified_value) end from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log WHERE hypertable_id = 21 ORDER BY 1,2;
+         start          |          end           
+------------------------+------------------------
+ 2022-01-01 00:00:00+00 | 2022-01-01 00:00:00+00
+ 2022-02-28 00:00:00+00 | 2022-02-28 00:00:00+00
+ 2022-12-31 00:00:00+00 | 2023-01-03 00:00:00+00
+ 2023-01-01 00:00:00+00 | 2023-01-03 00:00:00+00
+
+-- should have 1 uncompressed and 3 compressed chunk
+EXPLAIN (costs off,timing off,summary off) SELECT FROM direct_compress_copy;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_21_63_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_21_65_chunk
+         ->  Seq Scan on compress_hyper_22_66_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_21_67_chunk
+         ->  Seq Scan on compress_hyper_22_68_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_21_69_chunk
+         ->  Seq Scan on compress_hyper_22_70_chunk
+
+-- test direct compress invalidation with custom partitioning function (not supported atm)
+CREATE OR REPLACE FUNCTION f_month(timestamptz) returns int language sql AS $$ SELECT 12 * extract(year from $1) + extract(month from $1);$$ immutable;
+CREATE TABLE part_cagg (time timestamptz);
+SELECT create_hypertable('part_cagg', 'time', time_partitioning_func => 'f_month', chunk_time_interval => 1);
+    create_hypertable    
+-------------------------
+ (24,public,part_cagg,t)
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW part_cagg1 WITH (tsdb.continuous) AS SELECT time_bucket('1day', time) FROM part_cagg GROUP BY 1;
+ERROR:  custom partitioning functions not supported with continuous aggregates
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/direct_compress_copy.out
+++ b/tsl/test/expected/direct_compress_copy.out
@@ -189,19 +189,20 @@ SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id
 --------
 
 ROLLBACK;
--- test caggs prevent direct compress
+-- test caggs with direct compress
 BEGIN;
 SET timescaledb.enable_direct_compress_copy = true;
 CREATE MATERIALIZED VIEW metrics_cagg WITH (tsdb.continuous) AS SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value FROM metrics GROUP BY bucket, device WITH NO DATA;
 COPY metrics FROM STDIN WITH (FORMAT CSV);
-WARNING:  disabling direct compress because the destination table has continuous aggregates
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
- Seq Scan on _hyper_1_27_chunk (actual rows=1.00 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_1_27_chunk (actual rows=1.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_28_chunk (actual rows=1.00 loops=1)
 
 SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
  status 
 --------
+      3
 
 ROLLBACK;
 -- test chunk status handling
@@ -269,7 +270,7 @@ SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics
 SELECT compress_chunk(show_chunks('metrics_status'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_4_35_chunk
+ _timescaledb_internal._hyper_4_36_chunk
 
 SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_status') chunk;
  chunk_status_text 
@@ -331,10 +332,10 @@ COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-01 + I minute" 
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
  Append (actual rows=3000.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_37_chunk (actual rows=959.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_38_chunk (actual rows=2.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_39_chunk (actual rows=2041.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_40_chunk (actual rows=5.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_38_chunk (actual rows=959.00 loops=1)
+         ->  Seq Scan on compress_hyper_2_39_chunk (actual rows=2.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_40_chunk (actual rows=2041.00 loops=1)
+         ->  Seq Scan on compress_hyper_2_41_chunk (actual rows=5.00 loops=1)
 
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
             first             |             last             

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -417,19 +417,20 @@ SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id
 --------
 
 ROLLBACK;
--- test caggs prevent direct compress
+-- test caggs with direct compress
 BEGIN;
 SET timescaledb.enable_direct_compress_insert = true;
 CREATE MATERIALIZED VIEW metrics_cagg WITH (tsdb.continuous) AS SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value FROM metrics GROUP BY bucket, device WITH NO DATA;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
-WARNING:  disabling direct compress because the destination table has continuous aggregates
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
- Seq Scan on _hyper_1_45_chunk (actual rows=101.00 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_1_45_chunk (actual rows=101.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_46_chunk (actual rows=1.00 loops=1)
 
 SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
  status 
 --------
+      3
 
 ROLLBACK;
 -- test chunk status handling
@@ -510,7 +511,7 @@ SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics
 SELECT compress_chunk(show_chunks('metrics_status'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_4_53_chunk
+ _timescaledb_internal._hyper_4_54_chunk
 
 -- status should be COMPRESSED
 SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_status') chunk;
@@ -559,7 +560,7 @@ EXPLAIN (costs off,summary off,timing off) INSERT INTO :CHUNK SELECT '2025-01-01
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable)
    Direct Compress: true
-   ->  Insert on _hyper_6_55_chunk
+   ->  Insert on _hyper_6_56_chunk
          ->  Function Scan on generate_series i
 
 BEGIN;
@@ -581,8 +582,8 @@ EXPLAIN (analyze,buffers off,costs off,summary off,timing off) DELETE FROM :CHUN
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    Batches decompressed: 1
    Tuples decompressed: 101
-   ->  Delete on _hyper_6_55_chunk (actual rows=0.00 loops=1)
-         ->  Index Scan using _hyper_6_55_chunk_metrics_chunk_time_idx on _hyper_6_55_chunk (actual rows=100.00 loops=1)
+   ->  Delete on _hyper_6_56_chunk (actual rows=0.00 loops=1)
+         ->  Index Scan using _hyper_6_56_chunk_metrics_chunk_time_idx on _hyper_6_56_chunk (actual rows=100.00 loops=1)
                Index Cond: ("time" > 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
 
 SELECT count(*) FROM :CHUNK;
@@ -610,10 +611,10 @@ INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interva
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
  Append (actual rows=3001.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_58_chunk (actual rows=960.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_59_chunk (actual rows=2.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_60_chunk (actual rows=2041.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_61_chunk (actual rows=5.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_59_chunk (actual rows=960.00 loops=1)
+         ->  Seq Scan on compress_hyper_2_60_chunk (actual rows=2.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_61_chunk (actual rows=2041.00 loops=1)
+         ->  Seq Scan on compress_hyper_2_62_chunk (actual rows=5.00 loops=1)
 
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
             first             |             last             

--- a/tsl/test/sql/direct_compress_copy.sql
+++ b/tsl/test/sql/direct_compress_copy.sql
@@ -115,7 +115,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
 ROLLBACK;
 
--- test caggs prevent direct compress
+-- test caggs with direct compress
 BEGIN;
 SET timescaledb.enable_direct_compress_copy = true;
 CREATE MATERIALIZED VIEW metrics_cagg WITH (tsdb.continuous) AS SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value FROM metrics GROUP BY bucket, device WITH NO DATA;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -199,7 +199,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
 ROLLBACK;
 
--- test caggs prevent direct compress
+-- test caggs with direct compress
 BEGIN;
 SET timescaledb.enable_direct_compress_insert = true;
 CREATE MATERIALIZED VIEW metrics_cagg WITH (tsdb.continuous) AS SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value FROM metrics GROUP BY bucket, device WITH NO DATA;


### PR DESCRIPTION
When we initially introduced direct compress we blocked hypertables with continuous aggregates from using it because invalidation would not work for these hypertables. This patch enables direct compress for hypertables with continuous aggregates and adds invalidation for data added with direct compress.