### PR TITLE
Support continuous aggregates on UUIDv7-partitioned hypertables

### DIFF
--- a/.unreleased/pr_8939
+++ b/.unreleased/pr_8939
@@ -1,0 +1,1 @@
+Implements: #8939 Support continuous aggregates on UUIDv7-partitioned hypertables

--- a/src/func_cache.c
+++ b/src/func_cache.c
@@ -261,9 +261,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE,
 		.is_bucketing_func = true,
-		/* Do not allow uuid bucketing in caggs until support for it is
-		 * implemented and tested */
-		.allowed_in_cagg_definition = false,
+		.allowed_in_cagg_definition = true,
 		.funcname = "time_bucket",
 		.nargs = 2,
 		.arg_types = { INTERVALOID, UUIDOID },
@@ -274,9 +272,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE,
 		.is_bucketing_func = true,
-		/* Do not allow uuid bucketing in caggs until support for it is
-		 * implemented and tested */
-		.allowed_in_cagg_definition = false,
+		.allowed_in_cagg_definition = true,
 		.funcname = "time_bucket",
 		.nargs = 3,
 		.arg_types = { INTERVALOID, UUIDOID, TIMESTAMPTZOID },
@@ -287,9 +283,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE,
 		.is_bucketing_func = true,
-		/* Do not allow uuid bucketing in caggs until support for it is
-		 * implemented and tested */
-		.allowed_in_cagg_definition = false,
+		.allowed_in_cagg_definition = true,
 		.funcname = "time_bucket",
 		.nargs = 3,
 		.arg_types = { INTERVALOID, UUIDOID, INTERVALOID },

--- a/tsl/test/expected/cagg_uuid.out
+++ b/tsl/test/expected/cagg_uuid.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 --
 --
--- Test "time" partitioning on UUIDv7
+-- Test caggs with "time" partitioning on UUIDv7
 --
 --
 CREATE TABLE uuid_events(id uuid primary key, device int, temp float);
@@ -31,10 +31,252 @@ SELECT * FROM show_chunks('uuid_events');
  _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
 
--- Check that continuous aggregates with UUIDv7 time_bucket is blocked. This
--- will be unblocked later when full cagg support is implemented.
+CREATE TABLE ts_events(ts timestamptz primary key, device int, temp float);
+SELECT create_hypertable('ts_events', 'ts', chunk_time_interval => interval '1 day');
+   create_hypertable    
+------------------------
+ (2,public,ts_events,t)
+
+INSERT INTO ts_events SELECT uuid_timestamp(id), device, temp FROM uuid_events;
+SELECT
+    _timescaledb_functions.to_timestamp(range_start) AS chunk_range_start,
+    _timescaledb_functions.to_timestamp(range_end) AS chunk_range_end
+FROM _timescaledb_catalog.dimension_slice ds
+JOIN _timescaledb_catalog.dimension d ON (ds.dimension_id = d.id)
+JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.table_name = 'uuid_events'
+LIMIT 1 OFFSET 1 \gset
 CREATE MATERIALIZED VIEW daily_uuid_events WITH (timescaledb.continuous) AS
-SELECT time_bucket('1 day', id) AS day, avg(temp)
+SELECT time_bucket('1 day', id) AS day, round(avg(temp)::numeric, 3) AS temp
 FROM uuid_events WHERE device < 6
 GROUP BY 1;
