### PR TITLE
Avoid processing pending ranges far from refresh range

### DIFF
--- a/tsl/test/expected/cagg_policy_concurrent.out
+++ b/tsl/test/expected/cagg_policy_concurrent.out
@@ -1230,10 +1230,10 @@ FROM overlap_test_timestamptz_var
 GROUP BY 1
 WITH NO DATA;
 /* Create two policies on mat_m1 */
-SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval) AS agg_m1_job_1 \gset
-SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval) AS agg_m1_job_2 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval, buckets_per_batch => 0) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval, buckets_per_batch => 0) AS agg_m1_job_2 \gset
 /* Create single policy on mat_m2 */
-SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval) AS agg_m2_job \gset
+SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval, buckets_per_batch => 0) AS agg_m2_job \gset
 /* Cleanup any existing data */
 TRUNCATE mat_m1;
 TRUNCATE mat_m2;

--- a/tsl/test/expected/cagg_policy_incremental.out
+++ b/tsl/test/expected/cagg_policy_incremental.out
@@ -118,6 +118,10 @@ SELECT * FROM sorted_bgw_log;
      10 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
      11 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+
 CREATE MATERIALIZED VIEW conditions_by_day_manual_refresh
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT
@@ -191,6 +195,10 @@ SELECT * FROM sorted_bgw_log;
       5 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
       6 | 3600000000 | Refresh Continuous Aggregate Policy [1000] | reached maximum number of batches per execution (2), batches not processed (2)
 
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+
 SELECT count(*) FROM conditions_by_day;
  count 
 -------
@@ -243,6 +251,10 @@ SELECT * FROM sorted_bgw_log;
       3 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Mon Nov 24 00:00:00 4714 UTC BC, Sun Feb 09 00:00:00 2025 UTC ] (batch 2 of 2)
       4 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       5 | 7200000000 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
 
 -- Should have no differences
 SELECT
@@ -307,6 +319,10 @@ SELECT * FROM sorted_bgw_log;
       9 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Wed Feb 05 00:00:00 2020 UTC, Sun Feb 09 00:00:00 2020 UTC ] (batch 4 of 4)
      10 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
      11 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
 
 SELECT count(*) FROM conditions_by_day;
  count 
@@ -388,6 +404,10 @@ SELECT * FROM sorted_bgw_log;
       1 | 14400000000 | Refresh Continuous Aggregate Policy [1000] | deleted 295 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 | 14400000000 | Refresh Continuous Aggregate Policy [1000] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+
 -- Should return zero rows
 SELECT count(*) FROM conditions_by_day;
  count 
@@ -426,6 +446,10 @@ SELECT * FROM sorted_bgw_log;
       1 | 18000000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 | 18000000000 | Refresh Continuous Aggregate Policy [1000] | inserted 10 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+
 -- Should return 10 rows because the bucket width is `1 day` and buckets per batch is `10`
 SELECT count(*) FROM conditions_by_day;
  count 
@@ -457,6 +481,10 @@ SELECT * FROM sorted_bgw_log;
       0 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Mon Nov 24 00:00:00 4714 UTC BC, Thu Mar 06 00:00:00 2025 UTC ]
       1 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 | 21600000000 | Refresh Continuous Aggregate Policy [1000] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
 
 -- Should return 1 row
 SELECT count(*) FROM conditions_by_day;
@@ -527,6 +555,10 @@ SELECT * FROM sorted_bgw_log;
       0 |         0 | Refresh Continuous Aggregate Policy [1002] | continuous aggregate refresh (individual invalidation) on "conditions_by_day_manual_refresh" in window [ Mon Feb 24 00:00:00 2025 UTC, Wed Mar 12 00:00:00 2025 UTC ]
       1 |         0 | Refresh Continuous Aggregate Policy [1002] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1002] | inserted 80 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
 
 -- Both continuous aggregates should have the same data
 SELECT count(*) FROM conditions_by_day;
