### PR TITLE
Fix builds on macos13 due to missing cast

### DIFF
--- a/tsl/src/compression/batch_metadata_builder_bloom1.c
+++ b/tsl/src/compression/batch_metadata_builder_bloom1.c
@@ -603,7 +603,7 @@ bloom1_contains_any(PG_FUNCTION_ARGS)
 	 * systems.
 	 */
 #if FLOAT8PASSBYVAL
-	uint64 *item_base_hashes = items;
+	uint64 *item_base_hashes = (uint64 *) items;
 #else
 	uint64 *item_base_hashes = palloc(sizeof(uint64) * num_items);
 #endif


### PR DESCRIPTION
Added a missing cast that's been causing debug build failures on macos13 with PG18 after PR #8465

Disable-check: force-changelog-file