### PR TITLE
Fix lateral join handling for compressed chunks

### DIFF
--- a/.unreleased/pr_8942
+++ b/.unreleased/pr_8942
@@ -1,0 +1,1 @@
+Fixes: #8942 Fix lateral join handling for compressed chunks

--- a/tsl/test/shared/expected/lateral_subquery-15.out
+++ b/tsl/test/shared/expected/lateral_subquery-15.out
@@ -1,0 +1,76 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, buffers off, costs off)'
+SET parallel_leader_participation TO off;
+SET min_parallel_table_scan_size TO '0';
+SET enable_incremental_sort TO off;
+-- Test lateral query for partial chunk #8848
+:PREFIX
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Nested Loop (actual rows=205110.00 loops=1)
+   ->  Append (actual rows=68370.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_1 (actual rows=17990.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_2 (actual rows=25190.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_3 (actual rows=25190.00 loops=1)
+   ->  Nested Loop Left Join (actual rows=3.00 loops=68370)
+         Join Filter: false
+         ->  Seq Scan on sensors (actual rows=3.00 loops=68370)
+         ->  Result (actual rows=0.00 loops=205110)
+               One-Time Filter: false
+
+-- with parallel
+SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+:PREFIX_NO_ANALYZE
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Gather
+   Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+   Workers Planned: 4
+   ->  Nested Loop
+         Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+         ->  Parallel Append
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_2
+                     Output: subq_1_2."time", subq_1_2.device_id, subq_1_2.v0, subq_1_2.v1, subq_1_2.v2, subq_1_2.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_3
+                     Output: subq_1_3."time", subq_1_3.device_id, subq_1_3.v0, subq_1_3.v1, subq_1_3.v2, subq_1_3.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_1
+                     Output: subq_1_1."time", subq_1_1.device_id, subq_1_1.v0, subq_1_1.v1, subq_1_1.v2, subq_1_1.v3
+         ->  Nested Loop Left Join
+               Output: sensors.sensor_id, sensors.name, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3)
+               Join Filter: false
+               ->  Seq Scan on public.sensors
+                     Output: sensors.sensor_id, sensors.name
+               ->  Result
+                     Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3
+                     One-Time Filter: false
+
+--  now run the query to catch any coredump
+\o /dev/null
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+\o

--- a/tsl/test/shared/expected/lateral_subquery-16.out
+++ b/tsl/test/shared/expected/lateral_subquery-16.out
@@ -1,0 +1,76 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, buffers off, costs off)'
+SET parallel_leader_participation TO off;
+SET min_parallel_table_scan_size TO '0';
+SET enable_incremental_sort TO off;
+-- Test lateral query for partial chunk #8848
+:PREFIX
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Nested Loop (actual rows=205110.00 loops=1)
+   ->  Append (actual rows=68370.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_1 (actual rows=17990.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_2 (actual rows=25190.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_3 (actual rows=25190.00 loops=1)
+   ->  Nested Loop Left Join (actual rows=3.00 loops=68370)
+         Join Filter: false
+         ->  Seq Scan on sensors (actual rows=3.00 loops=68370)
+         ->  Result (actual rows=0.00 loops=205110)
+               One-Time Filter: false
+
+-- with parallel
+SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+:PREFIX_NO_ANALYZE
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Gather
+   Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+   Workers Planned: 4
+   ->  Nested Loop
+         Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+         ->  Parallel Append
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_2
+                     Output: subq_1_2."time", subq_1_2.device_id, subq_1_2.v0, subq_1_2.v1, subq_1_2.v2, subq_1_2.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_3
+                     Output: subq_1_3."time", subq_1_3.device_id, subq_1_3.v0, subq_1_3.v1, subq_1_3.v2, subq_1_3.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_1
+                     Output: subq_1_1."time", subq_1_1.device_id, subq_1_1.v0, subq_1_1.v1, subq_1_1.v2, subq_1_1.v3
+         ->  Nested Loop Left Join
+               Output: sensors.sensor_id, sensors.name, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3)
+               Join Filter: false
+               ->  Seq Scan on public.sensors
+                     Output: sensors.sensor_id, sensors.name
+               ->  Result
+                     Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3
+                     One-Time Filter: false
+
+--  now run the query to catch any coredump
+\o /dev/null
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+\o

--- a/tsl/test/shared/expected/lateral_subquery-17.out
+++ b/tsl/test/shared/expected/lateral_subquery-17.out
@@ -1,0 +1,76 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, buffers off, costs off)'
+SET parallel_leader_participation TO off;
+SET min_parallel_table_scan_size TO '0';
+SET enable_incremental_sort TO off;
+-- Test lateral query for partial chunk #8848
+:PREFIX
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Nested Loop (actual rows=205110.00 loops=1)
+   ->  Append (actual rows=68370.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_1 (actual rows=17990.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_2 (actual rows=25190.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_3 (actual rows=25190.00 loops=1)
+   ->  Nested Loop Left Join (actual rows=3.00 loops=68370)
+         Join Filter: false
+         ->  Seq Scan on sensors (actual rows=3.00 loops=68370)
+         ->  Result (actual rows=0.00 loops=205110)
+               One-Time Filter: false
+
+-- with parallel
+SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+:PREFIX_NO_ANALYZE
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Gather
+   Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+   Workers Planned: 4
+   ->  Nested Loop
+         Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+         ->  Parallel Append
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_2
+                     Output: subq_1_2."time", subq_1_2.device_id, subq_1_2.v0, subq_1_2.v1, subq_1_2.v2, subq_1_2.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_3
+                     Output: subq_1_3."time", subq_1_3.device_id, subq_1_3.v0, subq_1_3.v1, subq_1_3.v2, subq_1_3.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_1
+                     Output: subq_1_1."time", subq_1_1.device_id, subq_1_1.v0, subq_1_1.v1, subq_1_1.v2, subq_1_1.v3
+         ->  Nested Loop Left Join
+               Output: sensors.sensor_id, sensors.name, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3)
+               Join Filter: false
+               ->  Seq Scan on public.sensors
+                     Output: sensors.sensor_id, sensors.name
+               ->  Result
+                     Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3
+                     One-Time Filter: false
+
+--  now run the query to catch any coredump
+\o /dev/null
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+\o

--- a/tsl/test/shared/expected/lateral_subquery-18.out
+++ b/tsl/test/shared/expected/lateral_subquery-18.out
@@ -1,0 +1,76 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, buffers off, costs off)'
+SET parallel_leader_participation TO off;
+SET min_parallel_table_scan_size TO '0';
+SET enable_incremental_sort TO off;
+-- Test lateral query for partial chunk #8848
+:PREFIX
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Nested Loop (actual rows=205110.00 loops=1)
+   ->  Append (actual rows=68370.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_1 (actual rows=17990.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_2 (actual rows=25190.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk subq_1_3 (actual rows=25190.00 loops=1)
+   ->  Nested Loop Left Join (actual rows=3.00 loops=68370)
+         Join Filter: false
+         ->  Seq Scan on sensors (actual rows=3.00 loops=68370)
+         ->  Result (actual rows=0.00 loops=205110)
+               One-Time Filter: false
+
+-- with parallel
+SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+:PREFIX_NO_ANALYZE
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--- QUERY PLAN ---
+ Gather
+   Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+   Workers Planned: 4
+   ->  Nested Loop
+         Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3), sensors.sensor_id, sensors.name
+         ->  Parallel Append
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_2
+                     Output: subq_1_2."time", subq_1_2.device_id, subq_1_2.v0, subq_1_2.v1, subq_1_2.v2, subq_1_2.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_3
+                     Output: subq_1_3."time", subq_1_3.device_id, subq_1_3.v0, subq_1_3.v1, subq_1_3.v2, subq_1_3.v3
+               ->  Parallel Seq Scan on _timescaledb_internal._hyper_X_X_chunk subq_1_1
+                     Output: subq_1_1."time", subq_1_1.device_id, subq_1_1.v0, subq_1_1.v1, subq_1_1.v2, subq_1_1.v3
+         ->  Nested Loop Left Join
+               Output: sensors.sensor_id, sensors.name, (subq_1."time"), (subq_1.device_id), (subq_1.v0), (subq_1.v1), (subq_1.v2), (subq_1.v3)
+               Join Filter: false
+               ->  Seq Scan on public.sensors
+                     Output: sensors.sensor_id, sensors.name
+               ->  Result
+                     Output: subq_1."time", subq_1.device_id, subq_1.v0, subq_1.v1, subq_1.v2, subq_1.v3
+                     One-Time Filter: false
+
+--  now run the query to catch any coredump
+\o /dev/null
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+\o

--- a/tsl/test/shared/sql/.gitignore
+++ b/tsl/test/shared/sql/.gitignore
@@ -1,5 +1,6 @@
 /continuous_aggs_compression-*.sql
 /gapfill-*.sql
+/lateral_subquery-*.sql
 /ordered_append_join-*.sql
 /remote-copy-escapes.*sv
 /transparent_decompress_chunk-*.sql

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_FILES_SHARED
 
 set(TEST_TEMPLATES_SHARED
     gapfill.sql.in
+    lateral_subquery.sql.in
     ordered_append_join.sql.in
     constify_timestamptz_op_interval.sql.in
     constraint_exclusion_prepared.sql.in

--- a/tsl/test/shared/sql/lateral_subquery.sql.in
+++ b/tsl/test/shared/sql/lateral_subquery.sql.in
@@ -1,0 +1,47 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, buffers off, costs off)'
+SET parallel_leader_participation TO off;
+SET min_parallel_table_scan_size TO '0';
+SET enable_incremental_sort TO off;
+-- Test lateral query for partial chunk #8848
+
+:PREFIX
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+
+-- with parallel
+
+SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+
+:PREFIX_NO_ANALYZE
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+--  now run the query to catch any coredump
+\o /dev/null
+SELECT *
+FROM metrics subq_1,
+    LATERAL (
+        SELECT *
+        FROM (
+            SELECT subq_1.*
+            FROM metrics_compressed) AS subq_2
+            RIGHT JOIN sensors ON FALSE) AS lat;
+\o


### PR DESCRIPTION
Compressed relations now properly inherit lateral_relids from chunk
relations and correctly handle parameterized paths during decompression.
Parameterized partial paths are checked with an assertion, and parallel
paths are skipped for laterally-dependent compressed relations.

Fixes: #8848

Relevant postgres commit:
```
commit 2309eff62b463fb3f19e6dd229243902b3b44501
Author: Richard Guo <rguo@postgresql.org>
Date:   Tue Jul 30 15:49:44 2024 +0900

    Refactor the checks for parameterized partial paths
    
    Parameterized partial paths are not supported, and we have several
    checks in try_partial_xxx_path functions to enforce this.  For a
    partial nestloop join path, we need to ensure that if the inner path
    is parameterized, the parameterization is fully satisfied by the
    proposed outer path.  For a partial merge/hashjoin join path, we need
    to ensure that the inner path is not parameterized.  In all cases, we
    need to ensure that the outer path is not parameterized.
    
    However, the comment in try_partial_hashjoin_path does not describe
    this correctly.  This patch fixes that.
    
    In addtion, this patch simplifies the checks peformed in
    try_partial_hashjoin_path and try_partial_mergejoin_path with the help
    of macro PATH_REQ_OUTER, and also adds asserts that the outer path is
    not parameterized in try_partial_xxx_path functions.
    
    Author: Richard Guo
    Discussion: https://postgr.es/m/CAMbWs48mKJ6g_GnYNa7dnw04MHaMK-jnAEBrMVhTp2uUg3Ut4A@mail.gmail.com
```

Relevant function:
`set_plain_rel_pathlist` -> partial seq scan path has no required outer, just like other partial scan paths

Tested output against regular postgres tables

