### PR TITLE
Enable PG18 tests for windows

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -58,7 +58,7 @@ jobs:
           - { pg: 15, pg_version: "${{ needs.config.outputs.pg15_latest }}" }
           - { pg: 16, pg_version: "${{ needs.config.outputs.pg16_latest }}" }
           - { pg: 17, pg_version: "${{ needs.config.outputs.pg17_latest }}" }
-#          - { pg: 18, pg_version: "${{ needs.config.outputs.pg18_latest }}" }
+          - { pg: 18, pg_version: "${{ needs.config.outputs.pg18_latest }}" }
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         event_name: ["${{ github.event_name }}"]


### PR DESCRIPTION
PG18 packages for windows are available now so we can enable it in CI

Disable-check: force-changelog-file
