### PR TITLE
Fix Postgres version matching in labelling

### DIFF
--- a/.github/workflows/label-handling.yaml
+++ b/.github/workflows/label-handling.yaml
@@ -84,7 +84,7 @@ jobs:
             }
             
             // Extract PostgreSQL version (X.Y or X.Y.Z format, create X.Y label)
-            const postgresRegex = /PostgreSQL version used:\s*(\d+\.\d+(?:\.\d+)?)/i;
+            const postgresRegex = /PostgreSQL version used:\s*[\r\n]+\s*(\d+\.\d+(?:\.\d+)?)/i;
             const postgresMatch = issueBody.match(postgresRegex);
             
             if (postgresMatch) {


### PR DESCRIPTION
Follow up of #8902 - Regex matching the Postgres version from bug issues missed the new line.

Disable-check: force-changelog-file
Disable-check: approval-count