### PR TITLE
Fix test flake due to ordering in merge_chunks test

### DIFF
--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -767,7 +767,8 @@ select
     chunk_relid,
     n as new_chunk_id,
     (select count(indexrelid::regclass) from pg_index where indrelid=new_relid) as num_new_indexes
-from (select *, dense_rank() over (order by new_relid) as n from _timescaledb_catalog.chunk_rewrite) cr;
+from (select *, dense_rank() over (order by new_relid) as n from _timescaledb_catalog.chunk_rewrite) cr
+order by 1, 2;
 grant select on chunks_being_merged to public;
 -- Concurrent merge cannot run in a transaction block
 \set ON_ERROR_STOP 0
@@ -788,8 +789,8 @@ select * from chunks_being_merged;
 -------------------------------------------------+--------------+-----------------
  _timescaledb_internal._hyper_1_1_chunk          |            1 |               2
  _timescaledb_internal._hyper_1_4_chunk          |            1 |               2
- _timescaledb_internal._hyper_1_12_chunk         |            1 |               2
  _timescaledb_internal._hyper_1_5_chunk          |            1 |               2
+ _timescaledb_internal._hyper_1_12_chunk         |            1 |               2
  _timescaledb_internal.compress_hyper_2_17_chunk |            2 |               1
 
 reset role;
@@ -822,8 +823,8 @@ select * from chunks_being_merged;
 -------------------------------------------------+--------------+-----------------
  _timescaledb_internal._hyper_1_1_chunk          |            1 |               0
  _timescaledb_internal._hyper_1_4_chunk          |            1 |               0
- _timescaledb_internal._hyper_1_12_chunk         |            1 |               0
  _timescaledb_internal._hyper_1_5_chunk          |            1 |               0
+ _timescaledb_internal._hyper_1_12_chunk         |            1 |               0
  _timescaledb_internal.compress_hyper_2_17_chunk |            2 |               1
  _timescaledb_internal._hyper_4_18_chunk         |            3 |               1
  _timescaledb_internal._hyper_4_19_chunk         |            3 |               1
@@ -881,8 +882,8 @@ select * from chunks_being_merged;
 -------------------------------------------------+--------------+-----------------
  _timescaledb_internal._hyper_1_1_chunk          |            1 |               2
  _timescaledb_internal._hyper_1_4_chunk          |            1 |               2
- _timescaledb_internal._hyper_1_12_chunk         |            1 |               2
  _timescaledb_internal._hyper_1_5_chunk          |            1 |               2
+ _timescaledb_internal._hyper_1_12_chunk         |            1 |               2
  _timescaledb_internal.compress_hyper_2_17_chunk |            2 |               1
  _timescaledb_internal._hyper_4_18_chunk         |            3 |               1
  _timescaledb_internal._hyper_4_19_chunk         |            3 |               1

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -387,7 +387,8 @@ select
     chunk_relid,
     n as new_chunk_id,
     (select count(indexrelid::regclass) from pg_index where indrelid=new_relid) as num_new_indexes
-from (select *, dense_rank() over (order by new_relid) as n from _timescaledb_catalog.chunk_rewrite) cr;
+from (select *, dense_rank() over (order by new_relid) as n from _timescaledb_catalog.chunk_rewrite) cr
+order by 1, 2;
 grant select on chunks_being_merged to public;
 
 


### PR DESCRIPTION
A view in the merge_chunks test could cause test flakes due to different ordering of chunks. Add an ORDER BY clause to prevent these flakes.