@@ -608,6 +640,10 @@ SELECT * FROM sorted_bgw_log;
       9 |         0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Mar 11 00:00:00 2025 UTC, Wed Mar 12 00:00:00 2025 UTC ] (batch 4 of 4)
      10 |         0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
      11 |         0 | Refresh Continuous Aggregate Policy [1003] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
 
 -- Both continuous aggregates should have the same data
 SELECT count(*) FROM conditions_by_day;
@@ -705,6 +741,10 @@ SELECT * FROM sorted_bgw_log;
       6 |         0 | Refresh Continuous Aggregate Policy [1004] | continuous aggregate refresh (individual invalidation) on "conditions_by_month" in window [ Fri Feb 21 00:00:00 2025 UTC, Sat Mar 01 00:00:00 2025 UTC ] (batch 3 of 3)
       7 |         0 | Refresh Continuous Aggregate Policy [1004] | deleted 5 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_4"
       8 |         0 | Refresh Continuous Aggregate Policy [1004] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_4"
+
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REASSIGN OWNED BY test_cagg_refresh_policy_user TO :ROLE_SUPERUSER;

--- a/tsl/test/isolation/expected/cagg_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_refresh.out
@@ -606,7 +606,7 @@ conditions |        100
 conditions2|-2147483648
 
 
-starting permutation: WP_after_enable R6_pending_materialization_ranges R1_refresh R3_refresh K1_cancelpid R6_pending_materialization_ranges WP_after_release R13_refresh R6_pending_materialization_ranges
+starting permutation: WP_after_enable R6_pending_materialization_ranges R1_refresh R3_refresh K1_cancelpid R6_pending_materialization_ranges WP_after_release R13_refresh1 R6_pending_materialization_ranges R13_refresh2 R6_pending_materialization_ranges
 R5: LOG:  statement: 
     SET SESSION lock_timeout = '500ms';
     SET SESSION deadlock_timeout = '500ms';
@@ -656,8 +656,112 @@ debug_waitpoint_release
                        
 
 step R3_refresh: <... completed>
-step R13_refresh: 
+R13: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+step R13_refresh1: 
+    -- the window start 65 is far from the pending range start 30
+    -- so in this case the left behind pending range will NOT be processed
     CALL refresh_continuous_aggregate('cond_10', 65, 100);
+
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                     70
+
+step R13_refresh2: 
+    -- the window start 40 is one bucket before the pending range start 30
+    -- so in this case the left behind pending range will be processed
+    CALL refresh_continuous_aggregate('cond_10', 40, 100);
+
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+
+
+starting permutation: WP_after_enable R6_pending_materialization_ranges R1_refresh2 R3_refresh K1_cancelpid R6_pending_materialization_ranges WP_after_release R13_refresh3 R6_pending_materialization_ranges R13_refresh5 R6_pending_materialization_ranges R13_refresh4 R6_pending_materialization_ranges
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
+L1: WARNING:  there is already a transaction in progress
+L2: WARNING:  there is already a transaction in progress
+L3: WARNING:  there is already a transaction in progress
+step WP_after_enable: 
+    SELECT debug_waitpoint_enable('after_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+
+step R1_refresh2: 
+    CALL refresh_continuous_aggregate('cond_10', 30, 120);
+ <waiting ...>
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 70, 107);
+ <waiting ...>
+step K1_cancelpid: 
+    CALL cancelpids();
+ <waiting ...>
+step R1_refresh2: <... completed>
+ERROR:  canceling statement due to user request
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                    120
+
+step K1_cancelpid: <... completed>
+step WP_after_release: 
+    SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+R3: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+step R3_refresh: <... completed>
+R13: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+step R13_refresh3: 
+    -- the window end 100 is far from the pending range end 120
+    -- so in this case the left behind pending range will NOT be processed
+    CALL refresh_continuous_aggregate('cond_10', 40, 100);
+
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                    120
+
+R13: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+step R13_refresh5: 
+    -- the window start and end are far in more than one bucket from
+    -- pending range, so in this case the left behind pending range
+    -- will NOT be processed
+    CALL refresh_continuous_aggregate('cond_10', 50, 100);
+
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                    120
+
+step R13_refresh4: 
+    -- the window end 110 is one bucket after the pending range end 120
+    -- so in this case the left behind pending range will be processed
+    CALL refresh_continuous_aggregate('cond_10', 40, 110);
 
 step R6_pending_materialization_ranges: 
     SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';

