### PR TITLE
Use stack allocated StringInfoData

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1108,7 +1108,8 @@ ts_bgw_job_function_call_string(BgwJob *job)
 	Oid funcid = ts_bgw_job_get_funcid(job);
 	/* If do not found the function or procedure then fallback to PROKIND_FUNCTION */
 	char prokind = OidIsValid(funcid) ? get_func_prokind(funcid) : PROKIND_FUNCTION;
-	StringInfo stmt = makeStringInfo();
+	StringInfoData stmt;
+	initStringInfo(&stmt);
 	char *jsonb_str = "NULL";
 
 	if (job->fd.config)
@@ -1118,7 +1119,7 @@ ts_bgw_job_function_call_string(BgwJob *job)
 	switch (prokind)
 	{
 		case PROKIND_FUNCTION:
-			appendStringInfo(stmt,
+			appendStringInfo(&stmt,
 							 "SELECT %s.%s('%d', %s)",
 							 quote_identifier(NameStr(job->fd.proc_schema)),
 							 quote_identifier(NameStr(job->fd.proc_name)),
@@ -1126,7 +1127,7 @@ ts_bgw_job_function_call_string(BgwJob *job)
 							 jsonb_str);
 			break;
 		case PROKIND_PROCEDURE:
-			appendStringInfo(stmt,
+			appendStringInfo(&stmt,
 							 "CALL %s.%s('%d', %s)",
 							 quote_identifier(NameStr(job->fd.proc_schema)),
 							 quote_identifier(NameStr(job->fd.proc_name)),
@@ -1140,7 +1141,7 @@ ts_bgw_job_function_call_string(BgwJob *job)
 			break;
 	}
 
-	return stmt->data;
+	return stmt.data;
 }
 
 extern Datum

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2568,20 +2568,21 @@ chunk_scan_find(int indexid, ScanKeyData scankey[], int nkeys, MemoryContext mct
 			if (fail_if_not_found)
 			{
 				int i = 0;
-				StringInfo info = makeStringInfo();
+				StringInfoData info;
+				initStringInfo(&info);
 				while (i < nkeys)
 				{
-					appendStringInfo(info,
+					appendStringInfo(&info,
 									 "%s: %s",
 									 displaykey[i].name,
 									 displaykey[i].as_string(scankey[i].sk_argument));
 					if (++i < nkeys)
-						appendStringInfoString(info, ", ");
+						appendStringInfoString(&info, ", ");
 				}
 				ereport(ERROR,
 						(errcode(ERRCODE_UNDEFINED_OBJECT),
 						 errmsg("chunk not found"),
-						 errdetail("%s", info->data)));
+						 errdetail("%s", info.data)));
 			}
 			break;
 		case 1:
@@ -2790,17 +2791,21 @@ chunk_simple_scan(ScanIterator *iterator, FormData_chunk *form, bool missing_ok,
 	if (count == 0 && !missing_ok)
 	{
 		int i = 0;
-		StringInfo info = makeStringInfo();
+		StringInfoData info;
+		initStringInfo(&info);
 		while (i < iterator->ctx.nkeys)
 		{
-			appendStringInfo(info,
+			appendStringInfo(&info,
 							 "%s: %s",
 							 displaykey[i].name,
 							 displaykey[i].as_string(iterator->ctx.scankey[i].sk_argument));
 			if (++i < iterator->ctx.nkeys)
-				appendStringInfoString(info, ", ");
+				appendStringInfoString(&info, ", ");
 		}
-		ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("chunk not found")));
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("chunk not found"),
+				 errdetail("%s", info.data)));
 	}
 
 	return count == 1;

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2264,7 +2264,7 @@ ts_hypertable_create_compressed(Oid table_relid, int32 hypertable_id)
 int64
 ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, bool *isnull)
 {
-	StringInfo command;
+	StringInfoData command;
 	const Dimension *dim;
 	int res;
 	bool max_isnull;
@@ -2285,8 +2285,8 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 	 * search_path and instead have to fully schema-qualify
 	 * everything.
 	 */
-	command = makeStringInfo();
-	appendStringInfo(command,
+	initStringInfo(&command);
+	appendStringInfo(&command,
 					 "SELECT pg_catalog.max(%s) FROM %s.%s",
 					 quote_identifier(NameStr(dim->fd.column_name)),
 					 quote_identifier(NameStr(ht->fd.schema_name)),
@@ -2295,7 +2295,7 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 	if (SPI_connect() != SPI_OK_CONNECT)
 		elog(ERROR, "could not connect to SPI");
 
-	res = SPI_execute(command->data, true /* read_only */, 0 /*count*/);
+	res = SPI_execute(command.data, true /* read_only */, 0 /*count*/);
 
 	if (res < 0)
 		ereport(ERROR,

--- a/src/net/http_request.c
+++ b/src/net/http_request.c
@@ -139,13 +139,14 @@ void
 ts_http_request_set_body_jsonb(HttpRequest *req, const Jsonb *json)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
-	StringInfo jtext = makeStringInfo();
+	StringInfoData jtext;
+	initStringInfo(&jtext);
 	char content_length[10];
 
-	JsonbToCString(jtext, (JsonbContainer *) &json->root, VARSIZE(json));
-	req->body = jtext->data;
-	req->body_len = jtext->len;
-	snprintf(content_length, sizeof(content_length), "%d", jtext->len);
+	JsonbToCString(&jtext, (JsonbContainer *) &json->root, VARSIZE(json));
+	req->body = jtext.data;
+	req->body_len = jtext.len;
+	snprintf(content_length, sizeof(content_length), "%d", jtext.len);
 	set_header(req, HTTP_CONTENT_TYPE, "application/json");
 	set_header(req, HTTP_CONTENT_LENGTH, content_length);
 	MemoryContextSwitchTo(old);

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -333,7 +333,7 @@ static void
 add_errors_by_sqlerrcode(JsonbParseState *parse_state)
 {
 	int res;
-	StringInfo command;
+	StringInfoData command;
 	MemoryContext orig_context = CurrentMemoryContext;
 
 	const char *command_string = "SELECT "
@@ -367,10 +367,10 @@ add_errors_by_sqlerrcode(JsonbParseState *parse_state)
 	int save_nestlevel = NewGUCNestLevel();
 	RestrictSearchPath();
 
-	command = makeStringInfo();
+	initStringInfo(&command);
 
-	appendStringInfoString(command, command_string);
-	res = SPI_execute(command->data, true /*read only*/, 0 /* count */);
+	appendStringInfoString(&command, command_string);
+	res = SPI_execute(command.data, true /*read only*/, 0 /* count */);
 	if (res < 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),
@@ -435,7 +435,7 @@ add_job_stats_internal(JsonbParseState *state, const char *job_type, TelemetryJo
 static void
 add_job_stats_by_job_type(JsonbParseState *parse_state)
 {
-	StringInfo command;
+	StringInfoData command;
 	int res;
 	MemoryContext orig_context = CurrentMemoryContext;
 	SPITupleTable *tuptable = NULL;
@@ -471,10 +471,10 @@ add_job_stats_by_job_type(JsonbParseState *parse_state)
 	int save_nestlevel = NewGUCNestLevel();
 	RestrictSearchPath();
 
-	command = makeStringInfo();
+	initStringInfo(&command);
 
-	appendStringInfoString(command, command_string);
-	res = SPI_execute(command->data, true /* read_only */, 0 /*count*/);
+	appendStringInfoString(&command, command_string);
+	res = SPI_execute(command.data, true /* read_only */, 0 /*count*/);
 	if (res < 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),
@@ -561,7 +561,7 @@ add_related_extensions(JsonbParseState *state)
 static char *
 get_pgversion_string()
 {
-	StringInfo buf = makeStringInfo();
+	StringInfoData buf;
 	int major, patch;
 
 	/*
@@ -577,9 +577,10 @@ get_pgversion_string()
 	patch = server_version_num % 100;
 
 	Assert(major >= PG_MAJOR_MIN);
-	appendStringInfo(buf, "%d.%d", major, patch);
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "%d.%d", major, patch);
 
-	return buf->data;
+	return buf.data;
 }
 
 #define ISO8601_FORMAT "YYYY-MM-DD\"T\"HH24:MI:SSOF"

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -368,8 +368,9 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 {
 	PolicyContinuousAggData policy_data;
 
-	StringInfo str = makeStringInfo();
-	JsonbToCStringIndent(str, &config->root, VARSIZE(config));
+	StringInfoData str;
+	initStringInfo(&str);
+	JsonbToCStringIndent(&str, &config->root, VARSIZE(config));
 
 	policy_refresh_cagg_read_and_validate_config(config, &policy_data);
 	bool extend_last_bucket = !policy_refresh_cagg_check_if_last_policy(&policy_data);
@@ -712,7 +713,7 @@ job_execute(BgwJob *job)
 	Oid proc;
 	FuncExpr *funcexpr;
 	MemoryContext parent_ctx = CurrentMemoryContext;
-	StringInfo query;
+	StringInfoData query;
 	Portal portal = ActivePortal;
 
 	if (job->fd.config)
@@ -787,12 +788,12 @@ job_execute(BgwJob *job)
 	 * any job, not just custom jobs. We just provide more detailed
 	 * information here that we are actually calling a specific custom
 	 * function. */
-	query = makeStringInfo();
-	appendStringInfo(query,
+	initStringInfo(&query);
+	appendStringInfo(&query,
 					 "CALL %s.%s()",
 					 quote_identifier(NameStr(job->fd.proc_schema)),
 					 quote_identifier(NameStr(job->fd.proc_name)));
-	pgstat_report_activity(STATE_RUNNING, query->data);
+	pgstat_report_activity(STATE_RUNNING, query.data);
 
 	switch (prokind)
 	{

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -298,7 +298,8 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 	HeapTuple index_tuple;
 	List *indexcols = NIL;
 
-	StringInfo buf = makeStringInfo();
+	StringInfoData buf;
+	initStringInfo(&buf);
 
 	if (settings->fd.segmentby)
 	{
@@ -309,8 +310,8 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 		{
 			IndexElem *segment_elem = makeNode(IndexElem);
 			segment_elem->name = TextDatumGetCString(datum);
-			appendStringInfoString(buf, segment_elem->name);
-			appendStringInfoString(buf, ", ");
+			appendStringInfoString(&buf, segment_elem->name);
+			appendStringInfoString(&buf, ", ");
 			indexcols = lappend(indexcols, segment_elem);
 		}
 	}
@@ -318,21 +319,22 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 	SortByDir ordering;
 	SortByNulls nulls_ordering;
 
-	StringInfo orderby_buf = makeStringInfo();
+	StringInfoData orderby_buf;
+	initStringInfo(&orderby_buf);
 	for (int i = 1; i <= ts_array_length(settings->fd.orderby); i++)
 	{
-		resetStringInfo(orderby_buf);
+		resetStringInfo(&orderby_buf);
 		/* Add min metadata column */
 		IndexElem *orderby_min_elem = makeNode(IndexElem);
 		orderby_min_elem->name = column_segment_min_name(i);
 		if (ts_array_get_element_bool(settings->fd.orderby_desc, i))
 		{
-			appendStringInfoString(orderby_buf, " DESC");
+			appendStringInfoString(&orderby_buf, " DESC");
 			ordering = SORTBY_DESC;
 		}
 		else
 		{
-			appendStringInfoString(orderby_buf, " ASC");
+			appendStringInfoString(&orderby_buf, " ASC");
 			ordering = SORTBY_ASC;
 		}
 		orderby_min_elem->ordering = ordering;
@@ -341,7 +343,7 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 		{
 			if (orderby_min_elem->ordering != SORTBY_DESC)
 			{
-				appendStringInfoString(orderby_buf, " NULLS FIRST");
+				appendStringInfoString(&orderby_buf, " NULLS FIRST");
 				nulls_ordering = SORTBY_NULLS_FIRST;
 			}
 			else
@@ -357,14 +359,14 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 			}
 			else
 			{
-				appendStringInfoString(orderby_buf, " NULLS LAST");
+				appendStringInfoString(&orderby_buf, " NULLS LAST");
 				nulls_ordering = SORTBY_NULLS_LAST;
 			}
 		}
 		orderby_min_elem->nulls_ordering = nulls_ordering;
-		appendStringInfoString(buf, orderby_min_elem->name);
-		appendStringInfoString(buf, orderby_buf->data);
-		appendStringInfoString(buf, ", ");
+		appendStringInfoString(&buf, orderby_min_elem->name);
+		appendStringInfoString(&buf, orderby_buf.data);
+		appendStringInfoString(&buf, ", ");
 		indexcols = lappend(indexcols, orderby_min_elem);
 
 		/* Add max metadata column */
@@ -372,9 +374,9 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 		orderby_max_elem->name = column_segment_max_name(i);
 		orderby_max_elem->ordering = orderby_min_elem->ordering;
 		orderby_max_elem->nulls_ordering = orderby_min_elem->nulls_ordering;
-		appendStringInfoString(buf, orderby_max_elem->name);
-		appendStringInfoString(buf, orderby_buf->data);
-		appendStringInfoString(buf, ", ");
+		appendStringInfoString(&buf, orderby_max_elem->name);
+		appendStringInfoString(&buf, orderby_buf.data);
+		appendStringInfoString(&buf, ", ");
 		indexcols = lappend(indexcols, orderby_max_elem);
 	}
 
@@ -401,7 +403,7 @@ create_compressed_chunk_indexes(Chunk *chunk, CompressionSettings *settings)
 		 NameStr(index_name),
 		 NameStr(chunk->fd.schema_name),
 		 NameStr(chunk->fd.table_name),
-		 buf->data);
+		 buf.data);
 
 	ReleaseSysCache(index_tuple);
 }

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -94,7 +94,8 @@ cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht)
 	List *grp_colnames = cagg_find_groupingcols(agg, mat_ht);
 	if (grp_colnames)
 	{
-		StringInfo info = makeStringInfo();
+		StringInfoData info;
+		initStringInfo(&info);
 		ListCell *lc;
 		foreach (lc, grp_colnames)
 		{
@@ -102,17 +103,17 @@ cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht)
 			/* skip time dimension col if it appears in group-by list */
 			if (namestrcmp((Name) & (mat_ht_dim->fd.column_name), grpcol) == 0)
 				continue;
-			if (info->len > 0)
-				appendStringInfoString(info, ",");
-			appendStringInfoString(info, quote_identifier(grpcol));
+			if (info.len > 0)
+				appendStringInfoString(&info, ",");
+			appendStringInfoString(&info, quote_identifier(grpcol));
 		}
 
-		if (info->len > 0)
+		if (info.len > 0)
 		{
 			DefElem *segby;
 			segby = makeDefElemExtended(EXTENSION_NAMESPACE,
 										"compress_segmentby",
-										(Node *) makeString(info->data),
+										(Node *) makeString(info.data),
 										DEFELEM_UNSPEC,
 										-1);
 			defelems = lappend(defelems, segby);

--- a/tsl/src/partialize_finalize.c
+++ b/tsl/src/partialize_finalize.c
@@ -340,13 +340,14 @@ inner_agg_deserialize(FACombineFnMeta *combine_meta, bytea *volatile serialized_
 	else if (!serialized_isnull)
 	{
 		int32 typmod = -1;
-		StringInfo string = makeStringInfo();
+		StringInfoData string;
+		initStringInfo(&string);
 		FunctionCallInfo internal_deserialfn_fcinfo = combine_meta->internal_deserialfn_fcinfo;
 
-		appendBinaryStringInfo(string,
+		appendBinaryStringInfo(&string,
 							   VARDATA_ANY(serialized_partial),
 							   VARSIZE_ANY_EXHDR(serialized_partial));
-		FC_SET_ARG(internal_deserialfn_fcinfo, 0, PointerGetDatum(string));
+		FC_SET_ARG(internal_deserialfn_fcinfo, 0, PointerGetDatum(&string));
 		FC_SET_ARG(internal_deserialfn_fcinfo, 1, ObjectIdGetDatum(combine_meta->typIOParam));
 		FC_SET_ARG(internal_deserialfn_fcinfo, 2, Int32GetDatum(typmod));
 


### PR DESCRIPTION
Instead of using long living StringInfo we can use StringInfoData cause it don't need to exist beyond the function scope.

Inspired by Postgres upstream commit:
https://github.com/postgres/postgres/commit/6d0eba66275b125bf634bbdffda90c70856e3f93

Disable-check: force-changelog-file
