### PR TITLE
Fix wrong usage of \if in upgrade tests

### DIFF
--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -6,7 +6,8 @@ SELECT NOT (extversion >= '2.19.0' AND extversion <= '2.20.3') AS has_fixed_comp
   FROM pg_extension
  WHERE extname = 'timescaledb' \gset
 
-\if ! :PG_UPGRADE_TEST
+\if :PG_UPGRADE_TEST
+\else
 \d+ _timescaledb_catalog.hypertable
 \d+ _timescaledb_catalog.chunk
 \d+ _timescaledb_catalog.dimension


### PR DESCRIPTION
It doesn't perform boolean operations and only evaluates the argument as a bool GUC value.