### PR TITLE
Avoid triggering flaky test check when injecting errors

### DIFF
--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -266,5 +266,7 @@ ts_debug_point_raise_error_if_enabled(const char *name)
 			break;
 	}
 
-	ereport(ERROR, (errmsg("error injected at debug point '%s'", point.name)));
+	ereport(ERROR,
+			(errcode(ERRCODE_TRIGGERED_ACTION_EXCEPTION),
+			 errmsg("error injected at debug point '%s'", point.name)));
 }


### PR DESCRIPTION
Use error code TRIGGERED_ACTION_EXCEPTION instead of INTERNAL_ERROR in debug point error injections in order to avoid triggering the flaky tests check.

Disable-check: force-changelog-file
Disable-check: approval-count