--- a/tsl/test/sql/cagg_policy_concurrent.sql
+++ b/tsl/test/sql/cagg_policy_concurrent.sql
@@ -587,11 +587,11 @@ GROUP BY 1
 WITH NO DATA;
 
 /* Create two policies on mat_m1 */
-SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval) AS agg_m1_job_1 \gset
-SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval) AS agg_m1_job_2 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, '30 days'::interval, '12 h'::interval, buckets_per_batch => 0) AS agg_m1_job_1 \gset
+SELECT add_continuous_aggregate_policy('mat_m1', '30 days'::interval,  NULL, '12 h'::interval, buckets_per_batch => 0) AS agg_m1_job_2 \gset
 
 /* Create single policy on mat_m2 */
-SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval) AS agg_m2_job \gset
+SELECT add_continuous_aggregate_policy('mat_m2', NULL, NULL, '12 h'::interval, buckets_per_batch => 0) AS agg_m2_job \gset
 
 /* Cleanup any existing data */
 TRUNCATE mat_m1;

--- a/tsl/test/sql/cagg_policy_incremental.sql
+++ b/tsl/test/sql/cagg_policy_incremental.sql
@@ -100,6 +100,7 @@ WHERE
 SELECT ts_bgw_params_reset_time(0, true);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 CREATE MATERIALIZED VIEW conditions_by_day_manual_refresh
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -145,6 +146,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '1 hour')::bigint * 
 
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 SELECT count(*) FROM conditions_by_day;
 SELECT count(*) FROM conditions_by_day_manual_refresh;
@@ -162,6 +164,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '2 hour')::bigint * 
 
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 -- Should have no differences
 SELECT
@@ -199,6 +202,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '3 hour')::bigint * 
 -- Should process all four batches in the past
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 SELECT count(*) FROM conditions_by_day;
 SELECT count(*) FROM conditions_by_day_manual_refresh;
@@ -245,6 +249,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '4 hour')::bigint * 
 -- Should fallback to single batch processing because there's no data to be refreshed on the original hypertable
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 -- Should return zero rows
 SELECT count(*) FROM conditions_by_day;
@@ -268,6 +273,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '5 hour')::bigint * 
 -- Should fallback to single batch processing because the refresh size is too small
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 -- Should return 10 rows because the bucket width is `1 day` and buckets per batch is `10`
 SELECT count(*) FROM conditions_by_day;
@@ -284,6 +290,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '6 hour')::bigint * 
 -- Should fallback to single batch processing because the refresh size is too small
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 -- Should return 1 row
 SELECT count(*) FROM conditions_by_day;
@@ -324,6 +331,7 @@ FROM
 SELECT ts_bgw_params_reset_time(0, true);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 -- Both continuous aggregates should have the same data
 SELECT count(*) FROM conditions_by_day;
@@ -363,6 +371,7 @@ TRUNCATE bgw_log, conditions_by_day;
 SELECT ts_bgw_params_reset_time(0, true);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 -- Both continuous aggregates should have the same data
 SELECT count(*) FROM conditions_by_day;
@@ -428,6 +437,7 @@ TRUNCATE bgw_log, conditions_by_day;
 SELECT ts_bgw_params_reset_time(0, true);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REASSIGN OWNED BY test_cagg_refresh_policy_user TO :ROLE_SUPERUSER;


### PR DESCRIPTION
If the materialization phase of the Continuous Aggregate refresh don't finish successful it left behing pending range rows in the metadata table `_timescaledb_catalog.continuous_aggs_materialization_ranges`. It is not a problem when refreshing small ranges because an next attempt will pick this pending range left behind and process it.

The problem happens when refresh a big range and for some reason it don't finish successful lefting behing this big range, so an next attempt for a small range that overlaps with the big range will pick up this big range and try to refresh it again leading to performance issues.

Improved it by limiting the overlaping ranges that start at maximum one bucket before the refresh range start.

Disable-check: force-changelog-file