-ERROR:  continuous aggregate view must include a valid time bucket function
+NOTICE:  refreshing continuous aggregate "daily_uuid_events"
+CREATE MATERIALIZED VIEW daily_ts_events WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', ts) AS day, round(avg(temp)::numeric, 3) AS temp
+FROM ts_events WHERE device < 6
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "daily_ts_events"
+-- The uuid and timestmap caggs should look the same
+SELECT * FROM daily_uuid_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 3.500
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+
+SELECT * FROM daily_ts_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 3.500
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+
+-- Update both caggs with new data with same timestamps
+INSERT INTO uuid_events VALUES
+       ('0194254e-cd00-7000-a9a7-63f1416dab45', 2, 2.0),
+       ('019552dd-7500-7000-8a80-103c4d6ee60e', 3, 7.0);
+INSERT INTO ts_events VALUES
+       (uuid_timestamp('0194254e-cd00-7000-a9a7-63f1416dab45'), 2, 2.0),
+       (uuid_timestamp('019552dd-7500-7000-8a80-103c4d6ee60e'), 3, 7.0);
+-- Refresh the caggs
+CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+-- The caggs should be updated in the same way
+SELECT * FROM daily_uuid_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 3.000
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+ Fri Feb 28 16:00:00 2025 PST | 7.000
+
+SELECT * FROM daily_ts_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 3.000
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+ Fri Feb 28 16:00:00 2025 PST | 7.000
+
+-- Test merge refresh
+SET timescaledb.enable_merge_on_cagg_refresh = true;
+INSERT INTO uuid_events VALUES
+       ('0194256e-cd00-7000-a9a7-63f1416dab45', 4, 8.0),
+       ('019552fd-7500-7000-8a80-103c4d6ee60e', 5, 9.0);
+INSERT INTO ts_events VALUES
+       (uuid_timestamp('0194256e-cd00-7000-a9a7-63f1416dab45'), 4, 8.0),
+       (uuid_timestamp('019552fd-7500-7000-8a80-103c4d6ee60e'), 5, 9.0);
+CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+SELECT * FROM daily_uuid_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 4.250
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+ Fri Feb 28 16:00:00 2025 PST | 8.000
+
+SELECT * FROM daily_ts_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 4.250
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+ Fri Feb 28 16:00:00 2025 PST | 8.000
+
+ALTER MATERIALIZED VIEW daily_uuid_events SET (tsdb.enable_columnstore = true);
+NOTICE:  defaulting compress_orderby to day
+SELECT ch AS chunk FROM show_chunks('daily_uuid_events') ch ORDER BY ch LIMIT 1 \gset
+CALL convert_to_columnstore(:'chunk');
+SELECT * FROM daily_uuid_events ORDER BY day;
+             day              | temp  
+------------------------------+-------
+ Tue Dec 31 16:00:00 2024 PST | 1.500
+ Wed Jan 01 16:00:00 2025 PST | 4.250
+ Thu Jan 02 16:00:00 2025 PST | 5.000
+ Fri Feb 28 16:00:00 2025 PST | 8.000
+
+SET timescaledb.enable_merge_on_cagg_refresh = true;
+-- Test insert with direct compress enabled
+SET timescaledb.enable_direct_compress_insert = true;
+-- Enable compression also on the raw hypertable
+ALTER TABLE uuid_events SET (tsdb.enable_columnstore = true);
+SElECT setseed(0.9);
+ setseed 
+---------
+ 
+
+-- Generate 2000 rows with UUIDv7 from timestamps
+CREATE TEMP TABLE tmpdata (ts, device, temp) AS
+SELECT
+    ts,
+    (row_number() OVER () % 10) + 1,
+    random() * 100
+FROM generate_series(
+  '2025-03-01 11:00',
+  '2025-03-04 11:00',
+    interval '1 minute'
+) AS ts;
+INSERT INTO uuid_events
+SELECT to_uuidv7(ts), device, temp
+FROM tmpdata;
+WARNING:  disabling direct compress because the destination table has unique constraints
+INSERT INTO ts_events
+SELECT ts, device, temp
+FROM tmpdata;
+select count(*) from uuid_events;
+ count 
+-------
+  4331
+
+select count(*) from ts_events;
+ count 
+-------
+  4331
+
+CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+SELECT * FROM daily_uuid_events ORDER BY day;
+             day              |  temp  
+------------------------------+--------
+ Tue Dec 31 16:00:00 2024 PST |  1.500
+ Wed Jan 01 16:00:00 2025 PST |  4.250
+ Thu Jan 02 16:00:00 2025 PST |  5.000
+ Fri Feb 28 16:00:00 2025 PST | 47.928
+ Sat Mar 01 16:00:00 2025 PST | 50.767
+ Sun Mar 02 16:00:00 2025 PST | 49.410
+ Mon Mar 03 16:00:00 2025 PST | 52.474
+
+SELECT * FROM daily_ts_events ORDER BY day;
+             day              |  temp  
+------------------------------+--------
+ Tue Dec 31 16:00:00 2024 PST |  1.500
+ Wed Jan 01 16:00:00 2025 PST |  4.250
+ Thu Jan 02 16:00:00 2025 PST |  5.000
+ Fri Feb 28 16:00:00 2025 PST | 47.928
+ Sat Mar 01 16:00:00 2025 PST | 50.767
+ Sun Mar 02 16:00:00 2025 PST | 49.410
+ Mon Mar 03 16:00:00 2025 PST | 52.474
+
+-- Test hierarchical cagg
+CREATE MATERIALIZED VIEW weekly_uuid_events WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', day) AS week, max(temp) AS max_temp
+FROM daily_uuid_events
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "weekly_uuid_events"
+CREATE MATERIALIZED VIEW weekly_ts_events WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', day) AS week, max(temp) AS max_temp
+FROM daily_ts_events
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "weekly_ts_events"
+SELECT * FROM weekly_uuid_events ORDER BY week;
+             week             | max_temp 
+------------------------------+----------
+ Sun Dec 29 16:00:00 2024 PST |    5.000
+ Sun Feb 23 16:00:00 2025 PST |   50.767
+ Sun Mar 02 16:00:00 2025 PST |   52.474
+
+SELECT * FROM weekly_ts_events ORDER BY week;
+             week             | max_temp 
+------------------------------+----------
+ Sun Dec 29 16:00:00 2024 PST |    5.000
+ Sun Feb 23 16:00:00 2025 PST |   50.767
+ Sun Mar 02 16:00:00 2025 PST |   52.474
+
+INSERT INTO uuid_events
+VALUES
+  ('01958280-4800-7000-bc29-713158a4e8b6', 1, 11.0),
+  ('019587a6-a400-7000-ac1e-577d59f409af', 2, 12.0);
+WARNING:  disabling direct compress because the destination table has unique constraints
+INSERT INTO ts_events
+VALUES
+  (uuid_timestamp('01958280-4800-7000-bc29-713158a4e8b6'), 1, 11.0),
+  (uuid_timestamp('019587a6-a400-7000-ac1e-577d59f409af'), 2, 12.0);
+-- Test refresh via policy
+SELECT add_continuous_aggregate_policy('daily_uuid_events', start_offset => NULL, end_offset => NULL, schedule_interval => '1 minute') AS job_id \gset
+CALL run_job(:job_id);
+CALL refresh_continuous_aggregate('weekly_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+CALL refresh_continuous_aggregate('weekly_ts_events', NULL, NULL);
+SELECT * FROM daily_uuid_events ORDER BY day;
+             day              |  temp  
+------------------------------+--------
+ Tue Dec 31 16:00:00 2024 PST |  1.500
+ Wed Jan 01 16:00:00 2025 PST |  4.250
+ Thu Jan 02 16:00:00 2025 PST |  5.000
+ Fri Feb 28 16:00:00 2025 PST | 47.928
+ Sat Mar 01 16:00:00 2025 PST | 50.767
+ Sun Mar 02 16:00:00 2025 PST | 49.410
+ Mon Mar 03 16:00:00 2025 PST | 52.474
+ Mon Mar 10 17:00:00 2025 PDT | 11.000
+ Tue Mar 11 17:00:00 2025 PDT | 12.000
+
+SELECT * FROM weekly_uuid_events ORDER BY week;
+             week             | max_temp 
+------------------------------+----------
+ Sun Dec 29 16:00:00 2024 PST |    5.000
+ Sun Feb 23 16:00:00 2025 PST |   50.767
+ Sun Mar 02 16:00:00 2025 PST |   52.474
+ Sun Mar 09 17:00:00 2025 PDT |   12.000
+
+SELECT * FROM daily_ts_events ORDER BY day;
+             day              |  temp  
+------------------------------+--------
+ Tue Dec 31 16:00:00 2024 PST |  1.500
+ Wed Jan 01 16:00:00 2025 PST |  4.250
+ Thu Jan 02 16:00:00 2025 PST |  5.000
+ Fri Feb 28 16:00:00 2025 PST | 47.928
+ Sat Mar 01 16:00:00 2025 PST | 50.767
+ Sun Mar 02 16:00:00 2025 PST | 49.410
+ Mon Mar 03 16:00:00 2025 PST | 52.474
+ Mon Mar 10 17:00:00 2025 PDT | 11.000
+ Tue Mar 11 17:00:00 2025 PDT | 12.000
+
+SELECT * FROM weekly_ts_events ORDER BY week;
+             week             | max_temp 
+------------------------------+----------
+ Sun Dec 29 16:00:00 2024 PST |    5.000
+ Sun Feb 23 16:00:00 2025 PST |   50.767
+ Sun Mar 02 16:00:00 2025 PST |   52.474
+ Sun Mar 09 17:00:00 2025 PDT |   12.000
+

--- a/tsl/test/sql/cagg_uuid.sql
+++ b/tsl/test/sql/cagg_uuid.sql
@@ -4,7 +4,7 @@
 
 --
 --
--- Test "time" partitioning on UUIDv7
+-- Test caggs with "time" partitioning on UUIDv7
 --
 --
 CREATE TABLE uuid_events(id uuid primary key, device int, temp float);
@@ -24,11 +24,146 @@ INSERT INTO uuid_events VALUES
        ('01942bd2-7380-7000-9bc4-5f97443907b8', 5, 5.0),
        ('01942d52-f900-7000-866e-07d6404d53c1', 6, 6.0);
 
+
 SELECT * FROM show_chunks('uuid_events');
 
--- Check that continuous aggregates with UUIDv7 time_bucket is blocked. This
--- will be unblocked later when full cagg support is implemented.
+CREATE TABLE ts_events(ts timestamptz primary key, device int, temp float);
+SELECT create_hypertable('ts_events', 'ts', chunk_time_interval => interval '1 day');
+INSERT INTO ts_events SELECT uuid_timestamp(id), device, temp FROM uuid_events;
+
+
+SELECT
+    _timescaledb_functions.to_timestamp(range_start) AS chunk_range_start,
+    _timescaledb_functions.to_timestamp(range_end) AS chunk_range_end
+FROM _timescaledb_catalog.dimension_slice ds
+JOIN _timescaledb_catalog.dimension d ON (ds.dimension_id = d.id)
+JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.table_name = 'uuid_events'
+LIMIT 1 OFFSET 1 \gset
+
 CREATE MATERIALIZED VIEW daily_uuid_events WITH (timescaledb.continuous) AS
-SELECT time_bucket('1 day', id) AS day, avg(temp)
+SELECT time_bucket('1 day', id) AS day, round(avg(temp)::numeric, 3) AS temp
 FROM uuid_events WHERE device < 6
 GROUP BY 1;
+
+CREATE MATERIALIZED VIEW daily_ts_events WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', ts) AS day, round(avg(temp)::numeric, 3) AS temp
+FROM ts_events WHERE device < 6
+GROUP BY 1;
+
+-- The uuid and timestmap caggs should look the same
+SELECT * FROM daily_uuid_events ORDER BY day;
+SELECT * FROM daily_ts_events ORDER BY day;
+
+-- Update both caggs with new data with same timestamps
+INSERT INTO uuid_events VALUES
+       ('0194254e-cd00-7000-a9a7-63f1416dab45', 2, 2.0),
+       ('019552dd-7500-7000-8a80-103c4d6ee60e', 3, 7.0);
+
+INSERT INTO ts_events VALUES
+       (uuid_timestamp('0194254e-cd00-7000-a9a7-63f1416dab45'), 2, 2.0),
+       (uuid_timestamp('019552dd-7500-7000-8a80-103c4d6ee60e'), 3, 7.0);
+
+-- Refresh the caggs
+CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+
+-- The caggs should be updated in the same way
+SELECT * FROM daily_uuid_events ORDER BY day;
+SELECT * FROM daily_ts_events ORDER BY day;
+
+-- Test merge refresh
+SET timescaledb.enable_merge_on_cagg_refresh = true;
+INSERT INTO uuid_events VALUES
+       ('0194256e-cd00-7000-a9a7-63f1416dab45', 4, 8.0),
+       ('019552fd-7500-7000-8a80-103c4d6ee60e', 5, 9.0);
+
+INSERT INTO ts_events VALUES
+       (uuid_timestamp('0194256e-cd00-7000-a9a7-63f1416dab45'), 4, 8.0),
+       (uuid_timestamp('019552fd-7500-7000-8a80-103c4d6ee60e'), 5, 9.0);
+
+CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+
+SELECT * FROM daily_uuid_events ORDER BY day;
+SELECT * FROM daily_ts_events ORDER BY day;
+
+ALTER MATERIALIZED VIEW daily_uuid_events SET (tsdb.enable_columnstore = true);
+SELECT ch AS chunk FROM show_chunks('daily_uuid_events') ch ORDER BY ch LIMIT 1 \gset
+CALL convert_to_columnstore(:'chunk');
+
+SELECT * FROM daily_uuid_events ORDER BY day;
+
+SET timescaledb.enable_merge_on_cagg_refresh = true;
+-- Test insert with direct compress enabled
+SET timescaledb.enable_direct_compress_insert = true;
+-- Enable compression also on the raw hypertable
+ALTER TABLE uuid_events SET (tsdb.enable_columnstore = true);
+
+SElECT setseed(0.9);
+
+-- Generate 2000 rows with UUIDv7 from timestamps
+CREATE TEMP TABLE tmpdata (ts, device, temp) AS
+SELECT
+    ts,
+    (row_number() OVER () % 10) + 1,
+    random() * 100
+FROM generate_series(
+  '2025-03-01 11:00',
+  '2025-03-04 11:00',
+    interval '1 minute'
+) AS ts;
+
+INSERT INTO uuid_events
+SELECT to_uuidv7(ts), device, temp
+FROM tmpdata;
+
+INSERT INTO ts_events
+SELECT ts, device, temp
+FROM tmpdata;
+
+select count(*) from uuid_events;
+select count(*) from ts_events;
+CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+
+SELECT * FROM daily_uuid_events ORDER BY day;
+SELECT * FROM daily_ts_events ORDER BY day;
+
+-- Test hierarchical cagg
+CREATE MATERIALIZED VIEW weekly_uuid_events WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', day) AS week, max(temp) AS max_temp
+FROM daily_uuid_events
+GROUP BY 1;
+
+CREATE MATERIALIZED VIEW weekly_ts_events WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', day) AS week, max(temp) AS max_temp
+FROM daily_ts_events
+GROUP BY 1;
+
+SELECT * FROM weekly_uuid_events ORDER BY week;
+SELECT * FROM weekly_ts_events ORDER BY week;
+
+INSERT INTO uuid_events
+VALUES
+  ('01958280-4800-7000-bc29-713158a4e8b6', 1, 11.0),
+  ('019587a6-a400-7000-ac1e-577d59f409af', 2, 12.0);
+
+INSERT INTO ts_events
+VALUES
+  (uuid_timestamp('01958280-4800-7000-bc29-713158a4e8b6'), 1, 11.0),
+  (uuid_timestamp('019587a6-a400-7000-ac1e-577d59f409af'), 2, 12.0);
+
+-- Test refresh via policy
+SELECT add_continuous_aggregate_policy('daily_uuid_events', start_offset => NULL, end_offset => NULL, schedule_interval => '1 minute') AS job_id \gset
+
+CALL run_job(:job_id);
+CALL refresh_continuous_aggregate('weekly_uuid_events', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
+CALL refresh_continuous_aggregate('weekly_ts_events', NULL, NULL);
+
+SELECT * FROM daily_uuid_events ORDER BY day;
+SELECT * FROM weekly_uuid_events ORDER BY week;
+
+SELECT * FROM daily_ts_events ORDER BY day;
+SELECT * FROM weekly_ts_events ORDER BY week;


### PR DESCRIPTION
When refreshing a continuous aggregate, the materialization process needs to find the "latest" bucket using a max query on the
partitioning dimension. This was an issue for UUIDv7 since there is no `max()` function defined for the UUID type. To make this work for UUIDv7-partitioned hypertables, make this max query first extract the timestamp from the UUID using `uuid_timestamp()`.